### PR TITLE
fix bug in finsh when built with 64bit-gcc

### DIFF
--- a/components/finsh/cmd.c
+++ b/components/finsh/cmd.c
@@ -623,7 +623,9 @@ long list(void)
     rt_kprintf("--Variable List:\n");
     {
         struct finsh_sysvar *index;
-        for (index = _sysvar_table_begin; index < _sysvar_table_end; index ++)
+        for (index = _sysvar_table_begin;
+             index < _sysvar_table_end;
+             FINSH_NEXT_SYSVAR(index))
         {
 #ifdef FINSH_USING_DESCRIPTION
             rt_kprintf("%-16s -- %s\n", index->name, index->desc);
@@ -761,7 +763,9 @@ void list_prefix(char *prefix)
     /* checks in system variable */
     {
         struct finsh_sysvar* index;
-        for (index = _sysvar_table_begin; index < _sysvar_table_end; index ++)
+        for (index = _sysvar_table_begin;
+             index < _sysvar_table_end;
+             FINSH_NEXT_SYSVAR(index))
         {
             if (str_is_prefix(prefix, index->name) == 0)
             {

--- a/components/finsh/finsh.h
+++ b/components/finsh/finsh.h
@@ -64,8 +64,16 @@ typedef unsigned char  u_char;
 typedef unsigned short u_short;
 typedef unsigned long  u_long;
 
-#if !defined(__CC_ARM) && !defined(__IAR_SYSTEMS_ICC__) && !defined(__ADSPBLACKFIN__) && !defined(_MSC_VER)
+#if !defined(__CC_ARM)             && \
+    !defined(__IAR_SYSTEMS_ICC__)  && \
+    !defined(__ADSPBLACKFIN__)     && \
+    !defined(_MSC_VER)
+
+#if !(defined(__GNUC__) && defined(__x86_64__))
 typedef unsigned int size_t;
+#else
+#include <stdio.h>
+#endif
 
 #ifndef NULL
 #define NULL RT_NULL
@@ -148,11 +156,14 @@ struct finsh_sysvar
 	void*		 var ;		/* the address of variable */
 };
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || (defined(__GNUC__) && defined(__x86_64__))
 struct finsh_syscall* finsh_syscall_next(struct finsh_syscall* call);
+struct finsh_sysvar* finsh_sysvar_next(struct finsh_sysvar* call);
 #define FINSH_NEXT_SYSCALL(index)  index=finsh_syscall_next(index)
+#define FINSH_NEXT_SYSVAR(index)   index=finsh_sysvar_next(index)
 #else
 #define FINSH_NEXT_SYSCALL(index)  index++
+#define FINSH_NEXT_SYSVAR(index)   index++
 #endif
 
 /* system variable item */

--- a/components/finsh/finsh_var.c
+++ b/components/finsh/finsh_var.c
@@ -121,7 +121,9 @@ struct finsh_sysvar* finsh_sysvar_lookup(const char* name)
 	struct finsh_sysvar* index;
 	struct finsh_sysvar_item* item;
 
-	for (index = _sysvar_table_begin; index < _sysvar_table_end; index ++)
+	for (index = _sysvar_table_begin;
+	     index < _sysvar_table_end;
+	     FINSH_NEXT_SYSVAR(index))
 	{
 		if (strcmp(index->name, name) == 0)
 			return index;

--- a/components/finsh/finsh_vm.c
+++ b/components/finsh/finsh_vm.c
@@ -83,7 +83,7 @@ void finsh_syscall_append(const char* name, syscall_func func)
 }
 #endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || (defined(__GNUC__) && defined(__x86_64__))
 struct finsh_syscall* finsh_syscall_next(struct finsh_syscall* call)
 {
 	unsigned int *ptr;
@@ -92,6 +92,16 @@ struct finsh_syscall* finsh_syscall_next(struct finsh_syscall* call)
 		ptr ++;
 
 	return (struct finsh_syscall*)ptr;
+}
+
+struct finsh_sysvar* finsh_sysvar_next(struct finsh_sysvar* call)
+{
+	unsigned int *ptr;
+	ptr = (unsigned int*) (call + 1);
+	while ((*ptr == 0) && ((unsigned int*)ptr < (unsigned int*) _sysvar_table_end))
+		ptr ++;
+
+	return (struct finsh_sysvar*)ptr;
 }
 #endif
 


### PR DESCRIPTION
so simulator with finsh enableed can be built with gcc under 64-bit linux distributions.
