### PR TITLE
simulator: fix serial_write

### DIFF
--- a/bsp/simulator/drivers/serial.c
+++ b/bsp/simulator/drivers/serial.c
@@ -164,7 +164,7 @@ static rt_size_t rt_serial_write(rt_device_t dev, rt_off_t pos, const void *buff
 #endif
 
     level = rt_hw_interrupt_disable();
-    printf("%s", (char *)buffer);
+    fwrite(buffer, size, 1, stdout);
 	fflush(stdout);
     rt_hw_interrupt_enable(level);
     return size;


### PR DESCRIPTION
printf("%s") will print a NULL terminated string, while rt_serial_write
should print buffer for size length. This also fix segfault when the
string is not null terminated but specified by size.
