### PR TITLE
usbdevice/core: add reset function to support hotplug

### DIFF
--- a/components/drivers/include/drivers/usb_device.h
+++ b/components/drivers/include/drivers/usb_device.h
@@ -145,6 +145,7 @@ enum udev_msg_type
     USB_MSG_SETUP_NOTIFY,
     USB_MSG_DATA_NOTIFY,
     USB_MSG_SOF,
+    USB_MSG_RESET,
 };
 typedef enum udev_msg_type udev_msg_type;
 


### PR DESCRIPTION
When the USB got RESET packet from the host and the address is setup,
all the classes will got reset. The reset is done by class stop and than
class run. So the classes should reset their internal state in
class_{run,stop}.

Besides, the USB device driver could post a USB_MSG_RESET message on
every RESET packet.
