### PR TITLE
tools: add an option to generate cscope database

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -83,6 +83,11 @@ def PrepareBuilding(env, root_directory, has_libcpu=False, remove_components = [
                       action='store_true',
                       default=False,
                       help='copy header of rt-thread directory to local.')
+    AddOption('--cscope',
+                      dest='cscope',
+                      action='store_true',
+                      default=False,
+                      help='Build Cscope cross reference database. Requires cscope installed.')
 
     # add build library option
     AddOption('--buildlib', 
@@ -340,6 +345,10 @@ def EndBuilding(target, program = None):
         MakeCopy(program)
     if GetOption('copy-header') and program != None:
         MakeCopyHeader(program)
+
+    if GetOption('cscope'):
+        from cscope import CscopeDatabase
+        CscopeDatabase(Projects)
 
 def SrcRemove(src, remove):
     if type(src[0]) == type('str'):

--- a/tools/cscope.py
+++ b/tools/cscope.py
@@ -1,0 +1,37 @@
+import os
+
+def _get_src(project):
+    li = []
+    for group in project:
+        for f in group['src']:
+            li.append(os.path.normpath(f.rfile().abspath))
+    return li
+
+def _get_header_dir(dirp):
+    li = []
+    for root, dirs, files in os.walk(dirp):
+        for d in dirs:
+            fpath = os.path.join(root, d)
+            li.extend(_get_header_dir(fpath))
+
+        for f in files:
+            if f[-2:] == '.h':
+                fpath = os.path.join(root, f)
+                li.append(os.path.normpath(fpath))
+    return li
+
+def _get_header(project):
+    li = []
+    for g in project:
+        for d in g.get('CPPPATH', []):
+            li.extend(_get_header_dir(d))
+    return li
+
+def CscopeDatabase(project):
+    files = set(_get_src(project) + _get_header(project))
+    with open('cscope.files', 'w') as db:
+        db.write('-k\n-q\n')
+        db.write('\n'.join(files))
+        db.flush() # let cscope see the full content
+        os.system('cscope -b')
+


### PR DESCRIPTION
When --cscope option is given to Scons, it will generate a cscope
cross-reference database in current directory, which is useful in
Vim(and other cscope-aware text editors). For example, `scons -s
--cscope` will do nothing except generating the database. You can use
this option with other options together.

It is inspired by the `make cscope` of Linux.
