### PR TITLE
add MSVC components initialization support

### DIFF
--- a/components/init/components.c
+++ b/components/init/components.c
@@ -43,9 +43,9 @@ static int rti_end(void)
 }
 
 #ifdef _MSC_VER
-    #pragma section(".rti_fn$0", read,execute)
-    #pragma section(".rti_fn$1z", read,execute)
-    #pragma section(".rti_fn$7", read,execute)
+    #pragma section(".rti_fn$0", read)
+    #pragma section(".rti_fn$1z", read)
+    #pragma section(".rti_fn$7", read)
 __declspec(allocate(".rti_fn$0")) const init_fn_t __rt_init_rti_start = rti_start;
 __declspec(allocate(".rti_fn$1z")) const init_fn_t __rt_init_rti_board_end = rti_start;
 __declspec(allocate(".rti_fn$7")) const init_fn_t __rt_init_rti_end = rti_start;

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -184,13 +184,13 @@ typedef int (*init_fn_t)(void);
 #ifdef _MSC_VER
     /* The one in MSVC is complicated and lame. */
     /* we need to define the section before "allocate" it. */
-    #pragma section(".rti_fn$1", read,execute)
-    #pragma section(".rti_fn$2", read,execute)
-    #pragma section(".rti_fn$3", read,execute)
-    #pragma section(".rti_fn$4", read,execute)
-    #pragma section(".rti_fn$5", read,execute)
-    #pragma section(".rti_fn$6", read,execute)
-    #pragma section(".rti_fn$7", read,execute)
+    #pragma section(".rti_fn$1", read)
+    #pragma section(".rti_fn$2", read)
+    #pragma section(".rti_fn$3", read)
+    #pragma section(".rti_fn$4", read)
+    #pragma section(".rti_fn$5", read)
+    #pragma section(".rti_fn$6", read)
+    #pragma section(".rti_fn$7", read)
     /* __declspec(allocate()) take effect before string concatenation, so
        __declspec(allocate("A""B")) will result in compiling error:
          : error C2341: 'A' : segment must be defined using #pragma


### PR DESCRIPTION
MSVC handles section setting differently from other compilers. It seems that there is no way to add an abstract layer of such issue. The SECTION macro in rtdef.h is hard to adopt to different compilers.

This is a RFC rather than a serious "request" since I just test it on RTGUI. Although it compiles on MDK, I haven't tested it on the board neither tested compiling with GCC. Please test it on the board with various compilers before merging. If there is any problem, please comment here and I will try to fix them accordingly.
