### PR TITLE
device: add ref_count support

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -779,6 +779,7 @@ struct rt_device
     rt_uint16_t               flag;                     /**< device flag */
     rt_uint16_t               open_flag;                /**< device open flag */
 
+    rt_uint8_t                ref_count;                /**< reference count */
     rt_uint8_t                device_id;                /**< 0 - 255 */
 
     /* device call back */


### PR DESCRIPTION
This is a simple work around to the current device stack design. A
ref_count could let different modules to open/close the same device
independently without interfere others in some degree.

But there is still some data shared between the modules, like flag,
open_flag and user_data. Moreover, it won't yield an error if A open a
device, and B read from it before open it in B. Maybe alloc a new handle
in rt_device_open will be the ultimate solution. But that is much bigger
change and we may leave it to future development.
