### PR TITLE
simulator: update code for new component initialization support on mingw

### DIFF
--- a/bsp/simulator/applications/application.c
+++ b/bsp/simulator/applications/application.c
@@ -30,6 +30,10 @@ void rt_init_thread_entry(void *parameter)
     /* initialization RT-Thread Components */
     rt_components_init();
 
+#if defined(RT_USING_COMPONENTS_INIT) && defined(__GNUC__) && defined(RT_USING_FINSH)
+    finsh_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif
+
     /* File system Initialization */
 #ifdef RT_USING_DFS
     {

--- a/bsp/simulator/mingw.ld
+++ b/bsp/simulator/mingw.ld
@@ -40,6 +40,14 @@ SECTIONS
       KEEP(*(VSymTab))
       ___vsymtab_end = .; __vsymtab_end = .;
   }
+  . = ALIGN(__section_alignment__);
+  rti_fn () :
+  {
+      __rt_init_start = .;
+      KEEP(*(SORT(.rti_fn*)))
+	  __rt_init_end = .;
+  }
+  . = ALIGN(__section_alignment__);
   /* setction information for finsh shell end */
   
   /* The Cygwin32 library uses a section to avoid copying certain data


### PR DESCRIPTION
note that simulator can be built with gcc, so it may be necessary to add omponent initialization  support  for gcc.
