### PR TITLE
add __rt_ffs prototype in rtthread.h

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -503,6 +503,15 @@ rt_uint32_t rt_strcasecmp(const char *a, const char *b);
 
 void rt_show_version(void);
 
+#ifdef RT_USING_CPU_FFS
+#ifdef __GNUC__
+/* GCC will inline __builtin_ffs automatically */
+#define __rt_ffs __builtin_ffs
+#else
+int __rt_ffs(int);
+#endif
+#endif
+
 /*@}*/
 
 #ifdef __cplusplus


### PR DESCRIPTION
Note that we define __rt_ffs as __builtin_ffs in GCC. __builtin_ffs will
be inlined automatically.

Build passed with GCC/Keil in bsp/stm32f10x(RT_USING_CPU_FFS enabled).
