### PR TITLE
stm32f10x: fix the rtgui initialization

### DIFF
--- a/bsp/stm32f10x/applications/application.c
+++ b/bsp/stm32f10x/applications/application.c
@@ -111,7 +111,6 @@ void rt_init_thread_entry(void* parameter)
 
 #ifdef RT_USING_RTGUI
     {
-        extern void rtgui_system_server_init(void);
         extern void rt_hw_lcd_init();
         extern void rtgui_touch_hw_init(void);
 
@@ -132,8 +131,10 @@ void rt_init_thread_entry(void* parameter)
         /* set lcd device as rtgui graphic driver */
         rtgui_graphic_set_device(lcd);
 
+#ifndef RT_USING_COMPONENTS_INIT
         /* init rtgui system server */
         rtgui_system_server_init();
+#endif
 
         calibration_set_restore(cali_setup);
         calibration_set_after(cali_store);


### PR DESCRIPTION
The rtgui_system_server_init prototype is wrong. And if we use
RT_USING_COMPONENTS_INIT, there is no need to call
rtgui_system_server_init again.
