### PR TITLE
finsh: unregister rx_indicate when closing the device

### DIFF
--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -131,6 +131,7 @@ void finsh_set_device(const char* device_name)
 		{
 			/* close old finsh device */
 			rt_device_close(shell->device);
+            rt_device_set_rx_indicate(dev, RT_NULL);
 		}
 
 		shell->device = dev;


### PR DESCRIPTION
Because the device could still remain opened when closed by finsh, the
old rx_indicate is useless for finsh. Some buggy driver will still
generate rx_indicate even after the device has been closed. So FinSh
should unregister the rx_indicate when releasing the old device.
