### PR TITLE
kservice: export vsnprintf as rt_vsnprintf

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -469,6 +469,7 @@ int rt_system_module_init(void);
 void rt_kprintf(const char *fmt, ...);
 #endif
 rt_int32_t rt_vsprintf(char *dest, const char *format, va_list arg_ptr);
+rt_int32_t rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list args);
 rt_int32_t rt_sprintf(char *buf ,const char *format, ...);
 rt_int32_t rt_snprintf(char *buf, rt_size_t size, const char *format, ...);
 

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -718,10 +718,10 @@ static char *print_number(char *buf,
     return buf;
 }
 
-static rt_int32_t vsnprintf(char       *buf,
-                            rt_size_t   size,
-                            const char *fmt,
-                            va_list     args)
+rt_int32_t rt_vsnprintf(char       *buf,
+                        rt_size_t   size,
+                        const char *fmt,
+                        va_list     args)
 {
 #ifdef RT_PRINTF_LONGLONG
     unsigned long long num;
@@ -976,6 +976,7 @@ static rt_int32_t vsnprintf(char       *buf,
     */
     return str - buf;
 }
+RTM_EXPORT(rt_vsnprintf);
 
 /**
  * This function will fill a formatted string to buffer
@@ -990,7 +991,7 @@ rt_int32_t rt_snprintf(char *buf, rt_size_t size, const char *fmt, ...)
     va_list args;
 
     va_start(args, fmt);
-    n = vsnprintf(buf, size, fmt, args);
+    n = rt_vsnprintf(buf, size, fmt, args);
     va_end(args);
 
     return n;
@@ -1006,7 +1007,7 @@ RTM_EXPORT(rt_snprintf);
  */
 rt_int32_t rt_vsprintf(char *buf, const char *format, va_list arg_ptr)
 {
-    return vsnprintf(buf, (rt_size_t) -1, format, arg_ptr);
+    return rt_vsnprintf(buf, (rt_size_t) -1, format, arg_ptr);
 }
 RTM_EXPORT(rt_vsprintf);
 
@@ -1114,7 +1115,7 @@ void rt_kprintf(const char *fmt, ...)
      * large excluding the terminating null byte. If the output string
      * would be larger than the rt_log_buf, we have to adjust the output
      * length. */
-    length = vsnprintf(rt_log_buf, sizeof(rt_log_buf) - 1, fmt, args);
+    length = rt_vsnprintf(rt_log_buf, sizeof(rt_log_buf) - 1, fmt, args);
     if (length > RT_CONSOLEBUF_SIZE - 1)
         length = RT_CONSOLEBUF_SIZE - 1;
 #ifdef RT_USING_DEVICE


### PR DESCRIPTION
vsnprintf is a common string function that could be used in many places.
Using both vsnprintf in libc and vsnprintf in the RTT could make a
bigger image. Moreover, if newlib is enabled when compiling with GCC,
referencing vsnprintf will lead to link error:

```
.../arm-none-eabi/lib/armv7-ar/thumb/softfp/libc.a(lib_a-sbrkr.o):
In function `_sbrk_r':
sbrkr.c:(.text._sbrk_r+0xc): undefined reference to `_sbrk'
collect2: error: ld returned 1 exit status
```

Using rt_vsnprintf could avoid such problem.
