### PR TITLE
kernel: add RT_DEBUG_IN_THREAD_CONTEXT

### DIFF
--- a/include/rtdebug.h
+++ b/include/rtdebug.h
@@ -103,8 +103,29 @@ do                                                                            \
     rt_hw_interrupt_enable(level);                                            \
 }                                                                             \
 while (0)
+
+/* "In thread context" means:
+ *     1) the scheduler has been started
+ *     2) not in interrupt context.
+ */
+#define RT_DEBUG_IN_THREAD_CONTEXT                                            \
+do                                                                            \
+{                                                                             \
+    rt_base_t level;                                                          \
+    level = rt_hw_interrupt_disable();                                        \
+    if (rt_thread_self() == RT_NULL)                                          \
+    {                                                                         \
+        rt_kprintf("Function[%s] shall not be used before scheduler start\n", \
+                   __FUNCTION__);                                             \
+        RT_ASSERT(0)                                                          \
+    }                                                                         \
+    RT_DEBUG_NOT_IN_INTERRUPT;                                                \
+    rt_hw_interrupt_enable(level);                                            \
+}                                                                             \
+while (0)
 #else
 #define RT_DEBUG_NOT_IN_INTERRUPT
+#define RT_DEBUG_IN_THREAD_CONTEXT
 #endif
 
 #else /* RT_DEBUG */

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -362,7 +362,7 @@ rt_err_t rt_sem_take(rt_sem_t sem, rt_int32_t time)
         else
         {
             /* current context checking */
-            RT_DEBUG_NOT_IN_INTERRUPT;
+            RT_DEBUG_IN_THREAD_CONTEXT;
 
             /* semaphore is unavailable, push to suspend list */
             /* get current thread */
@@ -645,7 +645,7 @@ rt_err_t rt_mutex_take(rt_mutex_t mutex, rt_int32_t time)
     struct rt_thread *thread;
 
     /* this function must not be used in interrupt even if time = 0 */
-    RT_DEBUG_NOT_IN_INTERRUPT;
+    RT_DEBUG_IN_THREAD_CONTEXT;
 
     RT_ASSERT(mutex != RT_NULL);
 
@@ -1097,7 +1097,7 @@ rt_err_t rt_event_recv(rt_event_t   event,
     register rt_ubase_t level;
     register rt_base_t status;
 
-    RT_DEBUG_NOT_IN_INTERRUPT;
+    RT_DEBUG_IN_THREAD_CONTEXT;
 
     /* parameter check */
     RT_ASSERT(event != RT_NULL);
@@ -1442,7 +1442,7 @@ rt_err_t rt_mb_send_wait(rt_mailbox_t mb,
             return -RT_EFULL;
         }
 
-        RT_DEBUG_NOT_IN_INTERRUPT;
+        RT_DEBUG_IN_THREAD_CONTEXT;
         /* suspend current thread */
         rt_ipc_list_suspend(&(mb->suspend_sender_thread),
                             thread,
@@ -1589,7 +1589,7 @@ rt_err_t rt_mb_recv(rt_mailbox_t mb, rt_uint32_t *value, rt_int32_t timeout)
             return -RT_ETIMEOUT;
         }
 
-        RT_DEBUG_NOT_IN_INTERRUPT;
+        RT_DEBUG_IN_THREAD_CONTEXT;
         /* suspend current thread */
         rt_ipc_list_suspend(&(mb->parent.suspend_thread),
                             thread,
@@ -2123,7 +2123,7 @@ rt_err_t rt_mq_recv(rt_mq_t    mq,
     /* message queue is empty */
     while (mq->entry == 0)
     {
-        RT_DEBUG_NOT_IN_INTERRUPT;
+        RT_DEBUG_IN_THREAD_CONTEXT;
 
         /* reset error number in thread */
         thread->error = RT_EOK;


### PR DESCRIPTION
In thread context means: 1) the scheduler has been started; 2) not in
interrupt context. It is more stronger than RT_DEBUG_NOT_IN_INTERRUPT.
With this commit, you will catch the error on situations like taking
mutex before scheduling instead of crashing on NULL pointer reference.
