### PR TITLE
kernel: fix compiling error when RT_DEBUG is not defined

### DIFF
--- a/include/rtdebug.h
+++ b/include/rtdebug.h
@@ -133,6 +133,7 @@ while (0)
 #define RT_ASSERT(EX)
 #define RT_DEBUG_LOG(type, message)
 #define RT_DEBUG_NOT_IN_INTERRUPT
+#define RT_DEBUG_IN_THREAD_CONTEXT
 
 #endif /* RT_DEBUG */
 


### PR DESCRIPTION
Define RT_DEBUG_IN_THREAD_CONTEXT when RT_DEBUG is not defined.
