### PR TITLE
kernel: use skip list to implement timer list

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -410,6 +410,15 @@ struct rt_object_information
 #define RT_TIMER_CTRL_SET_ONESHOT       0x2             /**< change timer to one shot */
 #define RT_TIMER_CTRL_SET_PERIODIC      0x3             /**< change timer to periodic */
 
+#ifndef RT_TIMER_SKIP_LIST_LEVEL
+#define RT_TIMER_SKIP_LIST_LEVEL          1
+#endif
+
+/* 1 or 3 */
+#ifndef RT_TIMER_SKIP_LIST_MASK
+#define RT_TIMER_SKIP_LIST_MASK         0x3
+#endif
+
 /**
  * timer structure
  */
@@ -417,7 +426,7 @@ struct rt_timer
 {
     struct rt_object parent;                            /**< inherit from rt_object */
 
-    rt_list_t        list;                              /**< the node of timer list */
+    rt_list_t        row[RT_TIMER_SKIP_LIST_LEVEL];
 
     void (*timeout_func)(void *parameter);              /**< timeout function */
     void            *parameter;                         /**< timeout function's parameter */

--- a/src/thread.c
+++ b/src/thread.c
@@ -61,8 +61,7 @@ static void rt_thread_exit(void)
     thread->stat = RT_THREAD_CLOSE;
 
     /* remove it from timer list */
-    rt_list_remove(&(thread->thread_timer.list));
-    rt_object_detach((rt_object_t)&(thread->thread_timer));
+    rt_timer_detach(&thread->thread_timer);
 
     if ((rt_object_is_systemobject((rt_object_t)thread) == RT_TRUE) &&
         thread->cleanup == RT_NULL)
@@ -613,11 +612,7 @@ rt_err_t rt_thread_resume(rt_thread_t thread)
     /* remove from suspend list */
     rt_list_remove(&(thread->tlist));
 
-    /* remove thread timer */
-    rt_list_remove(&(thread->thread_timer.list));
-
-    /* change timer state */
-    thread->thread_timer.parent.flag &= ~RT_TIMER_FLAG_ACTIVATED;
+    rt_timer_stop(&thread->thread_timer);
 
     /* enable interrupt */
     rt_hw_interrupt_enable(temp);


### PR DESCRIPTION
Skip list is a "random" data structure that in high possibilities it
would get O(log(N)) time complexity in inserting while the old list get
O(N). Forthermore, when set RT_TIMER_SKIP_LIST_LEVEL to 1, it will just
the same as the old double linked list, both in time and space
complexity.

Benchmarks shows that when RT_TIMER_SKIP_LIST_LEVEL is 3, the average
time of random insertion of new timer is about 2 times faster than the
old timer when there are 100 timers and 3 times faster when there are
200 timers.

However, it restores the deprecated funcion rt_system_timer_init. BSPs
must invoke it upon system startup.

It has been running on some boards for some time and seems to be fine.
