### PR TITLE
kernel: mutex could only be released in thread context

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -777,6 +777,9 @@ rt_err_t rt_mutex_release(rt_mutex_t mutex)
 
     need_schedule = RT_FALSE;
 
+    /* only thread could release mutex because we need test the ownership */
+    RT_DEBUG_IN_THREAD_CONTEXT;
+
     /* get current thread */
     thread = rt_thread_self();
 


### PR DESCRIPTION
Mutex has the idea of ownership, only the thread which owns the mutex
can release it. So rt_mutex_release could only be called in thread
context.  Add a debug guard to it.
