### PR TITLE
simulator/jffs2: remove _TIME_T_DEFINED when built by VC++

### DIFF
--- a/bsp/simulator/SConstruct
+++ b/bsp/simulator/SConstruct
@@ -45,7 +45,6 @@ if rtconfig.PLATFORM == 'cl':
     _DEBUG
     _CONSOLE
     MSVC
-    _TIME_T_DEFINED
     ''')
     env.Append(CCFLAGS=rtconfig.CFLAGS)
     env.Append(LINKFLAGS=rtconfig.LFLAGS)

--- a/components/dfs/filesystems/jffs2/include/port/sys/stat.h
+++ b/components/dfs/filesystems/jffs2/include/port/sys/stat.h
@@ -317,10 +317,11 @@ typedef void *cyg_io_handle_t;
 #define S_ISGID  (1<<26)
 
 #if defined(MSVC)
+/* for time_t */
+#include <time.h>
 typedef unsigned long mode_t;
 typedef unsigned int ino_t;
 typedef unsigned int dev_t;
-typedef int time_t;
 typedef long ssize_t;
 #elif defined(__CC_ARM)  
 #define mode_t unsigned long

--- a/components/dfs/filesystems/jffs2/include/port/sys/types.h
+++ b/components/dfs/filesystems/jffs2/include/port/sys/types.h
@@ -78,7 +78,11 @@ typedef unsigned short gid_t;
 typedef unsigned short uid_t;
 typedef int pid_t;
 
+#if defined(MSVC)
+#include <time.h>
+#else
 typedef int time_t;
+#endif
 //#include "os_sys_stat.h"
 #endif /* CYGONCE_ISO_SYS_TYPES_H multiple inclusion protection */
 


### PR DESCRIPTION
_TIME_T_DEFINED was pre-defined in order to build jffs2 with VC.
While it may cause many side effects.
