### PR TITLE
initialize timer in bsp

### DIFF
--- a/bsp/beaglebone/applications/startup.c
+++ b/bsp/beaglebone/applications/startup.c
@@ -40,6 +40,9 @@ void rtthread_startup(void)
 	/* initialize scheduler system */
 	rt_system_scheduler_init();
 
+    /* initialize timer */
+    rt_system_timer_init();
+
 	/* initialize soft timer thread */
 	rt_system_timer_thread_init();
 

--- a/bsp/lpc176x/applications/startup.c
+++ b/bsp/lpc176x/applications/startup.c
@@ -95,6 +95,9 @@ void rtthread_startup(void)
 	/* initialize application */
 	rt_application_init();
 
+    /* initialize timer */
+    rt_system_timer_init();
+
     /* initialize timer thread */
     rt_system_timer_thread_init();
 

--- a/bsp/lpc178x/applications/startup.c
+++ b/bsp/lpc178x/applications/startup.c
@@ -87,6 +87,9 @@ void rtthread_startup(void)
 	finsh_set_device( FINSH_DEVICE_NAME );
 #endif
 
+    /* initialize timer */
+    rt_system_timer_init();
+
     /* initialize timer thread */
     rt_system_timer_thread_init();
 

--- a/bsp/ls1bdev/applications/startup.c
+++ b/bsp/ls1bdev/applications/startup.c
@@ -72,6 +72,9 @@ void rtthread_startup(void)
 	/* init application */
 	rt_application_init();
 
+    /* initialize timer */
+    rt_system_timer_init();
+
 	/* initialize timer thread */
 	rt_system_timer_thread_init();
 

--- a/bsp/mb9bf506r/applications/startup.c
+++ b/bsp/mb9bf506r/applications/startup.c
@@ -71,6 +71,9 @@ void rtthread_startup(void)
 	/* initialize application */
 	rt_application_init();
 
+    /* initialize timer */
+    rt_system_timer_init();
+
 	/* initialize timer thread */
 	rt_system_timer_thread_init();
 

--- a/bsp/stm32f10x/applications/startup.c
+++ b/bsp/stm32f10x/applications/startup.c
@@ -80,6 +80,9 @@ void rtthread_startup(void)
     /* init scheduler system */
     rt_system_scheduler_init();
 
+    /* initialize timer */
+    rt_system_timer_init();
+
     /* init timer thread */
     rt_system_timer_thread_init();
 

--- a/bsp/xplorer4330/applications/startup.c
+++ b/bsp/xplorer4330/applications/startup.c
@@ -64,6 +64,9 @@ void rtthread_startup(void)
     /* init application */
     rt_application_init();
 
+    /* initialize timer */
+    rt_system_timer_init();
+
     /* init timer thread */
     rt_system_timer_thread_init();
 


### PR DESCRIPTION
With new timer algorithm, timer should be initialized during startup. So
add them to the bsps. Use these commands to get which bsp is missing
calling the function:

```
% git grep rt_system_timer_init bsp|sed -n 's|bsp/\([^/]*\).*|\1|p' | sort | uniq > have_tm_init
% ls -1 bsp |sed -n 's|\([^/]*\).*|\1|p' | sort > all_bsp
% comm -3 all_bsp have_tm_init
beaglebone
lpc176x
lpc178x
ls1bdev
mb9bf506r
stm32f10x
xplorer4330
```
