### PR TITLE
K60: fix compile error

### DIFF
--- a/bsp/K60Fxxxx/drivers/drv_uart.c
+++ b/bsp/K60Fxxxx/drivers/drv_uart.c
@@ -162,14 +162,14 @@ static rt_err_t _control(struct rt_serial_device *serial, int cmd, void *arg)
         /* disable rx irq */
         uart_reg->C2 &= ~UART_C2_RIE_MASK;
         //disable NVIC
-        NVICICER1 |= 1 << (uart_irq_num % 32);
+        NVIC->ICER[uart_irq_num / 32] = 1 << (uart_irq_num % 32);
         break;
     case RT_DEVICE_CTRL_SET_INT:
         /* enable rx irq */
         uart_reg->C2 |= UART_C2_RIE_MASK;
         //enable NVIC,we are sure uart's NVIC vector is in NVICICPR1
-        NVICICPR1 |= 1 << (uart_irq_num % 32);
-        NVICISER1 |= 1 << (uart_irq_num % 32);
+        NVIC->ICPR[uart_irq_num / 32] = 1 << (uart_irq_num % 32);
+        NVIC->ISER[uart_irq_num / 32] = 1 << (uart_irq_num % 32);
         break;
     case RT_DEVICE_CTRL_SUSPEND:
         /* suspend device */


### PR DESCRIPTION
Modified the writing of NVIC registers configured in MDK compiler environment 
