### PR TITLE
Low latency

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -424,7 +424,7 @@ rt_err_t rt_thread_sleep(rt_tick_t tick)
 
     /* set to current thread */
     thread = rt_current_thread;
-    RT_ASSERT(thread != RT_NULL);
+    RT_DEBUG_IN_THREAD_CONTEXT;
 
     /* reset the timeout of thread timer and start it */
     rt_timer_control(&(thread->thread_timer), RT_TIMER_CTRL_SET_TIME, &tick);


### PR DESCRIPTION
rt_thread_sleep is meant to be called in thread context and, if it got
interrupted, when come back, all context will be restored. So there is
no need to protect the context by disabling interrupts.

I also moved the rt_thread_suspend to the very line before rt_schedule,
because it is "running" when setting up the timers.
