### PR TITLE
It is a big patch for stm32f0x, see the fellow :

### DIFF
--- a/bsp/stm32f0x/applications/application.c
+++ b/bsp/stm32f0x/applications/application.c
@@ -10,6 +10,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2009-01-05     Bernard      the first version
+ * 2013-11-15     bright       add init thread and components initial
  */
 
 /**
@@ -21,63 +22,65 @@
 
 #include <board.h>
 #include <rtthread.h>
+#ifdef  RT_USING_COMPONENTS_INIT
+#include <components.h>
+#endif  /* RT_USING_COMPONENTS_INIT */
 
-/*
-LED_GREEN: PC8
-LED_RED  : PC9
-*/
-#define rt_hw_led_on()   GPIO_SetBits(GPIOC, GPIO_Pin_9)
-#define rt_hw_led_off()  GPIO_ResetBits(GPIOC, GPIO_Pin_9)
+#include "led.h"
 
-static void rt_hw_led_init(void)
-{
-    GPIO_InitTypeDef  GPIO_InitStructure;
-
-    /* Enable the GPIO_LED Clock */
-    RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOC, ENABLE);
-
-    /* Configure the GPIO_LED pin */
-    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_9;
-    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
-    GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
-    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
-    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
-    GPIO_Init(GPIOC, &GPIO_InitStructure);
-}
-
-ALIGN(RT_ALIGN_SIZE)
-static char led_stack[384];
-static struct rt_thread led_thread;
-
+/* led thread entry */
 static void led_thread_entry(void* parameter)
 {
-    rt_hw_led_init();
-
-    while(1)
-    {
+	while(1)
+	{
         rt_hw_led_on();
-        rt_thread_delay(RT_TICK_PER_SECOND/4);
+        rt_thread_delay(RT_TICK_PER_SECOND);
 
         rt_hw_led_off();
-        rt_thread_delay(RT_TICK_PER_SECOND/4);
-    }
+        rt_thread_delay(RT_TICK_PER_SECOND);
+	}
+}
+
+static void rt_init_thread_entry(void* parameter)
+{
+	rt_thread_t led_thread;
+
+/* Initialization RT-Thread Components */
+#ifdef RT_USING_COMPONENTS_INIT
+    rt_components_init();
+#endif
+
+/* Set finsh device */
+#ifdef  RT_USING_FINSH
+    finsh_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif  /* RT_USING_FINSH */
+
+    /* Create led thread */
+    led_thread = rt_thread_create("led",
+    		led_thread_entry, RT_NULL,
+    		256, 20, 20);
+    if(led_thread != RT_NULL)
+    	rt_thread_startup(led_thread);
 }
 
 int rt_application_init()
 {
-    rt_err_t result;
+	rt_thread_t init_thread;
 
-    result = rt_thread_init(&led_thread,
-                            "led",
-                            led_thread_entry,
-                            RT_NULL,
-                            &led_stack[0],
-                            sizeof(led_stack),
-                            4,
-                            2);
-    if(result == RT_EOK) rt_thread_startup(&led_thread);
+#if (RT_THREAD_PRIORITY_MAX == 32)
+    init_thread = rt_thread_create("init",
+                                   rt_init_thread_entry, RT_NULL,
+                                   512, 8, 20);
+#else
+    init_thread = rt_thread_create("init",
+                                   rt_init_thread_entry, RT_NULL,
+                                   512, 80, 20);
+#endif
+    if(init_thread != RT_NULL)
+    	rt_thread_startup(init_thread);
 
     return 0;
 }
+
 
 /*@}*/

--- a/bsp/stm32f0x/applications/startup.c
+++ b/bsp/stm32f0x/applications/startup.c
@@ -10,7 +10,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2006-08-31     Bernard      first implementation
- * 2011-06-05     Bernard      modify for STM32F107 version
+ * 2013-11-15     bright       modify for stm32f0xx version and components initial
  */
 
 #include <rthw.h>
@@ -93,12 +93,6 @@ void rtthread_startup(void)
 
 	/* init application */
 	rt_application_init();
-
-#ifdef RT_USING_FINSH
-	/* init finsh */
-	finsh_system_init();
-	finsh_set_device( FINSH_DEVICE_NAME );
-#endif
 
     /* init timer thread */
     rt_system_timer_thread_init();

--- a/bsp/stm32f0x/drivers/board.c
+++ b/bsp/stm32f0x/drivers/board.c
@@ -10,13 +10,18 @@
  * Change Logs:
  * Date           Author       Notes
  * 2009-01-05     Bernard      first implementation
+ * 2013-11-15     bright       add RCC initial and print RCC freq function
  */
 
 #include <rthw.h>
 #include <rtthread.h>
 
 #include "board.h"
-
+#include "usart.h"
+/* RT_USING_COMPONENTS_INIT */
+#ifdef  RT_USING_COMPONENTS_INIT
+#include <components.h>
+#endif
 /**
  * @addtogroup STM32
  */
@@ -36,6 +41,79 @@ void NVIC_Configuration(void)
 }
 
 /**
+* @brief  Inserts a delay time.
+* @param  nCount: specifies the delay time length.
+* @retval None
+*/
+static void Delay(__IO uint32_t nCount)
+{
+	/* Decrement nCount value */
+	while (nCount != 0)
+	{
+		nCount--;
+	}
+}
+
+/**
+ * This RCC initial for system.
+ * use HSI clock source and pll
+ * HSI = 8; sysclk = 8/2 * 12 = 48MHZ
+ * sysclk source is pllclk
+ * AHB prescaler is 1, HCLK = SYSCKL = SystemCoreClock = 48MHZ
+ */
+static void RCC_Configuration(void)
+{
+	RCC_DeInit();
+	/* setup HSI */
+	RCC_HSICmd(ENABLE);
+	/* Configure PLL source is HSI */
+	RCC_PLLConfig(RCC_PLLSource_HSI_Div2, RCC_PLLMul_12);
+	RCC_PLLCmd(ENABLE);
+	/* Configure SYSCLK source is PLL */
+	RCC_SYSCLKConfig(RCC_SYSCLKSource_PLLCLK);
+	/* Conigure AHB prescaler value is 1 */
+	RCC_HCLKConfig(RCC_SYSCLK_Div1);
+	/* Delay for RCC setup */
+	Delay(0x3FFFF);
+	/* Update SystemCoreClock value from RCC configure */
+	SystemCoreClockUpdate();
+}
+
+#ifdef PRINT_RCC_FREQ_INFO
+/**
+ * print RCC freq information
+ *
+ * for example:
+ *
+ * SYSCLK_Frequency is 48000000HZ
+ * PCLK_Frequency is 48000000HZ
+ * HCLK_Frequency is 48000000HZ
+ * CECCLK_Frequency is 32786HZ
+ * ADCCLK_Frequency is 14000000HZ
+ * USART1CLK_Frequency is 48000000HZ
+ * I2C1CLK_Frequency is 8000000HZ
+ * SystemCoreClock is 48000000HZ
+ *
+ */
+void print_rcc_freq_info(void)
+{
+	RCC_ClocksTypeDef RCC_ClockFreq;
+
+	RCC_GetClocksFreq(&RCC_ClockFreq);
+
+	rt_kprintf("\nSYSCLK_Frequency is %dHZ", RCC_ClockFreq.SYSCLK_Frequency);
+	rt_kprintf("\nPCLK_Frequency is %dHZ", RCC_ClockFreq.PCLK_Frequency);
+	rt_kprintf("\nHCLK_Frequency is %dHZ", RCC_ClockFreq.HCLK_Frequency);
+
+	rt_kprintf("\nCECCLK_Frequency is %dHZ", RCC_ClockFreq.CECCLK_Frequency);
+	rt_kprintf("\nADCCLK_Frequency is %dHZ", RCC_ClockFreq.ADCCLK_Frequency);
+	rt_kprintf("\nUSART1CLK_Frequency is %dHZ", RCC_ClockFreq.USART1CLK_Frequency);
+	rt_kprintf("\nI2C1CLK_Frequency is %dHZ", RCC_ClockFreq.I2C1CLK_Frequency);
+	rt_kprintf("\nSystemCoreClock is %dHZ\n", SystemCoreClock);
+}
+#endif
+
+/**
  * This is the timer interrupt service routine.
  *
  */
@@ -49,7 +127,6 @@ void SysTick_Handler(void)
 	/* leave interrupt */
 	rt_interrupt_leave();
 }
-
 /**
  * This function will initial STM32 board.
  */
@@ -59,11 +136,21 @@ void rt_hw_board_init()
 	NVIC_Configuration();
 
 	/* Configure the SysTick */
+	RCC_Configuration();
 	SysTick_Config(SystemCoreClock / RT_TICK_PER_SECOND);
 
-	//rt_hw_usart_init();
+	/* Initial usart deriver, and set console device */
+	rt_hw_usart_init();
 #ifdef RT_USING_CONSOLE
-	rt_console_set_device(CONSOLE_DEVICE);
+	rt_console_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif
+	/* Print RCC freq info */
+#ifdef PRINT_RCC_FREQ_INFO
+	print_rcc_freq_info();
+#endif
+	/* Call components board initial (use INIT_BOARD_EXPORT()) */
+#ifdef RT_USING_COMPONENTS_INIT
+    rt_components_board_init();
 #endif
 }
 

--- a/bsp/stm32f0x/drivers/board.h
+++ b/bsp/stm32f0x/drivers/board.h
@@ -10,6 +10,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2009-09-22     Bernard      add board.h to this bsp
+ * 2013-11-15     bright       fix SRAM size for heap management
  */
 
 // <<< Use Configuration Wizard in Context Menu >>>
@@ -37,35 +38,15 @@
 
 // <o> Internal SRAM memory size[Kbytes] <8-64>
 //	<i>Default: 64
-#define STM32_SRAM_SIZE         128
+#define STM32_SRAM_SIZE         8
 #define STM32_SRAM_END          (0x20000000 + STM32_SRAM_SIZE * 1024)
-
-//#define RT_USING_UART1
-#define RT_USING_UART2
-//#define RT_USING_UART3
-
-// <o> Console on USART: <0=> no console <1=>USART 1 <2=>USART 2 <3=> USART 3
-// 	<i>Default: 1
-#define STM32_CONSOLE_USART		2
 
 void rt_hw_board_init(void);
 
-#if STM32_CONSOLE_USART == 0
-#define CONSOLE_DEVICE "no"
-#elif STM32_CONSOLE_USART == 1
-#define CONSOLE_DEVICE "uart1"
-#elif STM32_CONSOLE_USART == 2
-#define CONSOLE_DEVICE "uart2"
-#elif STM32_CONSOLE_USART == 3
-#define CONSOLE_DEVICE "uart3"
-#endif
-
-#define FINSH_DEVICE_NAME   CONSOLE_DEVICE
-
-void rt_hw_usart_init(void);
-
 /* SD Card init function */
 void rt_hw_msd_init(void);
+
+#define PRINT_RCC_FREQ_INFO
 
 #endif
 

--- a/bsp/stm32f0x/drivers/led.c
+++ b/bsp/stm32f0x/drivers/led.c
@@ -1,0 +1,44 @@
+/*
+ * File      : led.c
+ * This file is part of RT-Thread RTOS
+ * COPYRIGHT (C) 2006-2013, RT-Thread Development Team
+ *
+ * The license and distribution terms for this file may be
+ * found in the file LICENSE in this distribution or at
+ * http://www.rt-thread.org/license/LICENSE
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2013-11-15     bright       the first version
+ */
+
+#include "led.h"
+/* RT_USING_COMPONENTS_INIT */
+#ifdef  RT_USING_COMPONENTS_INIT
+#include <components.h>
+#endif
+
+/*
+LED_GREEN: PC8
+LED_RED  : PC9
+*/
+
+/* Initial led gpio pin  */
+void rt_hw_led_init(void)
+{
+    GPIO_InitTypeDef  GPIO_InitStructure;
+
+    /* Enable the GPIO_LED Clock */
+    RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOC, ENABLE);
+
+    /* Configure the GPIO_LED pin */
+    GPIO_InitStructure.GPIO_Pin = GPIO_Pin_9;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
+    GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+    GPIO_Init(GPIOC, &GPIO_InitStructure);
+}
+
+/* Initial components for device */
+INIT_DEVICE_EXPORT(rt_hw_led_init);

--- a/bsp/stm32f0x/drivers/led.h
+++ b/bsp/stm32f0x/drivers/led.h
@@ -1,0 +1,27 @@
+/*
+ * File      : led.h
+ * This file is part of RT-Thread RTOS
+ * COPYRIGHT (C) 2009, RT-Thread Development Team
+ *
+ * The license and distribution terms for this file may be
+ * found in the file LICENSE in this distribution or at
+ * http://www.rt-thread.org/license/LICENSE
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2013-13-05     bright       the first version
+ */
+
+#ifndef __LED_H__
+#define __LED_H__
+
+#include <rthw.h>
+#include <rtthread.h>
+#include <stm32f0xx.h>
+
+#define rt_hw_led_on()   GPIO_SetBits(GPIOC, GPIO_Pin_9)
+#define rt_hw_led_off()  GPIO_ResetBits(GPIOC, GPIO_Pin_9)
+
+void rt_hw_led_init(void);
+
+#endif

--- a/bsp/stm32f0x/drivers/usart.c
+++ b/bsp/stm32f0x/drivers/usart.c
@@ -1,0 +1,310 @@
+/*
+ * File      : usart.c
+ * This file is part of RT-Thread RTOS
+ * COPYRIGHT (C) 2006-2013, RT-Thread Development Team
+ *
+ * The license and distribution terms for this file may be
+ * found in the file LICENSE in this distribution or at
+ * http://www.rt-thread.org/license/LICENSE
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2013-11-15     bright       the first version
+ */
+
+#include <stm32f0xx.h>
+#include <rtdevice.h>
+#include "usart.h"
+
+/* USART1 */
+#define UART1_GPIO_TX			GPIO_Pin_9
+#define UART1_GPIO_TX_SOURCE	GPIO_PinSource9
+#define UART1_GPIO_RX			GPIO_Pin_10
+#define UART1_GPIO_RX_SOURCE	GPIO_PinSource10
+#define UART1_GPIO_AF			GPIO_AF_1
+#define UART1_GPIO				GPIOA
+
+/* USART2 */
+#define UART2_GPIO_TX			GPIO_Pin_2
+#define UART2_GPIO_TX_SOURCE	GPIO_PinSource2
+#define UART2_GPIO_RX			GPIO_Pin_3
+#define UART2_GPIO_RX_SOURCE	GPIO_PinSource3
+#define UART2_GPIO_AF			GPIO_AF_1
+#define UART2_GPIO				GPIOA
+
+/* STM32 uart driver */
+struct stm32_uart
+{
+    USART_TypeDef* uart_device;
+    IRQn_Type irq;
+};
+
+static rt_err_t stm32_configure(struct rt_serial_device *serial, struct serial_configure *cfg)
+{
+    struct stm32_uart* uart;
+    USART_InitTypeDef USART_InitStructure;
+
+    RT_ASSERT(serial != RT_NULL);
+    RT_ASSERT(cfg != RT_NULL);
+
+    uart = (struct stm32_uart *)serial->parent.user_data;
+
+    USART_InitStructure.USART_BaudRate = cfg->baud_rate;
+
+    if (cfg->data_bits == DATA_BITS_8)
+        USART_InitStructure.USART_WordLength = USART_WordLength_8b;
+
+    if (cfg->stop_bits == STOP_BITS_1)
+        USART_InitStructure.USART_StopBits = USART_StopBits_1;
+    else if (cfg->stop_bits == STOP_BITS_2)
+        USART_InitStructure.USART_StopBits = USART_StopBits_2;
+
+    USART_InitStructure.USART_Parity = USART_Parity_No;
+    USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+    USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
+    USART_Init(uart->uart_device, &USART_InitStructure);
+
+    /* Enable USART */
+    USART_Cmd(uart->uart_device, ENABLE);
+    /* enable interrupt */
+    USART_ITConfig(uart->uart_device, USART_IT_RXNE, ENABLE);
+
+    return RT_EOK;
+}
+
+static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *arg)
+{
+    struct stm32_uart* uart;
+
+    RT_ASSERT(serial != RT_NULL);
+    uart = (struct stm32_uart *)serial->parent.user_data;
+
+    switch (cmd)
+    {
+    case RT_DEVICE_CTRL_CLR_INT:
+        /* disable rx irq */
+        UART_DISABLE_IRQ(uart->irq);
+        break;
+    case RT_DEVICE_CTRL_SET_INT:
+        /* enable rx irq */
+        UART_ENABLE_IRQ(uart->irq);
+        break;
+    }
+
+    return RT_EOK;
+}
+
+static int stm32_putc(struct rt_serial_device *serial, char c)
+{
+    struct stm32_uart* uart;
+
+    RT_ASSERT(serial != RT_NULL);
+    uart = (struct stm32_uart *)serial->parent.user_data;
+
+    while (!(uart->uart_device->ISR & USART_FLAG_TXE));
+    uart->uart_device->TDR = c;
+
+    return 1;
+}
+
+static int stm32_getc(struct rt_serial_device *serial)
+{
+    int ch;
+    struct stm32_uart* uart;
+
+    RT_ASSERT(serial != RT_NULL);
+    uart = (struct stm32_uart *)serial->parent.user_data;
+
+    ch = -1;
+    if (uart->uart_device->ISR & USART_FLAG_RXNE)
+    {
+        ch = uart->uart_device->RDR & 0xff;
+    }
+
+    return ch;
+}
+
+static const struct rt_uart_ops stm32_uart_ops =
+{
+    stm32_configure,
+    stm32_control,
+    stm32_putc,
+    stm32_getc,
+};
+
+#if defined(RT_USING_UART1)
+/* UART1 device driver structure */
+struct serial_ringbuffer uart1_int_rx;
+struct stm32_uart uart1 =
+{
+    USART1,
+    USART1_IRQn,
+};
+struct rt_serial_device serial1;
+
+void USART1_IRQHandler(void)
+{
+    struct stm32_uart* uart;
+
+    uart = &uart1;
+
+    /* enter interrupt */
+    rt_interrupt_enter();
+    if(USART_GetITStatus(uart->uart_device, USART_IT_RXNE) != RESET)
+    {
+        rt_hw_serial_isr(&serial1);
+        /* clear interrupt */
+        USART_ClearITPendingBit(uart->uart_device, USART_IT_RXNE);
+    }
+    if (USART_GetITStatus(uart->uart_device, USART_IT_TC) != RESET)
+    {
+        /* clear interrupt */
+        USART_ClearITPendingBit(uart->uart_device, USART_IT_TC);
+    }
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+}
+#endif /* RT_USING_UART1 */
+
+#if defined(RT_USING_UART2)
+/* UART2 device driver structure */
+struct serial_ringbuffer uart2_int_rx;
+struct stm32_uart uart2 =
+{
+    USART2,
+    USART2_IRQn,
+};
+struct rt_serial_device serial2;
+
+void USART2_IRQHandler(void)
+{
+    struct stm32_uart* uart;
+
+    uart = &uart2;
+
+    /* enter interrupt */
+    rt_interrupt_enter();
+    if(USART_GetITStatus(uart->uart_device, USART_IT_RXNE) != RESET)
+    {
+        rt_hw_serial_isr(&serial2);
+        /* clear interrupt */
+        USART_ClearITPendingBit(uart->uart_device, USART_IT_RXNE);
+    }
+    if (USART_GetITStatus(uart->uart_device, USART_IT_TC) != RESET)
+    {
+        /* clear interrupt */
+        USART_ClearITPendingBit(uart->uart_device, USART_IT_TC);
+    }
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+}
+#endif /* RT_USING_UART2 */
+
+static void RCC_Configuration(void)
+{
+#ifdef RT_USING_UART1
+    /* Enable GPIO clock */
+    RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOA, ENABLE);
+    /* Enable USART clock */
+    RCC_APB2PeriphClockCmd(RCC_APB2Periph_USART1, ENABLE);
+#endif /* RT_USING_UART1 */
+
+#ifdef RT_USING_UART2
+    /* Enable GPIO clock */
+    RCC_AHBPeriphClockCmd(RCC_AHBPeriph_GPIOA, ENABLE);
+    /* Enable USART clock */
+    RCC_APB1PeriphClockCmd(RCC_APB1Periph_USART2, ENABLE);
+#endif /* RT_USING_UART2 */
+
+}
+
+static void GPIO_Configuration(void)
+{
+    GPIO_InitTypeDef GPIO_InitStructure;
+
+#ifdef RT_USING_UART1
+	/* Connect PXx to USARTx_Tx */
+	GPIO_PinAFConfig(UART1_GPIO, UART1_GPIO_TX_SOURCE, UART1_GPIO_AF);
+
+	/* Connect PXx to USARTx_Rx */
+	GPIO_PinAFConfig(UART1_GPIO, UART1_GPIO_RX_SOURCE, UART1_GPIO_AF);
+
+	/* Configure USART Tx, Rx as alternate function push-pull */
+	GPIO_InitStructure.GPIO_Pin = UART1_GPIO_TX | UART1_GPIO_RX;
+	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+	GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+	GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
+	GPIO_Init(UART1_GPIO, &GPIO_InitStructure);
+#endif /* RT_USING_UART1 */
+
+#ifdef RT_USING_UART2
+	/* Connect PXx to USARTx_Tx */
+	GPIO_PinAFConfig(UART2_GPIO, UART2_GPIO_TX_SOURCE, UART2_GPIO_AF);
+
+	/* Connect PXx to USARTx_Rx */
+	GPIO_PinAFConfig(UART2_GPIO, UART2_GPIO_RX_SOURCE, UART2_GPIO_AF);
+
+	/* Configure USART Tx, Rx as alternate function push-pull */
+	GPIO_InitStructure.GPIO_Pin = UART2_GPIO_TX | UART2_GPIO_RX;
+	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+	GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+	GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
+	GPIO_Init(UART2_GPIO, &GPIO_InitStructure);
+#endif /* RT_USING_UART2 */
+}
+
+static void NVIC_Configuration(struct stm32_uart* uart)
+{
+    NVIC_InitTypeDef NVIC_InitStructure;
+
+    /* Enable the USART Interrupt */
+    NVIC_InitStructure.NVIC_IRQChannel = uart->irq;
+    NVIC_InitStructure.NVIC_IRQChannelPriority = 0;
+    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
+    NVIC_Init(&NVIC_InitStructure);
+}
+
+void rt_hw_usart_init(void)
+{
+    struct stm32_uart* uart;
+    struct serial_configure config = RT_SERIAL_CONFIG_DEFAULT;
+
+    RCC_Configuration();
+    GPIO_Configuration();
+
+#ifdef RT_USING_UART1
+    uart = &uart1;
+    config.baud_rate = BAUD_RATE_115200;
+
+    serial1.ops    = &stm32_uart_ops;
+    serial1.int_rx = &uart1_int_rx;
+    serial1.config = config;
+
+    NVIC_Configuration(&uart1);
+
+    /* register UART1 device */
+    rt_hw_serial_register(&serial1, "uart1",
+                          RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_INT_RX | RT_DEVICE_FLAG_STREAM,
+                          uart);
+#endif /* RT_USING_UART1 */
+
+#ifdef RT_USING_UART2
+    uart = &uart2;
+
+    config.baud_rate = BAUD_RATE_115200;
+    serial2.ops    = &stm32_uart_ops;
+    serial2.int_rx = &uart2_int_rx;
+    serial2.config = config;
+
+    NVIC_Configuration(&uart2);
+
+    /* register UART1 device */
+    rt_hw_serial_register(&serial2, "uart2",
+                          RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_INT_RX,
+                          uart);
+#endif /* RT_USING_UART2 */
+}

--- a/bsp/stm32f0x/drivers/usart.h
+++ b/bsp/stm32f0x/drivers/usart.h
@@ -1,0 +1,30 @@
+/*
+ * File      : usart.h
+ * This file is part of RT-Thread RTOS
+ * COPYRIGHT (C) 2009, RT-Thread Development Team
+ *
+ * The license and distribution terms for this file may be
+ * found in the file LICENSE in this distribution or at
+ * http://www.rt-thread.org/license/LICENSE
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2013-11-15     bright       the first version
+ */
+
+#ifndef __USART_H__
+#define __USART_H__
+
+#include <rthw.h>
+#include <rtthread.h>
+#include "stm32f0xx.h"
+
+#define RT_USING_UART1
+#define RT_USING_UART2
+
+#define UART_ENABLE_IRQ(n)            NVIC_EnableIRQ((n))
+#define UART_DISABLE_IRQ(n)           NVIC_DisableIRQ((n))
+
+void rt_hw_usart_init(void);
+
+#endif

--- a/bsp/stm32f0x/rtconfig.h
+++ b/bsp/stm32f0x/rtconfig.h
@@ -9,15 +9,16 @@
 #define RT_ALIGN_SIZE	4
 
 /* PRIORITY_MAX */
-#define RT_THREAD_PRIORITY_MAX	8
+#define RT_THREAD_PRIORITY_MAX	32
 
 /* Tick per Second */
 #define RT_TICK_PER_SECOND	100
 
 /* SECTION: RT_DEBUG */
 /* Thread Debug */
-/* #define RT_DEBUG */
-/* #define RT_USING_OVERFLOW_CHECK */
+#define RT_DEBUG
+#define RT_DEBUG_INIT 1
+#define RT_USING_OVERFLOW_CHECK
 
 /* Using Hook */
 /* #define RT_USING_HOOK */
@@ -49,26 +50,57 @@
 /* #define RT_USING_MEMPOOL */
 
 /* Using Dynamic Heap Management */
-/* #define RT_USING_HEAP */
+#define RT_USING_HEAP
 
 /* Using Small MM */
 #define RT_USING_SMALL_MEM
 #define RT_USING_TINY_SIZE
 
+// <bool name="RT_USING_COMPONENTS_INIT" description="Using RT-Thread components initialization" default="true" />
+#define RT_USING_COMPONENTS_INIT
+
 /* SECTION: Device System */
 /* Using Device System */
-/* #define RT_USING_DEVICE */
+#define RT_USING_DEVICE
+// <bool name="RT_USING_DEVICE_IPC" description="Using device communication" default="true" />
+#define RT_USING_DEVICE_IPC
+// <bool name="RT_USING_SERIAL" description="Using Serial" default="true" />
+#define RT_USING_SERIAL
 
 /* SECTION: Console options */
-//#define RT_USING_CONSOLE
+#define RT_USING_CONSOLE
 /* the buffer size of console*/
 #define RT_CONSOLEBUF_SIZE	128
+// <string name="RT_CONSOLE_DEVICE_NAME" description="The device name for console" default="uart1" />
+#define RT_CONSOLE_DEVICE_NAME	    "uart1"
+
+
 
 /* SECTION: finsh, a C-Express shell */
-/* #define RT_USING_FINSH */
+#define RT_USING_FINSH
+/* configure finsh parameters */
+#define FINSH_THREAD_PRIORITY 25
+#define FINSH_THREAD_STACK_SIZE	1024
+#define FINSH_HISTORY_LINES	1
 /* Using symbol table */
 #define FINSH_USING_SYMTAB
 #define FINSH_USING_DESCRIPTION
+
+/* SECTION: libc management */
+#ifdef __CC_ARM
+/* #define RT_USING_MINILIBC */
+/* #define RT_USING_NEWLIB */
+#endif
+
+#ifdef __ICCARM__
+/* #define RT_USING_MINILIBC */
+/* #define RT_USING_NEWLIB */
+#endif
+
+#ifdef __GNUC__
+/* #define RT_USING_MINILIBC */
+#define RT_USING_NEWLIB
+#endif
 
 /* SECTION: device filesystem */
 /* #define RT_USING_DFS */


### PR DESCRIPTION
```
1. fix heap management for stm32f0xx(SRAM=8k)
2. add USART1, USART2 driver for stm32f051R8
3. fix finsh support for stm32f0x
4. fix board components initial for stm32f0x and open debug msg
5. add led driver(pc9) and test thread for stm32f0discovery board
6. add init thread for stm32f0x do components initial
7. add rcc initial for stm32f0x in rt_hw_board_init()
8. add print rcc freq information function
```

the console output example is:
    SYSCLK_Frequency is 48000000HZ
    PCLK_Frequency is 48000000HZ
    HCLK_Frequency is 48000000HZ
    CECCLK_Frequency is 32786HZ
    ADCCLK_Frequency is 14000000HZ
    USART1CLK_Frequency is 48000000HZ
    I2C1CLK_Frequency is 8000000HZ
    SystemCoreClock is 48000000HZ
    initialize rti_start:0 done

```
\ | /
- RT -     Thread Operating System
/ | \     1.2.0 build Nov 15 2013
2006 - 2013 Copyright by rt-thread team
do components intialization.
initialize rti_board_end:0 done
initialize rt_hw_led_init:32768 done
initialize finsh_system_init:0 done
finsh>>
```
