### PR TITLE
finsh: fix finsh device setting

### DIFF
--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -308,11 +308,16 @@ void finsh_thread_entry(void* parameter)
 	rt_kprintf(FINSH_PROMPT);
 
 	/* set console device as shell device */
-	shell->device = rt_console_get_device();
-	if (shell->device != RT_NULL)
+	if (shell->device == RT_NULL)
 	{
+#ifdef RT_USING_CONSOLE
+		shell->device = rt_console_get_device();
+		RT_ASSERT(shell->device);
 		rt_device_open(shell->device, RT_DEVICE_OFLAG_RDWR);
 		rt_device_set_rx_indicate(shell->device, finsh_rx_ind);
+#else
+		RT_ASSERT(shell->device);
+#endif
 	}
 
 	while (1)


### PR DESCRIPTION
1. rt_console_get_device should be call to set shell device only when it is null, or it will make finsh_set_device useless.
2. RT_USING_CONSOLE can be disabled in bsp/rtconfig.h
