### PR TITLE
fixed _sys_read()/_sys_write() issues.

### DIFF
--- a/components/libc/armlibc/stubs.c
+++ b/components/libc/armlibc/stubs.c
@@ -12,6 +12,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2012-11-23     Yihui        The first version
+ * 2013-11-24     aozima       fixed _sys_read()/_sys_write() issues.
  */
 
 #include <string.h>
@@ -45,6 +46,8 @@ const char __stderr_name[] = "STDERR";
  */
 FILEHANDLE _sys_open(const char *name, int openmode)
 {
+    int fd;
+
     /* Register standard Input Output devices. */
     if (strcmp(name, __stdin_name) == 0)
         return (STDIN);
@@ -57,7 +60,11 @@ FILEHANDLE _sys_open(const char *name, int openmode)
     return -1;
 #else
     /* TODO: adjust open file mode */
-    return open(name, openmode, 0);
+    fd = open(name, openmode, 0);
+    if(fd < 0)
+        return -1;
+    else
+        return fd + STDERR + 1;
 #endif
 }
 
@@ -66,10 +73,10 @@ int _sys_close(FILEHANDLE fh)
 #ifndef RT_USING_DFS
     return 0;
 #else
-    if (fh < 3)
+    if (fh < STDERR)
         return 0;
-    
-    return close(fh);
+
+    return close(fh - STDERR - 1);
 #endif
 }
 
@@ -80,21 +87,30 @@ int _sys_close(FILEHANDLE fh)
  * @param buf - buffer to save read data
  * @param len - max length of data buffer
  * @param mode - useless, for historical reasons
- * @return actual read data length
+ * @return The number of bytes not read.
  */
 int _sys_read(FILEHANDLE fh, unsigned char *buf, unsigned len, int mode)
 {
+    int size;
+
     if (fh == STDIN)
     {
         /* TODO */
-        
+
         return 0;
     }
-    
+
+    if ((fh == STDOUT) || (fh == STDERR))
+        return -1;
+
 #ifndef RT_USING_DFS
     return 0;
 #else
-    return read(fh, buf, len);
+    size = read(fh - STDERR - 1, buf, len);
+    if(size >= 0)
+        return len - size;
+    else
+        return -1;
 #endif
 }
 
@@ -105,10 +121,12 @@ int _sys_read(FILEHANDLE fh, unsigned char *buf, unsigned len, int mode)
  * @param buf - data buffer
  * @param len - buffer length
  * @param mode - useless, for historical reasons
- * @return actual written data length
+ * @return a positive number representing the number of characters not written.
  */
 int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
 {
+    int size;
+
     if ((fh == STDOUT) || (fh == STDERR))
     {
 #ifndef RT_USING_CONSOLE
@@ -122,11 +140,18 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
         return len;
 #endif
     }
-    
+
+    if(fh == STDIN)
+        return -1;
+
 #ifndef RT_USING_DFS
     return 0;
 #else
-    return write(fh, buf, len);
+    size = write(fh - STDERR - 1, buf, len);
+    if(size >= 0)
+        return len - size;
+    else
+        return -1;
 #endif
 }
 
@@ -138,11 +163,15 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
  */
 int _sys_seek(FILEHANDLE fh, long pos)
 {
+    if (fh < STDERR)
+        return -1;
+
 #ifndef RT_USING_DFS
     return -1;
 #else
+
     /* position is relative to the start of file fh */
-    return lseek(fh, pos, 0);
+    return lseek(fh - STDERR - 1, pos, 0);
 #endif
 }
 
@@ -162,7 +191,7 @@ char *_sys_command_string(char *cmd, int len)
 
 void _ttywrch(int ch)
 {
-   /* TODO */ 
+   /* TODO */
 }
 
 void _sys_exit(int return_code)
@@ -172,7 +201,7 @@ void _sys_exit(int return_code)
 }
 
 /**
- * return current length of file. 
+ * return current length of file.
  *
  * @param fh - file handle
  * @return file length, or -1 on failed
@@ -208,7 +237,7 @@ int rename(const char *old, const char *new)
 int system(const char *string)
 {
     RT_ASSERT(0);
-    for(;;);	
+    for(;;);
 }
 
 


### PR DESCRIPTION
1. _sys_read()/_sys_write() 返回的是不成功的大小，成功的操作应该返回0，任何非0值都表示失败。
2. RT-Thread的fd从0开始，因此，通过fopen打开的,恰好fd为STDIN，STDOUT，STDERR时，将会产生问题。
