### PR TITLE
TC: if TC is enabled, add the TC dir to CPPPATH

### DIFF
--- a/examples/kernel/SConscript
+++ b/examples/kernel/SConscript
@@ -34,6 +34,8 @@ memp_simple.c
 tc_sample.c
 """)
 
-group = DefineGroup('examples', src, depend = ['RT_USING_TC'])
+group = DefineGroup('examples', src,
+                    depend = ['RT_USING_TC'],
+                    CPPPATH=[GetCurrentDir()])
 
 Return('group')


### PR DESCRIPTION
Some component that depend on TC would like to include the tc_comm.h.
