### PR TITLE
Revert "BBB: init timer on startup"

### DIFF
--- a/bsp/beaglebone/applications/startup.c
+++ b/bsp/beaglebone/applications/startup.c
@@ -43,8 +43,7 @@ void rtthread_startup(void)
     /* initialize timer */
     rt_system_timer_init();
 
-	/* initialize timer */
-	rt_system_timer_init();
+	/* initialize soft timer thread */
 	rt_system_timer_thread_init();
 
 	/* initialize application */


### PR DESCRIPTION
This reverts commit 9cdf989c59257c06f46a36c6ee939be18363f857. The timer
has been initialized already.
