### PR TITLE
kernel: rearrange the header file include order

### DIFF
--- a/include/rtdebug.h
+++ b/include/rtdebug.h
@@ -21,8 +21,6 @@
 #ifndef __RTDEBUG_H__
 #define __RTDEBUG_H__
 
-#include <rtconfig.h>
-
 /* Using this macro to control all kernel debug features. */
 #ifdef RT_DEBUG
 
@@ -64,7 +62,7 @@
 #endif
 
 #ifndef RT_DEBUG_INIT
-#define RT_DEBUG_INIT					0
+#define RT_DEBUG_INIT                  0
 #endif
 
 /* Turn on this to enable context check */

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -34,8 +34,6 @@
 #ifndef __RT_DEF_H__
 #define __RT_DEF_H__
 
-#include <rtconfig.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -31,8 +31,9 @@
 #ifndef __RT_THREAD_H__
 #define __RT_THREAD_H__
 
-#include <rtdef.h>
+#include <rtconfig.h>
 #include <rtdebug.h>
+#include <rtdef.h>
 #include <rtservice.h>
 #include <rtm.h>
 


### PR DESCRIPTION
There are some CONFIG OPTIONS in rtdebug.h, which may influence the
rtdef.h, so rtdebug.h should be head of the rtdef.h
