### PR TITLE
Fix rt_serial_control() bug for customized command and indent the code

### DIFF
--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -346,20 +346,25 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
 
     switch (cmd)
     {
-    case RT_DEVICE_CTRL_SUSPEND:
-        /* suspend device */
-        dev->flag |= RT_DEVICE_FLAG_SUSPENDED;
-        break;
+        case RT_DEVICE_CTRL_SUSPEND:
+            /* suspend device */
+            dev->flag |= RT_DEVICE_FLAG_SUSPENDED;
+            break;
 
-    case RT_DEVICE_CTRL_RESUME:
-        /* resume device */
-        dev->flag &= ~RT_DEVICE_FLAG_SUSPENDED;
-        break;
+        case RT_DEVICE_CTRL_RESUME:
+            /* resume device */
+            dev->flag &= ~RT_DEVICE_FLAG_SUSPENDED;
+            break;
 
-    case RT_DEVICE_CTRL_CONFIG:
-        /* configure device */
-        serial->ops->configure(serial, (struct serial_configure *)args);
-        break;
+        case RT_DEVICE_CTRL_CONFIG:
+            /* configure device */
+            serial->ops->configure(serial, (struct serial_configure *)args);
+            break;
+
+        default :
+            /* control device */
+            serial->ops->control(serial, cmd, args);
+            break;
     }
 
     return RT_EOK;


### PR DESCRIPTION
i use rt_device_control() for my customized command, it can not call it, 
so i fix it , it`s work fine.
