### PR TITLE
[shell] define FINSH_PROMPT as finsh_get_prompt when FINSH_USING_MSH enabled

### DIFF
--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -54,8 +54,10 @@ ALIGN(RT_ALIGN_SIZE)
 static char finsh_thread_stack[FINSH_THREAD_STACK_SIZE];
 struct finsh_shell* shell;
 
-#if defined(RT_USING_DFS) && defined(DFS_USING_WORKDIR)
+#if defined(FINSH_USING_MSH) || (defined(RT_USING_DFS) && defined(DFS_USING_WORKDIR))
+#if defined(RT_USING_DFS)
 #include <dfs_posix.h>
+#endif
 const char* finsh_get_prompt()
 {
     #define _MSH_PROMPT "msh "
@@ -68,8 +70,10 @@ const char* finsh_get_prompt()
 #endif
     strcpy(finsh_prompt, _PROMPT);
 
+#ifdef DFS_USING_WORKDIR
     /* get current working directory */
     getcwd(&finsh_prompt[rt_strlen(finsh_prompt)], RT_CONSOLEBUF_SIZE - rt_strlen(finsh_prompt));
+#endif
     strcat(finsh_prompt, ">");
 
     return finsh_prompt;

--- a/components/finsh/shell.h
+++ b/components/finsh/shell.h
@@ -43,7 +43,7 @@
 #define FINSH_CMD_SIZE		80
 
 #define FINSH_OPTION_ECHO	0x01
-#if defined(RT_USING_DFS) && defined(DFS_USING_WORKDIR)
+#if defined(FINSH_USING_MSH) || (defined(RT_USING_DFS) && defined(DFS_USING_WORKDIR))
 #define FINSH_PROMPT		finsh_get_prompt()
 const char* finsh_get_prompt(void);
 #else


### PR DESCRIPTION
When MSH enabled, the prompt will change at the two shells. So we should
use dynamic prompt when FINSH_USING_MSH defined.

This should go to the stable branch as well:

```
git checkout stable-v1.2.x
git cherry-pick 841898a
```
