### PR TITLE
[bsp/taihu] fix the link error

### DIFF
--- a/bsp/taihu/taihu.lds
+++ b/bsp/taihu/taihu.lds
@@ -36,7 +36,7 @@ SECTIONS
 
   .text      :
   {
-    KEEP(build/libcpu/ppc/ppc405/start_gcc.o (.text))
+    KEEP(build/kernel/libcpu/ppc/ppc405/start_gcc.o (.text))
 
     *(.text)
     *(.fixup)


### PR DESCRIPTION
The taihu.lds hardcoded the path of start_gcc.o. Change it as the layout
of build/ has change by commit a03816ef9aa583bb.

This should fix the Travis build.
