### PR TITLE
[mempool] reset the thread->error before suspending thread

### DIFF
--- a/src/mempool.c
+++ b/src/mempool.c
@@ -356,6 +356,8 @@ void *rt_mp_alloc(rt_mp_t mp, rt_int32_t time)
             /* get current thread */
             thread = rt_thread_self();
 
+            thread->error = RT_EOK;
+
             /* need suspend thread */
             rt_thread_suspend(thread);
             rt_list_insert_after(&(mp->suspend_thread), &(thread->tlist));


### PR DESCRIPTION
Time out result and other errors is recorded in thread->error. Dirty
error will screw up the error handling code after the thread has been
wake up.
