### PR TITLE
tools/building: remove the use of startupinfo

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -27,8 +27,6 @@ class Win32Spawn:
 
         newargs = string.join(args[1:], ' ')
         cmdline = cmd + " " + newargs
-        startupinfo = subprocess.STARTUPINFO()
-        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 
         # Make sure the env is constructed by strings
         _e = {k: str(v) for k, v in env.items()}
@@ -40,8 +38,7 @@ class Win32Spawn:
         os.environ['PATH'] = _e['PATH']
 
         try:
-            proc = subprocess.Popen(cmdline, env=_e,
-                    startupinfo=startupinfo, shell=False)
+            proc = subprocess.Popen(cmdline, env=_e, shell=False)
         except Exception as e:
             print 'Error in calling:\n%s' % cmdline
             print 'Exception: %s: %s' % (e, os.strerror(e.errno))


### PR DESCRIPTION
The startupinfo does not have any visible effects on the building
process and some old Python version does not have it at all. So remove
it for the seek of simple.

Tested `scons -j4` in a dual core virtual machine.
