### PR TITLE
Remove unsupport syntex for python 2.6.

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -29,7 +29,7 @@ class Win32Spawn:
         cmdline = cmd + " " + newargs
 
         # Make sure the env is constructed by strings
-        _e = {k: str(v) for k, v in env.items()}
+        _e = dict([(k, str(v)) for k, v in env.items()])
 
         # Windows(tm) CreateProcess does not use the env passed to it to find
         # the executables. So we have to modify our own PATH to make Popen


### PR DESCRIPTION
Dict Comprehensions is imported in Python 2.7 & 3.0 which is PEP 274 [1]. Some
OS like CentOS 6 which is use Python 2.6 cannot support this syntex.

[1] http://legacy.python.org/dev/peps/pep-0274/

Signed-off-by: Xiongfei Guo xfguo@credosemi.com
