### PR TITLE
tools: preserve the order of CPPPATH/CPPDEFINES/LIBPATH/LIBS

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -435,12 +435,6 @@ def DoBuilding(target, objects):
 
                 break
     else:
-        # merge the repeated items in the Env
-        if Env.has_key('CPPPATH')   : Env['CPPPATH'] = list(set(Env['CPPPATH']))
-        if Env.has_key('CPPDEFINES'): Env['CPPDEFINES'] = list(set(Env['CPPDEFINES']))
-        if Env.has_key('LIBPATH')   : Env['LIBPATH'] = list(set(Env['LIBPATH']))
-        if Env.has_key('LIBS')      : Env['LIBS'] = list(set(Env['LIBS']))
-
         program = Env.Program(target, objects)
 
     EndBuilding(target, program)


### PR DESCRIPTION
The order of them are important while the uniqueness has nothing to do
with the compiling.

commit 2c5eea4c21ea66f711974ab6ce1048337f7b9efc in upstream.
