### PR TITLE
tools: fix SrcRemove on empty src

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -493,6 +493,9 @@ def EndBuilding(target, program = None):
         CscopeDatabase(Projects)
 
 def SrcRemove(src, remove):
+    if not src:
+        return
+
     if type(src[0]) == type('str'):
         for item in src:
             if os.path.basename(item) in remove:


### PR DESCRIPTION
If the src is empty list, it will crash at:

```
IndexError: list index out of range:
  File "/home/xxx/src/SConstruct", line 39:
    objs = PrepareBuilding(env, RTT_ROOT, has_libcpu=True)
  ...
  File "/home/xxx/src/drivers/SConscript", line 12:
    SrcRemove(src, src_need_remove)
  File "/home/rt-thread-stable/tools/building.py", line 496:
    if type(src[0]) == type('str'):
```

Commit d33df46f1921f241199e7520e384e851840571ef in master.
