### PR TITLE
fix #347 and update stm32f10x uart driver

### DIFF
--- a/bsp/stm32f10x/drivers/usart.c
+++ b/bsp/stm32f10x/drivers/usart.c
@@ -21,25 +21,27 @@
 #include <rtdevice.h>
 
 /* USART1 */
-#define UART1_GPIO_TX       GPIO_Pin_9
-#define UART1_GPIO_RX       GPIO_Pin_10
-#define UART1_GPIO          GPIOA
+#define UART1_GPIO_TX        GPIO_Pin_9
+#define UART1_GPIO_RX        GPIO_Pin_10
+#define UART1_GPIO           GPIOA
 
 /* USART2 */
-#define UART2_GPIO_TX       GPIO_Pin_2
-#define UART2_GPIO_RX       GPIO_Pin_3
-#define UART2_GPIO          GPIOA
+#define UART2_GPIO_TX        GPIO_Pin_2
+#define UART2_GPIO_RX        GPIO_Pin_3
+#define UART2_GPIO           GPIOA
 
 /* USART3_REMAP[1:0] = 00 */
-#define UART3_GPIO_TX       GPIO_Pin_10
-#define UART3_GPIO_RX       GPIO_Pin_11
-#define UART3_GPIO          GPIOB
+#define UART3_GPIO_TX        GPIO_Pin_10
+#define UART3_GPIO_RX        GPIO_Pin_11
+#define UART3_GPIO           GPIOB
 
 /* STM32 uart driver */
 struct stm32_uart
 {
     USART_TypeDef* uart_device;
     IRQn_Type irq;
+    /* transmit interrupt type */
+    rt_uint32_t tx_irq_type;
 };
 
 static rt_err_t stm32_configure(struct rt_serial_device *serial, struct serial_configure *cfg)
@@ -54,15 +56,26 @@ static rt_err_t stm32_configure(struct rt_serial_device *serial, struct serial_c
 
     USART_InitStructure.USART_BaudRate = cfg->baud_rate;
 
-    if (cfg->data_bits == DATA_BITS_8)
+    if (cfg->data_bits == DATA_BITS_8){
         USART_InitStructure.USART_WordLength = USART_WordLength_8b;
+    } else if (cfg->data_bits == DATA_BITS_9) {
+        USART_InitStructure.USART_WordLength = USART_WordLength_9b;
+    }
 
-    if (cfg->stop_bits == STOP_BITS_1)
+    if (cfg->stop_bits == STOP_BITS_1){
         USART_InitStructure.USART_StopBits = USART_StopBits_1;
-    else if (cfg->stop_bits == STOP_BITS_2)
+    } else if (cfg->stop_bits == STOP_BITS_2){
         USART_InitStructure.USART_StopBits = USART_StopBits_2;
+    }
 
-    USART_InitStructure.USART_Parity = USART_Parity_No;
+    if (cfg->parity == PARITY_NONE){
+        USART_InitStructure.USART_Parity = USART_Parity_No;
+    } else if (cfg->parity == PARITY_ODD) {
+        USART_InitStructure.USART_Parity = USART_Parity_Odd;
+    } else if (cfg->parity == PARITY_EVEN) {
+        USART_InitStructure.USART_Parity = USART_Parity_Even;
+    }
+
     USART_InitStructure.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
     USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
     USART_Init(uart->uart_device, &USART_InitStructure);
@@ -76,22 +89,63 @@ static rt_err_t stm32_configure(struct rt_serial_device *serial, struct serial_c
 static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *arg)
 {
     struct stm32_uart* uart;
+    rt_uint32_t irq_type = (rt_uint32_t)(arg);
 
     RT_ASSERT(serial != RT_NULL);
     uart = (struct stm32_uart *)serial->parent.user_data;
 
     switch (cmd)
     {
+        /* disable interrupt */
     case RT_DEVICE_CTRL_CLR_INT:
-        /* disable rx irq */
-        UART_DISABLE_IRQ(uart->irq);
-        break;
-    case RT_DEVICE_CTRL_SET_INT:
-        /* enable rx irq */
-        UART_ENABLE_IRQ(uart->irq);
-        break;
-    }
 
+        if (irq_type == RT_DEVICE_FLAG_INT_RX)
+        {
+            /* disable rx irq */
+            USART_ITConfig(uart->uart_device, USART_IT_RXNE, DISABLE);
+        }
+        else if (irq_type == RT_DEVICE_FLAG_INT_TX)
+        {
+            /* disable tx irq */
+            USART_ITConfig(uart->uart_device, uart->tx_irq_type, DISABLE);
+        }
+        else if (irq_type == RT_NULL)
+        {
+            /* disable irq */
+            UART_DISABLE_IRQ(uart->irq);
+        }
+        break;
+        /* enable interrupt */
+    case RT_DEVICE_CTRL_SET_INT:
+        if (irq_type == RT_DEVICE_FLAG_INT_RX)
+        {
+            /* enable rx irq */
+            USART_ITConfig(uart->uart_device, USART_IT_RXNE, ENABLE);
+        }
+        else if (irq_type == RT_DEVICE_FLAG_INT_TX)
+        {
+            /* enable tx irq */
+            USART_ITConfig(uart->uart_device, uart->tx_irq_type, ENABLE);
+        }
+        else if (irq_type == RT_NULL)
+        {
+            /* enable irq */
+            UART_ENABLE_IRQ(uart->irq);
+        }
+        break;
+        /* get interrupt flag */
+    case RT_DEVICE_CTRL_GET_INT:
+        if (irq_type == RT_DEVICE_FLAG_INT_RX)
+        {
+            /* return rx irq flag */
+            return USART_GetITStatus(uart->uart_device, USART_IT_RXNE);
+        }
+        else if (irq_type == RT_DEVICE_FLAG_INT_TX)
+        {
+            /* return tx irq flag */
+            return USART_GetITStatus(uart->uart_device, uart->tx_irq_type);
+        }
+    break;
     return RT_EOK;
 }
 
@@ -139,6 +193,7 @@ struct stm32_uart uart1 =
 {
     USART1,
     USART1_IRQn,
+    USART_IT_TC,
 };
 struct rt_serial_device serial1;
 
@@ -156,10 +211,15 @@ void USART1_IRQHandler(void)
         /* clear interrupt */
         USART_ClearITPendingBit(uart->uart_device, USART_IT_RXNE);
     }
-    if (USART_GetITStatus(uart->uart_device, USART_IT_TC) != RESET)
+
+    if (USART_GetITStatus(uart->uart_device, uart->tx_irq_type) != RESET)
     {
         /* clear interrupt */
-        USART_ClearITPendingBit(uart->uart_device, USART_IT_TC);
+        rt_hw_serial_isr(&serial1, RT_SERIAL_EVENT_TX_DONE);
+        if (uart->tx_irq_type == USART_IT_TC)
+        {
+            USART_ClearITPendingBit(uart->uart_device, uart->tx_irq_type);
+        }
     }
     if (USART_GetFlagStatus(uart->uart_device, USART_FLAG_ORE) == SET)
     {
@@ -176,6 +236,7 @@ struct stm32_uart uart2 =
 {
     USART2,
     USART2_IRQn,
+    USART_IT_TC,
 };
 struct rt_serial_device serial2;
 
@@ -193,10 +254,13 @@ void USART2_IRQHandler(void)
         /* clear interrupt */
         USART_ClearITPendingBit(uart->uart_device, USART_IT_RXNE);
     }
-    if (USART_GetITStatus(uart->uart_device, USART_IT_TC) != RESET)
+    if (USART_GetITStatus(uart->uart_device, uart->tx_irq_type) != RESET)
     {
         /* clear interrupt */
-        USART_ClearITPendingBit(uart->uart_device, USART_IT_TC);
+        if (uart->tx_irq_type == USART_IT_TC)
+        {
+            USART_ClearITPendingBit(uart->uart_device, uart->tx_irq_type);
+        }
     }
     if (USART_GetFlagStatus(uart->uart_device, USART_FLAG_ORE) == SET)
     {
@@ -214,6 +278,7 @@ struct stm32_uart uart3 =
 {
     USART3,
     USART3_IRQn,
+    USART_IT_TC,
 };
 struct rt_serial_device serial3;
 
@@ -231,10 +296,13 @@ void USART3_IRQHandler(void)
         /* clear interrupt */
         USART_ClearITPendingBit(uart->uart_device, USART_IT_RXNE);
     }
-    if (USART_GetITStatus(uart->uart_device, USART_IT_TC) != RESET)
+    if (USART_GetITStatus(uart->uart_device, uart->tx_irq_type) != RESET)
     {
         /* clear interrupt */
-        USART_ClearITPendingBit(uart->uart_device, USART_IT_TC);
+        if (uart->tx_irq_type == USART_IT_TC)
+        {
+            USART_ClearITPendingBit(uart->uart_device, uart->tx_irq_type);
+        }
     }
     if (USART_GetFlagStatus(uart->uart_device, USART_FLAG_ORE) == SET)
     {
@@ -248,21 +316,21 @@ void USART3_IRQHandler(void)
 
 static void RCC_Configuration(void)
 {
-#ifdef RT_USING_UART1
+#if defined(RT_USING_UART1)
     /* Enable UART GPIO clocks */
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
     /* Enable UART clock */
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_USART1, ENABLE);
 #endif /* RT_USING_UART1 */
 
-#ifdef RT_USING_UART2
+#if defined(RT_USING_UART2)
     /* Enable UART GPIO clocks */
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
     /* Enable UART clock */
     RCC_APB1PeriphClockCmd(RCC_APB1Periph_USART2, ENABLE);
 #endif /* RT_USING_UART2 */
 
-#ifdef RT_USING_UART3
+#if defined(RT_USING_UART3)
     /* Enable UART GPIO clocks */
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOB, ENABLE);
     /* Enable UART clock */
@@ -276,7 +344,7 @@ static void GPIO_Configuration(void)
 
     GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
 
-#ifdef RT_USING_UART1
+#if defined(RT_USING_UART1)
     /* Configure USART Rx/tx PIN */
     GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN_FLOATING;
     GPIO_InitStructure.GPIO_Pin = UART1_GPIO_RX;
@@ -287,7 +355,7 @@ static void GPIO_Configuration(void)
     GPIO_Init(UART1_GPIO, &GPIO_InitStructure);
 #endif /* RT_USING_UART1 */
 
-#ifdef RT_USING_UART2
+#if defined(RT_USING_UART2)
     /* Configure USART Rx/tx PIN */
     GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN_FLOATING;
     GPIO_InitStructure.GPIO_Pin = UART2_GPIO_RX;
@@ -298,7 +366,7 @@ static void GPIO_Configuration(void)
     GPIO_Init(UART2_GPIO, &GPIO_InitStructure);
 #endif /* RT_USING_UART2 */
 
-#ifdef RT_USING_UART3
+#if defined(RT_USING_UART3)
     /* Configure USART Rx/tx PIN */
     GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN_FLOATING;
     GPIO_InitStructure.GPIO_Pin = UART3_GPIO_RX;
@@ -330,7 +398,7 @@ void rt_hw_usart_init(void)
     RCC_Configuration();
     GPIO_Configuration();
 
-#ifdef RT_USING_UART1
+#if defined(RT_USING_UART1)
     uart = &uart1;
     config.baud_rate = BAUD_RATE_115200;
 
@@ -341,11 +409,11 @@ void rt_hw_usart_init(void)
 
     /* register UART1 device */
     rt_hw_serial_register(&serial1, "uart1",
-                          RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_INT_RX,
+                          RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_INT_RX ,
                           uart);
 #endif /* RT_USING_UART1 */
 
-#ifdef RT_USING_UART2
+#if defined(RT_USING_UART2)
     uart = &uart2;
 
     config.baud_rate = BAUD_RATE_115200;
@@ -360,7 +428,7 @@ void rt_hw_usart_init(void)
                           uart);
 #endif /* RT_USING_UART2 */
 
-#ifdef RT_USING_UART3
+#if defined(RT_USING_UART3)
     uart = &uart3;
 
     config.baud_rate = BAUD_RATE_115200;

--- a/bsp/stm32f10x/drivers/usart.c
+++ b/bsp/stm32f10x/drivers/usart.c
@@ -146,6 +146,27 @@ static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *ar
             return USART_GetITStatus(uart->uart_device, uart->tx_irq_type);
         }
     break;
+         /* get USART flag */
+    case RT_DEVICE_CTRL_GET_FLAG:
+        if (irq_type == RT_DEVICE_FLAG_INT_RX)
+        {
+            /* return rx irq flag */
+            return USART_GetFlagStatus(uart->uart_device, USART_FLAG_RXNE);
+        }
+        else if (irq_type == RT_DEVICE_FLAG_INT_TX)
+        {
+            /* return tx flag */
+            if (uart->tx_irq_type == USART_IT_TC)
+            {
+                return USART_GetFlagStatus(uart->uart_device, USART_FLAG_TC);
+            }
+            else if (uart->tx_irq_type == USART_IT_TXE)
+            {
+                return USART_GetFlagStatus(uart->uart_device, USART_FLAG_TXE);
+            }
+        }
+        break;
+    }
     return RT_EOK;
 }
 

--- a/bsp/stm32f10x/drivers/usart.c
+++ b/bsp/stm32f10x/drivers/usart.c
@@ -69,8 +69,6 @@ static rt_err_t stm32_configure(struct rt_serial_device *serial, struct serial_c
 
     /* Enable USART */
     USART_Cmd(uart->uart_device, ENABLE);
-    /* enable interrupt */
-    USART_ITConfig(uart->uart_device, USART_IT_RXNE, ENABLE);
 
     return RT_EOK;
 }

--- a/components/drivers/include/drivers/serial.h
+++ b/components/drivers/include/drivers/serial.h
@@ -66,9 +66,10 @@
 #endif
 
 #define RT_DEVICE_CTRL_CONFIG           0x03    /* configure device */
-#define RT_DEVICE_CTRL_SET_INT          0x10    /* enable receive irq */
-#define RT_DEVICE_CTRL_CLR_INT          0x11    /* disable receive irq */
+#define RT_DEVICE_CTRL_SET_INT          0x10    /* enable serial irq */
+#define RT_DEVICE_CTRL_CLR_INT          0x11    /* disable serial irq */
 #define RT_DEVICE_CTRL_GET_INT          0x12
+#define RT_DEVICE_CTRL_GET_FLAG         0x13
 
 #define RT_SERIAL_EVENT_RX_IND          0x01    /* Rx indication */
 #define RT_SERIAL_EVENT_TX_DONE         0x02    /* Tx complete   */
@@ -116,7 +117,7 @@ struct serial_configure
 };
 
 /*
- * Serial FIFO mode 
+ * Serial FIFO mode
  */
 struct rt_serial_rx_fifo
 {
@@ -131,7 +132,7 @@ struct rt_serial_tx_fifo
 	struct rt_completion completion;
 };
 
-/* 
+/*
  * Serial DMA mode
  */
 struct rt_serial_rx_dma
@@ -179,4 +180,3 @@ rt_err_t rt_hw_serial_register(struct rt_serial_device *serial,
                                void                    *data);
 
 #endif
-


### PR DESCRIPTION
1、修复了 #347 提到的问题；
2、在`STM32F10X`分支的串口代码中增加了可设置发送中断类型的功能；
3、修复了`STM32F10X`分支不支持奇偶校验设置的问题；
4、在串口框架中增加`RT_DEVICE_CTRL_GET_FLAG`标志，使得用户也可以通过control来读取串口设备标志。
上述2、3、4项是为了串口框架能够更好的支持485总线而添加的功能。