### PR TITLE
RT_TIMER_TICK_PER_SECOND in rtconfig.h for softtime scheduler is not used.

### DIFF
--- a/bsp/stm32f40x/rtconfig.h
+++ b/bsp/stm32f40x/rtconfig.h
@@ -32,7 +32,6 @@
 /* #define RT_USING_TIMER_SOFT */
 #define RT_TIMER_THREAD_PRIO		4
 #define RT_TIMER_THREAD_STACK_SIZE	512
-#define RT_TIMER_TICK_PER_SECOND	10
 
 /* SECTION: IPC */
 /* Using Semaphore*/


### PR DESCRIPTION
RT_TIMER_TICK_PER_SECOND in rtconfig.h for softtime scheduler is not used.
