### PR TITLE
ymodem: fix a race-condition in handshaking

### DIFF
--- a/components/utilities/ymodem/ymodem.h
+++ b/components/utilities/ymodem/ymodem.h
@@ -66,7 +66,8 @@ enum rym_stage {
     RYM_STAGE_ESTABLISHING,
     /* set when we've got the packet 0 and sent ACK and second C */
     RYM_STAGE_ESTABLISHED,
-    /* set when the sender respond to our second C */
+    /* set when the sender respond to our second C and recviever got a real
+     * data packet. */
     RYM_STAGE_TRANSMITTING,
     /* set when the sender send a EOT */
     RYM_STAGE_FINISHING,


### PR DESCRIPTION
As we are sending C continuously, there is a chance that the
sender(remote) receive an C after sending the first handshake package.
So the sender will interpret it as NAK and re-send the package. So we
just ignore it and proceed.
