### PR TITLE
fix stm32f407 uart3 bug

### DIFF
--- a/bsp/stm32f40x/drivers/usart.c
+++ b/bsp/stm32f40x/drivers/usart.c
@@ -187,7 +187,7 @@ static void GPIO_Configuration(void)
 
 #ifdef RT_USING_UART3
     /* Configure USART3 Rx/tx PIN */
-    GPIO_InitStructure.GPIO_Pin = UART3_GPIO_RX | UART3_GPIO_RX;
+    GPIO_InitStructure.GPIO_Pin = UART3_GPIO_TX | UART3_GPIO_RX;
     GPIO_Init(UART3_GPIO, &GPIO_InitStructure);
 
     /* Connect alternate function */


### PR DESCRIPTION
fix “bsp\stm32f40x\drivers\usart.c of usart3 GPIO configuration error
