### PR TITLE
bsp/{cortex-M}: fix the SysTick_Config

### DIFF
--- a/bsp/lpc178x/drivers/board.c
+++ b/bsp/lpc178x/drivers/board.c
@@ -65,7 +65,7 @@ void rt_hw_board_init()
 #endif
 
     /* init systick */
-    SysTick_Config( SystemCoreClock/RT_TICK_PER_SECOND - 1);
+    SysTick_Config(SystemCoreClock/RT_TICK_PER_SECOND);
     /* set pend exception priority */
     NVIC_SetPriority(PendSV_IRQn, (1<<__NVIC_PRIO_BITS) - 1);
 

--- a/bsp/lpc408x/applications/board.c
+++ b/bsp/lpc408x/applications/board.c
@@ -52,7 +52,7 @@ void rt_hw_board_init()
 #endif
 
     /* init systick */
-    SysTick_Config(SystemCoreClock / RT_TICK_PER_SECOND - 1);
+    SysTick_Config(SystemCoreClock / RT_TICK_PER_SECOND);
     /* set pend exception priority */
     NVIC_SetPriority(PendSV_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
     /*init uart device*/

--- a/bsp/lpc5410x/applications/board.c
+++ b/bsp/lpc5410x/applications/board.c
@@ -60,7 +60,7 @@ void rt_hw_board_init()
 #endif
 		SystemCoreClockUpdate();
     /* init systick  1 systick = 1/(100M / 100) 100¸ösystick = 1s*/
-    SysTick_Config(SystemCoreClock / RT_TICK_PER_SECOND - 1);
+    SysTick_Config(SystemCoreClock / RT_TICK_PER_SECOND);
     /* set pend exception priority */
     NVIC_SetPriority(PendSV_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
 

--- a/bsp/mb9bf500r/board.c
+++ b/bsp/mb9bf500r/board.c
@@ -48,7 +48,7 @@ void SysTick_Handler(void)
 void rt_hw_board_init()
 {
     /* init systick */
-    SysTick_Config(SystemFrequency/RT_TICK_PER_SECOND - 1);
+    SysTick_Config(SystemFrequency/RT_TICK_PER_SECOND);
 }
 
 /*@}*/

--- a/bsp/xplorer4330/drivers/board.c
+++ b/bsp/xplorer4330/drivers/board.c
@@ -56,7 +56,7 @@ void rt_hw_board_init()
     SystemCoreClockUpdate();
 
     /* init systick */
-    SysTick_Config(SystemCoreClock / RT_TICK_PER_SECOND - 1);
+    SysTick_Config(SystemCoreClock / RT_TICK_PER_SECOND);
 
     /* set pend exception priority */
     NVIC_SetPriority(PendSV_IRQn, (1 << __NVIC_PRIO_BITS) - 1);


### PR DESCRIPTION
SysTick_Config substract one inside the function. So there is no need to
substract one when passing the parameter.