### PR TITLE
Fix ringbuffer bug

### DIFF
--- a/components/drivers/src/ringbuffer.c
+++ b/components/drivers/src/ringbuffer.c
@@ -100,11 +100,11 @@ rt_size_t rt_ringbuffer_put_force(struct rt_ringbuffer *rb,
                             const rt_uint8_t     *ptr,
                             rt_uint16_t           length)
 {
-    enum rt_ringbuffer_state old_state;
+    rt_uint16_t space_length;
 
     RT_ASSERT(rb != RT_NULL);
 
-    old_state = rt_ringbuffer_status(rb);
+    space_length = rt_ringbuffer_space_len(rb))
 
     if (length > rb->buffer_size)
         length = rb->buffer_size;
@@ -117,7 +117,7 @@ rt_size_t rt_ringbuffer_put_force(struct rt_ringbuffer *rb,
          * length of data in current mirror */
         rb->write_index += length;
 
-        if (old_state == RT_RINGBUFFER_FULL)
+        if (length > space_length)
             rb->read_index = rb->write_index;
 
         return length;
@@ -134,7 +134,7 @@ rt_size_t rt_ringbuffer_put_force(struct rt_ringbuffer *rb,
     rb->write_mirror = ~rb->write_mirror;
     rb->write_index = length - (rb->buffer_size - rb->write_index);
 
-    if (old_state == RT_RINGBUFFER_FULL)
+    if (length > space_length)
     {
         rb->read_mirror = ~rb->read_mirror;
         rb->read_index = rb->write_index;


### PR DESCRIPTION
首先声明，这个bug是论坛里 OXape仁兄发现的，并在论坛里做了讨论并给出了修复的方法，修复方法经
测试可以正常工作了。

if (old_state == RT_RINGBUFFER_FULL)只判断了满的情况，还有一种有空间，但是不够的情况没有考虑到。
所以改成
if (length > rt_ringbuffer_space_len(rb))可以处理这两种情况。

具体的讨论地址如下：
http://www.rt-thread.org/phpBB3/topic3939.html
但是@grissiom告诉他提交pr到这里来，到现在都没有动静，不知道是忘记了，还是什么样没有提交修复，
由于这个bug涉及到驱动层的api，所以不修复的话，对所有用到这个api的bsp都有影响，我就越俎代庖了，
希望OXape不要介意。

     