### PR TITLE
更新FreeModbus主机及从机

### DIFF
--- a/components/net/freemodbus-v1.6.0/SConscript
+++ b/components/net/freemodbus-v1.6.0/SConscript
@@ -7,7 +7,6 @@ modbus/functions/mbutils.c
 modbus/functions/mbfuncother.c
 modbus/rtu/mbcrc.c
 port/port.c
-port/user_mb_app.c
 """)
 
 master_rtu_src = Split("""
@@ -20,6 +19,7 @@ modbus/mb_m.c
 port/portevent_m.c
 port/portserial_m.c
 port/porttimer_m.c
+port/user_mb_app_m.c
 """)
 
 slave_rtu_src = Split("""
@@ -32,6 +32,7 @@ modbus/mb.c
 port/portevent.c
 port/portserial.c
 port/porttimer.c
+port/user_mb_app.c
 """)
 
 master_slave_rtu_src = Split("""
@@ -53,6 +54,8 @@ port/portserial.c
 port/portserial_m.c
 port/porttimer.c
 port/porttimer_m.c
+port/user_mb_app.c
+port/user_mb_app_m.c
 """)
 
 # The set of source files associated with this SConscript file.

--- a/components/net/freemodbus-v1.6.0/modbus/include/mb_m.h
+++ b/components/net/freemodbus-v1.6.0/modbus/include/mb_m.h
@@ -77,13 +77,10 @@ typedef enum
     MB_MRE_NO_ERR,                  /*!< no error. */
     MB_MRE_NO_REG,                  /*!< illegal register address. */
     MB_MRE_ILL_ARG,                 /*!< illegal argument. */
-    MB_MRE_PORT_ERR,                /*!< porting layer error. */
-    MB_MRE_NO_RES,                  /*!< insufficient resources. */
-    MB_MRE_IO,                      /*!< I/O error. */
-    MB_MRE_ILL_STATE,               /*!< protocol stack in illegal state. */
+    MB_MRE_REV_DATA,                /*!< receive data error. */
     MB_MRE_TIMEDOUT,                /*!< timeout error occurred. */
     MB_MRE_MASTER_BUSY,             /*!< master is busy now. */
-    MB_MRE_SLAVE_EXCE               /*!< slave has exception. */
+    MB_MRE_EXE_FUN                  /*!< execute function error. */
 } eMBMasterReqErrCode;
 /*! \ingroup modbus
  *  \brief TimerMode is Master 3 kind of Timer modes.
@@ -189,31 +186,176 @@ eMBErrorCode    eMBMasterDisable( void );
  */
 eMBErrorCode    eMBMasterPoll( void );
 
+/*! \ingroup modbus
+ * \brief Registers a callback handler for a given function code.
+ *
+ * This function registers a new callback handler for a given function code.
+ * The callback handler supplied is responsible for interpreting the Modbus PDU and
+ * the creation of an appropriate response. In case of an error it should return
+ * one of the possible Modbus exceptions which results in a Modbus exception frame
+ * sent by the protocol stack.
+ *
+ * \param ucFunctionCode The Modbus function code for which this handler should
+ *   be registers. Valid function codes are in the range 1 to 127.
+ * \param pxHandler The function handler which should be called in case
+ *   such a frame is received. If \c NULL a previously registered function handler
+ *   for this function code is removed.
+ *
+ * \return eMBErrorCode::MB_ENOERR if the handler has been installed. If no
+ *   more resources are available it returns eMBErrorCode::MB_ENORES. In this
+ *   case the values in mbconfig.h should be adjusted. If the argument was not
+ *   valid it returns eMBErrorCode::MB_EINVAL.
+ */
+eMBErrorCode    eMBMasterRegisterCB( UCHAR ucFunctionCode,
+                               pxMBFunctionHandler pxHandler );
+
+/* ----------------------- Callback -----------------------------------------*/
+
+/*! \defgroup modbus_master registers Modbus Registers
+ * \code #include "mb_m.h" \endcode
+ * The protocol stack does not internally allocate any memory for the
+ * registers. This makes the protocol stack very small and also usable on
+ * low end targets. In addition the values don't have to be in the memory
+ * and could for example be stored in a flash.<br>
+ * Whenever the protocol stack requires a value it calls one of the callback
+ * function with the register address and the number of registers to read
+ * as an argument. The application should then read the actual register values
+ * (for example the ADC voltage) and should store the result in the supplied
+ * buffer.<br>
+ * If the protocol stack wants to update a register value because a write
+ * register function was received a buffer with the new register values is
+ * passed to the callback function. The function should then use these values
+ * to update the application register values.
+ */
+
+/*! \ingroup modbus_registers
+ * \brief Callback function used if the value of a <em>Input Register</em>
+ *   is required by the protocol stack. The starting register address is given
+ *   by \c usAddress and the last register is given by <tt>usAddress +
+ *   usNRegs - 1</tt>.
+ *
+ * \param pucRegBuffer A buffer where the callback function should write
+ *   the current value of the modbus registers to.
+ * \param usAddress The starting address of the register. Input registers
+ *   are in the range 1 - 65535.
+ * \param usNRegs Number of registers the callback function must supply.
+ *
+ * \return The function must return one of the following error codes:
+ *   - eMBErrorCode::MB_ENOERR If no error occurred. In this case a normal
+ *       Modbus response is sent.
+ *   - eMBErrorCode::MB_ENOREG If the application does not map an coils
+ *       within the requested address range. In this case a
+ *       <b>ILLEGAL DATA ADDRESS</b> is sent as a response.
+ */
+eMBErrorCode eMBMasterRegInputCB( UCHAR * pucRegBuffer, USHORT usAddress,
+		USHORT usNRegs );
+
+/*! \ingroup modbus_registers
+ * \brief Callback function used if a <em>Holding Register</em> value is
+ *   read or written by the protocol stack. The starting register address
+ *   is given by \c usAddress and the last register is given by
+ *   <tt>usAddress + usNRegs - 1</tt>.
+ *
+ * \param pucRegBuffer If the application registers values should be updated the
+ *   buffer points to the new registers values. If the protocol stack needs
+ *   to now the current values the callback function should write them into
+ *   this buffer.
+ * \param usAddress The starting address of the register.
+ * \param usNRegs Number of registers to read or write.
+ * \param eMode If eMBRegisterMode::MB_REG_WRITE the application register
+ *   values should be updated from the values in the buffer. For example
+ *   this would be the case when the Modbus master has issued an
+ *   <b>WRITE SINGLE REGISTER</b> command.
+ *   If the value eMBRegisterMode::MB_REG_READ the application should copy
+ *   the current values into the buffer \c pucRegBuffer.
+ *
+ * \return The function must return one of the following error codes:
+ *   - eMBErrorCode::MB_ENOERR If no error occurred. In this case a normal
+ *       Modbus response is sent.
+ *   - eMBErrorCode::MB_ENOREG If the application does not map an coils
+ *       within the requested address range. In this case a
+ *       <b>ILLEGAL DATA ADDRESS</b> is sent as a response.
+ */
+eMBErrorCode eMBMasterRegHoldingCB( UCHAR * pucRegBuffer, USHORT usAddress,
+		USHORT usNRegs, eMBRegisterMode eMode );
+
+/*! \ingroup modbus_registers
+ * \brief Callback function used if a <em>Coil Register</em> value is
+ *   read or written by the protocol stack. If you are going to use
+ *   this function you might use the functions xMBUtilSetBits(  ) and
+ *   xMBUtilGetBits(  ) for working with bitfields.
+ *
+ * \param pucRegBuffer The bits are packed in bytes where the first coil
+ *   starting at address \c usAddress is stored in the LSB of the
+ *   first byte in the buffer <code>pucRegBuffer</code>.
+ *   If the buffer should be written by the callback function unused
+ *   coil values (I.e. if not a multiple of eight coils is used) should be set
+ *   to zero.
+ * \param usAddress The first coil number.
+ * \param usNCoils Number of coil values requested.
+ * \param eMode If eMBRegisterMode::MB_REG_WRITE the application values should
+ *   be updated from the values supplied in the buffer \c pucRegBuffer.
+ *   If eMBRegisterMode::MB_REG_READ the application should store the current
+ *   values in the buffer \c pucRegBuffer.
+ *
+ * \return The function must return one of the following error codes:
+ *   - eMBErrorCode::MB_ENOERR If no error occurred. In this case a normal
+ *       Modbus response is sent.
+ *   - eMBErrorCode::MB_ENOREG If the application does not map an coils
+ *       within the requested address range. In this case a
+ *       <b>ILLEGAL DATA ADDRESS</b> is sent as a response.
+ */
+eMBErrorCode eMBMasterRegCoilsCB( UCHAR * pucRegBuffer, USHORT usAddress,
+		USHORT usNCoils, eMBRegisterMode eMode );
+
+/*! \ingroup modbus_registers
+ * \brief Callback function used if a <em>Input Discrete Register</em> value is
+ *   read by the protocol stack.
+ *
+ * If you are going to use his function you might use the functions
+ * xMBUtilSetBits(  ) and xMBUtilGetBits(  ) for working with bitfields.
+ *
+ * \param pucRegBuffer The buffer should be updated with the current
+ *   coil values. The first discrete input starting at \c usAddress must be
+ *   stored at the LSB of the first byte in the buffer. If the requested number
+ *   is not a multiple of eight the remaining bits should be set to zero.
+ * \param usAddress The starting address of the first discrete input.
+ * \param usNDiscrete Number of discrete input values.
+ * \return The function must return one of the following error codes:
+ *   - eMBErrorCode::MB_ENOERR If no error occurred. In this case a normal
+ *       Modbus response is sent.
+ *   - eMBErrorCode::MB_ENOREG If the application does not map an coils
+ *       within the requested address range. In this case a
+ *       <b>ILLEGAL DATA ADDRESS</b> is sent as a response.
+ */
+eMBErrorCode eMBMasterRegDiscreteCB( UCHAR * pucRegBuffer, USHORT usAddress,
+		USHORT usNDiscrete );
 
 /*! \ingroup modbus
  *\brief These Modbus functions are called for user when Modbus run in Master Mode.
  */
 eMBMasterReqErrCode
-eMBMasterReqReadInputRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usNRegs );
+eMBMasterReqReadInputRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usNRegs, LONG lTimeOut );
 eMBMasterReqErrCode
-eMBMasterReqWriteHoldingRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usRegData );
+eMBMasterReqWriteHoldingRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usRegData, LONG lTimeOut );
 eMBMasterReqErrCode
-eMBMasterReqWriteMultipleHoldingRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usNRegs, USHORT * pusDataBuffer );
+eMBMasterReqWriteMultipleHoldingRegister( UCHAR ucSndAddr, USHORT usRegAddr,
+		USHORT usNRegs, USHORT * pusDataBuffer, LONG lTimeOut );
 eMBMasterReqErrCode
-eMBMasterReqReadHoldingRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usNRegs );
+eMBMasterReqReadHoldingRegister( UCHAR ucSndAddr, USHORT usRegAddr, USHORT usNRegs, LONG lTimeOut );
 eMBMasterReqErrCode
 eMBMasterReqReadWriteMultipleHoldingRegister( UCHAR ucSndAddr,
 		USHORT usReadRegAddr, USHORT usNReadRegs, USHORT * pusDataBuffer,
-		USHORT usWriteRegAddr, USHORT usNWriteRegs );
+		USHORT usWriteRegAddr, USHORT usNWriteRegs, LONG lTimeOut );
 eMBMasterReqErrCode
-eMBMasterReqReadCoils( UCHAR ucSndAddr, USHORT usCoilAddr, USHORT usNCoils );
+eMBMasterReqReadCoils( UCHAR ucSndAddr, USHORT usCoilAddr, USHORT usNCoils, LONG lTimeOut );
 eMBMasterReqErrCode
-eMBMasterReqWriteCoil( UCHAR ucSndAddr, USHORT usCoilAddr, USHORT usCoilData );
+eMBMasterReqWriteCoil( UCHAR ucSndAddr, USHORT usCoilAddr, USHORT usCoilData, LONG lTimeOut );
 eMBMasterReqErrCode
 eMBMasterReqWriteMultipleCoils( UCHAR ucSndAddr,
-		USHORT usCoilAddr, USHORT usNCoils, UCHAR * pucDataBuffer );
+		USHORT usCoilAddr, USHORT usNCoils, UCHAR * pucDataBuffer, LONG lTimeOut );
 eMBMasterReqErrCode
-eMBMasterReqReadDiscreteInputs( UCHAR ucSndAddr, USHORT usDiscreteAddr, USHORT usNDiscreteIn );
+eMBMasterReqReadDiscreteInputs( UCHAR ucSndAddr, USHORT usDiscreteAddr, USHORT usNDiscreteIn, LONG lTimeOut );
 
 eMBException
 eMBMasterFuncReportSlaveID( UCHAR * pucFrame, USHORT * usLen );
@@ -239,16 +381,18 @@ eMBMasterFuncReadWriteMultipleHoldingRegister( UCHAR * pucFrame, USHORT * usLen 
 /*£¡ \ingroup modbus
  *\brief These functions are interface for Modbus Master
  */
-BOOL xMBMasterGetIsBusy( void );
 void vMBMasterGetPDUSndBuf( UCHAR ** pucFrame );
 UCHAR ucMBMasterGetDestAddress( void );
 void vMBMasterSetDestAddress( UCHAR Address );
-void vMBMasterSetIsBusy( BOOL IsBusy );
 BOOL xMBMasterGetCBRunInMasterMode( void );
 void vMBMasterSetCBRunInMasterMode( BOOL IsMasterMode );
-UCHAR ucMBMasterGetPDUSndLength( void );
-void vMBMasterSetPDUSndLength( UCHAR SendPDULength );
+USHORT usMBMasterGetPDUSndLength( void );
+void vMBMasterSetPDUSndLength( USHORT SendPDULength );
 void vMBMasterSetCurTimerMode( eMBMasterTimerMode eMBTimerMode );
+BOOL xMBMasterRequestIsBroadcast( void );
+eMBMasterErrorEventType eMBMasterGetErrorType( void );
+void vMBMasterSetErrorType( eMBMasterErrorEventType errorType );
+eMBMasterReqErrCode eMBMasterWaitRequestFinish( void );
 
 /* ----------------------- Callback -----------------------------------------*/
 

--- a/components/net/freemodbus-v1.6.0/modbus/include/mbconfig.h
+++ b/components/net/freemodbus-v1.6.0/modbus/include/mbconfig.h
@@ -115,9 +115,9 @@ PR_BEGIN_EXTERN_C
 /*! \brief If master send a frame which is not broadcast,the master will wait sometime for slave.
  * And if slave is not respond in this time,the master will process this timeout error.
  * Then master can send other frame */
-#define MB_MASTER_TIMEOUT_MS_RESPOND            (2000)
-/*! \brief The total slaves in Modbus Master system.Default 16.
- * Note : The slave ID must be continuous from 0.*/
+#define MB_MASTER_TIMEOUT_MS_RESPOND            (100 )
+/*! \brief The total slaves in Modbus Master system. Default 16.
+ * \note : The slave ID must be continuous from 1.*/
 #define MB_MASTER_TOTAL_SLAVE_NUM               ( 16 )
 #endif
 

--- a/components/net/freemodbus-v1.6.0/modbus/include/mbport.h
+++ b/components/net/freemodbus-v1.6.0/modbus/include/mbport.h
@@ -36,24 +36,37 @@
 PR_BEGIN_EXTERN_C
 #endif
 
+/* ----------------------- Defines ------------------------------------------*/
+
 /* ----------------------- Type definitions ---------------------------------*/
 
 typedef enum
 {
-    EV_READY,                   /*!< Startup finished. */
-    EV_FRAME_RECEIVED,          /*!< Frame received. */
-    EV_EXECUTE,                 /*!< Execute function. */
-    EV_FRAME_SENT               /*!< Frame sent. */
+    EV_READY            = 1<<0,         /*!< Startup finished. */
+    EV_FRAME_RECEIVED   = 1<<1,         /*!< Frame received. */
+    EV_EXECUTE          = 1<<2,         /*!< Execute function. */
+    EV_FRAME_SENT       = 1<<3          /*!< Frame sent. */
 } eMBEventType;
 
 typedef enum
 {
-    EV_MASTER_READY,                   /*!< Startup finished. */
-    EV_MASTER_FRAME_RECEIVED,          /*!< Frame received. */
-    EV_MASTER_EXECUTE,                 /*!< Execute function. */
-    EV_MASTER_FRAME_SENT,              /*!< Frame sent. */
-    EV_MASTER_ERROR_PROCESS            /*!< Frame error process*/
+    EV_MASTER_READY                    = 1<<0,  /*!< Startup finished. */
+    EV_MASTER_FRAME_RECEIVED           = 1<<1,  /*!< Frame received. */
+    EV_MASTER_EXECUTE                  = 1<<2,  /*!< Execute function. */
+    EV_MASTER_FRAME_SENT               = 1<<3,  /*!< Frame sent. */
+    EV_MASTER_ERROR_PROCESS            = 1<<4,  /*!< Frame error process. */
+    EV_MASTER_PROCESS_SUCESS           = 1<<5,  /*!< Request process success. */
+    EV_MASTER_ERROR_RESPOND_TIMEOUT    = 1<<6,  /*!< Request respond timeout. */
+    EV_MASTER_ERROR_RECEIVE_DATA       = 1<<7,  /*!< Request receive data error. */
+    EV_MASTER_ERROR_EXECUTE_FUNCTION   = 1<<8,  /*!< Request execute function error. */
 } eMBMasterEventType;
+
+typedef enum
+{
+    EV_ERROR_RESPOND_TIMEOUT,         /*!< Slave respond timeout. */
+    EV_ERROR_RECEIVE_DATA,            /*!< Receive frame data erroe. */
+    EV_ERROR_EXECUTE_FUNCTION,        /*!< Execute function error. */
+} eMBMasterErrorEventType;
 
 /*! \ingroup modbus
  * \brief Parity used for characters in serial mode.
@@ -82,6 +95,12 @@ BOOL            xMBMasterPortEventPost( eMBMasterEventType eEvent );
 
 BOOL            xMBMasterPortEventGet(  /*@out@ */ eMBMasterEventType * eEvent );
 
+void            vMBMasterOsResInit( void );
+
+BOOL            xMBMasterRunResTake( int32_t time );
+
+void            vMBMasterRunResRelease( void );
+
 /* ----------------------- Serial port functions ----------------------------*/
 
 BOOL            xMBPortSerialInit( UCHAR ucPort, ULONG ulBaudRate,
@@ -96,7 +115,6 @@ void            vMBPortSerialEnable( BOOL xRxEnable, BOOL xTxEnable );
 INLINE BOOL     xMBPortSerialGetByte( CHAR * pucByte );
 
 INLINE BOOL     xMBPortSerialPutByte( CHAR ucByte );
-
 
 BOOL            xMBMasterPortSerialInit( UCHAR ucPort, ULONG ulBaudRate,
                                    UCHAR ucDataBits, eMBParity eParity );
@@ -131,6 +149,18 @@ INLINE void     vMBMasterPortTimersConvertDelayEnable( void );
 INLINE void     vMBMasterPortTimersRespondTimeoutEnable( void );
 
 INLINE void     vMBMasterPortTimersDisable( void );
+
+/* ----------------- Callback for the master error process ------------------*/
+void            vMBMasterErrorCBRespondTimeout( UCHAR ucDestAddress, const UCHAR* pucPDUData,
+                                                USHORT ucPDULength );
+
+void            vMBMasterErrorCBReceiveData( UCHAR ucDestAddress, const UCHAR* pucPDUData,
+                                             USHORT ucPDULength );
+
+void            vMBMasterErrorCBExecuteFunction( UCHAR ucDestAddress, const UCHAR* pucPDUData,
+                                                 USHORT ucPDULength );
+
+void            vMBMasterCBRequestScuuess( void );
 
 /* ----------------------- Callback for the protocol stack ------------------*/
 

--- a/components/net/freemodbus-v1.6.0/port/port.c
+++ b/components/net/freemodbus-v1.6.0/port/port.c
@@ -1,6 +1,6 @@
  /*
-  * FreeModbus Libary: LPC214X Port
-  * Copyright (C) 2007 Tiago Prado Lone <tiago@maxwellbohr.com.br>
+  * FreeModbus Libary: RT-Thread Port
+  * Copyright (C) 2013 Armink <armink.ztl@gmail.com>
   *
   * This library is free software; you can redistribute it and/or
   * modify it under the terms of the GNU Lesser General Public
@@ -16,7 +16,7 @@
   * License along with this library; if not, write to the Free Software
   * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
   *
-  * File: $Id: port.c,v 1.1 2007/04/24 23:15:18 wolti Exp $
+  * File: $Id: portevent.c,v 1.60 2015/02/01 9:18:05 Armink $
   */
 
 /* ----------------------- System includes --------------------------------*/
@@ -24,16 +24,15 @@
 /* ----------------------- Modbus includes ----------------------------------*/
 #include "port.h"
 /* ----------------------- Variables ----------------------------------------*/
-
+static rt_base_t level;
 /* ----------------------- Start implementation -----------------------------*/
 void EnterCriticalSection(void)
 {
-	//关闭全局中断
-	__disable_irq();
+	level = rt_hw_interrupt_disable();
 }
 
 void ExitCriticalSection(void)
 {
-	//开启全局中断
-	__enable_irq();
+	rt_hw_interrupt_enable(level);
 }
+

--- a/components/net/freemodbus-v1.6.0/port/port.c
+++ b/components/net/freemodbus-v1.6.0/port/port.c
@@ -16,7 +16,7 @@
   * License along with this library; if not, write to the Free Software
   * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
   *
-  * File: $Id: portevent.c,v 1.60 2015/02/01 9:18:05 Armink $
+  * File: $Id: port.c,v 1.60 2015/02/01 9:18:05 Armink $
   */
 
 /* ----------------------- System includes --------------------------------*/
@@ -28,11 +28,11 @@ static rt_base_t level;
 /* ----------------------- Start implementation -----------------------------*/
 void EnterCriticalSection(void)
 {
-	level = rt_hw_interrupt_disable();
+    level = rt_hw_interrupt_disable();
 }
 
 void ExitCriticalSection(void)
 {
-	rt_hw_interrupt_enable(level);
+    rt_hw_interrupt_enable(level);
 }
 

--- a/components/net/freemodbus-v1.6.0/port/port.h
+++ b/components/net/freemodbus-v1.6.0/port/port.h
@@ -30,11 +30,11 @@
 #include <assert.h>
 #include <inttypes.h>
 
-#define	INLINE
+#define INLINE
 #define PR_BEGIN_EXTERN_C           extern "C" {
-#define	PR_END_EXTERN_C             }
+#define PR_END_EXTERN_C             }
 
-#define ENTER_CRITICAL_SECTION()	EnterCriticalSection()
+#define ENTER_CRITICAL_SECTION()    EnterCriticalSection()
 #define EXIT_CRITICAL_SECTION()    ExitCriticalSection()
 
 typedef uint8_t BOOL;

--- a/components/net/freemodbus-v1.6.0/port/port.h
+++ b/components/net/freemodbus-v1.6.0/port/port.h
@@ -1,6 +1,6 @@
 /*
  * FreeModbus Libary: BARE Port
- * Copyright (C) 2006 Christian Walter <wolti@sil.at>
+ * Copyright (C) 2013 Armink <armink.ztl@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -34,17 +34,8 @@
 #define PR_BEGIN_EXTERN_C           extern "C" {
 #define	PR_END_EXTERN_C             }
 
-//TODO  暂时先写B13引脚，等组网测试时再确认
-#define SLAVE_RS485_SEND_MODE  GPIO_SetBits(GPIOB,GPIO_Pin_13)
-#define SLAVE_RS485_RECEIVE_MODE  GPIO_ResetBits(GPIOB,GPIO_Pin_13)
-#define MASTER_RS485_SEND_MODE  GPIO_SetBits(GPIOB,GPIO_Pin_13)
-#define MASTER_RS485_RECEIVE_MODE  GPIO_ResetBits(GPIOB,GPIO_Pin_13)
-
 #define ENTER_CRITICAL_SECTION()	EnterCriticalSection()
 #define EXIT_CRITICAL_SECTION()    ExitCriticalSection()
-
-void EnterCriticalSection(void);
-void ExitCriticalSection(void);
 
 typedef uint8_t BOOL;
 
@@ -64,5 +55,8 @@ typedef int32_t LONG;
 #ifndef FALSE
 #define FALSE           0
 #endif
+
+void EnterCriticalSection(void);
+void ExitCriticalSection(void);
 
 #endif

--- a/components/net/freemodbus-v1.6.0/port/portevent_m.c
+++ b/components/net/freemodbus-v1.6.0/port/portevent_m.c
@@ -1,5 +1,5 @@
 /*
- * FreeModbus Libary: STM32 Port
+ * FreeModbus Libary: RT-Thread Port
  * Copyright (C) 2013 Armink <armink.ztl@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -21,41 +21,219 @@
 
 /* ----------------------- Modbus includes ----------------------------------*/
 #include "mb.h"
+#include "mb_m.h"
 #include "mbport.h"
+#include "port.h"
 
-#if MB_MASTER_RTU_ENABLED > 0 || MB_MASTER_ASCII_ENABLED
+#if MB_MASTER_RTU_ENABLED > 0 || MB_MASTER_ASCII_ENABLED > 0
+/* ----------------------- Defines ------------------------------------------*/
 /* ----------------------- Variables ----------------------------------------*/
-static eMBMasterEventType eMasterQueuedEvent;
-static BOOL     xMasterEventInQueue;
-
+static struct rt_semaphore xMasterRunRes;
+static struct rt_event     xMasterOsEvent;
 /* ----------------------- Start implementation -----------------------------*/
 BOOL
 xMBMasterPortEventInit( void )
 {
-    xMasterEventInQueue = FALSE;
+    rt_event_init(&xMasterOsEvent,"master event",RT_IPC_FLAG_PRIO);
     return TRUE;
 }
 
 BOOL
 xMBMasterPortEventPost( eMBMasterEventType eEvent )
 {
-    xMasterEventInQueue = TRUE;
-    eMasterQueuedEvent = eEvent;
+    rt_event_send(&xMasterOsEvent, eEvent);
     return TRUE;
 }
 
 BOOL
 xMBMasterPortEventGet( eMBMasterEventType * eEvent )
 {
-    BOOL            xEventHappened = FALSE;
-
-    if( xMasterEventInQueue )
+    rt_uint32_t recvedEvent;
+    /* waiting forever OS event */
+    rt_event_recv(&xMasterOsEvent,
+            EV_MASTER_READY | EV_MASTER_FRAME_RECEIVED | EV_MASTER_EXECUTE |
+            EV_MASTER_FRAME_SENT | EV_MASTER_ERROR_PROCESS,
+            RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, RT_WAITING_FOREVER,
+            &recvedEvent);
+    /* the enum type couldn't convert to int type */
+    switch (recvedEvent)
     {
-        *eEvent = eMasterQueuedEvent;
-        xMasterEventInQueue = FALSE;
-        xEventHappened = TRUE;
+    case EV_MASTER_READY:
+        *eEvent = EV_MASTER_READY;
+        break;
+    case EV_MASTER_FRAME_RECEIVED:
+        *eEvent = EV_MASTER_FRAME_RECEIVED;
+        break;
+    case EV_MASTER_EXECUTE:
+        *eEvent = EV_MASTER_EXECUTE;
+        break;
+    case EV_MASTER_FRAME_SENT:
+        *eEvent = EV_MASTER_FRAME_SENT;
+        break;
+    case EV_MASTER_ERROR_PROCESS:
+        *eEvent = EV_MASTER_ERROR_PROCESS;
+        break;
     }
-    return xEventHappened;
+    return TRUE;
+}
+/**
+ * This function is initialize the OS resource for modbus master.
+ * Note:The resource is define by OS.If you not use OS this function can be empty.
+ *
+ */
+void vMBMasterOsResInit( void )
+{
+    rt_sem_init(&xMasterRunRes, "master res", 0x01 , RT_IPC_FLAG_PRIO);
+}
+
+/**
+ * This function is take Mobus Master running resource.
+ * Note:The resource is define by Operating System.If you not use OS this function can be just return TRUE.
+ *
+ * @param lTimeOut the waiting time.
+ *
+ * @return resource taked result
+ */
+BOOL xMBMasterRunResTake( LONG lTimeOut )
+{
+    /*If waiting time is -1 .It will wait forever */
+    return rt_sem_take(&xMasterRunRes, lTimeOut) ? FALSE : TRUE ;
+}
+
+/**
+ * This function is release Mobus Master running resource.
+ * Note:The resource is define by Operating System.If you not use OS this function can be empty.
+ *
+ */
+void vMBMasterRunResRelease( void )
+{
+    /* release resource */
+    rt_sem_release(&xMasterRunRes);
+}
+
+/**
+ * This is modbus master respond timeout error process callback function.
+ * @note There functions will block modbus master poll while execute OS waiting.
+ * So,for real-time of system.Do not execute too much waiting process.
+ *
+ * @param ucDestAddress destination salve address
+ * @param pucPDUData PDU buffer data
+ * @param ucPDULength PDU buffer length
+ *
+ */
+void vMBMasterErrorCBRespondTimeout(UCHAR ucDestAddress, const UCHAR* pucPDUData,
+        USHORT ucPDULength) {
+    /**
+     * @note This code is use OS's event mechanism for modbus master protocol stack.
+     * If you don't use OS, you can change it.
+     */
+    rt_event_send(&xMasterOsEvent, EV_MASTER_ERROR_RESPOND_TIMEOUT);
+
+    /* You can add your code under here. */
+
+}
+
+/**
+ * This is modbus master receive data error process callback function.
+ * @note There functions will block modbus master poll while execute OS waiting.
+ * So,for real-time of system.Do not execute too much waiting process.
+ *
+ * @param ucDestAddress destination salve address
+ * @param pucPDUData PDU buffer data
+ * @param ucPDULength PDU buffer length
+ *
+ */
+void vMBMasterErrorCBReceiveData(UCHAR ucDestAddress, const UCHAR* pucPDUData,
+        USHORT ucPDULength) {
+    /**
+     * @note This code is use OS's event mechanism for modbus master protocol stack.
+     * If you don't use OS, you can change it.
+     */
+    rt_event_send(&xMasterOsEvent, EV_MASTER_ERROR_RECEIVE_DATA);
+
+    /* You can add your code under here. */
+
+}
+
+/**
+ * This is modbus master execute function error process callback function.
+ * @note There functions will block modbus master poll while execute OS waiting.
+ * So,for real-time of system.Do not execute too much waiting process.
+ *
+ * @param ucDestAddress destination salve address
+ * @param pucPDUData PDU buffer data
+ * @param ucPDULength PDU buffer length
+ *
+ */
+void vMBMasterErrorCBExecuteFunction(UCHAR ucDestAddress, const UCHAR* pucPDUData,
+        USHORT ucPDULength) {
+    /**
+     * @note This code is use OS's event mechanism for modbus master protocol stack.
+     * If you don't use OS, you can change it.
+     */
+    rt_event_send(&xMasterOsEvent, EV_MASTER_ERROR_EXECUTE_FUNCTION);
+
+    /* You can add your code under here. */
+
+}
+
+/**
+ * This is modbus master request process success callback function.
+ * @note There functions will block modbus master poll while execute OS waiting.
+ * So,for real-time of system.Do not execute too much waiting process.
+ *
+ */
+void vMBMasterCBRequestScuuess( void ) {
+    /**
+     * @note This code is use OS's event mechanism for modbus master protocol stack.
+     * If you don't use OS, you can change it.
+     */
+    rt_event_send(&xMasterOsEvent, EV_MASTER_PROCESS_SUCESS);
+
+    /* You can add your code under here. */
+
+}
+
+/**
+ * This function is wait for modbus master request finish and return result.
+ * Waiting result include request process success, request respond timeout,
+ * receive data error and execute function error.You can use the above callback function.
+ * @note If you are use OS, you can use OS's event mechanism. Otherwise you have to run
+ * much user custom delay for waiting.
+ *
+ * @return request error code
+ */
+eMBMasterReqErrCode eMBMasterWaitRequestFinish( void ) {
+    eMBMasterReqErrCode    eErrStatus = MB_MRE_NO_ERR;
+    rt_uint32_t recvedEvent;
+    /* waiting for OS event */
+    rt_event_recv(&xMasterOsEvent,
+            EV_MASTER_PROCESS_SUCESS | EV_MASTER_ERROR_RESPOND_TIMEOUT
+                    | EV_MASTER_ERROR_RECEIVE_DATA
+                    | EV_MASTER_ERROR_EXECUTE_FUNCTION,
+            RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, RT_WAITING_FOREVER,
+            &recvedEvent);
+    switch (recvedEvent)
+    {
+    case EV_MASTER_PROCESS_SUCESS:
+        break;
+    case EV_MASTER_ERROR_RESPOND_TIMEOUT:
+    {
+        eErrStatus = MB_MRE_TIMEDOUT;
+        break;
+    }
+    case EV_MASTER_ERROR_RECEIVE_DATA:
+    {
+        eErrStatus = MB_MRE_REV_DATA;
+        break;
+    }
+    case EV_MASTER_ERROR_EXECUTE_FUNCTION:
+    {
+        eErrStatus = MB_MRE_EXE_FUN;
+        break;
+    }
+    }
+    return eErrStatus;
 }
 
 #endif

--- a/components/net/freemodbus-v1.6.0/port/portserial.c
+++ b/components/net/freemodbus-v1.6.0/port/portserial.c
@@ -133,7 +133,7 @@ void vMBPortSerialEnable(BOOL xRxEnable, BOOL xTxEnable)
     else
     {
         /* switch 485 to transmit mode */
-    	rt_pin_write(MODBUS_SLAVE_RT_CONTROL_PIN_INDEX, PIN_HIGH);
+        rt_pin_write(MODBUS_SLAVE_RT_CONTROL_PIN_INDEX, PIN_HIGH);
         /* disable RX interrupt */
         serial->ops->control(serial, RT_DEVICE_CTRL_CLR_INT, (void *)RT_DEVICE_FLAG_INT_RX);
     }

--- a/components/net/freemodbus-v1.6.0/port/portserial.c
+++ b/components/net/freemodbus-v1.6.0/port/portserial.c
@@ -25,7 +25,7 @@
 #include "mb.h"
 #include "mbport.h"
 #include "rtdevice.h"
-#include "bsp.h"
+#include "board.h"
 
 /* ----------------------- Static variables ---------------------------------*/
 ALIGN(RT_ALIGN_SIZE)

--- a/components/net/freemodbus-v1.6.0/port/portserial.c
+++ b/components/net/freemodbus-v1.6.0/port/portserial.c
@@ -1,5 +1,5 @@
 /*
- * FreeModbus Libary: STM32 Port
+ * FreeModbus Libary: RT-Thread Port
  * Copyright (C) 2013 Armink <armink.ztl@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -24,122 +24,148 @@
 /* ----------------------- Modbus includes ----------------------------------*/
 #include "mb.h"
 #include "mbport.h"
+#include "rtdevice.h"
+#include "bsp.h"
+
+/* ----------------------- Static variables ---------------------------------*/
+ALIGN(RT_ALIGN_SIZE)
+/* software simulation serial transmit IRQ handler thread stack */
+static rt_uint8_t serial_soft_trans_irq_stack[512];
+/* software simulation serial transmit IRQ handler thread */
+static struct rt_thread thread_serial_soft_trans_irq;
+/* serial event */
+static struct rt_event event_serial;
+/* modbus slave serial device */
+static rt_serial_t *serial;
+
+/* ----------------------- Defines ------------------------------------------*/
+/* serial transmit event */
+#define EVENT_SERIAL_TRANS_START    (1<<0)
+
 /* ----------------------- static functions ---------------------------------*/
 static void prvvUARTTxReadyISR(void);
 static void prvvUARTRxISR(void);
+static rt_err_t serial_rx_ind(rt_device_t dev, rt_size_t size);
+static void serial_soft_trans_irq(void* parameter);
+
 /* ----------------------- Start implementation -----------------------------*/
+BOOL xMBPortSerialInit(UCHAR ucPORT, ULONG ulBaudRate, UCHAR ucDataBits,
+        eMBParity eParity)
+{
+    /**
+     * set 485 mode receive and transmit control IO
+     * @note MODBUS_SLAVE_RT_CONTROL_PIN_INDEX need be defined by user
+     */
+    rt_pin_mode(MODBUS_SLAVE_RT_CONTROL_PIN_INDEX, PIN_MODE_OUTPUT);
+
+    /* set serial name */
+    if (ucPORT == 1) {
+#if defined(RT_USING_UART1) || defined(RT_USING_REMAP_UART1)
+        extern struct rt_serial_device serial1;
+        serial = &serial1;
+#endif
+    } else if (ucPORT == 2) {
+#if defined(RT_USING_UART2)
+        extern struct rt_serial_device serial2;
+        serial = &serial2;
+#endif
+    } else if (ucPORT == 3) {
+#if defined(RT_USING_UART3)
+        extern struct rt_serial_device serial3;
+        serial = &serial3;
+#endif
+    }
+    /* set serial configure parameter */
+    serial->config.baud_rate = ulBaudRate;
+    serial->config.stop_bits = STOP_BITS_1;
+    switch(eParity){
+    case MB_PAR_NONE: {
+        serial->config.data_bits = DATA_BITS_8;
+        serial->config.parity = PARITY_NONE;
+        break;
+    }
+    case MB_PAR_ODD: {
+        serial->config.data_bits = DATA_BITS_9;
+        serial->config.parity = PARITY_ODD;
+        break;
+    }
+    case MB_PAR_EVEN: {
+        serial->config.data_bits = DATA_BITS_9;
+        serial->config.parity = PARITY_EVEN;
+        break;
+    }
+    }
+    /* set serial configure */
+    serial->ops->configure(serial, &(serial->config));
+
+    /* open serial device */
+    if (!serial->parent.open(&serial->parent,
+            RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_INT_RX )) {
+        serial->parent.rx_indicate = serial_rx_ind;
+    } else {
+        return FALSE;
+    }
+
+    /* software initialize */
+    rt_thread_init(&thread_serial_soft_trans_irq,
+                   "slave trans",
+                   serial_soft_trans_irq,
+                   RT_NULL,
+                   serial_soft_trans_irq_stack,
+                   sizeof(serial_soft_trans_irq_stack),
+                   10, 5);
+    rt_thread_startup(&thread_serial_soft_trans_irq);
+    rt_event_init(&event_serial, "slave event", RT_IPC_FLAG_PRIO);
+
+    return TRUE;
+}
 
 void vMBPortSerialEnable(BOOL xRxEnable, BOOL xTxEnable)
 {
-	if (xRxEnable)
-	{
-		SLAVE_RS485_RECEIVE_MODE;
-		USART_ITConfig(USART1, USART_IT_RXNE, ENABLE);
-	}
-	else
-	{
-		SLAVE_RS485_SEND_MODE;
-		USART_ITConfig(USART1, USART_IT_RXNE, DISABLE);
-	}
-	if (xTxEnable)
-	{
-		USART_ITConfig(USART1, USART_IT_TXE, ENABLE);
-	}
-	else
-	{
-		USART_ITConfig(USART1, USART_IT_TXE, DISABLE);
-	}
+    rt_uint32_t recved_event;
+    if (xRxEnable)
+    {
+        /* enable RX interrupt */
+        serial->ops->control(serial, RT_DEVICE_CTRL_SET_INT, (void *)RT_DEVICE_FLAG_INT_RX);
+        /* switch 485 to receive mode */
+        rt_pin_write(MODBUS_SLAVE_RT_CONTROL_PIN_INDEX, PIN_LOW);
+    }
+    else
+    {
+        /* switch 485 to transmit mode */
+    	rt_pin_write(MODBUS_SLAVE_RT_CONTROL_PIN_INDEX, PIN_HIGH);
+        /* disable RX interrupt */
+        serial->ops->control(serial, RT_DEVICE_CTRL_CLR_INT, (void *)RT_DEVICE_FLAG_INT_RX);
+    }
+    if (xTxEnable)
+    {
+        /* start serial transmit */
+        rt_event_send(&event_serial, EVENT_SERIAL_TRANS_START);
+    }
+    else
+    {
+        /* stop serial transmit */
+        rt_event_recv(&event_serial, EVENT_SERIAL_TRANS_START,
+                RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, 0,
+                &recved_event);
+    }
 }
 
 void vMBPortClose(void)
 {
-	USART_ITConfig(USART1, USART_IT_TXE | USART_IT_RXNE, DISABLE);
-	USART_Cmd(USART1, DISABLE);
-}
-//默认一个从机 串口1 波特率可设置  奇偶检验可设置
-BOOL xMBPortSerialInit(UCHAR ucPORT, ULONG ulBaudRate, UCHAR ucDataBits,
-		eMBParity eParity)
-{
-	GPIO_InitTypeDef GPIO_InitStructure;
-	USART_InitTypeDef USART_InitStructure;
-	NVIC_InitTypeDef NVIC_InitStructure;
-	//======================时钟初始化=======================================
-	RCC_APB2PeriphClockCmd(
-			RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_USART1,
-			ENABLE);
-	//======================IO初始化=======================================	
-	//USART1_TX
-	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
-	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_PP;
-	GPIO_InitStructure.GPIO_Pin = GPIO_Pin_9;
-	GPIO_Init(GPIOA, &GPIO_InitStructure);
-	//USART1_RX
-	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN_FLOATING;
-	GPIO_InitStructure.GPIO_Pin = GPIO_Pin_10;
-	GPIO_Init(GPIOA, &GPIO_InitStructure);
-	//配置485发送和接收模式
-//    TODO   暂时先写B13 等之后组网测试时再修改
-	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_PP;
-	GPIO_InitStructure.GPIO_Pin = GPIO_Pin_13;
-	GPIO_Init(GPIOB, &GPIO_InitStructure);
-	//======================串口初始化=======================================
-	USART_InitStructure.USART_BaudRate = ulBaudRate;
-	//设置校验模式
-	switch (eParity)
-	{
-	case MB_PAR_NONE: //无校验
-		USART_InitStructure.USART_Parity = USART_Parity_No;
-		USART_InitStructure.USART_WordLength = USART_WordLength_8b;
-		break;
-	case MB_PAR_ODD: //奇校验
-		USART_InitStructure.USART_Parity = USART_Parity_Odd;
-		USART_InitStructure.USART_WordLength = USART_WordLength_9b;
-		break;
-	case MB_PAR_EVEN: //偶校验
-		USART_InitStructure.USART_Parity = USART_Parity_Even;
-		USART_InitStructure.USART_WordLength = USART_WordLength_9b;
-		break;
-	default:
-		return FALSE;
-	}
-
-	USART_InitStructure.USART_StopBits = USART_StopBits_1;
-	USART_InitStructure.USART_HardwareFlowControl =
-			USART_HardwareFlowControl_None;
-	USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
-	if (ucPORT != 1)
-		return FALSE;
-
-	ENTER_CRITICAL_SECTION(); //关全局中断
-
-	USART_Init(USART1, &USART_InitStructure);
-	USART_ITConfig(USART1, USART_IT_RXNE, ENABLE);
-	USART_Cmd(USART1, ENABLE);
-
-	//=====================中断初始化======================================
-	//设置NVIC优先级分组为Group2：0-3抢占式优先级，0-3的响应式优先级
-	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_2);
-	NVIC_InitStructure.NVIC_IRQChannel = USART1_IRQn;
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
-	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 1;
-	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-	NVIC_Init(&NVIC_InitStructure);
-
-	EXIT_CRITICAL_SECTION(); //开全局中断
-
-	return TRUE;
+    serial->parent.close(&(serial->parent));
 }
 
 BOOL xMBPortSerialPutByte(CHAR ucByte)
 {
-	USART_SendData(USART1, ucByte);
-	return TRUE;
+    serial->parent.write(&(serial->parent), 0, &ucByte, 1);
+    return TRUE;
 }
 
 BOOL xMBPortSerialGetByte(CHAR * pucByte)
 {
-	*pucByte = USART_ReceiveData(USART1);
-	return TRUE;
+    serial->parent.read(&(serial->parent), 0, pucByte, 1);
+    return TRUE;
 }
 
 /* 
@@ -151,7 +177,7 @@ BOOL xMBPortSerialGetByte(CHAR * pucByte)
  */
 void prvvUARTTxReadyISR(void)
 {
-	pxMBFrameCBTransmitterEmpty();
+    pxMBFrameCBTransmitterEmpty();
 }
 
 /* 
@@ -162,28 +188,35 @@ void prvvUARTTxReadyISR(void)
  */
 void prvvUARTRxISR(void)
 {
-	pxMBFrameCBByteReceived();
+    pxMBFrameCBByteReceived();
 }
-/*******************************************************************************
- * Function Name  : USART1_IRQHandler
- * Description    : This function handles USART1 global interrupt request.
- * Input          : None
- * Output         : None
- * Return         : None
- *******************************************************************************/
-void USART1_IRQHandler(void)
-{
-	rt_interrupt_enter();
-	//接收中断
-	if (USART_GetITStatus(USART1, USART_IT_RXNE) == SET)
-	{
-		USART_ClearITPendingBit(USART1, USART_IT_RXNE);
-		prvvUARTRxISR();
-	}
-	//发送中断
-	if (USART_GetITStatus(USART1, USART_IT_TXE) == SET)
-	{
-		prvvUARTTxReadyISR();
-	}
-	rt_interrupt_leave();
+
+/**
+ * Software simulation serial transmit IRQ handler.
+ *
+ * @param parameter parameter
+ */
+static void serial_soft_trans_irq(void* parameter) {
+    rt_uint32_t recved_event;
+    while (1)
+    {
+        /* waiting for serial transmit start */
+        rt_event_recv(&event_serial, EVENT_SERIAL_TRANS_START, RT_EVENT_FLAG_OR,
+                RT_WAITING_FOREVER, &recved_event);
+        /* execute modbus callback */
+        prvvUARTTxReadyISR();
+    }
+}
+
+/**
+ * This function is serial receive callback function
+ *
+ * @param dev the device of serial
+ * @param size the data size that receive
+ *
+ * @return return RT_EOK
+ */
+static rt_err_t serial_rx_ind(rt_device_t dev, rt_size_t size) {
+    prvvUARTRxISR();
+    return RT_EOK;
 }

--- a/components/net/freemodbus-v1.6.0/port/portserial_m.c
+++ b/components/net/freemodbus-v1.6.0/port/portserial_m.c
@@ -57,7 +57,7 @@ BOOL xMBMasterPortSerialInit(UCHAR ucPORT, ULONG ulBaudRate, UCHAR ucDataBits,
      * set 485 mode receive and transmit control IO
      * @note MODBUS_MASTER_RT_CONTROL_PIN_INDEX need be defined by user
      */
-	rt_pin_mode(MODBUS_MASTER_RT_CONTROL_PIN_INDEX, PIN_MODE_OUTPUT);
+    rt_pin_mode(MODBUS_MASTER_RT_CONTROL_PIN_INDEX, PIN_MODE_OUTPUT);
 
     /* set serial name */
     if (ucPORT == 1) {
@@ -129,12 +129,12 @@ void vMBMasterPortSerialEnable(BOOL xRxEnable, BOOL xTxEnable)
         /* enable RX interrupt */
         serial->ops->control(serial, RT_DEVICE_CTRL_SET_INT, (void *)RT_DEVICE_FLAG_INT_RX);
         /* switch 485 to receive mode */
-		rt_pin_write(MODBUS_MASTER_RT_CONTROL_PIN_INDEX, PIN_LOW);
+        rt_pin_write(MODBUS_MASTER_RT_CONTROL_PIN_INDEX, PIN_LOW);
     }
     else
     {
         /* switch 485 to transmit mode */
-    	rt_pin_write(MODBUS_MASTER_RT_CONTROL_PIN_INDEX, PIN_HIGH);
+        rt_pin_write(MODBUS_MASTER_RT_CONTROL_PIN_INDEX, PIN_HIGH);
         /* disable RX interrupt */
         serial->ops->control(serial, RT_DEVICE_CTRL_CLR_INT, (void *)RT_DEVICE_FLAG_INT_RX);
     }
@@ -154,13 +154,13 @@ void vMBMasterPortSerialEnable(BOOL xRxEnable, BOOL xTxEnable)
 
 void vMBMasterPortClose(void)
 {
-	serial->parent.close(&(serial->parent));
+    serial->parent.close(&(serial->parent));
 }
 
 BOOL xMBMasterPortSerialPutByte(CHAR ucByte)
 {
     serial->parent.write(&(serial->parent), 0, &ucByte, 1);
-	return TRUE;
+    return TRUE;
 }
 
 BOOL xMBMasterPortSerialGetByte(CHAR * pucByte)

--- a/components/net/freemodbus-v1.6.0/port/portserial_m.c
+++ b/components/net/freemodbus-v1.6.0/port/portserial_m.c
@@ -1,5 +1,5 @@
 /*
- * FreeModbus Libary: STM32 Port
+ * FreeModbus Libary: RT-Thread Port
  * Copyright (C) 2013 Armink <armink.ztl@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -24,123 +24,149 @@
 /* ----------------------- Modbus includes ----------------------------------*/
 #include "mb.h"
 #include "mbport.h"
+#include "rtdevice.h"
+#include "bsp.h"
 
-#if MB_MASTER_RTU_ENABLED > 0 || MB_MASTER_ASCII_ENABLED
+#if MB_MASTER_RTU_ENABLED > 0 || MB_MASTER_ASCII_ENABLED > 0
+/* ----------------------- Static variables ---------------------------------*/
+ALIGN(RT_ALIGN_SIZE)
+/* software simulation serial transmit IRQ handler thread stack */
+static rt_uint8_t serial_soft_trans_irq_stack[512];
+/* software simulation serial transmit IRQ handler thread */
+static struct rt_thread thread_serial_soft_trans_irq;
+/* serial event */
+static struct rt_event event_serial;
+/* modbus slave serial device */
+static rt_serial_t *serial;
+
+/* ----------------------- Defines ------------------------------------------*/
+/* serial transmit event */
+#define EVENT_SERIAL_TRANS_START    (1<<0)
+
 /* ----------------------- static functions ---------------------------------*/
 static void prvvUARTTxReadyISR(void);
 static void prvvUARTRxISR(void);
+static rt_err_t serial_rx_ind(rt_device_t dev, rt_size_t size);
+static void serial_soft_trans_irq(void* parameter);
+
 /* ----------------------- Start implementation -----------------------------*/
+BOOL xMBMasterPortSerialInit(UCHAR ucPORT, ULONG ulBaudRate, UCHAR ucDataBits,
+        eMBParity eParity)
+{
+    /**
+     * set 485 mode receive and transmit control IO
+     * @note MODBUS_MASTER_RT_CONTROL_PIN_INDEX need be defined by user
+     */
+	rt_pin_mode(MODBUS_MASTER_RT_CONTROL_PIN_INDEX, PIN_MODE_OUTPUT);
+
+    /* set serial name */
+    if (ucPORT == 1) {
+#if defined(RT_USING_UART1) || defined(RT_USING_REMAP_UART1)
+        extern struct rt_serial_device serial1;
+        serial = &serial1;
+#endif
+    } else if (ucPORT == 2) {
+#if defined(RT_USING_UART2)
+        extern struct rt_serial_device serial2;
+        serial = &serial2;
+#endif
+    } else if (ucPORT == 3) {
+#if defined(RT_USING_UART3)
+        extern struct rt_serial_device serial3;
+        serial = &serial3;
+#endif
+    }
+    /* set serial configure parameter */
+    serial->config.baud_rate = ulBaudRate;
+    serial->config.stop_bits = STOP_BITS_1;
+    switch(eParity){
+    case MB_PAR_NONE: {
+        serial->config.data_bits = DATA_BITS_8;
+        serial->config.parity = PARITY_NONE;
+        break;
+    }
+    case MB_PAR_ODD: {
+        serial->config.data_bits = DATA_BITS_9;
+        serial->config.parity = PARITY_ODD;
+        break;
+    }
+    case MB_PAR_EVEN: {
+        serial->config.data_bits = DATA_BITS_9;
+        serial->config.parity = PARITY_EVEN;
+        break;
+    }
+    }
+    /* set serial configure */
+    serial->ops->configure(serial, &(serial->config));
+
+    /* open serial device */
+    if (!serial->parent.open(&serial->parent,
+            RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_INT_RX )) {
+        serial->parent.rx_indicate = serial_rx_ind;
+    } else {
+        return FALSE;
+    }
+
+    /* software initialize */
+    rt_thread_init(&thread_serial_soft_trans_irq,
+                   "slave trans",
+                   serial_soft_trans_irq,
+                   RT_NULL,
+                   serial_soft_trans_irq_stack,
+                   sizeof(serial_soft_trans_irq_stack),
+                   10, 5);
+    rt_thread_startup(&thread_serial_soft_trans_irq);
+    rt_event_init(&event_serial, "slave event", RT_IPC_FLAG_PRIO);
+
+    return TRUE;
+}
 
 void vMBMasterPortSerialEnable(BOOL xRxEnable, BOOL xTxEnable)
 {
-	if (xRxEnable)
-	{
-		MASTER_RS485_RECEIVE_MODE;
-		USART_ITConfig(USART2, USART_IT_RXNE, ENABLE);
-	}
-	else
-	{
-		MASTER_RS485_SEND_MODE;
-		USART_ITConfig(USART2, USART_IT_RXNE, DISABLE);
-	}
-	if (xTxEnable)
-	{
-		USART_ITConfig(USART2, USART_IT_TXE, ENABLE);
-	}
-	else
-	{
-		USART_ITConfig(USART2, USART_IT_TXE, DISABLE);
-	}
+    rt_uint32_t recved_event;
+    if (xRxEnable)
+    {
+        /* enable RX interrupt */
+        serial->ops->control(serial, RT_DEVICE_CTRL_SET_INT, (void *)RT_DEVICE_FLAG_INT_RX);
+        /* switch 485 to receive mode */
+		rt_pin_write(MODBUS_MASTER_RT_CONTROL_PIN_INDEX, PIN_LOW);
+    }
+    else
+    {
+        /* switch 485 to transmit mode */
+    	rt_pin_write(MODBUS_MASTER_RT_CONTROL_PIN_INDEX, PIN_HIGH);
+        /* disable RX interrupt */
+        serial->ops->control(serial, RT_DEVICE_CTRL_CLR_INT, (void *)RT_DEVICE_FLAG_INT_RX);
+    }
+    if (xTxEnable)
+    {
+        /* start serial transmit */
+        rt_event_send(&event_serial, EVENT_SERIAL_TRANS_START);
+    }
+    else
+    {
+        /* stop serial transmit */
+        rt_event_recv(&event_serial, EVENT_SERIAL_TRANS_START,
+                RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, 0,
+                &recved_event);
+    }
 }
 
 void vMBMasterPortClose(void)
 {
-	USART_ITConfig(USART2, USART_IT_TXE | USART_IT_RXNE, DISABLE);
-	USART_Cmd(USART2, DISABLE);
-}
-//默认一个主机 串口2 波特率可设置  奇偶检验可设置
-BOOL xMBMasterPortSerialInit(UCHAR ucPORT, ULONG ulBaudRate, UCHAR ucDataBits,
-		eMBParity eParity)
-{
-	GPIO_InitTypeDef GPIO_InitStructure;
-	USART_InitTypeDef USART_InitStructure;
-	NVIC_InitTypeDef NVIC_InitStructure;
-	//======================时钟初始化=======================================
-	RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB, ENABLE);
-	RCC_APB1PeriphClockCmd(RCC_APB1Periph_USART2, ENABLE);
-	//======================IO初始化=======================================	
-	//USART2_TX
-	GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
-	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF_PP;
-	GPIO_InitStructure.GPIO_Pin = GPIO_Pin_2;
-	GPIO_Init(GPIOA, &GPIO_InitStructure);
-	//USART2_RX
-	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN_FLOATING;
-	GPIO_InitStructure.GPIO_Pin = GPIO_Pin_3;
-	GPIO_Init(GPIOA, &GPIO_InitStructure);
-	//配置485发送和接收模式
-//    TODO   暂时先写B13 等之后组网测试时再修改
-	GPIO_InitStructure.GPIO_Mode = GPIO_Mode_Out_PP;
-	GPIO_InitStructure.GPIO_Pin = GPIO_Pin_13;
-	GPIO_Init(GPIOB, &GPIO_InitStructure);
-	//======================串口初始化=======================================
-	USART_InitStructure.USART_BaudRate = ulBaudRate;
-	//设置校验模式
-	switch (eParity)
-	{
-	case MB_PAR_NONE: //无校验
-		USART_InitStructure.USART_Parity = USART_Parity_No;
-		USART_InitStructure.USART_WordLength = USART_WordLength_8b;
-		break;
-	case MB_PAR_ODD: //奇校验
-		USART_InitStructure.USART_Parity = USART_Parity_Odd;
-		USART_InitStructure.USART_WordLength = USART_WordLength_9b;
-		break;
-	case MB_PAR_EVEN: //偶校验
-		USART_InitStructure.USART_Parity = USART_Parity_Even;
-		USART_InitStructure.USART_WordLength = USART_WordLength_9b;
-		break;
-	default:
-		return FALSE;
-	}
-
-	USART_InitStructure.USART_StopBits = USART_StopBits_1;
-	USART_InitStructure.USART_HardwareFlowControl =
-			USART_HardwareFlowControl_None;
-	USART_InitStructure.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
-	if (ucPORT != 2)
-		return FALSE;
-
-	ENTER_CRITICAL_SECTION(); //关全局中断
-
-	USART_Init(USART2, &USART_InitStructure);
-	USART_ITConfig(USART2, USART_IT_RXNE, ENABLE);
-	USART_Cmd(USART2, ENABLE);
-
-	//=====================中断初始化======================================
-	//设置NVIC优先级分组为Group2：0-3抢占式优先级，0-3的响应式优先级
-	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_2);
-	NVIC_InitStructure.NVIC_IRQChannel = USART2_IRQn;
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
-	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
-	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-	NVIC_Init(&NVIC_InitStructure);
-
-	EXIT_CRITICAL_SECTION(); //开全局中断
-
-	return TRUE;
+	serial->parent.close(&(serial->parent));
 }
 
 BOOL xMBMasterPortSerialPutByte(CHAR ucByte)
 {
-	USART_SendData(USART2, ucByte);
+    serial->parent.write(&(serial->parent), 0, &ucByte, 1);
 	return TRUE;
 }
 
 BOOL xMBMasterPortSerialGetByte(CHAR * pucByte)
 {
-	*pucByte = USART_ReceiveData(USART2);
-	return TRUE;
+    serial->parent.read(&(serial->parent), 0, pucByte, 1);
+    return TRUE;
 }
 
 /* 
@@ -152,7 +178,7 @@ BOOL xMBMasterPortSerialGetByte(CHAR * pucByte)
  */
 void prvvUARTTxReadyISR(void)
 {
-	pxMBMasterFrameCBTransmitterEmpty();
+    pxMBMasterFrameCBTransmitterEmpty();
 }
 
 /* 
@@ -163,30 +189,37 @@ void prvvUARTTxReadyISR(void)
  */
 void prvvUARTRxISR(void)
 {
-	pxMBMasterFrameCBByteReceived();
+    pxMBMasterFrameCBByteReceived();
 }
-/*******************************************************************************
- * Function Name  : USART2_IRQHandler
- * Description    : This function handles USART2 global interrupt request.
- * Input          : None
- * Output         : None
- * Return         : None
- *******************************************************************************/
-void USART2_IRQHandler(void)
-{
-	rt_interrupt_enter();
-	//接收中断
-	if (USART_GetITStatus(USART2, USART_IT_RXNE) == SET)
-	{
-		USART_ClearITPendingBit(USART2, USART_IT_RXNE);
-		prvvUARTRxISR();
-	}
-	//发送中断
-	if (USART_GetITStatus(USART2, USART_IT_TXE) == SET)
-	{
-		prvvUARTTxReadyISR();
-	}
-	rt_interrupt_leave();
+
+/**
+ * Software simulation serial transmit IRQ handler.
+ *
+ * @param parameter parameter
+ */
+static void serial_soft_trans_irq(void* parameter) {
+    rt_uint32_t recved_event;
+    while (1)
+    {
+        /* waiting for serial transmit start */
+        rt_event_recv(&event_serial, EVENT_SERIAL_TRANS_START, RT_EVENT_FLAG_OR,
+                RT_WAITING_FOREVER, &recved_event);
+        /* execute modbus callback */
+        prvvUARTTxReadyISR();
+    }
+}
+
+/**
+ * This function is serial receive callback function
+ *
+ * @param dev the device of serial
+ * @param size the data size that receive
+ *
+ * @return return RT_EOK
+ */
+static rt_err_t serial_rx_ind(rt_device_t dev, rt_size_t size) {
+    prvvUARTRxISR();
+    return RT_EOK;
 }
 
 #endif

--- a/components/net/freemodbus-v1.6.0/port/portserial_m.c
+++ b/components/net/freemodbus-v1.6.0/port/portserial_m.c
@@ -25,7 +25,7 @@
 #include "mb.h"
 #include "mbport.h"
 #include "rtdevice.h"
-#include "bsp.h"
+#include "board.h"
 
 #if MB_MASTER_RTU_ENABLED > 0 || MB_MASTER_ASCII_ENABLED > 0
 /* ----------------------- Static variables ---------------------------------*/

--- a/components/net/freemodbus-v1.6.0/port/porttimer.c
+++ b/components/net/freemodbus-v1.6.0/port/porttimer.c
@@ -1,5 +1,5 @@
 /*
- * FreeModbus Libary: STM32 Port
+ * FreeModbus Libary: RT-Thread Port
  * Copyright (C) 2013 Armink <armink.ztl@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -27,81 +27,37 @@
 #include "mbport.h"
 
 /* ----------------------- static functions ---------------------------------*/
+static struct rt_timer timer;
 static void prvvTIMERExpiredISR(void);
+static void timer_timeout_ind(void* parameter);
 
 /* ----------------------- Start implementation -----------------------------*/
 BOOL xMBPortTimersInit(USHORT usTim1Timerout50us)
 {
-
-	uint16_t PrescalerValue = 0;
-	TIM_TimeBaseInitTypeDef TIM_TimeBaseStructure;
-	NVIC_InitTypeDef NVIC_InitStructure;
-	//====================================时钟初始化===========================
-	//使能定时器3时钟
-	RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM3, ENABLE);
-	//====================================定时器初始化===========================
-	//定时器时间基配置说明
-	//HCLK为72MHz，APB1经过2分频为36MHz
-	//TIM3的时钟倍频后为72MHz（硬件自动倍频,达到最大）
-	//TIM3的分频系数为3599，时间基频率为72 / (1 + Prescaler) = 20KHz,基准为50us
-	//TIM最大计数值为usTim1Timerout50u
-	
-	PrescalerValue = (uint16_t) (SystemCoreClock / 20000) - 1;
-	//定时器1初始化
-	TIM_TimeBaseStructure.TIM_Period = (uint16_t) usTim1Timerout50us;
-	TIM_TimeBaseStructure.TIM_Prescaler = PrescalerValue;
-	TIM_TimeBaseStructure.TIM_ClockDivision = 0;
-	TIM_TimeBaseStructure.TIM_CounterMode = TIM_CounterMode_Up;
-	TIM_TimeBaseInit(TIM3, &TIM_TimeBaseStructure);
-	//预装载使能
-	TIM_ARRPreloadConfig(TIM3, ENABLE);
-	//====================================中断初始化===========================
-	//设置NVIC优先级分组为Group2：0-3抢占式优先级，0-3的响应式优先级
-	NVIC_PriorityGroupConfig(NVIC_PriorityGroup_2);
-	NVIC_InitStructure.NVIC_IRQChannel = TIM3_IRQn;
-	NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
-	NVIC_InitStructure.NVIC_IRQChannelSubPriority = 1;
-	NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-	NVIC_Init(&NVIC_InitStructure);
-	//清除溢出中断标志位
-	TIM_ClearITPendingBit(TIM3, TIM_IT_Update);
-	//定时器3溢出中断关闭
-	TIM_ITConfig(TIM3, TIM_IT_Update, DISABLE);
-	//定时器3禁能
-	TIM_Cmd(TIM3, DISABLE);
-	return TRUE;
+    rt_timer_init(&timer, "slave timer",
+                   timer_timeout_ind, /* bind timeout callback function */
+                   RT_NULL,
+                   (50*usTim1Timerout50us)/(1000*1000/RT_TICK_PER_SECOND),
+                   RT_TIMER_FLAG_ONE_SHOT); /* one shot */
+    return TRUE;
 }
 
 void vMBPortTimersEnable()
 {
-	TIM_ClearITPendingBit(TIM3, TIM_IT_Update);
-	TIM_ITConfig(TIM3, TIM_IT_Update, ENABLE);
-	TIM_SetCounter(TIM3, 0);
-	TIM_Cmd(TIM3, ENABLE);
+    rt_timer_start(&timer);
 }
 
 void vMBPortTimersDisable()
 {
-	TIM_ClearITPendingBit(TIM3, TIM_IT_Update);
-	TIM_ITConfig(TIM3, TIM_IT_Update, DISABLE);
-	TIM_SetCounter(TIM3, 0);
-	TIM_Cmd(TIM3, DISABLE);
+    rt_timer_stop(&timer);
 }
 
 void prvvTIMERExpiredISR(void)
 {
-	(void) pxMBPortCBTimerExpired();
+    (void) pxMBPortCBTimerExpired();
 }
 
-void TIM3_IRQHandler(void)
+static void timer_timeout_ind(void* parameter)
 {
-	rt_interrupt_enter();
-	if (TIM_GetITStatus(TIM3, TIM_IT_Update) != RESET)
-	{
-		
-		TIM_ClearFlag(TIM3, TIM_FLAG_Update);	     //清中断标记
-		TIM_ClearITPendingBit(TIM3, TIM_IT_Update);	 //清除定时器T3溢出中断标志位
-		prvvTIMERExpiredISR();
-	}
-	rt_interrupt_leave();
+    prvvTIMERExpiredISR();
 }

--- a/components/net/freemodbus-v1.6.0/port/porttimer_m.c
+++ b/components/net/freemodbus-v1.6.0/port/porttimer_m.c
@@ -54,44 +54,44 @@ BOOL xMBMasterPortTimersInit(USHORT usTimeOut50us)
 
 void vMBMasterPortTimersT35Enable()
 {
-	rt_tick_t timer_tick = (50 * usT35TimeOut50us)
-			/ (1000 * 1000 / RT_TICK_PER_SECOND);
+    rt_tick_t timer_tick = (50 * usT35TimeOut50us)
+            / (1000 * 1000 / RT_TICK_PER_SECOND);
 
     /* Set current timer mode, don't change it.*/
     vMBMasterSetCurTimerMode(MB_TMODE_T35);
 
-	rt_timer_control(&timer, RT_TIMER_CTRL_SET_TIME, &timer_tick);
+    rt_timer_control(&timer, RT_TIMER_CTRL_SET_TIME, &timer_tick);
 
     rt_timer_start(&timer);
 }
 
 void vMBMasterPortTimersConvertDelayEnable()
 {
-	rt_tick_t timer_tick = MB_MASTER_DELAY_MS_CONVERT * RT_TICK_PER_SECOND / 1000;
+    rt_tick_t timer_tick = MB_MASTER_DELAY_MS_CONVERT * RT_TICK_PER_SECOND / 1000;
 
     /* Set current timer mode, don't change it.*/
     vMBMasterSetCurTimerMode(MB_TMODE_CONVERT_DELAY);
 
-	rt_timer_control(&timer, RT_TIMER_CTRL_SET_TIME, &timer_tick);
+    rt_timer_control(&timer, RT_TIMER_CTRL_SET_TIME, &timer_tick);
 
     rt_timer_start(&timer);
 }
 
 void vMBMasterPortTimersRespondTimeoutEnable()
 {
-	rt_tick_t timer_tick = MB_MASTER_TIMEOUT_MS_RESPOND * RT_TICK_PER_SECOND / 1000;
+    rt_tick_t timer_tick = MB_MASTER_TIMEOUT_MS_RESPOND * RT_TICK_PER_SECOND / 1000;
 
     /* Set current timer mode, don't change it.*/
     vMBMasterSetCurTimerMode(MB_TMODE_RESPOND_TIMEOUT);
 
-	rt_timer_control(&timer, RT_TIMER_CTRL_SET_TIME, &timer_tick);
+    rt_timer_control(&timer, RT_TIMER_CTRL_SET_TIME, &timer_tick);
 
     rt_timer_start(&timer);
 }
 
 void vMBMasterPortTimersDisable()
 {
-	rt_timer_stop(&timer);
+    rt_timer_stop(&timer);
 }
 
 void prvvTIMERExpiredISR(void)

--- a/components/net/freemodbus-v1.6.0/port/user_mb_app.c
+++ b/components/net/freemodbus-v1.6.0/port/user_mb_app.c
@@ -260,8 +260,8 @@ eMBErrorCode eMBRegDiscreteCB( UCHAR * pucRegBuffer, USHORT usAddress, USHORT us
     if ((usAddress >= DISCRETE_INPUT_START)
             && (usAddress + usNDiscrete    <= DISCRETE_INPUT_START + DISCRETE_INPUT_NDISCRETES))
     {
-        iRegIndex = (USHORT) (usAddress - usDiscreteInputStart) / 8; //每个寄存器存8个
-        iRegBitIndex = (USHORT) (usAddress - usDiscreteInputStart) % 8; //相对于寄存器内部的位地址
+        iRegIndex = (USHORT) (usAddress - usDiscreteInputStart) / 8;
+        iRegBitIndex = (USHORT) (usAddress - usDiscreteInputStart) % 8;
 
         while (iNReg > 0)
         {

--- a/components/net/freemodbus-v1.6.0/port/user_mb_app.h
+++ b/components/net/freemodbus-v1.6.0/port/user_mb_app.h
@@ -18,8 +18,6 @@
 #define S_REG_HOLDING_NREGS           100
 /* salve mode: holding register's all address */
 #define          S_HD_RESERVE                     0
-#define          S_HD_CPU_USAGE_MAJOR             1
-#define          S_HD_CPU_USAGE_MINOR             2
 /* salve mode: input register's all address */
 #define          S_IN_RESERVE                     0
 /* salve mode: coil's all address */

--- a/components/net/freemodbus-v1.6.0/port/user_mb_app.h
+++ b/components/net/freemodbus-v1.6.0/port/user_mb_app.h
@@ -1,4 +1,4 @@
-#ifndef	USER_APP
+#ifndef    USER_APP
 #define USER_APP
 /* ----------------------- Modbus includes ----------------------------------*/
 #include "mb.h"
@@ -8,47 +8,41 @@
 #include "mbutils.h"
 
 /* -----------------------Slave Defines -------------------------------------*/
-#define S_DISCRETE_INPUT_START        1
+#define S_DISCRETE_INPUT_START        0
 #define S_DISCRETE_INPUT_NDISCRETES   16
-#define S_COIL_START                  1
+#define S_COIL_START                  0
 #define S_COIL_NCOILS                 64
-#define S_REG_INPUT_START             1
+#define S_REG_INPUT_START             0
 #define S_REG_INPUT_NREGS             100
-#define S_REG_HOLDING_START           1
+#define S_REG_HOLDING_START           0
 #define S_REG_HOLDING_NREGS           100
-//从机模式：在保持寄存器中，各个地址对应的功能定义
-#define          S_HD_RESERVE                     0		  //保留
-#define          S_HD_CPU_USAGE_MAJOR             1         //当前CPU利用率的整数位
-#define          S_HD_CPU_USAGE_MINOR             2         //当前CPU利用率的小数位
-
-//从机模式：在输入寄存器中，各个地址对应的功能定义
-#define          S_IN_RESERVE                     0		  //保留
-
-//从机模式：在线圈中，各个地址对应的功能定义
-#define          S_CO_RESERVE                     2		  //保留
-
-//从机模式：在离散输入中，各个地址对应的功能定义
-#define          S_DI_RESERVE                     1		  //保留
+/* salve mode: holding register's all address */
+#define          S_HD_RESERVE                     0
+#define          S_HD_CPU_USAGE_MAJOR             1
+#define          S_HD_CPU_USAGE_MINOR             2
+/* salve mode: input register's all address */
+#define          S_IN_RESERVE                     0
+/* salve mode: coil's all address */
+#define          S_CO_RESERVE                     0
+/* salve mode: discrete's all address */
+#define          S_DI_RESERVE                     0
 
 /* -----------------------Master Defines -------------------------------------*/
-#define M_DISCRETE_INPUT_START        1
+#define M_DISCRETE_INPUT_START        0
 #define M_DISCRETE_INPUT_NDISCRETES   16
-#define M_COIL_START                  1
+#define M_COIL_START                  0
 #define M_COIL_NCOILS                 64
-#define M_REG_INPUT_START             1
+#define M_REG_INPUT_START             0
 #define M_REG_INPUT_NREGS             100
-#define M_REG_HOLDING_START           1
+#define M_REG_HOLDING_START           0
 #define M_REG_HOLDING_NREGS           100
-//主机模式：在保持寄存器中，各个地址对应的功能定义
-#define          M_HD_RESERVE                     0		  //保留
-
-//主机模式：在输入寄存器中，各个地址对应的功能定义
-#define          M_IN_RESERVE                     0		  //保留
-
-//主机模式：在线圈中，各个地址对应的功能定义
-#define          M_CO_RESERVE                     2		  //保留
-
-//主机模式：在离散输入中，各个地址对应的功能定义
-#define          M_DI_RESERVE                     1		  //保留
+/* master mode: holding register's all address */
+#define          M_HD_RESERVE                     0
+/* master mode: input register's all address */
+#define          M_IN_RESERVE                     0
+/* master mode: coil's all address */
+#define          M_CO_RESERVE                     0
+/* master mode: discrete's all address */
+#define          M_DI_RESERVE                     0
 
 #endif


### PR DESCRIPTION
1、更新FreeModbus主机及从机代码至最新版本；
2、移植采用RTT自带的设备驱动框架，降低在RTT平台上的移植难度。