### PR TITLE
Fix compile warning

### DIFF
--- a/libcpu/arm/cortex-m3/context_rvds.S
+++ b/libcpu/arm/cortex-m3/context_rvds.S
@@ -203,4 +203,5 @@ HardFault_Handler    PROC
     BX      lr
     ENDP
 
+    NOP
     END


### PR DESCRIPTION
..\..\libcpu\arm\cortex-m3\context_rvds.S(207):  
warning: A1581W: Added 2 bytes of padding at address 0xd6