### PR TITLE
building: PrepareBuilding forgot to declare BuildOptions as global

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -259,6 +259,7 @@ def PrepareBuilding(env, root_directory, has_libcpu=False, remove_components = [
 def PrepareModuleBuilding(env, root_directory, bsp_directory):
     import rtconfig
 
+    global BuildOptions
     global Env
     global Rtt_Root
 


### PR DESCRIPTION
The global variables in the building.py are totally a pile of shit.