### PR TITLE
mv device ctl cmd macros from serial.h to rtdef.h

### DIFF
--- a/components/drivers/include/drivers/serial.h
+++ b/components/drivers/include/drivers/serial.h
@@ -65,11 +65,6 @@
 #define RT_SERIAL_RB_BUFSZ              64
 #endif
 
-#define RT_DEVICE_CTRL_CONFIG           0x03    /* configure device */
-#define RT_DEVICE_CTRL_SET_INT          0x10    /* enable receive irq */
-#define RT_DEVICE_CTRL_CLR_INT          0x11    /* disable receive irq */
-#define RT_DEVICE_CTRL_GET_INT          0x12
-
 #define RT_SERIAL_EVENT_RX_IND          0x01    /* Rx indication */
 #define RT_SERIAL_EVENT_TX_DONE         0x02    /* Tx complete   */
 #define RT_SERIAL_EVENT_RX_DMADONE      0x03    /* Rx DMA transfer done */

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -776,6 +776,11 @@ enum rt_device_class_type
 #define RT_DEVICE_FLAG_SUSPENDED        0x020           /**< device is suspended */
 #define RT_DEVICE_FLAG_STREAM           0x040           /**< stream mode */
 
+#define RT_DEVICE_CTRL_CONFIG           0x03    	/* configure device */
+#define RT_DEVICE_CTRL_SET_INT          0x10    	/* enable receive irq */
+#define RT_DEVICE_CTRL_CLR_INT          0x11    	/* disable receive irq */
+#define RT_DEVICE_CTRL_GET_INT          0x12
+
 #define RT_DEVICE_FLAG_INT_RX           0x100           /**< INT mode on Rx */
 #define RT_DEVICE_FLAG_DMA_RX           0x200           /**< DMA mode on Rx */
 #define RT_DEVICE_FLAG_INT_TX           0x400           /**< INT mode on Tx */


### PR DESCRIPTION
Maybe it is the best place to define these macros