### PR TITLE
correct rx_fifo init size error

### DIFF
--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -279,7 +279,7 @@ static rt_err_t rt_serial_open(struct rt_device *dev, rt_uint16_t oflag)
                 serial->config.bufsz);
             RT_ASSERT(rx_fifo != RT_NULL);
             rx_fifo->buffer = (rt_uint8_t*) (rx_fifo + 1);
-            rt_memset(rx_fifo->buffer, 0, RT_SERIAL_RB_BUFSZ);
+            rt_memset(rx_fifo->buffer, 0, serial->config.bufsz);
             rx_fifo->put_index = 0;
             rx_fifo->get_index = 0;
 


### PR DESCRIPTION
rx_fifo init size is error