### PR TITLE
[DeviceDriver] Fix inverted logic on SConscript

### DIFF
--- a/components/drivers/src/SConscript
+++ b/components/drivers/src/SConscript
@@ -4,7 +4,7 @@ cwd = GetCurrentDir()
 src	= Glob('*.c')
 CPPPATH = [cwd + '/../include']
 
-if GetDepend('RT_USING_HEAP'):
+if not GetDepend('RT_USING_HEAP'):
     SrcRemove(src, 'dataqueue.c')
     SrcRemove(src, 'pipe.c')
 


### PR DESCRIPTION
Remove dataqueue/pipe if not enable RT_USING_HEAP, supply the missing `not`.