### PR TITLE
[DeviceDriver] stm32: Remove explicity clear of RXNE flag

### DIFF
--- a/bsp/stm32f0x/drivers/usart.c
+++ b/bsp/stm32f0x/drivers/usart.c
@@ -152,8 +152,6 @@ void USART1_IRQHandler(void)
     if(USART_GetITStatus(uart->uart_device, USART_IT_RXNE) != RESET)
     {
         rt_hw_serial_isr(&serial1, RT_SERIAL_EVENT_RX_IND);
-        /* clear interrupt */
-        USART_ClearITPendingBit(uart->uart_device, USART_IT_RXNE);
     }
     if (USART_GetITStatus(uart->uart_device, USART_IT_TC) != RESET)
     {
@@ -186,8 +184,6 @@ void USART2_IRQHandler(void)
     if(USART_GetITStatus(uart->uart_device, USART_IT_RXNE) != RESET)
     {
         rt_hw_serial_isr(&serial2, RT_SERIAL_EVENT_RX_IND);
-        /* clear interrupt */
-        USART_ClearITPendingBit(uart->uart_device, USART_IT_RXNE);
     }
     if (USART_GetITStatus(uart->uart_device, USART_IT_TC) != RESET)
     {

--- a/bsp/stm32f40x/drivers/usart.c
+++ b/bsp/stm32f40x/drivers/usart.c
@@ -177,8 +177,6 @@ void USART1_IRQHandler(void)
     if (USART_GetITStatus(uart->uart_device, USART_IT_RXNE) != RESET)
     {
         rt_hw_serial_isr(&serial1, RT_SERIAL_EVENT_RX_IND);
-        /* clear interrupt */
-        USART_ClearITPendingBit(uart->uart_device, USART_IT_RXNE);
     }
     if (USART_GetITStatus(uart->uart_device, USART_IT_TC) != RESET)
     {
@@ -211,8 +209,6 @@ void USART2_IRQHandler(void)
     if (USART_GetITStatus(uart->uart_device, USART_IT_RXNE) != RESET)
     {
         rt_hw_serial_isr(&serial2, RT_SERIAL_EVENT_RX_IND);
-        /* clear interrupt */
-        USART_ClearITPendingBit(uart->uart_device, USART_IT_RXNE);
     }
     if (USART_GetITStatus(uart->uart_device, USART_IT_TC) != RESET)
     {
@@ -245,8 +241,6 @@ void USART3_IRQHandler(void)
     if (USART_GetITStatus(uart->uart_device, USART_IT_RXNE) != RESET)
     {
         rt_hw_serial_isr(&serial3, RT_SERIAL_EVENT_RX_IND);
-        /* clear interrupt */
-        USART_ClearITPendingBit(uart->uart_device, USART_IT_RXNE);
     }
     if (USART_GetITStatus(uart->uart_device, USART_IT_TC) != RESET)
     {


### PR DESCRIPTION
According to STM32 Manual, the USART RXNE flag will be clear automatically after
read to the USART_DR register[1], so the call to USART_ClearITPendingBit is
unnecessary.

[1]: See RM0090 Reference Manual p.992, Bit 5