### PR TITLE
memheap: check the USED bit in rt_memheap_free

### DIFF
--- a/src/memheap.c
+++ b/src/memheap.c
@@ -517,6 +517,7 @@ void rt_memheap_free(void *ptr)
 
     /* check magic */
     RT_ASSERT((header_ptr->magic & RT_MEMHEAP_MASK) == RT_MEMHEAP_MAGIC);
+    RT_ASSERT(header_ptr->magic & RT_MEMHEAP_USED);
     /* check whether this block of memory has been over-written. */
     RT_ASSERT((header_ptr->next->magic & RT_MEMHEAP_MASK) == RT_MEMHEAP_MAGIC);
 


### PR DESCRIPTION
This will ease the debugging of double-free bug.