### PR TITLE
correct stm32f10x pin64 define error

### DIFF
--- a/bsp/stm32f10x/drivers/gpio.c
+++ b/bsp/stm32f10x/drivers/gpio.c
@@ -36,6 +36,7 @@ static const struct pin_index pins[] =
 {
 #if (STM32F10X_PIN_NUMBERS == 64)
     __STM32_PIN_DEFAULT,
+    __STM32_PIN_DEFAULT,
     __STM32_PIN(2, APB2, C, 13),
     __STM32_PIN(3, APB2, C, 14),
     __STM32_PIN(4, APB2, C, 15),


### PR DESCRIPTION
stm32 pin64 define error