### PR TITLE
update stm32f2/f4: fixed PLL_M define.

### DIFF
--- a/bsp/stm32f20x/Libraries/CMSIS/CM3/DeviceSupport/ST/STM32F2xx/system_stm32f2xx.c
+++ b/bsp/stm32f20x/Libraries/CMSIS/CM3/DeviceSupport/ST/STM32F2xx/system_stm32f2xx.c
@@ -142,7 +142,7 @@
 
 
 /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLL_M) * PLL_N */
-#define PLL_M      25
+#define PLL_M      (HSE_VALUE / 1000000)
 #define PLL_N      240
 
 /* SYSCLK = PLL_VCO / PLL_P */

--- a/bsp/stm32f40x/Libraries/CMSIS/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c
+++ b/bsp/stm32f40x/Libraries/CMSIS/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c
@@ -146,7 +146,7 @@
 
 /************************* PLL Parameters *************************************/
 /* PLL_VCO = (HSE_VALUE or HSI_VALUE / PLL_M) * PLL_N */
-#define PLL_M      25
+#define PLL_M      (HSE_VALUE / 1000000)
 #define PLL_N      336
 
 /* SYSCLK = PLL_VCO / PLL_P */


### PR DESCRIPTION
原来的PLL_M被定义为固定值25，当晶振不是25Mhz时，会出现主频与预设值不对应的。