### PR TITLE
rt_mutex_take () return the value is inconsistent with the actual state

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -258,6 +258,7 @@ typedef int (*init_fn_t)(void);
 #define RT_ENOSYS                       6               /**< No system */
 #define RT_EBUSY                        7               /**< Busy */
 #define RT_EIO                          8               /**< IO error */
+#define RT_ESCHED_LOCKED                9               /**< scheduler had locked */
 
 /*@}*/
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -251,6 +251,10 @@ void rt_schedule(void)
                                                (rt_uint32_t)&to_thread->sp);
             }
         }
+	}
+	else
+	{
+		rt_current_thread->error = RT_ESCHED_LOCKED;
     }
 
     /* enable interrupt */


### PR DESCRIPTION
Fix in some cases rt_mutex_take () return the value is inconsistent with the actual state