### PR TITLE
The problem of finding ethernet interface

### DIFF
--- a/components/net/lwip_dhcpd/dhcp_server.c
+++ b/components/net/lwip_dhcpd/dhcp_server.c
@@ -376,13 +376,24 @@ static void dhcpd_thread_entry(void *parameter)
 void dhcpd_start(char* netif_name)
 {
     rt_thread_t thread;
-    struct netif *netif = RT_NULL;
+    struct netif *netif = netif_list;
 
-    /* find ethernet interface. */
-    netif = netif_find(netif_name);
-    if (netif == RT_NULL)
+		 if(strlen(netif_name) > sizeof(netif->name))
     {
-        DEBUG_PRINTF("Not found network interface:%s\n", netif_name);
+        rt_kprintf("network interface name too long!\r\n");
+        return;
+    }
+		while(netif != RT_NULL)
+    {
+        if(strncmp(netif_name, netif->name, sizeof(netif->name)) == 0)
+            break;
+
+        netif = netif->next;
+        if( netif == RT_NULL )
+        {
+            rt_kprintf("network interface: %s not found!\r\n", netif_name);
+            return;
+        }
     }
 
     thread = rt_thread_create("dhcpd",

--- a/components/net/lwip_dhcpd/dhcp_server.c
+++ b/components/net/lwip_dhcpd/dhcp_server.c
@@ -378,12 +378,12 @@ void dhcpd_start(char* netif_name)
     rt_thread_t thread;
     struct netif *netif = netif_list;
 
-		 if(strlen(netif_name) > sizeof(netif->name))
+    if(strlen(netif_name) > sizeof(netif->name))
     {
         rt_kprintf("network interface name too long!\r\n");
         return;
     }
-		while(netif != RT_NULL)
+    while(netif != RT_NULL)
     {
         if(strncmp(netif_name, netif->name, sizeof(netif->name)) == 0)
             break;


### PR DESCRIPTION
Since it use "netif_find" function, the num variable in netif_find() will return meaningless value when you are using "e0" , eventually it will return NULL for struct netif. This patch was used to solve this problem.