### PR TITLE
[libcpu][am335x] Fix the booting failure when enabling MMU

### DIFF
--- a/libcpu/arm/am335x/mmu.c
+++ b/libcpu/arm/am335x/mmu.c
@@ -15,7 +15,7 @@
 #include <rtthread.h>
 #include "am33xx.h"
 
-#define DESC_SEC		(0x2|(1<<4))
+#define DESC_SEC		(0x2)
 #define CB				(3<<2)  //cache_on, write_back
 #define CNB				(2<<2)  //cache_on, write_through
 #define NCB				(1<<2)  //cache_off,WR_BUF on


### PR DESCRIPTION
Since the 16 domains are configured as the client domains in
mmu_setttbase(), a Permission fault is generated if the XN bit
(Execute-never) is set in the short-descriptor translation table
(for section and supersection). This leads to the booting failure
when enabling MMU for beagleboard bsp. Here is log:

----------------------------------------------------------------
SD/MMC found on device 0
reading uEnv.txt
117 bytes read in 3 ms (38.1 KiB/s)
Loaded environment from uEnv.txt
Importing environment from mmc ...
Running uenvcmd ...
reading rtthread.bin
162624 bytes read in 24 ms (6.5 MiB/s)
\## Starting application at 0x80200000 ...

----------------------------------------------------------------

This commit removes the XN bit configuration in the section of the
short-descriptor translation table. The OS can be booted successfully
with applying this commit.