### PR TITLE
fixed assembly warnings.

### DIFF
--- a/libcpu/arm/cortex-m0/context_rvds.S
+++ b/libcpu/arm/cortex-m0/context_rvds.S
@@ -183,13 +183,11 @@ rt_hw_context_switch_to    PROC
     LDR     r0, =NVIC_INT_CTRL
     LDR     r1, =NVIC_PENDSVSET
     STR     r1, [r0]
-    NOP
 
     ; restore MSP
     LDR     r0, =SCB_VTOR
     LDR     r0, [r0]
     LDR     r0, [r0]
-    NOP
     MSR     msp, r0
 
     ; enable interrupts at processor level
@@ -215,5 +213,7 @@ HardFault_Handler    PROC
     BL      rt_hw_hard_fault_exception
     POP     {pc}
     ENDP
+
+    ALIGN   4
 
     END

--- a/libcpu/arm/cortex-m3/context_rvds.S
+++ b/libcpu/arm/cortex-m3/context_rvds.S
@@ -177,7 +177,6 @@ rt_hw_context_switch_to    PROC
 rt_hw_interrupt_thread_switch PROC
     EXPORT rt_hw_interrupt_thread_switch
     BX      lr
-    NOP
     ENDP
 
     IMPORT rt_hw_hard_fault_exception
@@ -203,5 +202,6 @@ HardFault_Handler    PROC
     BX      lr
     ENDP
 
-    NOP
+    ALIGN   4
+
     END

--- a/libcpu/arm/cortex-m4/context_rvds.S
+++ b/libcpu/arm/cortex-m4/context_rvds.S
@@ -218,7 +218,6 @@ rt_hw_context_switch_to    PROC
 rt_hw_interrupt_thread_switch PROC
     EXPORT rt_hw_interrupt_thread_switch
     BX      lr
-    NOP
     ENDP
 
     IMPORT rt_hw_hard_fault_exception
@@ -234,5 +233,7 @@ HardFault_Handler    PROC
     ORR     lr, lr, #0x04
     BX      lr
     ENDP
+
+    ALIGN   4
 
     END


### PR DESCRIPTION
使用 ALIGN 显式对齐，消除自动填充带来的警告。