### PR TITLE
when the macro of RT_USING_COMPONENTS_INIT is not open ,then remove the source of components.c  from the project.

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -15,6 +15,9 @@ if rtconfig.CROSS_TOOL == 'keil':
 else:
     LINKFLAGS = ''
 
+if GetDepend('RT_USING_COMPONENTS_INIT') == False:
+    SrcRemove(src, ['components.c'])
+
 if GetDepend('RT_USING_MODULE') == False:
     SrcRemove(src, ['module.c'])
 


### PR DESCRIPTION
when the macro of RT_USING_COMPONENTS_INIT is not open ,then remove the source of components.c  from the project.
