### PR TITLE
Update timer.c

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -353,7 +353,7 @@ rt_err_t rt_timer_start(rt_timer_t timer)
              * So insert the new timer to the end the the some-timeout timer
              * list.
              */
-            if ((t->timeout_tick - timer->timeout_tick) == 0)
+            if (((t->timeout_tick - timer->timeout_tick) == 0) && (timer->init_tick >= t->init_tick))
             {
                 continue;
             }


### PR DESCRIPTION
If we have two timers which periods are 10 and 30 ticks, the output will be listed as:

periodic timer1 is timeout:10
periodic timer1 is timeout:20
periodic timer2 is timeout:30
periodic timer1 is timeout:30

this may not be resonable especially in the rm scheduling. so this patch can correct this issue.

the new output:
 periodic timer1 is timeout:10
periodic timer1 is timeout:20
periodic timer1 is timeout:30
periodic timer2 is timeout:30