### PR TITLE
add support of rms

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -369,6 +369,9 @@ enum rt_object_class_type
 #ifdef RT_USING_MODULE
     RT_Object_Class_Module,                             /**< The object is a module. */
 #endif
+#ifdef RT_USING_RMS
+    RT_Object_Class_Rms,                                /**< The object is a rms */
+#endif
     RT_Object_Class_Unknown,                            /**< The object is unknown. */
     RT_Object_Class_Static = 0x80                       /**< The object is a static object. */
 };
@@ -527,6 +530,20 @@ struct rt_thread
     rt_uint32_t user_data;                              /**< private user data beyond this thread */
 };
 typedef struct rt_thread *rt_thread_t;
+
+#ifdef RT_USING_RMS
+
+#define RT_RMS_INACTIVE    0
+#define RT_RMS_ACTIVE      1
+
+struct rt_rms
+{
+    struct rt_object parent;
+    rt_uint8_t rt_rms_stat;
+    rt_tick_t deadline;
+};
+typedef struct rt_rms *rt_rms_t;
+#endif
 
 /*@}*/
 

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -153,6 +153,20 @@ rt_err_t rt_thread_suspend(rt_thread_t thread);
 rt_err_t rt_thread_resume(rt_thread_t thread);
 void rt_thread_timeout(void *parameter);
 
+#ifdef RT_USING_RMS
+void rt_rms_init(rt_rms_t rms, const char *name);
+
+rt_rms_t rt_rms_create(const char *name);
+
+rt_err_t rt_rms_detach(rt_rms_t rms);
+
+
+rt_err_t rt_rms_delete(rt_rms_t rms);
+
+rt_err_t rt_rms_period(rt_rms_t rms, rt_tick_t period);
+						
+#endif
+
 /*
  * idle thread interface
  */

--- a/src/object.c
+++ b/src/object.c
@@ -74,6 +74,9 @@ struct rt_object_information rt_object_container[RT_Object_Class_Unknown] =
     /* initialize object container - module */
     {RT_Object_Class_Module, _OBJ_CONTAINER_LIST_INIT(RT_Object_Class_Module), sizeof(struct rt_module)},
 #endif
+#ifdef RT_USING_RMS
+    {RT_Object_Class_Rms, _OBJ_CONTAINER_LIST_INIT(RT_Object_Class_Rms), sizeof(struct rt_rms)},
+#endif
 };
 
 #ifdef RT_USING_HOOK

--- a/src/rms.c
+++ b/src/rms.c
@@ -1,0 +1,149 @@
+/*
+ *  File : rms.c
+ *  This file is part of RT-Thread RTOS
+ *  COPYRIGHT (C) 2006 - 2015, RT-Thread Development Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Change Logs:
+ *  Date           Author       Notes
+ *  2015-05-25     hduffddybz   first version
+ */
+
+#include <rtthread.h>
+#include <rthw.h>
+
+#ifdef RT_USING_RMS
+
+static void _rt_rms_init(rt_rms_t rms)
+{
+    rms->rt_rms_stat = RT_RMS_INACTIVE;
+    rms->deadline = 0;
+}
+
+/**
+ * This function will initialize a rms task
+ */
+void rt_rms_init(rt_rms_t rms, const char *name)
+{
+    RT_ASSERT(rms != RT_NULL);
+
+    /* rms object initialization */
+    rt_object_init((rt_object_t)rms, RT_Object_Class_Rms, name);
+
+    _rt_rms_init(rms);	
+}
+
+/**
+ * This function will create the rms task
+ */
+rt_rms_t rt_rms_create(const char *name)
+{
+    struct rt_rms *rms;
+	
+    /* allocate a rms object */
+    rms = (struct rt_rms *)rt_object_allocate(RT_Object_Class_Rms, name);
+    if(rms == RT_NULL)
+    {		
+        return RT_NULL;
+    }	
+    /* set status and deadline of rms object */
+    _rt_rms_init(rms);
+
+    return rms;
+}
+
+/**
+ * This function will detach a rms object
+ */
+rt_err_t rt_rms_detach(rt_rms_t rms)
+{
+    RT_ASSERT(rms != RT_NULL);
+	
+    rms->rt_rms_stat = RT_RMS_INACTIVE;
+    rt_object_detach((rt_object_t)rms);
+	
+    return RT_EOK;
+}
+
+/**
+ * This function will delete the rms task
+ */
+rt_err_t rt_rms_delete(rt_rms_t rms)
+{
+    RT_ASSERT(rms != RT_NULL);
+	
+    /* only change the stat of rms object, the application should call break manually */
+    rms->rt_rms_stat = RT_RMS_INACTIVE;
+    rt_object_delete((rt_object_t)rms);
+	
+    return RT_EOK;
+}
+
+/**
+ * This function will set the period of rms task
+ */
+rt_err_t rt_rms_period(rt_rms_t rms, rt_tick_t period)
+{
+    rt_tick_t end_time;
+    rt_tick_t temp;
+    rt_thread_t thread;
+	
+    RT_ASSERT(rms != RT_NULL);
+    RT_ASSERT(period != 0);
+	
+    switch(rms->rt_rms_stat)
+    {
+    case RT_RMS_INACTIVE:
+        rms->deadline = rt_tick_get() + period;
+#ifndef RT_RMS_ACCURACY
+#define RT_RMS_ACCURACY		1
+#endif			
+        temp = period / RT_RMS_ACCURACY;
+        thread = rt_thread_self();
+        /* change the priority of thread */
+        rt_thread_control(thread,
+                          RT_THREAD_CTRL_CHANGE_PRIORITY,
+                          &temp);
+        /* set the stat of rms object */				  
+        rms->rt_rms_stat = RT_RMS_ACTIVE;
+			
+        return RT_EOK;
+
+    case RT_RMS_ACTIVE:
+        end_time = rt_tick_get();
+
+        end_time = rms->deadline - end_time;
+        /* guarantee that task did not exceed deadline  */
+        if(end_time < 0)
+        {
+            return RT_ERROR;
+        }
+         
+        /* set the next period */		 
+        rms->deadline += period;
+        /* sleep until next period comes */
+        if(end_time != 0)
+        {
+            rt_thread_sleep(end_time);
+        }
+		
+        return RT_EOK;
+			
+    default:
+        return RT_ERROR;			
+    }
+}
+#endif


### PR DESCRIPTION
This is a very simple implementation of rms, it may not change the interface of "task creation and so on". So, you can use rm scheduling without any changes in your code.You can only use one rms task in one thread.

Please concern that #496 was a patch using for the correctness of timer which is related to rms.
If you want to use rms, please use "#define RT_USING_RMS" in your rtconfig.h, a very simple demo can list below:

``` c

#include <rtthread.h>
 
#define THREAD_PRIORITY         25
#define THREAD_STACK_SIZE       512
#define THREAD_TIMESLICE        5
 

static rt_thread_t tid1 = RT_NULL, tid2 = RT_NULL;
static rt_rms_t rms1 = RT_NULL, rms2 = RT_NULL;
 

static void thread_entry(void* parameter)
{
	rt_tick_t now, last, diff = 0;
	int a;
	
	rms1 = rt_rms_create("rms1");
	last = rt_tick_get();
	while(1)
	{
		rt_rms_period(rms1, 10);
		now = rt_tick_get();
		diff = now;
		diff = diff - last;
		last = now;
		
		for(a = 0; a < 1000; a++);
		
		rt_kprintf("thread1:%d\n", diff);
//  		if(rt_rms_delete(rms1) == RT_NULL)
// 			break;
 
	}
}
 
static void thread2_entry(void* parameter)
{
	rt_tick_t now, last, diff = 0;
	int a;
	
	rms2 = rt_rms_create("rms1");
	last = rt_tick_get();
	while(1)
	{
		rt_rms_period(rms2, 20);
		now = rt_tick_get();
		diff = now;
		diff = diff - last;
		last = now;
		
		for(a = 0; a < 1000; a++);
 
		rt_kprintf("thread2:%d\n", diff);
 
	}
}

int rt_application_init()
{

    tid1 = rt_thread_create("t1",
        thread_entry, (void*)1, 
        THREAD_STACK_SIZE, THREAD_PRIORITY + 1, THREAD_TIMESLICE);
    if (tid1 != RT_NULL)
        rt_thread_startup(tid1);
    else
        return -1;
 
    tid2 = rt_thread_create("t2",
		thread2_entry, (void *)1,
		THREAD_STACK_SIZE, THREAD_PRIORITY, THREAD_TIMESLICE);
    if(tid2 != RT_NULL)
        rt_thread_startup(tid2);
    else
        return -1;		
 
    return 0;
}

```