### PR TITLE
update scons MDK5 project script: clean old groups.

### DIFF
--- a/tools/keil.py
+++ b/tools/keil.py
@@ -310,6 +310,7 @@ def MDK5Project(target, script):
     groups = tree.find('Targets/Target/Groups')
     if groups is None:
         groups = SubElement(tree.find('Targets/Target'), 'Groups')
+    groups.clear() # clean old groups
     for group in script:
         group_xml = MDK4AddGroup(ProjectFiles, groups, group['name'], group['src'], project_path)
 


### PR DESCRIPTION
生成MDK时，如果模板中有一些分组，则删除之。