### PR TITLE
fixed rt_can_close issues.

### DIFF
--- a/components/drivers/can/can.c
+++ b/components/drivers/can/can.c
@@ -433,7 +433,7 @@ static rt_err_t rt_can_close(struct rt_device *dev)
     {
         struct rt_can_tx_fifo *tx_fifo;
 
-        tx_fifo = (struct rt_can_tx_fifo *)can->can_rx;
+        tx_fifo = (struct rt_can_tx_fifo *)can->can_tx;
         RT_ASSERT(tx_fifo != RT_NULL);
 
         rt_free(tx_fifo);


### PR DESCRIPTION
修正代码拼写错误，造成关闭CAN设备时出错的问题。