### PR TITLE
open and then get the new device

### DIFF
--- a/src/kservice.c
+++ b/src/kservice.c
@@ -1073,8 +1073,8 @@ rt_device_t rt_console_set_device(const char *name)
         }
 
         /* set new console device */
+        rt_device_open(new, RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_STREAM);
         _console_device = new;
-        rt_device_open(_console_device, RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_STREAM);
     }
 
     return old;


### PR DESCRIPTION
in rt_console_set_device, open new device first and get the new device to _console_device.
我在编写程序时，在device驱动中打印log，但是使用rt_kprintf时，如果_console_device存在非空，那就执行驱动的write函数，但是这是device还没有初始化成功，但是已经提前给_console_device赋值，导致了程序无故fault，以上述修改可避开这样的矛盾。