### PR TITLE
[libc][dlib] Add missing definition of mode_t

### DIFF
--- a/components/libc/dlib/sys/types.h
+++ b/components/libc/dlib/sys/types.h
@@ -9,4 +9,6 @@ typedef rt_int32_t key_t;       /* Used for interprocess communication. */
 typedef rt_int32_t pid_t;       /* Used for process IDs and process group IDs. */
 typedef signed long ssize_t;    /* Used for a count of bytes or an error indication. */
 
+typedef int mode_t;
+
 #endif


### PR DESCRIPTION
For using pthread with IAR tool chain