### PR TITLE
为finsh导出API增加宏判断

### DIFF
--- a/components/finsh/finsh.h
+++ b/components/finsh/finsh.h
@@ -321,8 +321,14 @@ struct finsh_sysvar* finsh_sysvar_lookup(const char* name);
  * @param name the name of function.
  * @param desc the description of function, which will show in help.
  */
+#ifdef RT_USING_FINSH                
 #define FINSH_FUNCTION_EXPORT(name, desc)   \
     FINSH_FUNCTION_EXPORT_CMD(name, name, desc)
+#else
+#if !defined(FINSH_FUNCTION_EXPORT)
+#define FINSH_FUNCTION_EXPORT(name, desc)
+#endif
+#endif
 
 /**
  * @ingroup finsh
@@ -333,8 +339,14 @@ struct finsh_sysvar* finsh_sysvar_lookup(const char* name);
  * @param alias the alias name of function.
  * @param desc the description of function, which will show in help.
  */
+#ifdef RT_USING_FINSH
 #define FINSH_FUNCTION_EXPORT_ALIAS(name, alias, desc)  \
         FINSH_FUNCTION_EXPORT_CMD(name, alias, desc)
+#else
+#if !defined(FINSH_FUNCTION_EXPORT_ALIAS)
+#define FINSH_FUNCTION_EXPORT_ALIAS(name, alias, desc)
+#endif
+#endif
 
 /**
  * @ingroup finsh


### PR DESCRIPTION
复现BUG：
              在rtconfig.h中注释掉下面FINSH相关宏1）RT_USING_FINSH   2）FINSH_USING_SYMTAB  3）FINSH_USING_DESCRIPTION，重新编译工程，会出现错误

问题原因：
              1）finish.h和redef.h都定义了FINSH_FUNCTION_EXPORT这个宏
              2）文件中先包含rtdef.h，然后包含finish.h
              3）finish.h里面的没有检测是否启用FINISH功能，也没有检测FINSH_FUNCTION_EXPORT宏是否存在，从而直接覆盖掉rtdef.h里面的置空定义，所以FINSH_FUNCTION_EXPORT仍然不为空，so，编译时出现一堆错误

解决方案：
              增加FINSH开关检测，增加宏存在检测