### PR TITLE
[bsp][stm32f746g-disco] Fix MPU init bug.

### DIFF
--- a/bsp/stm32f7-disco/drivers/board.c
+++ b/bsp/stm32f7-disco/drivers/board.c
@@ -25,7 +25,7 @@
 #include <rtthread.h>
 #include "board.h"
 #include "sram.h"
-
+#include "drv_mpu.h"
 
 /**
  * @addtogroup STM32
@@ -165,7 +165,7 @@ void HAL_ResumeTick(void)
 void rt_hw_board_init()
 {
     /* Configure the MPU attributes as Write Through */
-    //mpu_init();
+    mpu_init();
 
     /* Enable the CPU Cache */
     CPU_CACHE_Enable();

--- a/bsp/stm32f7-disco/drivers/drv_mpu.c
+++ b/bsp/stm32f7-disco/drivers/drv_mpu.c
@@ -81,4 +81,4 @@ int mpu_init(void)
   HAL_MPU_Enable(MPU_PRIVILEGED_DEFAULT);
 	return 0;
 }
-INIT_BOARD_EXPORT(mpu_init);
+//INIT_BOARD_EXPORT(mpu_init);


### PR DESCRIPTION
1. Fixed the bug that MPU init function was called 2 times.