### PR TITLE
include iar startup code

### DIFF
--- a/bsp/stm32f40x/Libraries/SConscript
+++ b/bsp/stm32f40x/Libraries/SConscript
@@ -18,8 +18,8 @@ if rtconfig.CROSS_TOOL == 'gcc':
      src = src + ['CMSIS/ST/STM32F4xx/Source/Templates/gcc_ride7/startup_stm32f4xx.s']
 elif rtconfig.CROSS_TOOL == 'keil':
      src = src + ['CMSIS/ST/STM32F4xx/Source/Templates/arm/startup_stm32f4xx.s']
-# elif rtconfig.CROSS_TOOL == 'iar':
-    # src = src + ['CMSIS/CM3/DeviceSupport/ST/STM32F10x/startup/iar/' + startup_scripts[rtconfig.STM32_TYPE]]
+elif rtconfig.CROSS_TOOL == 'iar':
+    src = src + ['CMSIS/ST/STM32F4xx/Source/Templates/iar/startup_stm32f4xx.s']
 
 path = [cwd + '/STM32F4xx_StdPeriph_Driver/inc', 
     cwd + '/CMSIS/ST/STM32F4xx/Include',


### PR DESCRIPTION
fixed bug: 'scons --target=iar -s' output iar project missing startup code, and link file

修复scons生成IAR工程中没有startup code和链接文件，导致工程中断异常和Finsh无法工作