### PR TITLE
修正romfs在输入的目录名称比实际的名称短时存在的判断错误

### DIFF
--- a/components/dfs/filesystems/romfs/dfs_romfs.c
+++ b/components/dfs/filesystems/romfs/dfs_romfs.c
@@ -96,7 +96,8 @@ struct romfs_dirent *dfs_romfs_lookup(struct romfs_dirent *root_dirent, const ch
 		{
             if (check_dirent(&dirent[index]) != 0)
                 return RT_NULL;
-			if (rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
+			if (rt_strlen(dirent[index].name) == (subpath_end - subpath) &&
+					rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
 			{
 				dirent_size = dirent[index].size;
 


### PR DESCRIPTION
比如实际目录为abcde，msh执行 cd abc也能执行成功，判断名称时存在bug