### PR TITLE
Update stm32f40x_flash.icf

### DIFF
--- a/bsp/stm32f40x/stm32f40x_flash.icf
+++ b/bsp/stm32f40x/stm32f40x_flash.icf
@@ -8,6 +8,9 @@ define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
 define symbol __ICFEDIT_region_ROM_end__   = 0x0807FFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_RAM_end__   = 0x2001FFFF; /*STM32 F446RE*/
+
+/*Export the end address of ram, to avoid hard-code heap size in application*/
+export symbol __ICFEDIT_region_RAM_end__;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x200;
 define symbol __ICFEDIT_size_heap__   = 0x000;


### PR DESCRIPTION
Export the end address of ram, to avoid hard-code heap size in application

导出RAM结束地址，从而避免程序中出现
1）用hard-code的方式来定义HEAP
2）同时在*.icf和board.h里面修改RAM信息

以上两点都是容易导致bug的地方