### PR TITLE
【提交说明】：增加 CFS-文件系统

### DIFF
--- a/components/dfs/filesystems/cfs/SConscript
+++ b/components/dfs/filesystems/cfs/SConscript
@@ -1,0 +1,11 @@
+# RT-Thread building script for component
+
+from building import *
+
+cwd = GetCurrentDir()
+src = Glob('*.c')
+CPPPATH = [cwd]
+
+group = DefineGroup('Filesystem', src, depend = ['RT_USING_DFS', 'RT_USING_DFS_CFS'], CPPPATH = CPPPATH)
+
+Return('group')

--- a/components/dfs/filesystems/cfs/cfs-coffee.c
+++ b/components/dfs/filesystems/cfs/cfs-coffee.c
@@ -1,0 +1,1292 @@
+/*********************************************************************************************************
+**
+**                                苏州诺金智通信息科技有限公司
+**
+**                               Copyright All Rights Reserved
+**
+**--------------文件信息--------------------------------------------------------------------------------
+**
+** 文 件 名: spi_nor_cfs.c
+**
+** 创 建 人: Urey(风飘柳絮)
+**
+** 创建日期: 2015年11月11日
+**
+** 描    述: TODO
+*********************************************************************************************************/
+
+
+/*********************************************************************************************************
+**   头文件
+*********************************************************************************************************/
+#include <limits.h>
+#include <string.h>
+
+#include <cfs.h>
+#include "cfs-coffee.h"
+#include "cfs-coffee_arch.h"
+
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) rt_kprintf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+#if (__STDC_VERSION__ < 199901L)
+	#error "use option --c99(mdk) -std=c99 or -std=gnu99 to compile your code "
+#endif
+
+#define COFFEE_FD_FREE          0x0
+#define COFFEE_FD_READ          0x1
+#define COFFEE_FD_WRITE         0x2
+#define COFFEE_FD_APPEND        0x4
+
+#define COFFEE_FILE_MODIFIED    0x1
+
+#define INVALID_PAGE            ((coffee_page_t)-1)
+#define UNKNOWN_OFFSET          ((cfs_offset_t)-1)
+
+#define REMOVE_LOG      1
+#define CLOSE_FDS       1
+#define ALLOW_GC        1
+
+/* "Greedy" garbage collection erases as many sectors as possible. */
+#define GC_GREEDY       0
+/* "Reluctant" garbage collection stops after erasing one sector. */
+#define GC_RELUCTANT    1
+
+/* File descriptor macros. */
+#define FD_VALID(fd) \
+  ((fd) >= 0 && (fd) < COFFEE_FD_SET_SIZE && \
+   coffee_fd_set[(fd)].flags != COFFEE_FD_FREE)
+#define FD_READABLE(fd)   (coffee_fd_set[(fd)].flags & CFS_READ)
+#define FD_WRITABLE(fd)   (coffee_fd_set[(fd)].flags & CFS_WRITE)
+#define FD_APPENDABLE(fd) (coffee_fd_set[(fd)].flags & CFS_APPEND)
+
+/* File object macros. */
+#define FILE_MODIFIED(file) ((file)->flags & COFFEE_FILE_MODIFIED)
+#define FILE_FREE(file)   ((file)->max_pages == 0)
+#define FILE_UNREFERENCED(file) ((file)->references == 0)
+
+/* File header flags. */
+#define HDR_FLAG_VALID    0x1 /* Completely written header. */
+#define HDR_FLAG_ALLOCATED  0x2 /* Allocated file. */
+#define HDR_FLAG_OBSOLETE 0x4 /* File marked for GC. */
+#define HDR_FLAG_MODIFIED 0x8 /* Modified file, log exists. */
+#define HDR_FLAG_LOG    0x10  /* Log file. */
+#define HDR_FLAG_ISOLATED 0x20  /* Isolated page. */
+
+/* File header macros. */
+#define CHECK_FLAG(hdr, flag) ((hdr).flags & (flag))
+#define HDR_VALID(hdr)    CHECK_FLAG(hdr, HDR_FLAG_VALID)
+#define HDR_ALLOCATED(hdr)  CHECK_FLAG(hdr, HDR_FLAG_ALLOCATED)
+#define HDR_FREE(hdr)   !HDR_ALLOCATED(hdr)
+#define HDR_LOG(hdr)    CHECK_FLAG(hdr, HDR_FLAG_LOG)
+#define HDR_MODIFIED(hdr) CHECK_FLAG(hdr, HDR_FLAG_MODIFIED)
+#define HDR_ISOLATED(hdr) CHECK_FLAG(hdr, HDR_FLAG_ISOLATED)
+#define HDR_OBSOLETE(hdr)   CHECK_FLAG(hdr, HDR_FLAG_OBSOLETE)
+#define HDR_ACTIVE(hdr)   (HDR_ALLOCATED(hdr) && \
+                           !HDR_OBSOLETE(hdr) && \
+                           !HDR_ISOLATED(hdr))
+
+/* Shortcuts derived from the hardware-dependent configuration of Coffee. */
+#define COFFEE_SECTOR_COUNT (unsigned)(COFFEE_SIZE / COFFEE_SECTOR_SIZE)
+#define COFFEE_PAGE_COUNT \
+  ((coffee_page_t)(COFFEE_SIZE / COFFEE_PAGE_SIZE))
+#define COFFEE_PAGES_PER_SECTOR \
+  ((coffee_page_t)(COFFEE_SECTOR_SIZE / COFFEE_PAGE_SIZE))
+
+/* This structure is used for garbage collection statistics. */
+struct sector_status {
+  coffee_page_t active;
+  coffee_page_t obsolete;
+  coffee_page_t free;
+};
+
+
+/* This is needed because of a buggy compiler. */
+struct log_param {
+  cfs_offset_t offset;
+  const char *buf;
+  uint16_t size;
+};
+
+/*
+ * The protected memory consists of structures that should not be
+ * overwritten during system checkpointing because they may be used by
+ * the checkpointing implementation. These structures need not be
+ * protected if checkpointing is not used.
+ */
+static struct protected_mem_t {
+  struct file coffee_files[COFFEE_MAX_OPEN_FILES];
+  struct file_desc coffee_fd_set[COFFEE_FD_SET_SIZE];
+  coffee_page_t next_free;
+  char gc_wait;
+} protected_mem;
+static struct file *const coffee_files = protected_mem.coffee_files;
+static struct file_desc *const coffee_fd_set = protected_mem.coffee_fd_set;
+static coffee_page_t *const next_free = &protected_mem.next_free;
+static char *const gc_wait = &protected_mem.gc_wait;
+
+/*---------------------------------------------------------------------------*/
+static void
+write_header(struct file_header *hdr, coffee_page_t page)
+{
+  hdr->flags |= HDR_FLAG_VALID;
+  COFFEE_WRITE(hdr, sizeof(*hdr), page * COFFEE_PAGE_SIZE);
+}
+/*---------------------------------------------------------------------------*/
+static void
+read_header(struct file_header *hdr, coffee_page_t page)
+{
+  COFFEE_READ(hdr, sizeof(*hdr), page * COFFEE_PAGE_SIZE);
+#if DEBUG
+  if(HDR_ACTIVE(*hdr) && !HDR_VALID(*hdr)) {
+    PRINTF("Invalid header at page %u!\n", (unsigned)page);
+  }
+#endif
+}
+/*---------------------------------------------------------------------------*/
+static cfs_offset_t
+absolute_offset(coffee_page_t page, cfs_offset_t offset)
+{
+  return page * COFFEE_PAGE_SIZE + sizeof(struct file_header) + offset;
+}
+/*---------------------------------------------------------------------------*/
+static coffee_page_t
+get_sector_status(uint16_t sector, struct sector_status *stats)
+{
+  static coffee_page_t skip_pages;
+  static char last_pages_are_active;
+  struct file_header hdr;
+  coffee_page_t active, obsolete, free;
+  coffee_page_t sector_start, sector_end;
+  coffee_page_t page;
+
+  memset(stats, 0, sizeof(*stats));
+  active = obsolete = free = 0;
+
+  /*
+   * get_sector_status() is an iterative function using local static
+   * state. It therefore requires that the caller starts iterating from
+   * sector 0 in order to reset the internal state.
+   */
+  if(sector == 0) {
+    skip_pages = 0;
+    last_pages_are_active = 0;
+  }
+
+  sector_start = sector * COFFEE_PAGES_PER_SECTOR;
+  sector_end = sector_start + COFFEE_PAGES_PER_SECTOR;
+
+  /*
+   * Account for pages belonging to a file starting in a previous
+   * segment that extends into this segment. If the whole segment is
+   * covered, we do not need to continue counting pages in this iteration.
+   */
+  if(last_pages_are_active) {
+    if(skip_pages >= COFFEE_PAGES_PER_SECTOR) {
+      stats->active = COFFEE_PAGES_PER_SECTOR;
+      skip_pages -= COFFEE_PAGES_PER_SECTOR;
+      return 0;
+    }
+    active = skip_pages;
+  } else {
+    if(skip_pages >= COFFEE_PAGES_PER_SECTOR) {
+      stats->obsolete = COFFEE_PAGES_PER_SECTOR;
+      skip_pages -= COFFEE_PAGES_PER_SECTOR;
+      return skip_pages >= COFFEE_PAGES_PER_SECTOR ? 0 : skip_pages;
+    }
+    obsolete = skip_pages;
+  }
+
+  /* Determine the amount of pages of each type that have not been
+     accounted for yet in the current sector. */
+  for(page = sector_start + skip_pages; page < sector_end;) {
+    read_header(&hdr, page);
+    last_pages_are_active = 0;
+    if(HDR_ACTIVE(hdr)) {
+      last_pages_are_active = 1;
+      page += hdr.max_pages;
+      active += hdr.max_pages;
+    } else if(HDR_ISOLATED(hdr)) {
+      page++;
+      obsolete++;
+    } else if(HDR_OBSOLETE(hdr)) {
+      page += hdr.max_pages;
+      obsolete += hdr.max_pages;
+    } else {
+      free = sector_end - page;
+      break;
+    }
+  }
+
+  /*
+   * Determine the amount of pages in the following sectors that
+   * should be remembered for the next iteration. This is necessary
+   * because no page except the first of a file contains information
+   * about what type of page it is. A side effect of remembering this
+   * amount is that there is no need to read in the headers of each
+   * of these pages from the storage.
+   */
+  skip_pages = active + obsolete + free - COFFEE_PAGES_PER_SECTOR;
+  if(skip_pages > 0) {
+    if(last_pages_are_active) {
+      active = COFFEE_PAGES_PER_SECTOR - obsolete;
+    } else {
+      obsolete = COFFEE_PAGES_PER_SECTOR - active;
+    }
+  }
+
+  stats->active = active;
+  stats->obsolete = obsolete;
+  stats->free = free;
+
+  /*
+   * To avoid unnecessary page isolation, we notify the caller that
+   * "skip_pages" pages should be isolated only if the current file extent
+   * ends in the next sector. If the file extent ends in a more distant
+   * sector, however, the garbage collection can free the next sector
+   * immediately without requiring page isolation.
+   */
+  return (last_pages_are_active || (skip_pages >= COFFEE_PAGES_PER_SECTOR)) ?
+         0 : skip_pages;
+}
+/*---------------------------------------------------------------------------*/
+static void
+isolate_pages(coffee_page_t start, coffee_page_t skip_pages)
+{
+  struct file_header hdr;
+  coffee_page_t page;
+
+  /* Split an obsolete file starting in the previous sector and mark
+     the following pages as isolated. */
+  memset(&hdr, 0, sizeof(hdr));
+  hdr.flags = HDR_FLAG_ALLOCATED | HDR_FLAG_ISOLATED;
+
+  /* Isolation starts from the next sector. */
+  for(page = 0; page < skip_pages; page++) {
+    write_header(&hdr, start + page);
+  }
+  PRINTF("Coffee: Isolated %u pages starting in sector %d\n",
+         (unsigned)skip_pages, (int)start / COFFEE_PAGES_PER_SECTOR);
+}
+/*---------------------------------------------------------------------------*/
+static void
+collect_garbage(int mode)
+{
+  uint16_t sector;
+  struct sector_status stats;
+  coffee_page_t first_page, isolation_count;
+
+  PRINTF("Coffee: Running the file system garbage collector in %s mode\n",
+         mode == GC_RELUCTANT ? "reluctant" : "greedy");
+  /*
+   * The garbage collector erases as many sectors as possible. A sector is
+   * erasable if there are only free or obsolete pages in it.
+   */
+  for(sector = 0; sector < COFFEE_SECTOR_COUNT; sector++) {
+    isolation_count = get_sector_status(sector, &stats);
+    PRINTF("Coffee: Sector %u has %u active, %u obsolete, and %u free pages.\n",
+           sector, (unsigned)stats.active,
+           (unsigned)stats.obsolete, (unsigned)stats.free);
+
+    if(stats.active > 0) {
+      continue;
+    }
+
+    if((mode == GC_RELUCTANT && stats.free == 0) ||
+       (mode == GC_GREEDY && stats.obsolete > 0)) {
+      first_page = sector * COFFEE_PAGES_PER_SECTOR;
+      if(first_page < *next_free) {
+        *next_free = first_page;
+      }
+
+      if(isolation_count > 0) {
+        isolate_pages(first_page + COFFEE_PAGES_PER_SECTOR, isolation_count);
+      }
+
+      COFFEE_ERASE(sector);
+      PRINTF("Coffee: Erased sector %d!\n", sector);
+
+      if(mode == GC_RELUCTANT && isolation_count > 0) {
+        break;
+      }
+    }
+  }
+}
+/*---------------------------------------------------------------------------*/
+static coffee_page_t
+next_file(coffee_page_t page, struct file_header *hdr)
+{
+  /*
+   * The quick-skip algorithm for finding file extents is the most
+   * essential part of Coffee. The file allocation rules enables this
+   * algorithm to quickly jump over free areas and allocated extents
+   * after reading single headers and determining their status.
+   *
+   * The worst-case performance occurs when we encounter multiple long
+   * sequences of isolated pages, but such sequences are uncommon and
+   * always shorter than a sector.
+   */
+  if(HDR_FREE(*hdr)) {
+    return (page + COFFEE_PAGES_PER_SECTOR) & ~(COFFEE_PAGES_PER_SECTOR - 1);
+  } else if(HDR_ISOLATED(*hdr)) {
+    return page + 1;
+  }
+  return page + hdr->max_pages;
+}
+/*---------------------------------------------------------------------------*/
+static struct file *
+load_file(coffee_page_t start, struct file_header *hdr)
+{
+  int i, unreferenced, free;
+  struct file *file;
+
+  /*
+   * We prefer to overwrite a free slot since unreferenced ones
+   * contain usable data. Free slots are designated by the page
+   * value INVALID_PAGE.
+   */
+  for(i = 0, unreferenced = free = -1; i < COFFEE_MAX_OPEN_FILES; i++) {
+    if(FILE_FREE(&coffee_files[i])) {
+      free = i;
+      break;
+    } else if(FILE_UNREFERENCED(&coffee_files[i])) {
+      unreferenced = i;
+    }
+  }
+
+  if(free == -1) {
+    if(unreferenced != -1) {
+      i = unreferenced;
+    } else {
+      return NULL;
+    }
+  }
+
+  file = &coffee_files[i];
+  file->page = start;
+  file->end = UNKNOWN_OFFSET;
+  file->max_pages = hdr->max_pages;
+  file->flags = 0;
+  if(HDR_MODIFIED(*hdr)) {
+    file->flags |= COFFEE_FILE_MODIFIED;
+  }
+  /* We don't know the amount of records yet. */
+  file->record_count = -1;
+
+  return file;
+}
+/*---------------------------------------------------------------------------*/
+static struct file *
+find_file(const char *name)
+{
+  int i;
+  struct file_header hdr;
+  coffee_page_t page;
+
+  /* First check if the file metadata is cached. */
+  for(i = 0; i < COFFEE_MAX_OPEN_FILES; i++) {
+    if(FILE_FREE(&coffee_files[i])) {
+      continue;
+    }
+
+    read_header(&hdr, coffee_files[i].page);
+    if(HDR_ACTIVE(hdr) && !HDR_LOG(hdr) && strcmp(name, hdr.name) == 0) {
+      return &coffee_files[i];
+    }
+  }
+
+  /* Scan the flash memory sequentially otherwise. */
+  for(page = 0; page < COFFEE_PAGE_COUNT; page = next_file(page, &hdr)) {
+    read_header(&hdr, page);
+    if(HDR_ACTIVE(hdr) && !HDR_LOG(hdr) && strcmp(name, hdr.name) == 0) {
+      return load_file(page, &hdr);
+    }
+  }
+
+  return NULL;
+}
+/*---------------------------------------------------------------------------*/
+static cfs_offset_t
+file_end(coffee_page_t start)
+{
+  struct file_header hdr;
+  unsigned char buf[COFFEE_PAGE_SIZE];
+  coffee_page_t page;
+  int i;
+
+  read_header(&hdr, start);
+
+  /*
+   * Move from the end of the range towards the beginning and look for
+   * a byte that has been modified.
+   *
+   * An important implication of this is that if the last written bytes
+   * are zeroes, then these are skipped from the calculation.
+   */
+
+  for(page = hdr.max_pages - 1; page >= 0; page--) {
+    COFFEE_READ(buf, sizeof(buf), (start + page) * COFFEE_PAGE_SIZE);
+    for(i = COFFEE_PAGE_SIZE - 1; i >= 0; i--) {
+      if(buf[i] != 0) {
+        if(page == 0 && i < sizeof(hdr)) {
+          return 0;
+        }
+        return 1 + i + (page * COFFEE_PAGE_SIZE) - sizeof(hdr);
+      }
+    }
+  }
+
+  /* All bytes are writable. */
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static coffee_page_t
+find_contiguous_pages(coffee_page_t amount)
+{
+  coffee_page_t page, start;
+  struct file_header hdr;
+
+  start = INVALID_PAGE;
+  for(page = *next_free; page < COFFEE_PAGE_COUNT;) {
+    read_header(&hdr, page);
+    if(HDR_FREE(hdr)) {
+      if(start == INVALID_PAGE) {
+        start = page;
+        if(start + amount >= COFFEE_PAGE_COUNT) {
+          /* We can stop immediately if the remaining pages are not enough. */
+          break;
+        }
+      }
+
+      /* All remaining pages in this sector are free --
+         jump to the next sector. */
+      page = next_file(page, &hdr);
+
+      if(start + amount <= page) {
+        if(start == *next_free) {
+          *next_free = start + amount;
+        }
+        return start;
+      }
+    } else {
+      start = INVALID_PAGE;
+      page = next_file(page, &hdr);
+    }
+  }
+  return INVALID_PAGE;
+}
+/*---------------------------------------------------------------------------*/
+static int
+remove_by_page(coffee_page_t page, int remove_log, int close_fds,
+               int gc_allowed)
+{
+  struct file_header hdr;
+  int i;
+
+  read_header(&hdr, page);
+  if(!HDR_ACTIVE(hdr)) {
+    return -1;
+  }
+
+  if(remove_log && HDR_MODIFIED(hdr)) {
+    if(remove_by_page(hdr.log_page, !REMOVE_LOG, !CLOSE_FDS, !ALLOW_GC) < 0) {
+      return -1;
+    }
+  }
+
+  hdr.flags |= HDR_FLAG_OBSOLETE;
+  write_header(&hdr, page);
+
+  *gc_wait = 0;
+
+  /* Close all file descriptors that reference the removed file. */
+  if(close_fds) {
+    for(i = 0; i < COFFEE_FD_SET_SIZE; i++) {
+      if(coffee_fd_set[i].file != NULL && coffee_fd_set[i].file->page == page) {
+        coffee_fd_set[i].flags = COFFEE_FD_FREE;
+      }
+    }
+  }
+
+  for(i = 0; i < COFFEE_MAX_OPEN_FILES; i++) {
+    if(coffee_files[i].page == page) {
+      coffee_files[i].page = INVALID_PAGE;
+      coffee_files[i].references = 0;
+      coffee_files[i].max_pages = 0;
+    }
+  }
+
+#if !COFFEE_EXTENDED_WEAR_LEVELLING
+  if(gc_allowed) {
+    collect_garbage(GC_RELUCTANT);
+  }
+#endif
+
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+static coffee_page_t
+page_count(cfs_offset_t size)
+{
+  return (size + sizeof(struct file_header) + COFFEE_PAGE_SIZE - 1) /
+         COFFEE_PAGE_SIZE;
+}
+/*---------------------------------------------------------------------------*/
+static struct file *
+reserve(const char *name, coffee_page_t pages,
+        int allow_duplicates, unsigned flags)
+{
+  struct file_header hdr;
+  coffee_page_t page;
+  struct file *file;
+
+  if(!allow_duplicates && find_file(name) != NULL) {
+    return NULL;
+  }
+
+  page = find_contiguous_pages(pages);
+  if(page == INVALID_PAGE) {
+    if(*gc_wait) {
+      return NULL;
+    }
+    collect_garbage(GC_GREEDY);
+    page = find_contiguous_pages(pages);
+    if(page == INVALID_PAGE) {
+      *gc_wait = 1;
+      return NULL;
+    }
+  }
+
+  memset(&hdr, 0, sizeof(hdr));
+  strncpy(hdr.name, name, sizeof(hdr.name) - 1);
+  hdr.max_pages = pages;
+  hdr.flags = HDR_FLAG_ALLOCATED | flags;
+  write_header(&hdr, page);
+
+  PRINTF("Coffee: Reserved %u pages starting from %u for file %s\n",
+         pages, page, name);
+
+  file = load_file(page, &hdr);
+  if(file != NULL) {
+    file->end = 0;
+  }
+
+  return file;
+}
+/*---------------------------------------------------------------------------*/
+#if COFFEE_MICRO_LOGS
+static void
+adjust_log_config(struct file_header *hdr,
+                  uint16_t *log_record_size, uint16_t *log_records)
+{
+  *log_record_size = hdr->log_record_size == 0 ?
+    COFFEE_PAGE_SIZE : hdr->log_record_size;
+  *log_records = hdr->log_records == 0 ?
+    COFFEE_LOG_SIZE / *log_record_size : hdr->log_records;
+}
+#endif /* COFFEE_MICRO_LOGS */
+/*---------------------------------------------------------------------------*/
+#if COFFEE_MICRO_LOGS
+static uint16_t
+modify_log_buffer(uint16_t log_record_size,
+                  cfs_offset_t *offset, uint16_t *size)
+{
+  uint16_t region;
+
+  region = *offset / log_record_size;
+  *offset %= log_record_size;
+
+  if(*size > log_record_size - *offset) {
+    *size = log_record_size - *offset;
+  }
+
+  return region;
+}
+#endif /* COFFEE_MICRO_LOGS */
+/*---------------------------------------------------------------------------*/
+#if COFFEE_MICRO_LOGS
+static int
+get_record_index(coffee_page_t log_page, uint16_t search_records,
+                 uint16_t region)
+{
+  cfs_offset_t base;
+  uint16_t processed;
+  uint16_t batch_size;
+  int16_t match_index, i;
+
+  base = absolute_offset(log_page, sizeof(uint16_t) * search_records);
+  batch_size = search_records > COFFEE_LOG_TABLE_LIMIT ?
+    COFFEE_LOG_TABLE_LIMIT : search_records;
+  processed = 0;
+  match_index = -1;
+
+  {
+    uint16_t indices[batch_size];
+
+    while(processed < search_records && match_index < 0) {
+      if(batch_size + processed > search_records) {
+        batch_size = search_records - processed;
+      }
+
+      base -= batch_size * sizeof(indices[0]);
+      COFFEE_READ(&indices, sizeof(indices[0]) * batch_size, base);
+
+      for(i = batch_size - 1; i >= 0; i--) {
+        if(indices[i] - 1 == region) {
+          match_index = search_records - processed - (batch_size - i);
+          break;
+        }
+      }
+
+      processed += batch_size;
+    }
+  }
+
+  return match_index;
+}
+#endif /* COFFEE_MICRO_LOGS */
+/*---------------------------------------------------------------------------*/
+#if COFFEE_MICRO_LOGS
+static int
+read_log_page(struct file_header *hdr, int16_t record_count,
+              struct log_param *lp)
+{
+  uint16_t region;
+  int16_t match_index;
+  uint16_t log_record_size;
+  uint16_t log_records;
+  cfs_offset_t base;
+  uint16_t search_records;
+
+  adjust_log_config(hdr, &log_record_size, &log_records);
+  region = modify_log_buffer(log_record_size, &lp->offset, &lp->size);
+
+  search_records = record_count < 0 ? log_records : record_count;
+  match_index = get_record_index(hdr->log_page, search_records, region);
+  if(match_index < 0) {
+    return -1;
+  }
+
+  base = absolute_offset(hdr->log_page, log_records * sizeof(region));
+  base += (cfs_offset_t)match_index * log_record_size;
+  base += lp->offset;
+  COFFEE_READ(lp->buf, lp->size, base);
+
+  return lp->size;
+}
+#endif /* COFFEE_MICRO_LOGS */
+/*---------------------------------------------------------------------------*/
+#if COFFEE_MICRO_LOGS
+static coffee_page_t
+create_log(struct file *file, struct file_header *hdr)
+{
+  uint16_t log_record_size, log_records;
+  cfs_offset_t size;
+  struct file *log_file;
+
+  adjust_log_config(hdr, &log_record_size, &log_records);
+
+  /* Log index size + log data size. */
+  size = log_records * (sizeof(uint16_t) + log_record_size);
+
+  log_file = reserve(hdr->name, page_count(size), 1, HDR_FLAG_LOG);
+  if(log_file == NULL) {
+    return INVALID_PAGE;
+  }
+
+  hdr->flags |= HDR_FLAG_MODIFIED;
+  hdr->log_page = log_file->page;
+  write_header(hdr, file->page);
+
+  file->flags |= COFFEE_FILE_MODIFIED;
+  return log_file->page;
+}
+#endif /* COFFEE_MICRO_LOGS */
+/*---------------------------------------------------------------------------*/
+static int
+merge_log(coffee_page_t file_page, int extend)
+{
+  struct file_header hdr, hdr2;
+  int fd, n;
+  cfs_offset_t offset;
+  coffee_page_t max_pages;
+  struct file *new_file;
+  int i;
+
+  read_header(&hdr, file_page);
+
+  fd = cfs_open(hdr.name, CFS_READ);
+  if(fd < 0) {
+    return -1;
+  }
+
+  /*
+   * The reservation function adds extra space for the header, which has
+   * already been accounted for in the previous reservation.
+   */
+  max_pages = hdr.max_pages << extend;
+  new_file = reserve(hdr.name, max_pages, 1, 0);
+  if(new_file == NULL) {
+    cfs_close(fd);
+    return -1;
+  }
+
+  offset = 0;
+  do {
+    char buf[hdr.log_record_size == 0 ? COFFEE_PAGE_SIZE : hdr.log_record_size];
+    n = cfs_read(fd, buf, sizeof(buf));
+    if(n < 0) {
+      remove_by_page(new_file->page, !REMOVE_LOG, !CLOSE_FDS, ALLOW_GC);
+      cfs_close(fd);
+      return -1;
+    } else if(n > 0) {
+      COFFEE_WRITE(buf, n, absolute_offset(new_file->page, offset));
+      offset += n;
+    }
+  } while(n != 0);
+
+  for(i = 0; i < COFFEE_FD_SET_SIZE; i++) {
+    if(coffee_fd_set[i].flags != COFFEE_FD_FREE &&
+       coffee_fd_set[i].file->page == file_page) {
+      coffee_fd_set[i].file = new_file;
+      new_file->references++;
+    }
+  }
+
+  if(remove_by_page(file_page, REMOVE_LOG, !CLOSE_FDS, !ALLOW_GC) < 0) {
+    remove_by_page(new_file->page, !REMOVE_LOG, !CLOSE_FDS, !ALLOW_GC);
+    cfs_close(fd);
+    return -1;
+  }
+
+  /* Copy the log configuration and the EOF hint. */
+  read_header(&hdr2, new_file->page);
+  hdr2.log_record_size = hdr.log_record_size;
+  hdr2.log_records = hdr.log_records;
+  write_header(&hdr2, new_file->page);
+
+  new_file->flags &= ~COFFEE_FILE_MODIFIED;
+  new_file->end = offset;
+
+  cfs_close(fd);
+
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+#if COFFEE_MICRO_LOGS
+static int
+find_next_record(struct file *file, coffee_page_t log_page,
+                 int log_records)
+{
+  int log_record, preferred_batch_size;
+
+  if(file->record_count >= 0) {
+    return file->record_count;
+  }
+
+  preferred_batch_size = log_records > COFFEE_LOG_TABLE_LIMIT ?
+    COFFEE_LOG_TABLE_LIMIT : log_records;
+  {
+    /* The next log record is unknown at this point; search for it. */
+    uint16_t indices[preferred_batch_size];
+    uint16_t processed;
+    uint16_t batch_size;
+
+    log_record = log_records;
+    for(processed = 0; processed < log_records; processed += batch_size) {
+      batch_size = log_records - processed >= preferred_batch_size ?
+        preferred_batch_size : log_records - processed;
+
+      COFFEE_READ(&indices, batch_size * sizeof(indices[0]),
+                  absolute_offset(log_page, processed * sizeof(indices[0])));
+      for(log_record = 0; log_record < batch_size; log_record++) {
+        if(indices[log_record] == 0) {
+          log_record += processed;
+          break;
+        }
+      }
+    }
+  }
+
+  return log_record;
+}
+#endif /* COFFEE_MICRO_LOGS */
+/*---------------------------------------------------------------------------*/
+#if COFFEE_MICRO_LOGS
+static int
+write_log_page(struct file *file, struct log_param *lp)
+{
+  struct file_header hdr;
+  uint16_t region;
+  coffee_page_t log_page;
+  int16_t log_record;
+  uint16_t log_record_size;
+  uint16_t log_records;
+  cfs_offset_t offset;
+  struct log_param lp_out;
+
+  read_header(&hdr, file->page);
+
+  adjust_log_config(&hdr, &log_record_size, &log_records);
+  region = modify_log_buffer(log_record_size, &lp->offset, &lp->size);
+
+  log_page = 0;
+  if(HDR_MODIFIED(hdr)) {
+    /* A log structure has already been created. */
+    log_page = hdr.log_page;
+    log_record = find_next_record(file, log_page, log_records);
+    if(log_record >= log_records) {
+      /* The log is full; merge the log. */
+      PRINTF("Coffee: Merging the file %s with its log\n", hdr.name);
+      return merge_log(file->page, 0);
+    }
+  } else {
+    /* Create a log structure. */
+    log_page = create_log(file, &hdr);
+    if(log_page == INVALID_PAGE) {
+      return -1;
+    }
+    PRINTF("Coffee: Created a log structure for file %s at page %u\n",
+           hdr.name, (unsigned)log_page);
+    hdr.log_page = log_page;
+    log_record = 0;
+  }
+
+  {
+    char copy_buf[log_record_size];
+
+    lp_out.offset = offset = region * log_record_size;
+    lp_out.buf = copy_buf;
+    lp_out.size = log_record_size;
+
+    if((lp->offset > 0 || lp->size != log_record_size) &&
+       read_log_page(&hdr, log_record, &lp_out) < 0) {
+      COFFEE_READ(copy_buf, sizeof(copy_buf),
+                  absolute_offset(file->page, offset));
+    }
+
+    memcpy(&copy_buf[lp->offset], lp->buf, lp->size);
+
+    /*
+     * Write the region number in the region index table.
+     * The region number is incremented to avoid values of zero.
+     */
+    offset = absolute_offset(log_page, 0);
+    ++region;
+    COFFEE_WRITE(&region, sizeof(region),
+                 offset + log_record * sizeof(region));
+
+    offset += log_records * sizeof(region);
+    COFFEE_WRITE(copy_buf, sizeof(copy_buf),
+                 offset + log_record * log_record_size);
+    file->record_count = log_record + 1;
+  }
+
+  return lp->size;
+}
+#endif /* COFFEE_MICRO_LOGS */
+/*---------------------------------------------------------------------------*/
+static int
+get_available_fd(void)
+{
+  int i;
+
+  for(i = 0; i < COFFEE_FD_SET_SIZE; i++) {
+    if(coffee_fd_set[i].flags == COFFEE_FD_FREE) {
+      return i;
+    }
+  }
+  return -1;
+}
+/*---------------------------------------------------------------------------*/
+int
+cfs_open(const char *name, int flags)
+{
+  int fd;
+  struct file_desc *fdp;
+
+  fd = get_available_fd();
+  if(fd < 0) {
+    PRINTF("Coffee: Failed to allocate a new file descriptor!\n");
+    return -1;
+  }
+
+  fdp = &coffee_fd_set[fd];
+  fdp->flags = 0;
+
+  fdp->file = find_file(name);
+  if(fdp->file == NULL) {
+    if((flags & (CFS_READ | CFS_WRITE)) == CFS_READ) {
+      return -1;
+    }
+    fdp->file = reserve(name, page_count(COFFEE_DYN_SIZE), 1, 0);
+    if(fdp->file == NULL) {
+      return -1;
+    }
+    fdp->file->end = 0;
+  } else if(fdp->file->end == UNKNOWN_OFFSET) {
+    fdp->file->end = file_end(fdp->file->page);
+  }
+
+  fdp->flags |= flags;
+  fdp->offset = flags & CFS_APPEND ? fdp->file->end : 0;
+  fdp->file->references++;
+
+  return fd;
+}
+/*---------------------------------------------------------------------------*/
+void
+cfs_close(int fd)
+{
+  if(FD_VALID(fd)) {
+    coffee_fd_set[fd].flags = COFFEE_FD_FREE;
+    coffee_fd_set[fd].file->references--;
+    coffee_fd_set[fd].file = NULL;
+  }
+}
+
+struct file_desc* cfs_getdesc(int fd)
+{
+    if(!FD_VALID(fd)) {
+      return NULL;
+    }
+
+    return &coffee_fd_set[fd];
+}
+
+/*---------------------------------------------------------------------------*/
+cfs_offset_t
+cfs_seek(int fd, cfs_offset_t offset, int whence)
+{
+  struct file_desc *fdp;
+  cfs_offset_t new_offset;
+
+  if(!FD_VALID(fd)) {
+    return -1;
+  }
+  fdp = &coffee_fd_set[fd];
+
+  if(whence == CFS_SEEK_SET) {
+    new_offset = offset;
+  } else if(whence == CFS_SEEK_END) {
+    new_offset = fdp->file->end + offset;
+  } else if(whence == CFS_SEEK_CUR) {
+    new_offset = fdp->offset + offset;
+  } else {
+    return (cfs_offset_t)-1;
+  }
+
+  if(new_offset < 0 || new_offset > fdp->file->max_pages * COFFEE_PAGE_SIZE) {
+    return -1;
+  }
+
+  if(fdp->file->end < new_offset) {
+    fdp->file->end = new_offset;
+  }
+
+  return fdp->offset = new_offset;
+}
+/*---------------------------------------------------------------------------*/
+int
+cfs_remove(const char *name)
+{
+  struct file *file;
+
+  /*
+   * Coffee removes files by marking them as obsolete. The space
+   * is not guaranteed to be reclaimed immediately, but must be
+   * sweeped by the garbage collector. The garbage collector is
+   * called once a file reservation request cannot be granted.
+   */
+  file = find_file(name);
+  if(file == NULL) {
+    return -1;
+  }
+
+  return remove_by_page(file->page, REMOVE_LOG, CLOSE_FDS, ALLOW_GC);
+}
+/*---------------------------------------------------------------------------*/
+int
+cfs_read(int fd, void *buf, unsigned size)
+{
+  struct file_desc *fdp;
+  struct file *file;
+#if COFFEE_MICRO_LOGS
+  struct file_header hdr;
+  struct log_param lp;
+  unsigned bytes_left;
+  int r;
+#endif
+
+  if(!(FD_VALID(fd) && FD_READABLE(fd))) {
+    return -1;
+  }
+
+  fdp = &coffee_fd_set[fd];
+  file = fdp->file;
+  if(fdp->offset + size > file->end) {
+    size = file->end - fdp->offset;
+  }
+
+  /* If the file is allocated, read directly in the file. */
+  if(!FILE_MODIFIED(file)) {
+    COFFEE_READ(buf, size, absolute_offset(file->page, fdp->offset));
+    fdp->offset += size;
+    return size;
+  }
+
+#if COFFEE_MICRO_LOGS
+  read_header(&hdr, file->page);
+
+  /*
+   * Fill the buffer by copying from the log in first hand, or the
+   * ordinary file if the page has no log record.
+   */
+  for(bytes_left = size; bytes_left > 0; bytes_left -= r) {
+    lp.offset = fdp->offset;
+    lp.buf = buf;
+    lp.size = bytes_left;
+    r = read_log_page(&hdr, file->record_count, &lp);
+
+    /* Read from the original file if we cannot find the data in the log. */
+    if(r < 0) {
+      COFFEE_READ(buf, lp.size, absolute_offset(file->page, fdp->offset));
+      r = lp.size;
+    }
+    fdp->offset += r;
+    buf = (char *)buf + r;
+  }
+#endif /* COFFEE_MICRO_LOGS */
+
+  return size;
+}
+/*---------------------------------------------------------------------------*/
+int
+cfs_write(int fd, const void *buf, unsigned size)
+{
+  struct file_desc *fdp;
+  struct file *file;
+#if COFFEE_MICRO_LOGS
+  int i;
+  struct log_param lp;
+  cfs_offset_t bytes_left;
+  int8_t need_dummy_write;
+  const char dummy[1] = { 0xff };
+#endif
+
+  if(!(FD_VALID(fd) && FD_WRITABLE(fd))) {
+    return -1;
+  }
+
+  fdp = &coffee_fd_set[fd];
+  file = fdp->file;
+
+  /* Attempt to extend the file if we try to write past the end. */
+#if COFFEE_IO_SEMANTICS
+  if(!(fdp->io_flags & CFS_COFFEE_IO_FIRM_SIZE)) {
+#endif
+  while(size + fdp->offset + sizeof(struct file_header) >
+        (file->max_pages * COFFEE_PAGE_SIZE)) {
+    if(merge_log(file->page, 1) < 0) {
+      return -1;
+    }
+    file = fdp->file;
+    PRINTF("Extended the file at page %u\n", (unsigned)file->page);
+  }
+#if COFFEE_IO_SEMANTICS
+}
+#endif
+
+#if COFFEE_MICRO_LOGS
+#if COFFEE_IO_SEMANTICS
+  if(!(fdp->io_flags & CFS_COFFEE_IO_FLASH_AWARE) &&
+     (FILE_MODIFIED(file) || fdp->offset < file->end)) {
+#else
+  if(FILE_MODIFIED(file) || fdp->offset < file->end) {
+#endif
+    need_dummy_write = 0;
+    for(bytes_left = size; bytes_left > 0;) {
+      lp.offset = fdp->offset;
+      lp.buf = buf;
+      lp.size = bytes_left;
+      i = write_log_page(file, &lp);
+      if(i < 0) {
+        /* Return -1 if we wrote nothing because the log write failed. */
+        if(size == bytes_left) {
+          return -1;
+        }
+        break;
+      } else if(i == 0) {
+        /* The file was merged with the log. */
+        file = fdp->file;
+      } else {
+        /* A log record was written. */
+        bytes_left -= i;
+        fdp->offset += i;
+        buf = (char *)buf + i;
+
+        /* Update the file end for a potential log merge that might
+           occur while writing log records. */
+        if(fdp->offset > file->end) {
+          file->end = fdp->offset;
+          need_dummy_write = 1;
+        }
+      }
+    }
+
+    if(need_dummy_write) {
+      /*
+       * A log record has been written at an offset beyond the original
+       * extent's end. Consequently, we need to write a dummy value at the
+       * corresponding end offset in the original extent to ensure that
+       * the correct file size is calculated when opening the file again.
+       */
+      COFFEE_WRITE(dummy, 1, absolute_offset(file->page, fdp->offset - 1));
+    }
+  } else {
+#endif /* COFFEE_MICRO_LOGS */
+#if COFFEE_APPEND_ONLY
+  if(fdp->offset < file->end) {
+    return -1;
+  }
+#endif /* COFFEE_APPEND_ONLY */
+
+  COFFEE_WRITE(buf, size, absolute_offset(file->page, fdp->offset));
+  fdp->offset += size;
+#if COFFEE_MICRO_LOGS
+}
+#endif /* COFFEE_MICRO_LOGS */
+
+  if(fdp->offset > file->end) {
+    file->end = fdp->offset;
+  }
+
+  return size;
+}
+/*---------------------------------------------------------------------------*/
+int
+cfs_opendir(struct cfs_dir *dir, const char *name)
+{
+  /*
+   * Coffee is only guaranteed to support "/" and ".", but it does not
+   * currently enforce this.
+   */
+  memset(dir->dummy_space, 0, sizeof(coffee_page_t));
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+int
+cfs_readdir(struct cfs_dir *dir, struct cfs_dirent *record)
+{
+  struct file_header hdr;
+  coffee_page_t page;
+
+  memcpy(&page, dir->dummy_space, sizeof(coffee_page_t));
+
+  while(page < COFFEE_PAGE_COUNT) {
+    read_header(&hdr, page);
+    if(HDR_ACTIVE(hdr) && !HDR_LOG(hdr)) {
+      coffee_page_t next_page;
+      memcpy(record->name, hdr.name, sizeof(record->name));
+      record->name[sizeof(record->name) - 1] = '\0';
+      record->size = file_end(page);
+
+      next_page = next_file(page, &hdr);
+      memcpy(dir->dummy_space, &next_page, sizeof(coffee_page_t));
+      return 0;
+    }
+    page = next_file(page, &hdr);
+  }
+
+  return -1;
+}
+/*---------------------------------------------------------------------------*/
+void
+cfs_closedir(struct cfs_dir *dir)
+{
+  return;
+}
+/*---------------------------------------------------------------------------*/
+int
+cfs_coffee_reserve(const char *name, cfs_offset_t size)
+{
+  return reserve(name, page_count(size), 0, 0) == NULL ? -1 : 0;
+}
+/*---------------------------------------------------------------------------*/
+int
+cfs_coffee_configure_log(const char *filename, unsigned log_size,
+                         unsigned log_record_size)
+{
+  struct file *file;
+  struct file_header hdr;
+
+  if(log_record_size == 0 || log_record_size > COFFEE_PAGE_SIZE ||
+     log_size < log_record_size) {
+    return -1;
+  }
+
+  file = find_file(filename);
+  if(file == NULL) {
+    return -1;
+  }
+
+  read_header(&hdr, file->page);
+  if(HDR_MODIFIED(hdr)) {
+    /* Too late to customize the log. */
+    return -1;
+  }
+
+  hdr.log_records = log_size / log_record_size;
+  hdr.log_record_size = log_record_size;
+  write_header(&hdr, file->page);
+
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+#if COFFEE_IO_SEMANTICS
+int
+cfs_coffee_set_io_semantics(int fd, unsigned flags)
+{
+  if(!FD_VALID(fd)) {
+    return -1;
+  }
+
+  coffee_fd_set[fd].io_flags |= flags;
+
+  return 0;
+}
+#endif
+/*---------------------------------------------------------------------------*/
+int
+cfs_coffee_format(void)
+{
+  unsigned i;
+
+  PRINTF("Coffee: Formatting %u sectors", COFFEE_SECTOR_COUNT);
+
+  *next_free = 0;
+
+  for(i = 0; i < COFFEE_SECTOR_COUNT; i++) {
+    COFFEE_ERASE(i);
+    PRINTF(".");
+  }
+
+  /* Formatting invalidates the file information. */
+  memset(&protected_mem, 0, sizeof(protected_mem));
+
+  PRINTF(" done!\n");
+
+  return 0;
+}
+/*---------------------------------------------------------------------------*/
+void *
+cfs_coffee_get_protected_mem(unsigned *size)
+{
+  *size = sizeof(protected_mem);
+  return &protected_mem;
+}

--- a/components/dfs/filesystems/cfs/cfs-coffee.h
+++ b/components/dfs/filesystems/cfs/cfs-coffee.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2008, Swedish Institute of Computer Science
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ */
+
+/**
+ * \addtogroup cfs
+ * @{
+ */
+
+#ifndef CFS_COFFEE_H
+#define CFS_COFFEE_H
+
+#include "cfs.h"
+
+/**
+ * Instruct Coffee that the access pattern to this file is adapted to
+ * flash I/O semantics by design, and Coffee should therefore not
+ * invoke its own micro logs when file modifications occur.
+ *
+ * This semantical I/O setting is useful when implementing flash storage
+ * algorithms on top of Coffee.
+ *
+ * \sa cfs_coffee_set_io_semantics()
+ */
+#define CFS_COFFEE_IO_FLASH_AWARE	0x1
+
+/**
+ * Instruct Coffee not to attempt to extend the file when there is
+ * an attempt to write past the reserved file size.
+ *
+ * A case when this is necessary is when the file has a firm size limit,
+ * and a safeguard is needed to protect against writes beyond this limit.
+ *
+ * \sa cfs_coffee_set_io_semantics()
+ */
+#define CFS_COFFEE_IO_FIRM_SIZE		0x2
+
+/**
+ * \file
+ *	Header for the Coffee file system.
+ * \author
+ * 	Nicolas Tsiftes <nvt@sics.se>
+ *
+ * \name Functions called from application programs
+ * @{
+ */
+
+/**
+ * \brief Reserve space for a file.
+ * \param name The filename.
+ * \param size The size of the file.
+ * \return 0 on success, -1 on failure.
+ *
+ * Coffee uses sequential page structures for files. The sequential
+ * structure can be reserved with a certain size. If a file has not
+ * been reserved when it is opened for the first time, it will be
+ * allocated with a default size.
+ */
+int cfs_coffee_reserve(const char *name, cfs_offset_t size);
+
+/**
+ * \brief Configure the on-demand log file.
+ * \param file The filename.
+ * \param log_size The total log size.
+ * \param log_entry_size The log entry size.
+ * \return 0 on success, -1 on failure.
+ *
+ * When file data is first modified, Coffee creates a micro log for the
+ * file. The micro log stores a table of modifications whose
+ * parameters--the log size and the log entry size--can be modified
+ * through the cfs_coffee_configure_log function.
+ */
+int cfs_coffee_configure_log(const char *file, unsigned log_size,
+                             unsigned log_entry_size);
+
+/**
+ * \brief Set the I/O semantics for accessing a file.
+ *
+ * \param fd The file descriptor through which the file is accessed.
+ * \param flags A bit vector of flags.
+ *
+ * Coffee is used on a wide range of storage types, and the default
+ * I/O file semantics may not be optimal for the access pattern
+ * of a certain file. Hence, this functions allows programmers to
+ * switch the /O semantics on a file that is accessed through a
+ * particular file descriptor.
+ *
+ */
+int cfs_coffee_set_io_semantics(int fd, unsigned flags);
+
+/**
+ * \brief Format the storage area assigned to Coffee.
+ * \return 0 on success, -1 on failure.
+ *
+ * Coffee formats the underlying storage by setting all bits to zero.
+ * Formatting must be done before using Coffee for the first time in
+ * a mote.
+ */
+int cfs_coffee_format(void);
+
+/**
+ * \brief Points out a memory region that may not be altered during
+ * checkpointing operations that use the file system.
+ * \param size
+ * \return A pointer to the protected memory.
+ *
+ * This function returns the protected memory pointer and writes its size
+ * to the given parameter. Mainly used by sensornet checkpointing to protect
+ * the coffee state during CFS-based checkpointing operations.
+ */
+void *cfs_coffee_get_protected_mem(unsigned *size);
+
+/** @} */
+/** @} */
+
+#endif /* !COFFEE_H */

--- a/components/dfs/filesystems/cfs/cfs-coffee_arch.c
+++ b/components/dfs/filesystems/cfs/cfs-coffee_arch.c
@@ -1,0 +1,121 @@
+/*********************************************************************************************************
+**
+**                                苏州诺金智通信息科技有限公司
+**
+**                               Copyright All Rights Reserved
+**
+**--------------文件信息--------------------------------------------------------------------------------
+**
+** 文 件 名: cfs-coffee_arch.c
+**
+** 创 建 人: Urey(风飘柳絮)
+**
+** 创建日期: 2015年11月12日
+**
+** 描    述: TODO
+*********************************************************************************************************/
+
+
+/*********************************************************************************************************
+**   头文件
+*********************************************************************************************************/
+#include <rtthread.h>
+#include <rtdevice.h>
+
+#include <cfs.h>
+
+
+/*********************************************************************************************************
+**   宏定义
+*********************************************************************************************************/
+#define DEBUG 0
+#if DEBUG
+#include <stdio.h>
+#define PRINTF(...) rt_kprintf(__VA_ARGS__)
+#else
+#define PRINTF(...)
+#endif
+
+
+
+/*********************************************************************************************************
+**   全局变量
+*********************************************************************************************************/
+static rt_device_t              xmem_device = RT_NULL;
+struct rt_device_blk_geometry   xmem_geometry = {0};
+
+int xmem_init(rt_device_t device)
+{
+    int result ;
+
+    RT_ASSERT(device != RT_NULL);
+
+    xmem_device = device;
+
+    //获取 mem 设备容量信息
+    result = rt_device_control(xmem_device,RT_DEVICE_CTRL_BLK_GETGEOME,&xmem_geometry);
+    RT_ASSERT(result == RT_EOK);
+
+    return result;
+}
+
+
+int xmem_erase(long size, unsigned long addr)
+{
+    unsigned long end = addr + size;
+
+    RT_ASSERT(xmem_device != RT_NULL);
+
+    if(size % XMEM_ERASE_UNIT_SIZE != 0) {
+      PRINTF("xmem_erase: bad size\n");
+      return -1;
+    }
+
+    if(addr % XMEM_ERASE_UNIT_SIZE != 0) {
+      PRINTF("xmem_erase: bad offset\n");
+      return -1;
+    }
+
+    for (; addr < end; addr += XMEM_ERASE_UNIT_SIZE)
+    {
+        rt_device_control(xmem_device, RT_DEVICE_CTRL_BLK_ERASE, (void *) addr);
+    }
+
+    return size;
+}
+
+int xmem_pwrite(const void *_buf, int size, unsigned long addr)
+{
+    const unsigned char *p = _buf;
+    const unsigned long end = addr + size;
+    unsigned long i, next_page;
+
+    RT_ASSERT(xmem_device != RT_NULL);
+
+    for (i = addr; i < end;)
+    {
+        next_page = (i | 0xff) + 1;
+        if (next_page > end)
+        {
+            next_page = end;
+        }
+        p += rt_device_write(xmem_device, i, p, next_page - i);
+        i = next_page;
+    }
+
+    return size;
+}
+
+
+int xmem_pread(void *_p, int size, unsigned long offset)
+{
+    int retSize;
+
+    RT_ASSERT(xmem_device != RT_NULL);
+
+    retSize = rt_device_read(xmem_device,offset,_p,size);
+
+    return retSize;
+}
+
+

--- a/components/dfs/filesystems/cfs/cfs-coffee_arch.h
+++ b/components/dfs/filesystems/cfs/cfs-coffee_arch.h
@@ -1,0 +1,68 @@
+/*********************************************************************************************************
+**
+**                                苏州诺金智通信息科技有限公司
+**
+**                               Copyright All Rights Reserved
+**
+**--------------文件信息--------------------------------------------------------------------------------
+**
+** 文 件 名: cfs-coffee_arch.h
+**
+** 创 建 人: Urey(风飘柳絮)
+**
+** 创建日期: 2015年11月11日
+**
+** 描    述: TODO
+*********************************************************************************************************/
+
+
+#ifndef _CFS_COFFEE_ARCH_H_
+#define _CFS_COFFEE_ARCH_H_
+
+#include <rtdef.h>
+
+extern struct rt_device_blk_geometry   xmem_geometry;
+//extern rt_device_t xmem_device;
+
+
+/* Coffee configuration parameters. */
+#define COFFEE_SECTOR_SIZE      (xmem_geometry.block_size)
+#define COFFEE_PAGE_SIZE        256UL
+#define COFFEE_START            COFFEE_SECTOR_SIZE
+#define COFFEE_SIZE             ((xmem_geometry.sector_count * xmem_geometry.bytes_per_sector) - COFFEE_START)
+
+#define COFFEE_NAME_LENGTH      16
+#define COFFEE_MAX_OPEN_FILES   6
+#define COFFEE_FD_SET_SIZE      8
+#define COFFEE_LOG_TABLE_LIMIT  256
+#define COFFEE_DYN_SIZE         4*1024
+#define COFFEE_LOG_SIZE         1024
+
+
+#define COFFEE_MICRO_LOGS       1
+
+#define XMEM_ERASE_UNIT_SIZE    (COFFEE_SECTOR_SIZE)
+
+
+/* Flash operations. */
+#define COFFEE_WRITE(buf, size, offset)             \
+        xmem_pwrite((char *)(buf), (size), COFFEE_START + (offset))
+
+#define COFFEE_READ(buf, size, offset)              \
+        xmem_pread((char *)(buf), (size), COFFEE_START + (offset))
+
+#define COFFEE_ERASE(sector)                        \
+        xmem_erase(COFFEE_SECTOR_SIZE, COFFEE_START + (sector) * COFFEE_SECTOR_SIZE)
+
+/* Coffee types. */
+typedef int16_t coffee_page_t;
+
+/*********************************************************************************************************
+**   函数申明
+*********************************************************************************************************/
+int xmem_init   (rt_device_t device);
+int xmem_erase  (long size, unsigned long addr);
+int xmem_pwrite (const void *_buf, int size, unsigned long addr);
+int xmem_pread  (void *_p, int size, unsigned long offset);
+
+#endif /* _CFS_COFFEE_ARCH_H_ */

--- a/components/dfs/filesystems/cfs/cfs-coffee_test.c
+++ b/components/dfs/filesystems/cfs/cfs-coffee_test.c
@@ -1,0 +1,413 @@
+/*********************************************************************************************************
+**
+**                                苏州诺金智通信息科技有限公司
+**
+**                               Copyright All Rights Reserved
+**
+**--------------文件信息--------------------------------------------------------------------------------
+**
+** 文 件 名: cfs_test.c
+**
+** 创 建 人: Urey(风飘柳絮)
+**
+** 创建日期: 2015年11月12日
+**
+** 描    述: TODO
+*********************************************************************************************************/
+
+#include <cfs.h>
+
+#define FILE_SIZE 512
+
+/*--------------------------------------------------------------------------*/
+int
+coffee_file_test(void)
+{
+  int error;
+  int wfd, rfd, afd;
+  unsigned char buf[256], buf2[11];
+  int r, i, j, total_read;
+  unsigned offset;
+
+  cfs_remove("T1.bin");
+  cfs_remove("T2");
+  cfs_remove("T3");
+  cfs_remove("T4");
+  cfs_remove("T5");
+  wfd = rfd = afd = -1;
+
+  for(r = 0; r < sizeof(buf); r++) {
+    buf[r] = r;
+  }
+
+  PRINTF("TEST 1\n");
+
+  /* Test 1: Open for writing. */
+  wfd = cfs_open("T1.bin", CFS_WRITE);
+  if(wfd < 0) {
+    FAIL(-1);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("2\n");
+
+  /* Test 2: Write buffer. */
+  r = cfs_write(wfd, buf, sizeof(buf));
+  if(r < 0) {
+    FAIL(-2);
+  } else if(r < sizeof(buf)) {
+    FAIL(-3);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("3\n");
+
+  /* Test 3: Deny reading. */
+  r = cfs_read(wfd, buf, sizeof(buf));
+  if(r >= 0) {
+    FAIL(-4);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("4\n");
+
+  /* Test 4: Open for reading. */
+  rfd = cfs_open("T1", CFS_READ);
+  if(rfd < 0) {
+    FAIL(-5);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("5\n");
+
+  /* Test 5: Write to read-only file. */
+  r = cfs_write(rfd, buf, sizeof(buf));
+  if(r >= 0) {
+    FAIL(-6);
+  }
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("7\n");
+
+  /* Test 7: Read the buffer written in Test 2. */
+  rt_memset(buf, 0, sizeof(buf));
+  r = cfs_read(rfd, buf, sizeof(buf));
+  if(r < 0) {
+    FAIL(-8);
+  } else if(r < sizeof(buf)) {
+    PRINTF("r=%d\n", r);
+    FAIL(-9);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("8\n");
+
+  /* Test 8: Verify that the buffer is correct. */
+  for(r = 0; r < sizeof(buf); r++) {
+    if(buf[r] != r) {
+      PRINTF("r=%d. buf[r]=%d\n", r, buf[r]);
+      FAIL(-10);
+    }
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("9\n");
+
+  /* Test 9: Seek to beginning. */
+  if(cfs_seek(wfd, 0, CFS_SEEK_SET) != 0) {
+    FAIL(-11);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("10\n");
+
+  /* Test 10: Write to the log. */
+  r = cfs_write(wfd, buf, sizeof(buf));
+  if(r < 0) {
+    FAIL(-12);
+  } else if(r < sizeof(buf)) {
+    FAIL(-13);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("11\n");
+
+  /* Test 11: Read the data from the log. */
+  cfs_seek(rfd, 0, CFS_SEEK_SET);
+  rt_memset(buf, 0, sizeof(buf));
+  r = cfs_read(rfd, buf, sizeof(buf));
+  if(r < 0) {
+    FAIL(-14);
+  } else if(r < sizeof(buf)) {
+    FAIL(-15);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("12\n");
+
+  /* Test 12: Verify that the data is correct. */
+  for(r = 0; r < sizeof(buf); r++) {
+    if(buf[r] != r) {
+      FAIL(-16);
+    }
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("13\n");
+
+  /* Test 13: Write a reversed buffer to the file. */
+  for(r = 0; r < sizeof(buf); r++) {
+    buf[r] = sizeof(buf) - r - 1;
+  }
+  if(cfs_seek(wfd, 0, CFS_SEEK_SET) != 0) {
+    FAIL(-17);
+  }
+  r = cfs_write(wfd, buf, sizeof(buf));
+  if(r < 0) {
+    FAIL(-18);
+  } else if(r < sizeof(buf)) {
+    FAIL(-19);
+  }
+  if(cfs_seek(rfd, 0, CFS_SEEK_SET) != 0) {
+    FAIL(-20);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("14\n");
+
+  /* Test 14: Read the reversed buffer. */
+  cfs_seek(rfd, 0, CFS_SEEK_SET);
+  rt_memset(buf, 0, sizeof(buf));
+  r = cfs_read(rfd, buf, sizeof(buf));
+  if(r < 0) {
+    FAIL(-21);
+  } else if(r < sizeof(buf)) {
+    PRINTF("r = %d\n", r);
+    FAIL(-22);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("15\n");
+
+  /* Test 15: Verify that the data is correct. */
+  for(r = 0; r < sizeof(buf); r++) {
+    if(buf[r] != sizeof(buf) - r - 1) {
+      FAIL(-23);
+    }
+  }
+
+  cfs_close(rfd);
+  cfs_close(wfd);
+
+  if(cfs_coffee_reserve("T2", FILE_SIZE) < 0) {
+    FAIL(-24);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("16\n");
+
+  /* Test 16: Test multiple writes at random offset. */
+  for(r = 0; r < 100; r++) {
+    wfd = cfs_open("T2", CFS_WRITE | CFS_READ);
+    if(wfd < 0) {
+      FAIL(-25);
+    }
+    offset = rand() % FILE_SIZE;
+    for(r = 0; r < sizeof(buf); r++) {
+      buf[r] = r;
+    }
+    if(cfs_seek(wfd, offset, CFS_SEEK_SET) != offset) {
+      FAIL(-26);
+    }
+    if(cfs_write(wfd, buf, sizeof(buf)) != sizeof(buf)) {
+      FAIL(-27);
+    }
+    if(cfs_seek(wfd, offset, CFS_SEEK_SET) != offset) {
+      FAIL(-28);
+    }
+    rt_memset(buf, 0, sizeof(buf));
+    if(cfs_read(wfd, buf, sizeof(buf)) != sizeof(buf)) {
+      FAIL(-29);
+    }
+    for(i = 0; i < sizeof(buf); i++) {
+      if(buf[i] != i) {
+        PRINTF("buf[%d] != %d\n", i, buf[i]);
+        FAIL(-30);
+      }
+    }
+  }
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("17\n");
+
+  /* Test 17: Append data to the same file many times. */
+#define APPEND_BYTES 3000
+#define BULK_SIZE 10
+  for(i = 0; i < APPEND_BYTES; i += BULK_SIZE) {
+    afd = cfs_open("T3", CFS_WRITE | CFS_APPEND);
+    if(afd < 0) {
+      FAIL(-31);
+    }
+    for(j = 0; j < BULK_SIZE; j++) {
+      buf[j] = 1 + ((i + j) & 0x7f);
+    }
+    if((r = cfs_write(afd, buf, BULK_SIZE)) != BULK_SIZE) {
+      PRINTF("Count:%d, r=%d\n", i, r);
+      FAIL(-32);
+    }
+    cfs_close(afd);
+  }
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("18\n");
+
+  /* Test 18: Read back the data written in Test 17 and verify. */
+  afd = cfs_open("T3", CFS_READ);
+  if(afd < 0) {
+    FAIL(-33);
+  }
+  total_read = 0;
+  while((r = cfs_read(afd, buf2, sizeof(buf2))) > 0) {
+    for(j = 0; j < r; j++) {
+      if(buf2[j] != 1 + ((total_read + j) & 0x7f)) {
+        FAIL(-34);
+      }
+    }
+    total_read += r;
+  }
+  if(r < 0) {
+    PRINTF("FAIL:-35 r=%d\n", r);
+    FAIL(-35);
+  }
+  if(total_read != APPEND_BYTES) {
+    PRINTF("FAIL:-35 total_read=%d\n", total_read);
+    FAIL(-35);
+  }
+  cfs_close(afd);
+
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("19\n");
+
+  /* T4 */
+  /*
+   * file T4 and T5 writing forces to use garbage collector in greedy mode
+   * this test is designed for 10kb of file system
+   */
+#define APPEND_BYTES_1 2000
+#define BULK_SIZE_1 10
+  for(i = 0; i < APPEND_BYTES_1; i += BULK_SIZE_1) {
+    afd = cfs_open("T4", CFS_WRITE | CFS_APPEND);
+    if(afd < 0) {
+      FAIL(-36);
+    }
+    for(j = 0; j < BULK_SIZE_1; j++) {
+      buf[j] = 1 + ((i + j) & 0x7f);
+    }
+
+    if((r = cfs_write(afd, buf, BULK_SIZE_1)) != BULK_SIZE_1) {
+      PRINTF("Count:%d, r=%d\n", i, r);
+      FAIL(-37);
+    }
+    cfs_close(afd);
+  }
+
+  afd = cfs_open("T4", CFS_READ);
+  if(afd < 0) {
+    FAIL(-38);
+  }
+
+  total_read = 0;
+  while((r = cfs_read(afd, buf2, sizeof(buf2))) > 0) {
+    for(j = 0; j < r; j++) {
+      if(buf2[j] != 1 + ((total_read + j) & 0x7f)) {
+        PRINTF("FAIL:-39, total_read=%d r=%d\n", total_read, r);
+        FAIL(-39);
+      }
+    }
+    total_read += r;
+  }
+  if(r < 0) {
+    PRINTF("FAIL:-40 r=%d\n", r);
+    FAIL(-40);
+  }
+  if(total_read != APPEND_BYTES_1) {
+    PRINTF("FAIL:-41 total_read=%d\n", total_read);
+    FAIL(-41);
+  }
+  cfs_close(afd);
+
+  /* T5 */
+  PRINTF("PASSED\n");
+  PRINTF("TEST ");
+  PRINTF("20\n");
+#define APPEND_BYTES_2 1000
+#define BULK_SIZE_2 10
+  for(i = 0; i < APPEND_BYTES_2; i += BULK_SIZE_2) {
+    afd = cfs_open("T5", CFS_WRITE | CFS_APPEND);
+    if(afd < 0) {
+      FAIL(-42);
+    }
+    for(j = 0; j < BULK_SIZE_2; j++) {
+      buf[j] = 1 + ((i + j) & 0x7f);
+    }
+
+    if((r = cfs_write(afd, buf, BULK_SIZE_2)) != BULK_SIZE_2) {
+      PRINTF("Count:%d, r=%d\n", i, r);
+      FAIL(-43);
+    }
+
+    cfs_close(afd);
+  }
+
+  afd = cfs_open("T5", CFS_READ);
+  if(afd < 0) {
+    FAIL(-44);
+  }
+  total_read = 0;
+  while((r = cfs_read(afd, buf2, sizeof(buf2))) > 0) {
+    for(j = 0; j < r; j++) {
+      if(buf2[j] != 1 + ((total_read + j) & 0x7f)) {
+        PRINTF("FAIL:-45, total_read=%d r=%d\n", total_read, r);
+        FAIL(-45);
+      }
+    }
+    total_read += r;
+  }
+  if(r < 0) {
+    PRINTF("FAIL:-46 r=%d\n", r);
+    FAIL(-46);
+  }
+  if(total_read != APPEND_BYTES_2) {
+    PRINTF("FAIL:-47 total_read=%d\n", total_read);
+    FAIL(-47);
+  }
+  cfs_close(afd);
+
+  PRINTF("PASSED\n");
+
+  error = 0;
+      cfs_close(wfd);
+  cfs_close(rfd);
+  cfs_close(afd);
+    return error;
+end:
+  cfs_close(wfd);
+  cfs_close(rfd);
+  cfs_close(afd);
+  return error;
+}

--- a/components/dfs/filesystems/cfs/cfs.h
+++ b/components/dfs/filesystems/cfs/cfs.h
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) 2004, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * This file is part of the Contiki operating system.
+ *
+ * Author: Adam Dunkels <adam@sics.se>
+ *
+ */
+
+/**
+ * \file
+ *         CFS header file.
+ * \author
+ *         Adam Dunkels <adam@sics.se>
+ *
+ */
+
+/**
+ * \addtogroup sys
+ * @{
+ */
+
+/**
+ * \defgroup cfs The Contiki file system interface
+ *
+ * The Contiki file system interface (CFS) defines an abstract API for
+ * reading directories and for reading and writing files. The CFS API
+ * is intentionally simple. The CFS API is modeled after the POSIX
+ * file API, and slightly simplified.
+ *
+ * @{
+ */
+
+#ifndef CFS_H_
+#define CFS_H_
+
+//#include "contiki.h"
+#include <stdint.h>
+#include <stddef.h>
+
+#include "cfs-coffee_arch.h"
+
+#ifndef CFS_CONF_OFFSET_TYPE
+typedef int cfs_offset_t;
+#else
+typedef CFS_CONF_OFFSET_TYPE cfs_offset_t;
+#endif
+
+#ifndef CCIF
+#   define CCIF
+#endif
+
+
+
+/* Micro logs enable modifications on storage types that do not support
+   in-place updates. This applies primarily to flash memories. */
+#ifndef COFFEE_MICRO_LOGS
+#define COFFEE_MICRO_LOGS 1
+#endif
+
+/* If the files are expected to be appended to only, this parameter
+   can be set to save some code space. */
+#ifndef COFFEE_APPEND_ONLY
+#define COFFEE_APPEND_ONLY  0
+#endif
+
+#if COFFEE_MICRO_LOGS && COFFEE_APPEND_ONLY
+#error "Cannot have COFFEE_APPEND_ONLY set when COFFEE_MICRO_LOGS is set."
+#endif
+
+/* I/O semantics can be set on file descriptors in order to optimize
+   file access on certain storage types. */
+#ifndef COFFEE_IO_SEMANTICS
+#define COFFEE_IO_SEMANTICS 0
+#endif
+
+/*
+ * Prevent sectors from being erased directly after file removal.
+ * This will level the wear across sectors better, but may lead
+ * to longer garbage collection procedures.
+ */
+#ifndef COFFEE_EXTENDED_WEAR_LEVELLING
+#define COFFEE_EXTENDED_WEAR_LEVELLING  1
+#endif
+
+//#if COFFEE_START & (COFFEE_SECTOR_SIZE - 1)
+//#error COFFEE_START must point to the first byte in a sector.
+//#endif
+
+struct cfs_dir {
+  char dummy_space[32];
+};
+
+struct cfs_dirent {
+  char name[32];
+  cfs_offset_t size;
+};
+
+/* The structure of cached file objects. */
+struct file {
+  cfs_offset_t end;
+  coffee_page_t page;
+  coffee_page_t max_pages;
+  int16_t record_count;
+  uint8_t references;
+  uint8_t flags;
+};
+
+
+/* The file descriptor structure. */
+struct file_desc
+{
+  cfs_offset_t offset;
+  struct file *file;
+  uint8_t flags;
+#if COFFEE_IO_SEMANTICS
+  uint8_t io_flags;
+#endif
+};
+
+/* The file header structure mimics the representation of file headers
+   in the physical storage medium. */
+struct file_header {
+  coffee_page_t log_page;
+  uint16_t log_records;
+  uint16_t log_record_size;
+  coffee_page_t max_pages;
+  uint8_t deprecated_eof_hint;
+  uint8_t flags;
+  char name[COFFEE_NAME_LENGTH];
+};
+
+typedef struct {
+    int                 fd;
+    struct file_desc   *desc;
+}CFS_FILE;
+
+/**
+ * Specify that cfs_open() should open a file for reading.
+ *
+ * This constant indicates to cfs_open() that a file should be opened
+ * for reading. CFS_WRITE should be used if the file is opened for
+ * writing, and CFS_READ + CFS_WRITE indicates that the file is opened
+ * for both reading and writing.
+ *
+ * \sa cfs_open()
+ */
+#ifndef CFS_READ
+#define CFS_READ  1
+#endif
+
+/**
+ * Specify that cfs_open() should open a file for writing.
+ *
+ * This constant indicates to cfs_open() that a file should be opened
+ * for writing. CFS_READ should be used if the file is opened for
+ * reading, and CFS_READ + CFS_WRITE indicates that the file is opened
+ * for both reading and writing.
+ *
+ * \sa cfs_open()
+ */
+#ifndef CFS_WRITE
+#define CFS_WRITE 2
+#endif
+
+/**
+ * Specify that cfs_open() should append written data to the file rather than overwriting it.
+ *
+ * This constant indicates to cfs_open() that a file that should be
+ * opened for writing gets written data appended to the end of the
+ * file. The default behaviour (without CFS_APPEND) is that the file
+ * is overwritten with the new data.
+ *
+ * \sa cfs_open()
+ */
+#ifndef CFS_APPEND
+#define CFS_APPEND 4
+#endif
+
+/**
+ * Specify that cfs_seek() should compute the offset from the beginning of the file.
+ *
+ * \sa cfs_seek()
+ */
+#ifndef CFS_SEEK_SET
+#define CFS_SEEK_SET 0
+#endif
+
+/**
+ * Specify that cfs_seek() should compute the offset from the current position of the file pointer.
+ *
+ * \sa cfs_seek()
+ */
+#ifndef CFS_SEEK_CUR
+#define CFS_SEEK_CUR 1
+#endif
+
+/**
+ * Specify that cfs_seek() should compute the offset from the end of the file.
+ *
+ * \sa cfs_seek()
+ */
+#ifndef CFS_SEEK_END
+#define CFS_SEEK_END 2
+#endif
+
+/**
+ * \brief      Open a file.
+ * \param name The name of the file.
+ * \param flags CFS_READ, or CFS_WRITE/CFS_APPEND, or both.
+ * \return     A file descriptor, if the file could be opened, or -1 if
+ *             the file could not be opened.
+ *
+ *             This function opens a file and returns a file
+ *             descriptor for the opened file. If the file could not
+ *             be opened, the function returns -1. The function can
+ *             open a file for reading or writing, or both.
+ *
+ *             An opened file must be closed with cfs_close().
+ *
+ * \sa         CFS_READ
+ * \sa         CFS_WRITE
+ * \sa         cfs_close()
+ */
+#ifndef cfs_open
+CCIF int cfs_open(const char *name, int flags);
+#endif
+
+/**
+ * \brief      Close an open file.
+ * \param fd   The file descriptor of the open file.
+ *
+ *             This function closes a file that has previously been
+ *             opened with cfs_open().
+ */
+#ifndef cfs_close
+CCIF void cfs_close(int fd);
+#endif
+
+/**
+ * \brief      Read data from an open file.
+ * \param fd   The file descriptor of the open file.
+ * \param buf  The buffer in which data should be read from the file.
+ * \param len  The number of bytes that should be read.
+ * \return     The number of bytes that was actually read from the file.
+ *
+ *             This function reads data from an open file into a
+ *             buffer. The file must have first been opened with
+ *             cfs_open() and the CFS_READ flag.
+ */
+#ifndef cfs_read
+CCIF int cfs_read(int fd, void *buf, unsigned int len);
+#endif
+
+/**
+ * \brief      Write data to an open file.
+ * \param fd   The file descriptor of the open file.
+ * \param buf  The buffer from which data should be written to the file.
+ * \param len  The number of bytes that should be written.
+ * \return     The number of bytes that was actually written to the file.
+ *
+ *             This function reads writes data from a memory buffer to
+ *             an open file. The file must have been opened with
+ *             cfs_open() and the CFS_WRITE flag.
+ */
+#ifndef cfs_write
+CCIF int cfs_write(int fd, const void *buf, unsigned int len);
+#endif
+
+/**
+ * \brief      Seek to a specified position in an open file.
+ * \param fd   The file descriptor of the open file.
+ * \param offset A position, either relative or absolute, in the file.
+ * \param whence Determines how to interpret the offset parameter.
+ * \return     The new position in the file, or (cfs_offset_t)-1 if the seek failed.
+ *
+ *             This function moves the file position to the specified
+ *             position in the file. The next byte that is read from
+ *             or written to the file will be at the position given
+ *             determined by the combination of the offset parameter
+ *             and the whence parameter.
+ *
+ * \sa         CFS_SEEK_CUR
+ * \sa         CFS_SEEK_END
+ * \sa         CFS_SEEK_SET
+ */
+#ifndef cfs_seek
+CCIF cfs_offset_t cfs_seek(int fd, cfs_offset_t offset, int whence);
+#endif
+
+/**
+ * \brief      Remove a file.
+ * \param name The name of the file.
+ * \retval 0   If the file was removed.
+ * \return -1  If the file could not be removed or if it doesn't exist.
+ */
+#ifndef cfs_remove
+CCIF int cfs_remove(const char *name);
+#endif
+
+/**
+ * \brief      Open a directory for reading directory entries.
+ * \param dirp A pointer to a struct cfs_dir that is filled in by the function.
+ * \param name The name of the directory.
+ * \return     0 or -1 if the directory could not be opened.
+ *
+ * \sa         cfs_readdir()
+ * \sa         cfs_closedir()
+ */
+#ifndef cfs_opendir
+CCIF int cfs_opendir(struct cfs_dir *dirp, const char *name);
+#endif
+
+/**
+ * \brief      Read a directory entry
+ * \param dirp A pointer to a struct cfs_dir that has been opened with cfs_opendir().
+ * \param dirent A pointer to a struct cfs_dirent that is filled in by cfs_readdir()
+ * \retval 0   If a directory entry was read.
+ * \retval -1  If no more directory entries can be read.
+ *
+ * \sa         cfs_opendir()
+ * \sa         cfs_closedir()
+ */
+#ifndef cfs_readdir
+CCIF int cfs_readdir(struct cfs_dir *dirp, struct cfs_dirent *dirent);
+#endif
+
+/**
+ * \brief      Close a directory opened with cfs_opendir().
+ * \param dirp A pointer to a struct cfs_dir that has been opened with cfs_opendir().
+ *
+ * \sa         cfs_opendir()
+ * \sa         cfs_readdir()
+ */
+#ifndef cfs_closedir
+CCIF void cfs_closedir(struct cfs_dir *dirp);
+#endif
+
+/**
+ *  添加获取文件描述符接口
+ */
+#ifndef cfs_getdesc
+CCIF struct file_desc* cfs_getdesc(int fd);
+#endif
+
+#endif /* CFS_H_ */
+
+/** @} */
+/** @} */

--- a/components/dfs/filesystems/cfs/dfs-cfs.c
+++ b/components/dfs/filesystems/cfs/dfs-cfs.c
@@ -1,0 +1,299 @@
+/*********************************************************************************************************
+**
+**                                苏州诺金智通信息科技有限公司
+**
+**                               Copyright All Rights Reserved
+**
+**--------------文件信息--------------------------------------------------------------------------------
+**
+** 文 件 名: dfs-cfs.c
+**
+** 创 建 人: Urey(风飘柳絮)
+**
+** 创建日期: 2015年11月11日
+**
+** 描    述: TODO
+*********************************************************************************************************/
+
+
+/*********************************************************************************************************
+**   头文件
+*********************************************************************************************************/
+#include <rtthread.h>
+#include <dfs.h>
+#include <dfs_fs.h>
+
+#include "cfs.h"
+#include "cfs-coffee.h"
+#include "cfs-coffee_arch.h"
+
+
+int dfs_cfs_mount    (struct dfs_filesystem *fs, unsigned long rwflag, const void *data)
+{
+    int result;
+
+    result = xmem_init(fs->dev_id);
+    if(result != RT_EOK)
+        return -DFS_STATUS_ENOSYS;
+
+    return DFS_STATUS_OK;
+}
+
+int dfs_cfs_unmount(struct dfs_filesystem *fs)
+{
+//    fs->data = RT_NULL;
+
+    return DFS_STATUS_OK;
+}
+
+
+
+/* make a file system */
+int dfs_cfs_mkfs(rt_device_t devid)
+{
+    cfs_coffee_format();
+
+    return DFS_STATUS_OK;
+}
+
+int dfs_cfs_open(struct dfs_fd *file)
+{
+    CFS_FILE    *cfsFile;
+    int flags;
+
+    if(file->flags & DFS_O_DIRECTORY)
+    {
+        static struct cfs_dir dir;
+        /* 打开根目录 */
+        if(cfs_opendir(&dir, file->path) != 0)
+            return  -DFS_STATUS_ENOSYS;
+
+        file->data = &dir;
+        return DFS_STATUS_OK;
+    }
+    else
+    {
+        if (file->flags == DFS_O_WRONLY)
+            flags = CFS_WRITE;
+        else if (file->flags == DFS_O_RDONLY)
+            flags = CFS_READ;
+        else
+            flags = (CFS_WRITE | CFS_READ);
+
+        if (file->flags & DFS_O_APPEND)
+            flags |= CFS_APPEND;
+
+        cfsFile = (CFS_FILE *) rt_malloc(sizeof(CFS_FILE));
+        if (cfsFile == RT_NULL)
+            return -DFS_STATUS_ENOMEM;
+
+        cfsFile->fd = cfs_open(file->path, flags);
+        if (cfsFile->fd >= 0)
+        {
+            cfsFile->desc = cfs_getdesc(cfsFile->fd);
+
+            file->pos = cfsFile->desc->offset;
+            file->size = cfsFile->desc->file->end;
+            file->data = cfsFile;
+
+            return DFS_STATUS_OK;
+        }
+    }
+
+    return -DFS_STATUS_EIO;
+}
+
+int dfs_cfs_close(struct dfs_fd *file)
+{
+    if (file->type == FT_DIRECTORY)
+    {
+        struct cfs_dir *dir;
+
+        dir = (struct cfs_dir *)file->data;
+        RT_ASSERT(dir != RT_NULL);
+
+        cfs_closedir(dir);
+    }
+    else
+    {
+        CFS_FILE *cfsFile = (CFS_FILE *) file->data;
+
+        cfs_close(cfsFile->fd);
+        if(cfsFile != RT_NULL)
+            rt_free(cfsFile);
+
+        file->data = RT_NULL;
+    }
+    return DFS_STATUS_OK;
+}
+int dfs_cfs_ioctl(struct dfs_fd *file, int cmd, void *args)
+{
+    return -DFS_STATUS_ENOSYS;
+}
+int dfs_cfs_read(struct dfs_fd *file, void *buf, rt_size_t count)
+{
+    CFS_FILE *cfsFile = (CFS_FILE *) file->data;
+    int bytes;
+
+    if (file->type == FT_DIRECTORY)
+    {
+        return -DFS_STATUS_EISDIR;
+    }
+
+    RT_ASSERT(cfsFile != RT_NULL);
+
+    bytes = cfs_read(cfsFile->fd, buf, count);
+    if (bytes > 0)
+    {
+        /* update position */
+        file->pos = cfsFile->desc->offset;
+
+        return bytes;
+    }
+
+    return -DFS_STATUS_EIO;
+}
+int dfs_cfs_write(struct dfs_fd *file, const void *buf, rt_size_t count)
+{
+    int bytes;
+    CFS_FILE *cfsFile = (CFS_FILE *) file->data;
+
+    if (file->type == FT_DIRECTORY)
+    {
+        return -DFS_STATUS_EISDIR;
+    }
+
+    RT_ASSERT(cfsFile != RT_NULL);
+
+    bytes = cfs_write(cfsFile->fd, buf, count);
+    if (bytes > 0)
+    {
+        /* update position */
+        file->pos = cfsFile->desc->offset;
+
+        return bytes;
+    }
+
+    return -DFS_STATUS_EIO;
+
+}
+
+int dfs_cfs_lseek(struct dfs_fd *file, rt_off_t offset)
+{
+    CFS_FILE *cfsFile = (CFS_FILE *) file->data;
+
+    if (file->type == FT_DIRECTORY)
+    {
+        return -DFS_STATUS_EISDIR;
+    }
+
+    RT_ASSERT(cfsFile != RT_NULL);
+
+    if (cfs_seek(cfsFile->fd, offset, CFS_SEEK_SET) > 0)
+    {
+        file->pos = cfsFile->desc->offset;
+        return file->pos;
+    }
+
+    return -DFS_STATUS_EIO;
+}
+
+int dfs_cfs_getdents (struct dfs_fd *file, struct dirent *dirp, rt_uint32_t count)
+{
+    rt_size_t index;
+
+    struct cfs_dir *cfs_dir = (struct cfs_dir *)file->data;
+    //static cfs_offset_t totsize;
+    struct cfs_dirent   cfs_dirent;
+
+    struct dirent *d;
+
+    if(cfs_dir == RT_NULL)
+       return  -DFS_STATUS_EINVAL;
+
+    /* make integer count */
+    count = (count / sizeof(struct dirent));
+    if (count == 0)
+        return -DFS_STATUS_EINVAL;
+
+
+    index = 0;
+    for (index = 0; index < count; index++)
+    {
+        d = dirp + index;
+
+        if(cfs_readdir(cfs_dir, &cfs_dirent) == 0)
+        {
+            /* coffee 根目录下只有文件 */
+            d->d_type = DFS_DT_REG;
+            d->d_namlen = rt_strlen(cfs_dirent.name);;
+            d->d_reclen = (rt_uint16_t)sizeof(struct dirent);
+            rt_strncpy(d->d_name, cfs_dirent.name, rt_strlen(cfs_dirent.name) + 1);
+
+            continue;
+        }
+
+        break;
+    }
+
+    return index * sizeof(struct dirent);
+}
+
+int dfs_cfs_stat(struct dfs_filesystem *fs, const char *path, struct stat *st)
+{
+    int fd;
+    struct file_desc *desc;
+
+    fd = cfs_open(path,CFS_READ);
+    if(fd >= 0)
+    {
+        desc = cfs_getdesc(fd);
+
+        st->st_dev = 0;
+        st->st_mode = DFS_S_IFREG | DFS_S_IRUSR | DFS_S_IRGRP | DFS_S_IROTH | DFS_S_IWUSR | DFS_S_IWGRP | DFS_S_IWOTH;
+
+
+        st->st_size = desc->file->end;
+        st->st_mtime = 0;
+        //st->st_blksize = 256;
+
+        cfs_close(fd);
+    }
+    return 0;
+}
+
+static const struct dfs_filesystem_operation _cfs =
+{
+                "cfs",
+                DFS_FS_FLAG_FULLPATH,
+                /* mount and unmount file system */
+                dfs_cfs_mount,
+                RT_NULL,
+
+                /* make a file system */
+                dfs_cfs_mkfs,
+                RT_NULL,
+
+                dfs_cfs_open,
+                dfs_cfs_close,
+                dfs_cfs_ioctl,
+                dfs_cfs_read,
+                dfs_cfs_write,
+                RT_NULL,
+                dfs_cfs_lseek,
+                dfs_cfs_getdents,
+
+                RT_NULL,
+                dfs_cfs_stat,
+                RT_NULL,
+};
+
+
+int cfs_init(void)
+{
+    /* register rom file system */
+    dfs_register(&_cfs);
+
+    return 0;
+}
+INIT_FS_EXPORT(cfs_init);


### PR DESCRIPTION
增加 CFS-COFFEE文件系统。已挂载到DFS接口。
还需要增加一个对应的SPI FLASH接口，目前RTT的SPI FLASH 是以块位单位操作的，不适用CFS文件系统。