### PR TITLE
allow parameter "recved" can be null in function "rt_event_recv"

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1140,7 +1140,7 @@ rt_err_t rt_event_recv(rt_event_t   event,
     {
         /* set received event */
         if (recved)
-        	*recved = (event->set & set);
+            *recved = (event->set & set);
 
         /* received event */
         if (option & RT_EVENT_FLAG_CLEAR)

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1139,7 +1139,8 @@ rt_err_t rt_event_recv(rt_event_t   event,
     if (status == RT_EOK)
     {
         /* set received event */
-        *recved = (event->set & set);
+        if (recved)
+        	*recved = (event->set & set);
 
         /* received event */
         if (option & RT_EVENT_FLAG_CLEAR)

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1086,7 +1086,7 @@ RTM_EXPORT(rt_event_send);
  * @param option the receive option, either RT_EVENT_FLAG_AND or
  *        RT_EVENT_FLAG_OR should be set.
  * @param timeout the waiting time
- * @param recved the received event
+ * @param recved the received event, if you don't care, RT_NULL can be set.
  *
  * @return the error code
  */


### PR DESCRIPTION
when we don't care which event raised, we can pass a null "recved".