### PR TITLE
finsh: change no echo mode. cpp: remove RT_USE_LIBC depends

### DIFF
--- a/components/cplusplus/SConscript
+++ b/components/cplusplus/SConscript
@@ -6,6 +6,6 @@ cwd = GetCurrentDir()
 src = Glob('*.cpp') + Glob('*.c')
 CPPPATH = [cwd]
 
-group = DefineGroup('CPlusPlus', src, depend = ['RT_USING_CPLUSPLUS', 'RT_USING_LIBC'], CPPPATH = CPPPATH)
+group = DefineGroup('CPlusPlus', src, depend = ['RT_USING_CPLUSPLUS'], CPPPATH = CPPPATH)
 
 Return('group')

--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -200,7 +200,8 @@ void finsh_run_line(struct finsh_parser *parser, const char *line)
 {
     const char *err_str;
 
-    rt_kprintf("\n");
+    if(shell->echo_mode)
+        rt_kprintf("\n");
     finsh_parser_run(parser, (unsigned char *)line);
 
     /* compile node root */
@@ -489,7 +490,8 @@ void finsh_thread_entry(void *parameter)
 #ifdef FINSH_USING_MSH
                 if (msh_is_used() == RT_TRUE)
                 {
-                    rt_kprintf("\n");
+                    if (shell->echo_mode)
+                        rt_kprintf("\n");
                     msh_exec(shell->line, shell->line_position);
                 }
                 else
@@ -500,7 +502,8 @@ void finsh_thread_entry(void *parameter)
                     shell->line[shell->line_position] = ';';
 
                     if (shell->line_position != 0) finsh_run_line(&shell->parser, shell->line);
-                    else rt_kprintf("\n");
+                    else
+                        if (shell->echo_mode) rt_kprintf("\n");
 #endif
                 }
 


### PR DESCRIPTION
finsh: 
rootcause: When set finsh echo = 0, now, still print '\n'. No echo mode check when print '\n'.
solution: Add echo mode check when print '\n'

CPP:
rootcause: When do not use RT_USE_LIBC, cpp support can not compile and link, due to Scons script add RT_USE_LIBC depends. But cpp support can work without RT_LIBC.
solution: Remove that depends.