### PR TITLE
Update dfs.h

### DIFF
--- a/components/dfs/include/dfs.h
+++ b/components/dfs/include/dfs.h
@@ -42,6 +42,8 @@ struct dfs_fd *fd_get(int fd);
 void fd_put(struct dfs_fd *fd);
 int fd_is_open(const char *pathname);
 
+int dfs_init(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
插入int dfs_init(void);
bsp\lpc176x的application.c文件调用int dfs_init(void)，遂在.h文件中插入