### PR TITLE
ramfs相关修正

### DIFF
--- a/components/dfs/filesystems/ramfs/dfs_ramfs.h
+++ b/components/dfs/filesystems/ramfs/dfs_ramfs.h
@@ -23,8 +23,8 @@
  * 2013-05-05     Bernard      remove CRC for ramfs persistence
  */
 
-#ifndef __DFS_ROMFS_H__
-#define __DFS_ROMFS_H__
+#ifndef __DFS_RAMFS_H__
+#define __DFS_RAMFS_H__
 
 #include <rtthread.h>
 #include <rtservice.h>

--- a/include/components.h
+++ b/include/components.h
@@ -63,8 +63,8 @@
 #ifdef RT_USING_DFS_YAFFS2
 #include <dfs_yaffs2.h>
 #endif
-#ifdef RT_USING_DFS_ROMFS
-#include <dfs_romfs.h>
+#ifdef RT_USING_DFS_RAMFS
+#include <dfs_ramfs.h>
 #endif
 #endif
 


### PR DESCRIPTION
修正ramfs.h中防止重复包含的宏定义名称
修正components.h中使能RT_USING_DFS_RAMFS宏时，加入ramfs.h头文件