### PR TITLE
SCons PreProcessor patch: Stop processing "#define" in false condition

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -36,6 +36,44 @@ Projects = []
 Rtt_Root = ''
 Env = None
 
+# SCons PreProcessor patch
+def start_handling_includes(self, t=None):
+    """
+    Causes the PreProcessor object to start processing #import,
+    #include and #include_next lines.
+
+    This method will be called when a #if, #ifdef, #ifndef or #elif
+    evaluates True, or when we reach the #else in a #if, #ifdef,
+    #ifndef or #elif block where a condition already evaluated
+    False.
+
+    """
+    d = self.dispatch_table
+    p = self.stack[-1] if self.stack else self.default_table
+
+    for k in ('import', 'include', 'include_next', 'define'):
+        d[k] = p[k]
+
+def stop_handling_includes(self, t=None):
+    """
+    Causes the PreProcessor object to stop processing #import,
+    #include and #include_next lines.
+
+    This method will be called when a #if, #ifdef, #ifndef or #elif
+    evaluates False, or when we reach the #else in a #if, #ifdef,
+    #ifndef or #elif block where a condition already evaluated True.
+    """
+    d = self.dispatch_table
+    d['import'] = self.do_nothing
+    d['include'] =  self.do_nothing
+    d['include_next'] =  self.do_nothing
+    d['define'] =  self.do_nothing
+    
+PatchedPreProcessor = SCons.cpp.PreProcessor
+PatchedPreProcessor.start_handling_includes = start_handling_includes
+PatchedPreProcessor.stop_handling_includes = stop_handling_includes
+
+
 class Win32Spawn:
     def spawn(self, sh, escape, cmd, args, env):
         # deal with the cmd build-in commands which cannot be used in
@@ -123,7 +161,7 @@ def PrepareBuilding(env, root_directory, has_libcpu=False, remove_components = [
     Env.Append(BUILDERS = {'BuildLib': bld})
 
     # parse rtconfig.h to get used component
-    PreProcessor = SCons.cpp.PreProcessor()
+    PreProcessor = PatchedPreProcessor()
     f = file('rtconfig.h', 'r')
     contents = f.read()
     f.close()
@@ -277,7 +315,7 @@ def PrepareModuleBuilding(env, root_directory, bsp_directory):
     Rtt_Root = root_directory
 
     # parse bsp rtconfig.h to get used component
-    PreProcessor = SCons.cpp.PreProcessor()
+    PreProcessor = PatchedPreProcessor()
     f = file(bsp_directory + '/rtconfig.h', 'r')
     contents = f.read()
     f.close()
@@ -631,7 +669,7 @@ def GetVersion():
     rtdef = os.path.join(Rtt_Root, 'include', 'rtdef.h')
 
     # parse rtdef.h to get RT-Thread version
-    prepcessor = SCons.cpp.PreProcessor()
+    prepcessor = PatchedPreProcessor()
     f = file(rtdef, 'r')
     contents = f.read()
     f.close()


### PR DESCRIPTION
Example "rtconfig.h" content:
 ...
 //#define BOARD_USING_LED
 #if defined(BOARD_USING_LED)
 #define RT_USING_RTGUI
 #endif
 ...

- Before patching, RTGUI module will be built although not intend to do so.
- After patching, RTGUI module will not be built.