### PR TITLE
fix initialization error in bsp/stm32f10x

### DIFF
--- a/bsp/stm32f10x/applications/SConscript
+++ b/bsp/stm32f10x/applications/SConscript
@@ -2,8 +2,16 @@ Import('RTT_ROOT')
 Import('rtconfig')
 from building import *
 
-cwd     = os.path.join(str(Dir('#')), 'applications')
-src	= Glob('*.c')
+cwd = os.path.join(str(Dir('#')), 'applications')
+
+src = Split("""
+application.c
+startup.c
+""")
+
+if GetDepend('RT_USING_CAN'):
+    src += ['canapp.c']
+
 CPPPATH = [cwd, str(Dir('#'))]
 
 group = DefineGroup('Applications', src, depend = [''], CPPPATH = CPPPATH)

--- a/bsp/stm32f10x/drivers/SConscript
+++ b/bsp/stm32f10x/drivers/SConscript
@@ -12,6 +12,10 @@ led.c
 usart.c
 """)
 
+# add canbus driver.
+if GetDepend('RT_USING_CAN'):
+    src += ['bxcan.c']
+
 # add Ethernet drivers.
 if GetDepend('RT_USING_LWIP'):
     src += ['dm9000a.c']

--- a/bsp/stm32f10x/drivers/bxcan.c
+++ b/bsp/stm32f10x/drivers/bxcan.c
@@ -1575,4 +1575,4 @@ int stm32_bxcan_init(void)
 }
 INIT_BOARD_EXPORT(stm32_bxcan_init);
 
-#endif /*RT_USING_CAN2*/
+#endif /*RT_USING_CAN*/

--- a/bsp/stm32f10x/rtconfig.h
+++ b/bsp/stm32f10x/rtconfig.h
@@ -82,7 +82,7 @@
 
 #define RT_USING_PIN
 
-#define RT_USING_CAN
+//#define RT_USING_CAN
 
 #define RT_CAN_USING_BUS_HOOK
 


### PR DESCRIPTION
temporarily disable canapp initialization.