### PR TITLE
remove function finsh_set_device in application.c in bsp/stm32f10x

### DIFF
--- a/bsp/stm32f10x/applications/application.c
+++ b/bsp/stm32f10x/applications/application.c
@@ -94,10 +94,6 @@ void rt_init_thread_entry(void* parameter)
     rt_components_init();
 #endif
 
-#ifdef  RT_USING_FINSH
-    finsh_set_device(RT_CONSOLE_DEVICE_NAME);
-#endif  /* RT_USING_FINSH */
-
     /* Filesystem Initialization */
 #if defined(RT_USING_DFS) && defined(RT_USING_DFS_ELMFAT)
     /* mount sd card fat partition 1 as root directory */


### PR DESCRIPTION
finsh_set_device is not needed since version 1.2.0