### PR TITLE
Update serial.c

### DIFF
--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -75,7 +75,7 @@ rt_inline int _serial_poll_tx(struct rt_serial_device *serial, const rt_uint8_t 
          */
         if (*data == '\n' && (serial->parent.open_flag & RT_DEVICE_FLAG_STREAM))
         {
-            serial->ops->putc(serial, '\r');
+            while(serial->ops->putc(serial, '\r') == -1);
         }
     
         serial->ops->putc(serial, *data);


### PR DESCRIPTION
串口轮询发送增加返回值来判断是否发送完成，即使putc无需等待发送完成就立刻返回，与 _serial_int_tx调用putc一致