### PR TITLE
fix can baud rate config error in bsp/stm32f10x  fix #597

### DIFF
--- a/bsp/stm32f10x/applications/canapp.c
+++ b/bsp/stm32f10x/applications/canapp.c
@@ -245,10 +245,12 @@ int rt_can_app_init(void)
                            512, RT_THREAD_PRIORITY_MAX / 3 - 1, 20);
     if (tid != RT_NULL) rt_thread_startup(tid);
 
+#ifdef USING_BXCAN2
     tid = rt_thread_create("canapp2",
                            rt_can_thread_entry, &can_data[1],
                            512, RT_THREAD_PRIORITY_MAX / 3 - 1, 20);
     if (tid != RT_NULL) rt_thread_startup(tid);
+#endif
 
     return 0;
 }

--- a/bsp/stm32f10x/drivers/SConscript
+++ b/bsp/stm32f10x/drivers/SConscript
@@ -12,6 +12,9 @@ led.c
 usart.c
 """)
 
+if GetDepend(['RT_USING_PIN']):
+    src += ['gpio.c']
+
 # add canbus driver.
 if GetDepend('RT_USING_CAN'):
     src += ['bxcan.c']

--- a/bsp/stm32f10x/rtconfig.h
+++ b/bsp/stm32f10x/rtconfig.h
@@ -84,7 +84,7 @@
 
 #define RT_USING_CAN
 
-//#define RT_CAN_USING_BUS_HOOK
+#define RT_CAN_USING_BUS_HOOK
 
 #define RT_CAN_USING_HDR
 /* SECTION: device filesystem */

--- a/bsp/stm32f10x/rtconfig.h
+++ b/bsp/stm32f10x/rtconfig.h
@@ -82,9 +82,9 @@
 
 #define RT_USING_PIN
 
-//#define RT_USING_CAN
+#define RT_USING_CAN
 
-#define RT_CAN_USING_BUS_HOOK
+//#define RT_CAN_USING_BUS_HOOK
 
 #define RT_CAN_USING_HDR
 /* SECTION: device filesystem */

--- a/components/drivers/misc/pin.c
+++ b/components/drivers/misc/pin.c
@@ -101,18 +101,21 @@ int rt_device_pin_register(const char *name, const struct rt_pin_ops *ops, void 
 /* RT-Thread Hardware PIN APIs */
 void rt_pin_mode(rt_base_t pin, rt_base_t mode)
 {
+	RT_ASSERT(_hw_pin.ops != RT_NULL);
     _hw_pin.ops->pin_mode(&_hw_pin.parent, pin, mode);
 }
 FINSH_FUNCTION_EXPORT_ALIAS(rt_pin_mode, pinMode, set hardware pin mode);
 
 void rt_pin_write(rt_base_t pin, rt_base_t value)
 {
+	RT_ASSERT(_hw_pin.ops != RT_NULL);
     _hw_pin.ops->pin_write(&_hw_pin.parent, pin, value);
 }
 FINSH_FUNCTION_EXPORT_ALIAS(rt_pin_write, pinWrite, write value to hardware pin);
 
 int  rt_pin_read(rt_base_t pin)
 {
+	RT_ASSERT(_hw_pin.ops != RT_NULL);
     return _hw_pin.ops->pin_read(&_hw_pin.parent, pin);
 }
 FINSH_FUNCTION_EXPORT_ALIAS(rt_pin_read, pinRead, read status from hardware pin);


### PR DESCRIPTION
enum CANBAUD was changed in components/drivers/include/drivers/can.h ,
which causes array index out of bound in bsp/stm32f10x/drivers/bxcan.c

temporarily remove RT_CAN_USING_BUS_HOOK, because there are some bugs in
bsp/stm32f10x/applications/canapp.c  function can_bus_hook