### PR TITLE
flush cache after exception code install

### DIFF
--- a/bsp/ls1bdev/applications/startup.c
+++ b/bsp/ls1bdev/applications/startup.c
@@ -32,6 +32,9 @@ extern int rt_application_init(void);
 extern void tlb_refill_exception(void);
 extern void general_exception(void);
 extern void irq_exception(void);
+extern void rt_hw_cache_init(void);
+extern void invalidate_writeback_dcache_all(void);
+extern void invalidate_icache_all(void);
 
 /**
  * This function will startup RT-Thread RTOS.

--- a/bsp/ls1bdev/applications/startup.c
+++ b/bsp/ls1bdev/applications/startup.c
@@ -54,6 +54,9 @@ void rtthread_startup(void)
     rt_memcpy((void *)(A_K0BASE + 0x180), general_exception, 0x20);
     rt_memcpy((void *)(A_K0BASE + 0x200), irq_exception, 0x20);
 
+    invalidate_writeback_dcache_all();
+    invalidate_icache_all();
+
     /* init board */
     rt_hw_board_init();
 

--- a/bsp/ls1cdev/applications/startup.c
+++ b/bsp/ls1cdev/applications/startup.c
@@ -33,6 +33,9 @@ extern int rt_application_init(void);
 extern void tlb_refill_exception(void);
 extern void general_exception(void);
 extern void irq_exception(void);
+extern void rt_hw_cache_init(void);
+extern void invalidate_writeback_dcache_all(void);
+extern void invalidate_icache_all(void);
 
 /**
  * This function will startup RT-Thread RTOS.
@@ -51,6 +54,9 @@ void rtthread_startup(void)
     rt_memcpy((void *)A_K0BASE, tlb_refill_exception, 0x20);
     rt_memcpy((void *)(A_K0BASE + 0x180), general_exception, 0x20);
     rt_memcpy((void *)(A_K0BASE + 0x200), irq_exception, 0x20);
+
+    invalidate_writeback_dcache_all();
+    invalidate_icache_all();
 
     /* init board */
     rt_hw_board_init();

--- a/libcpu/mips/loongson_1b/cache.c
+++ b/libcpu/mips/loongson_1b/cache.c
@@ -13,6 +13,7 @@
  * 2011-08-08     lgnq         modified for LS1B
  */
  
+#include <rtthread.h>
 #include "../common/mipsregs.h"
 
 #define K0BASE			0x80000000
@@ -23,6 +24,7 @@ extern void Invalidate_Icache_Ls1b(unsigned int);
 extern void Invalidate_Dcache_ClearTag_Ls1b(unsigned int);
 extern void Invalidate_Dcache_Fill_Ls1b(unsigned int);
 extern void Writeback_Invalidate_Dcache(unsigned int);
+extern void enable_cpu_cache(void);
 
 typedef struct cacheinfo_t 
 {
@@ -151,7 +153,7 @@ void invalidate_dcache_all(void)
 	unsigned int end  = (start + pcacheinfo->dcache_size);
 	while (start <end)
 	{
-		Invalidate_Dcache_Fill_Gc3210I(start);
+		Invalidate_Dcache_Fill_Ls1b(start);
 		start += pcacheinfo->icacheline_size;
 	}
 }

--- a/libcpu/mips/loongson_1c/cache.c
+++ b/libcpu/mips/loongson_1c/cache.c
@@ -14,6 +14,7 @@
  * 2015-07-08     chinesebear   modified for loongson 1c
  */
  
+#include <rtthread.h>
 #include "../common/mipsregs.h"
 
 #define K0BASE			0x80000000
@@ -24,6 +25,7 @@ extern void Invalidate_Icache_Ls1c(unsigned int);
 extern void Invalidate_Dcache_ClearTag_Ls1c(unsigned int);
 extern void Invalidate_Dcache_Fill_Ls1c(unsigned int);
 extern void Writeback_Invalidate_Dcache(unsigned int);
+extern void enable_cpu_cache(void);
 
 typedef struct cacheinfo_t 
 {
@@ -152,7 +154,7 @@ void invalidate_dcache_all(void)
 	unsigned int end  = (start + pcacheinfo->dcache_size);
 	while (start <end)
 	{
-		Invalidate_Dcache_Fill_Gc3210I(start);
+		Invalidate_Dcache_Fill_Ls1c(start);
 		start += pcacheinfo->icacheline_size;
 	}
 }


### PR DESCRIPTION
现象：
   通过pmon加载rtthread.elf，经常会出现pmon的异常打印，导致rtthread加载失败。
原因：
    安装异常处理程序后没有刷新cache，且网口收到数据产生中断，导致打开中断后立即进入PMON中断服务程序。
