### PR TITLE
Update SConscript

### DIFF
--- a/components/libc/SConscript
+++ b/components/libc/SConscript
@@ -17,7 +17,10 @@ else:
     if rtconfig.PLATFORM == 'gcc' and rtconfig.ARCH != 'sim':
         objs = objs + SConscript('minilibc/SConscript')
 
-objs = objs + SConscript('pthreads/SConscript')
-objs = objs + SConscript('libdl/SConscript')
+if GetDepend('RT_USING_LIBC') and GetDepend('RT_USING_PTHREADS'):
+	objs = objs + SConscript('pthreads/SConscript')
+	
+if GetDepend('RT_USING_MODULE') and GetDepend('RT_USING_LIBDL'):
+	objs = objs + SConscript('libdl/SConscript')
 
 Return('objs')


### PR DESCRIPTION
fix Sconscript  error in LIBC,if somebody run "scons --copy " and he doesn't defined RT_USING_LIBDL,
error occurs...