### PR TITLE
disable stm32 EMAC hardware checksum.

### DIFF
--- a/bsp/stm32f107/drivers/stm32_eth.c
+++ b/bsp/stm32f107/drivers/stm32_eth.c
@@ -23,7 +23,7 @@
 #include "stm32f10x_rcc.h"
 
 /* STM32F107 ETH dirver options */
-#define CHECKSUM_BY_HARDWARE    1       /* 0: disable.  1: use hardware checksum. */
+#define CHECKSUM_BY_HARDWARE    0       /* don't ues hardware checksum. */
 #define RMII_MODE               0       /* 0: MII MODE, 1: RMII MODE. */
 #define STM32_ETH_IO_REMAP      1       /* 0: default,  1: remap RXD to PDx. */
 #define USE_MCO                 1       /* 0: disable,  1: PA8(MCO) out 25Mhz(MII) or 50Mhz(RMII). */

--- a/bsp/stm32f20x/Drivers/stm32f2_eth.c
+++ b/bsp/stm32f20x/Drivers/stm32f2_eth.c
@@ -11,7 +11,7 @@
 #include "stm32f2x7_eth_conf.h"
 
 #define STM32_ETH_DEBUG		0
-#define CHECKSUM_BY_HARDWARE
+//#define CHECKSUM_BY_HARDWARE /* don't ues hardware checksum. */
 
 /* MII and RMII mode selection, for STM322xG-EVAL Board(MB786) RevB ***********/
 //#define MII_MODE       

--- a/bsp/stm32f40x/drivers/stm32f4xx_eth.c
+++ b/bsp/stm32f40x/drivers/stm32f4xx_eth.c
@@ -35,7 +35,7 @@
 /* STM32F ETH dirver options */
 #define RMII_MODE                       /* MII_MODE or RMII_MODE */
 #define RMII_TX_GPIO_GROUP        2     /* 1:GPIOB or 2:GPIOG */
-#define CHECKSUM_BY_HARDWARE
+//#define CHECKSUM_BY_HARDWARE          /* don't ues hardware checksum. */
 
 /** @addtogroup STM32F4XX_ETH_Driver
   * @brief ETH driver modules

--- a/bsp/stm32f40x/rtconfig.h
+++ b/bsp/stm32f40x/rtconfig.h
@@ -155,14 +155,6 @@
 /* TCP receive window. */
 #define RT_LWIP_TCP_WND		8192
 
-#define CHECKSUM_CHECK_TCP              0
-#define CHECKSUM_CHECK_IP               0
-#define CHECKSUM_CHECK_UDP              0
-
-#define CHECKSUM_GEN_TCP                0
-#define CHECKSUM_GEN_IP                 0
-#define CHECKSUM_GEN_UDP                0
-
 /* RT_GDB_STUB */
 //#define RT_USING_GDB
 


### PR DESCRIPTION
硬件校验的兼容性不太好。