### PR TITLE
修改newlib文件输出的不匹配

### DIFF
--- a/components/drivers/include/rtdevice.h
+++ b/components/drivers/include/rtdevice.h
@@ -303,7 +303,7 @@ rt_err_t rt_workqueue_destroy(struct rt_workqueue* queue);
 rt_err_t rt_workqueue_dowork(struct rt_workqueue* queue, struct rt_work* work);
 rt_err_t rt_workqueue_cancel_work(struct rt_workqueue* queue, struct rt_work* work);
 
-rt_inline void rt_work_init(struct rt_work* work, void (*work_func)(struct rt_work* work, void* work_data), 
+rt_inline void rt_work_init(struct rt_work* work, void (*work_func)(struct rt_work* work, void* work_data),
     void* work_data)
 {
     rt_list_init(&(work->list));

--- a/components/libc/newlib/libc.c
+++ b/components/libc/newlib/libc.c
@@ -28,6 +28,7 @@ int libc_system_init(void)
 #error Please enable devfs by defining RT_USING_DFS_DEVFS in rtconfig.h
 #endif
 
+#ifndef RT_USING_NEWLIB
     console_dev = rt_console_get_device();
     if (console_dev)
     {
@@ -42,6 +43,8 @@ int libc_system_init(void)
         /* skip warning */
         fd = fd;
     }
+#endif
+
 #endif
 
     /* set PATH and HOME */

--- a/components/libc/newlib/sys/fcntl.h
+++ b/components/libc/newlib/sys/fcntl.h
@@ -2,6 +2,21 @@
 #define __RTT_FCNTL_H__
 
 /* Operation flags */
+#ifdef RT_USING_NEWLIB
+
+#define O_RDONLY        0x0000000
+#define O_WRONLY        0x0000001
+#define O_RDWR          0x0000002
+#define O_ACCMODE       (O_RDONLY|O_WRONLY|O_RDWR)
+#define O_CREAT         0x0200
+#define O_EXCL          0x0800
+#define O_TRUNC         0x0400
+#define O_APPEND        0x0008
+#define O_DIRECTORY     0x200000
+#define O_BINARY        0x10000
+
+#else
+    
 #define O_RDONLY        0x0000000
 #define O_WRONLY        0x0000001
 #define O_RDWR          0x0000002
@@ -12,5 +27,7 @@
 #define O_APPEND        0x0002000
 #define O_DIRECTORY     0x0200000
 #define O_BINARY        0x0008000
+
+#endif
 
 #endif

--- a/components/libc/newlib/syscalls.c
+++ b/components/libc/newlib/syscalls.c
@@ -205,7 +205,11 @@ _wait_r(struct _reent *ptr, int *status)
 _ssize_t
 _write_r(struct _reent *ptr, int fd, const void *buf, size_t nbytes)
 {
-	if (fd < 3)
+#ifndef RT_USING_NEWLIB
+    if (fd < 3)
+#else
+    if (0)
+#endif
 	{
 #ifdef RT_USING_CONSOLE
 		rt_device_t console_device;


### PR DESCRIPTION
1. fcntl与newlib中的fcntl定义值不同，导致newlib文件打开参数传递给RTT的桩函数时，参数值解析错误，解决方法是使用newlib中的定义来覆盖 rtt中的fcntl.h的定义
2. 解决newlib中没有打开标准控制台时，_write_r判断fd<3后，会把输出直接输出到finsh中