### PR TITLE
Update rtconfig.h

### DIFF
--- a/bsp/simulator/rtconfig.h
+++ b/bsp/simulator/rtconfig.h
@@ -238,7 +238,7 @@
 
 #endif /* end of _MSC_VER */
 
-#ifdef _WIN32
+#ifdef _Win32
 #define RT_USING_DFS_WINSHAREDIR
 #endif
 


### PR DESCRIPTION
When useing the macro of  _WIN32 in the file of rtconfig.h , then the file of dfs_win32.c will removed and compiled some mistakes. Fix it.