### PR TITLE
Add cpu uasge profiling for each thread.

### DIFF
--- a/bsp/stm32f40x/rtconfig.h
+++ b/bsp/stm32f40x/rtconfig.h
@@ -72,6 +72,9 @@
 /* Using Hardware Timer framework */
 //#define RT_USING_HWTIMER
 
+/* Using profile */
+#define RT_USING_PROFILE
+
 /* SECTION: Console options */
 #define RT_USING_CONSOLE
 /* the buffer size of console*/

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -518,6 +518,15 @@ struct rt_thread
     rt_uint8_t  event_info;
 #endif
 
+#ifdef RT_USING_PROFILE
+	rt_uint16_t cpu_usage;                              /**< thread's cpu usage */ 
+	rt_uint16_t cpu_usage_max;                          /**< the maximum of thread's cpu usage */ 
+	rt_tick_t   ticks_delta;
+	rt_tick_t   ticks_start;
+	rt_tick_t   ticks_total;
+	rt_tick_t   tick_profile;  
+#endif
+
     rt_ubase_t  init_tick;                              /**< thread's initialized tick */
     rt_ubase_t  remaining_tick;                         /**< remaining tick */
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -248,6 +248,15 @@ rt_err_t rt_thread_startup(rt_thread_t thread)
 #else
     thread->number_mask = 1L << thread->current_priority;
 #endif
+    /* initialize  variables for profiling */
+#ifdef RT_USING_PROFILE
+	thread->cpu_usage        = 0;
+	thread->cpu_usage_max    = 0;
+	thread->ticks_delta      = 0;
+	thread->ticks_total      = 0;
+	thread->ticks_start      = rt_tick_get();
+	thread->tick_profile     = thread->ticks_start;
+#endif
 
     RT_DEBUG_LOG(RT_DEBUG_THREAD, ("startup a thread:%s with priority:%d\n",
                                    thread->name, thread->init_priority));
@@ -257,6 +266,7 @@ rt_err_t rt_thread_startup(rt_thread_t thread)
     rt_thread_resume(thread);
     if (rt_thread_self() != RT_NULL)
     {
+		
         /* do a scheduling */
         rt_schedule();
     }


### PR DESCRIPTION
Hi Bernard,我给调度器增加了几行代码，用来收集每个线程的CPU占用率。原理是统计每个线程运行时占用的tick数占每秒总tick数的比例。该方法也用在了uC/OS 3内核中。它能比较准确的统计大线程的CPU占用率。
        但有一个已知问题：但对于某些运行时间非常短的线程，会概率性出现从进入到退出时tick都还没有增加过的情况，这时，该方法不能统计到这次进入所占用的CPU，因此统计到的总CPU使用率相比实际略低。

```
    我明白这几行代码是对关键代码进行修改，进行的比较谨慎，也测试了几天，目前没有发现问题。相信这个pull request，你也会非常谨慎处理。当然，如果能接受，我会非常高兴，谢谢！
```
