### PR TITLE
add rt_hw_uart_init() in board.c. Initialize uart0, uart1 devices.

### DIFF
--- a/bsp/zynq7000/drivers/board.c
+++ b/bsp/zynq7000/drivers/board.c
@@ -83,6 +83,7 @@ INIT_BOARD_EXPORT(rt_hw_timer_init);
 void rt_hw_board_init()
 {
     rt_components_board_init();
+    rt_hw_uart_init();
     rt_console_set_device(RT_CONSOLE_DEVICE_NAME);
 }
 


### PR DESCRIPTION
为了在Vivado中编译成功并且成功运行例程，需要添加uart初始化代码。