### PR TITLE
修复 dataqueue 的两处 Bug

### DIFF
--- a/components/drivers/include/rtdevice.h
+++ b/components/drivers/include/rtdevice.h
@@ -134,7 +134,6 @@ struct rt_data_queue
 {
     rt_uint16_t size;
     rt_uint16_t lwm;
-    rt_bool_t   waiting_lwm;
 
     rt_uint16_t get_index;
     rt_uint16_t put_index;

--- a/components/drivers/src/dataqueue.c
+++ b/components/drivers/src/dataqueue.c
@@ -117,11 +117,7 @@ rt_err_t rt_data_queue_push(struct rt_data_queue *queue,
         /* thread is waked up */
         result = thread->error;
         level = rt_hw_interrupt_disable();
-        if (result != RT_EOK)
-        {
-            queue->waiting_lwm = RT_FALSE;
-            goto __exit;
-        }
+        if (result != RT_EOK) goto __exit;
     }
 
     queue->queue[queue->put_index % queue->size].data_ptr  = data_ptr;
@@ -243,6 +239,10 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
 
             /* perform a schedule */
             rt_schedule();
+        }
+        else
+        {
+            rt_hw_interrupt_enable(level);
         }
 
         if (queue->evt_notify != RT_NULL)

--- a/components/drivers/src/dataqueue.c
+++ b/components/drivers/src/dataqueue.c
@@ -20,6 +20,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2012-09-30     Bernard      first version.
+ * 2016-10-31     armink       fix some resume push and pop thread bugs
  */
 
 #include <rtthread.h>
@@ -220,8 +221,6 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
     if ((queue->waiting_lwm == RT_TRUE) && 
         (queue->put_index - queue->get_index) <= queue->lwm)
     {
-        queue->waiting_lwm = RT_FALSE;
-
         /*
          * there is at least one thread in suspended list
          * and less than low water mark
@@ -242,6 +241,7 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
         }
         else
         {
+            queue->waiting_lwm = RT_FALSE;
             rt_hw_interrupt_enable(level);
         }
 

--- a/components/drivers/src/dataqueue.c
+++ b/components/drivers/src/dataqueue.c
@@ -45,7 +45,6 @@ rt_data_queue_init(struct rt_data_queue *queue,
 
     queue->size = size;
     queue->lwm = lwm;
-    queue->waiting_lwm = RT_FALSE;
 
     queue->get_index = 0;
     queue->put_index = 0;
@@ -80,8 +79,6 @@ rt_err_t rt_data_queue_push(struct rt_data_queue *queue,
     level = rt_hw_interrupt_disable();
     while (queue->put_index - queue->get_index == queue->size)
     {
-        queue->waiting_lwm = RT_TRUE;
-
         /* queue is full */
         if (timeout == 0)
         {
@@ -218,8 +215,7 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
 
     queue->get_index += 1;
 
-    if ((queue->waiting_lwm == RT_TRUE) && 
-        (queue->put_index - queue->get_index) <= queue->lwm)
+    if ((queue->put_index - queue->get_index) <= queue->lwm)
     {
         /*
          * there is at least one thread in suspended list
@@ -241,7 +237,6 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
         }
         else
         {
-            queue->waiting_lwm = RT_FALSE;
             rt_hw_interrupt_enable(level);
         }
 

--- a/components/drivers/src/dataqueue.c
+++ b/components/drivers/src/dataqueue.c
@@ -122,10 +122,9 @@ rt_err_t rt_data_queue_push(struct rt_data_queue *queue,
     queue->queue[queue->put_index % queue->size].data_size = data_size;
     queue->put_index += 1;
 
+    /* there is at least one thread in suspended list */
     if (!rt_list_isempty(&(queue->suspended_pop_list)))
     {
-        /* there is at least one thread in suspended list */
-
         /* get thread entry */
         thread = rt_list_entry(queue->suspended_pop_list.next,
                                struct rt_thread,
@@ -217,10 +216,7 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
 
     if ((queue->put_index - queue->get_index) <= queue->lwm)
     {
-        /*
-         * there is at least one thread in suspended list
-         * and less than low water mark
-         */
+        /* there is at least one thread in suspended list */
         if (!rt_list_isempty(&(queue->suspended_push_list)))
         {
             /* get thread entry */

--- a/components/drivers/src/dataqueue.c
+++ b/components/drivers/src/dataqueue.c
@@ -119,7 +119,11 @@ rt_err_t rt_data_queue_push(struct rt_data_queue *queue,
         /* thread is waked up */
         result = thread->error;
         level = rt_hw_interrupt_disable();
-        if (result != RT_EOK) goto __exit;
+        if (result != RT_EOK)
+        {
+            queue->waiting_lwm = RT_FALSE;
+            goto __exit;
+        }
     }
 
     queue->queue[queue->put_index & mask].data_ptr  = data_ptr;


### PR DESCRIPTION
- 1、在 push 过程中，线程等待超时后，没有对 `queue->waiting_lwm` 标志清零，这导致接下来的 pop 操作发生全局中断无法恢复使能的问题；
- 2、push 和 pop 中对 data buffer 索引计算方式兼容性不好，部分 size 大小的场景下，计算出来的索引是错误的。下面是设定 dataqueue 长度为 10 ，使用之前的 `&mask` （mask = size -1）方式和新修改的 `%size` 方式进行 push 和 pop 操作，对实际计算出来的 索引值 结果的对比：

```
msh >dq push
queue->put_index & mask:0
queue->put_index % size:0
msh >dq push
queue->put_index & mask:1
queue->put_index % size:1
msh >dq push
queue->put_index & mask:0
queue->put_index % size:2
msh >dq push
queue->put_index & mask:1
queue->put_index % size:3
msh >dq push
queue->put_index & mask:0
queue->put_index % size:4
msh >dq push
queue->put_index & mask:1
queue->put_index % size:5
msh >dq push
queue->put_index & mask:0
queue->put_index % size:6
msh >dq push
queue->put_index & mask:1
queue->put_index % size:7
msh >dq push
queue->put_index & mask:8
queue->put_index % size:8
msh >dq push
queue->put_index & mask:9
queue->put_index % size:9
msh >dq pop
queue->get_index & mask:0
queue->get_index % size:0
msh >dq pop
queue->get_index & mask:1
queue->get_index % size:1
msh >dq pop
queue->get_index & mask:0
queue->get_index % size:2
msh >dq pop
queue->get_index & mask:1
queue->get_index % size:3
msh >dq pop
queue->get_index & mask:0
queue->get_index % size:4
msh >dq pop
queue->get_index & mask:1
queue->get_index % size:5
msh >dq pop
queue->get_index & mask:0
queue->get_index % size:6
msh >dq pop
queue->get_index & mask:1
queue->get_index % size:7
msh >dq pop
queue->get_index & mask:8
queue->get_index % size:8
msh >dq pop
queue->get_index & mask:9
queue->get_index % size:9
```

比较明显是第 3 次 push，,此时 push_index = 2，则 put_index & mask = 2 & 9 =0，正确的应该是 2
