### PR TITLE
add /bsp/beaglebone/uboot_cmd.txt file

### DIFF
--- a/bsp/beaglebone/uboot_cmd.txt
+++ b/bsp/beaglebone/uboot_cmd.txt
@@ -1,3 +1,5 @@
 mmcinfo
 fatload mmc 0 0x80200000 rtthread.bin
 go 0x80200000
+
+其中的地址0x80200000根据链接地址确定


### PR DESCRIPTION
When use u-boot or other tools to load rtthread.bin, change the load address 0x802000000 according to your link address!