### PR TITLE
修改stm32f4 bsp的标准库的一个BUG

### DIFF
--- a/bsp/stm32f40x/Libraries/STM32F4xx_StdPeriph_Driver/inc/stm32f4xx_dma.h
+++ b/bsp/stm32f40x/Libraries/STM32F4xx_StdPeriph_Driver/inc/stm32f4xx_dma.h
@@ -393,7 +393,7 @@ typedef struct
 #define DMA_FLAG_TCIF7                    ((uint32_t)0x28000000)
 
 #define IS_DMA_CLEAR_FLAG(FLAG) ((((FLAG) & 0x30000000) != 0x30000000) && (((FLAG) & 0x30000000) != 0) && \
-                                 (((FLAG) & 0xC082F082) == 0x00) && ((FLAG) != 0x00))
+                                 (((FLAG) & 0xC002F082) == 0x00) && ((FLAG) != 0x00))
 
 #define IS_DMA_GET_FLAG(FLAG) (((FLAG) == DMA_FLAG_TCIF0)  || ((FLAG) == DMA_FLAG_HTIF0)  || \
                                ((FLAG) == DMA_FLAG_TEIF0)  || ((FLAG) == DMA_FLAG_DMEIF0) || \


### PR DESCRIPTION
具体情况为
当前主分支上采用的stm32 f4标准库为1.0.0版本，该版本的stm32f4xx_dma.h文件 395行处，定义了IS_DMA_CLEAR_FLAG宏，这个宏的中检查的一个常量值是错误的。该错误导致清除Stream0上的DMA标志出现断言错误。
我已将标准库1.6.1中对应的实现复制过来，经测试问题已解决。