### PR TITLE
修正sdio驱动框架的一些bug

### DIFF
--- a/components/drivers/sdio/sdio.c
+++ b/components/drivers/sdio/sdio.c
@@ -1347,9 +1347,6 @@ rt_int32_t sdio_unregister_driver(struct rt_sdio_driver *driver)
     struct sdio_driver *sd = RT_NULL;
     struct rt_mmcsd_card *card;
 
-
-    rt_list_insert_after(&sdio_drivers, &sd->list);
-
     for (l = (&sdio_drivers)->next; l != &sdio_drivers; l = l->next)
     {
         sd = (struct sdio_driver *)rt_list_entry(l, struct sdio_driver, list);


### PR DESCRIPTION
1.修正sdio_irq_wakeup函数中的bug:关sdio中断前添加判断条件"if (host->flags & MMCSD_SUP_SDIO_IRQ)"，防止当sdio host->flags无"MMCSD_SUP_SDIO_IRQ"项时出错。
2.修正sdio_unregister_driver函数的bug：注释掉语句"rt_list_insert_after(&sdio_drivers, &sd->list);",否则不能正确卸载sdio驱动，而且会进入硬件错误中断。