### PR TITLE
rt_workqueue的一些修改

### DIFF
--- a/components/drivers/include/rtdevice.h
+++ b/components/drivers/include/rtdevice.h
@@ -159,7 +159,7 @@ struct rt_work
 {
 	rt_list_t list;
 
-	void (*work_func)(struct rt_work* work, void* work_data);
+	void (*work_func)(struct rt_work* work);
 	void *work_data;
 };
 
@@ -303,7 +303,7 @@ rt_err_t rt_workqueue_destroy(struct rt_workqueue* queue);
 rt_err_t rt_workqueue_dowork(struct rt_workqueue* queue, struct rt_work* work);
 rt_err_t rt_workqueue_cancel_work(struct rt_workqueue* queue, struct rt_work* work);
 
-rt_inline void rt_work_init(struct rt_work* work, void (*work_func)(struct rt_work* work, void* work_data),
+rt_inline void rt_work_init(struct rt_work* work, void (*work_func)(struct rt_work* work),
     void* work_data)
 {
     rt_list_init(&(work->list));

--- a/components/drivers/src/workqueue.c
+++ b/components/drivers/src/workqueue.c
@@ -53,7 +53,7 @@ static void _workqueue_thread_entry(void* parameter)
         rt_hw_interrupt_enable(level);
 
         /* do work */
-        work->work_func(work, work->work_data);
+        work->work_func(work);
         level = rt_hw_interrupt_disable();
         /* clean current work */
         queue->work_current = RT_NULL;


### PR DESCRIPTION
为了与Linux的workqueue兼容，建议将work_func多余的入口参数void* work_data去除