### PR TITLE
correct stm32f4xx flash vector table base location

### DIFF
--- a/bsp/stm32f429-apollo/drivers/board.c
+++ b/bsp/stm32f429-apollo/drivers/board.c
@@ -143,7 +143,7 @@ void rt_hw_board_init()
     SCB->VTOR  = (0x10000000 & NVIC_VTOR_MASK);
 #else  /* VECT_TAB_FLASH  */
     /* Set the Vector Table base location at 0x00000000 */
-    SCB->VTOR  = (0x00000000 & NVIC_VTOR_MASK);
+    SCB->VTOR  = (0x08000000 & NVIC_VTOR_MASK);
 #endif
     HAL_Init();
 


### PR DESCRIPTION
修正stm32fxx的flash向量基地址: 0x00000000 -> 0x08000000