### PR TITLE
Fix uart rx dma

### DIFF
--- a/bsp/stm32f10x/drivers/usart.c
+++ b/bsp/stm32f10x/drivers/usart.c
@@ -199,15 +199,7 @@ static void dma_uart_rx_idle_isr(struct rt_serial_device *serial) {
     level = rt_hw_interrupt_disable();
 
     recv_total_index = uart->dma.setting_recv_len - DMA_GetCurrDataCounter(uart->dma.rx_ch);
-    if (recv_total_index >= uart->dma.last_recv_index)
-    {
-        recv_len = recv_total_index - uart->dma.last_recv_index;
-    }
-    else
-    {
-        recv_len = uart->dma.setting_recv_len - uart->dma.last_recv_index + recv_total_index;
-    }
-
+    recv_len = recv_total_index - uart->dma.last_recv_index;
     uart->dma.last_recv_index = recv_total_index;
     /* enable interrupt */
     rt_hw_interrupt_enable(level);
@@ -226,23 +218,15 @@ static void dma_uart_rx_idle_isr(struct rt_serial_device *serial) {
  */
 static void dma_rx_done_isr(struct rt_serial_device *serial) {
     struct stm32_uart *uart = (struct stm32_uart *) serial->parent.user_data;
-    rt_size_t recv_total_index, recv_len;
+    rt_size_t recv_len;
     rt_base_t level;
 
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
 
-    recv_total_index = uart->dma.setting_recv_len - DMA_GetCurrDataCounter(uart->dma.rx_ch);
-    if (recv_total_index >= uart->dma.last_recv_index)
-    {
-        recv_len = recv_total_index - uart->dma.last_recv_index;
-    }
-    else
-    {
-        recv_len = uart->dma.setting_recv_len - uart->dma.last_recv_index + recv_total_index;
-    }
-
-    uart->dma.last_recv_index = recv_total_index;
+    recv_len = uart->dma.setting_recv_len - uart->dma.last_recv_index;
+    /* reset last recv index */
+    uart->dma.last_recv_index = 0;
     /* enable interrupt */
     rt_hw_interrupt_enable(level);
 
@@ -535,7 +519,7 @@ static void NVIC_Configuration(struct stm32_uart* uart)
     /* Enable the USART1 Interrupt */
     NVIC_InitStructure.NVIC_IRQChannel = uart->irq;
     NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
+    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 1;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);
 }
@@ -577,7 +561,7 @@ static void DMA_Configuration(struct rt_serial_device *serial) {
     /* rx dma interrupt config */
     NVIC_InitStructure.NVIC_IRQChannel = uart->dma.rx_irq_ch;
     NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 0;
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 1;
+    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
     NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
     NVIC_Init(&NVIC_InitStructure);
 }

--- a/components/drivers/include/drivers/serial.h
+++ b/components/drivers/include/drivers/serial.h
@@ -122,6 +122,8 @@ struct rt_serial_rx_fifo
     rt_uint8_t *buffer;
 
     rt_uint16_t put_index, get_index;
+
+    rt_bool_t is_full;
 };
 
 struct rt_serial_tx_fifo


### PR DESCRIPTION
- 1、修复了 STM32F10X 及 STM32F4XX BSP 中串口接收 DMA 驱动，在首次接收数据并一次性填满 FIFO 会导致数据丢失的 Bug；
- 2、在 rt_serial_rx_fifo 中增加了满标识，使得 FIFO 可以存储与缓冲区大小一致的数据（之前会少一个）。并在串口接收 DMA 驱动实现该功能。