### PR TITLE
	modified:   components/libc/newlib/libc.c

### DIFF
--- a/components/libc/newlib/libc.c
+++ b/components/libc/newlib/libc.c
@@ -47,8 +47,7 @@ int libc_system_init(void)
     /* set PATH and HOME */
     putenv("PATH=/bin");
     putenv("HOME=/home");
-
-#ifdef RT_USING_PTHREADS
+#if defined RT_USING_PTHREADS && !defined RT_USING_COMPONENTS_INIT
     pthread_system_init();
 #endif
 


### PR DESCRIPTION
修正pthread_system_init函数重复运行使信号量“psem”被重复初始化并导致list_sem陷入死循环的问题，