### PR TITLE
[bsp] fix bxcan.c inline bug

### DIFF
--- a/bsp/stm32f10x/drivers/bxcan.c
+++ b/bsp/stm32f10x/drivers/bxcan.c
@@ -20,7 +20,9 @@
 #endif
 #ifdef RT_USING_CAN
 
+#ifdef __CC_ARM
 #define inline __inline
+#endif
 #ifndef STM32F10X_CL
 #define BX_CAN_FMRNUMBER 14
 #define BX_CAN2_FMRSTART 7

--- a/bsp/stm32f10x/drivers/bxcan.c
+++ b/bsp/stm32f10x/drivers/bxcan.c
@@ -20,9 +20,6 @@
 #endif
 #ifdef RT_USING_CAN
 
-#ifdef __CC_ARM
-#define inline __inline
-#endif
 #ifndef STM32F10X_CL
 #define BX_CAN_FMRNUMBER 14
 #define BX_CAN2_FMRSTART 7
@@ -401,7 +398,7 @@ static void bxcan2_hw_init(void)
     NVIC_Init(&NVIC_InitStructure);
 }
 #endif
-static inline rt_err_t bxcan_enter_init(CAN_TypeDef *pcan)
+rt_inline rt_err_t bxcan_enter_init(CAN_TypeDef *pcan)
 {
     uint32_t wait_ack = 0x00000000;
 
@@ -417,7 +414,7 @@ static inline rt_err_t bxcan_enter_init(CAN_TypeDef *pcan)
     }
     return RT_EOK;
 }
-static inline rt_err_t bxcan_exit_init(CAN_TypeDef *pcan)
+rt_inline rt_err_t bxcan_exit_init(CAN_TypeDef *pcan)
 {
     uint32_t wait_ack = 0x00000000;
 


### PR DESCRIPTION
fix bsp/stm32f10x/drivers/bxcan.c “inline” bug on iar