### PR TITLE
在龙芯1c的编译配置脚本“rtconfig.py”中增加“交叉编译工具链的说明”

### DIFF
--- a/bsp/ls1cdev/rtconfig.py
+++ b/bsp/ls1cdev/rtconfig.py
@@ -12,7 +12,6 @@ if os.getenv('RTT_CC'):
 
 if  CROSS_TOOL == 'gcc':
 	PLATFORM    = 'gcc'
-#	EXEC_PATH   = '/opt/opt/gcc-4.3-ls232/bin'
 	EXEC_PATH   = r'D:\mgc\embedded\codebench\bin'
 else:
     print '================ERROR==========================='
@@ -25,6 +24,9 @@ if os.getenv('RTT_EXEC_PATH'):
 
 BUILD       = 'debug'
 
+# don't use loongson company's cross-compilation tool chain to compile the RT-Thread
+# must use the cross-compilation tool chain that RT-Thread recommand
+# download: https://coding.net/u/bernard/p/rtthread_tools/git/blob/master/GCC_Toolchains.md
 PREFIX = 'mips-sde-elf-'
 CC = PREFIX + 'gcc'
 AS = PREFIX + 'gcc'


### PR DESCRIPTION
使用龙芯官方推出的那个用于编译linux的交叉编译工具链来编译RT-Thread会报错，
可以使用RT-Thread官方推荐那个