### PR TITLE
[bsp] update core clock and add led task

### DIFF
--- a/bsp/lpc824/drivers/board.c
+++ b/bsp/lpc824/drivers/board.c
@@ -60,6 +60,7 @@ void SysTick_Handler(void)
  */
 void rt_hw_board_init()
 {
+    SystemCoreClockUpdate();
     SysTick_Config(SystemCoreClock / RT_TIMER_TICK_PER_SECOND);
 
 #ifdef RT_USING_COMPONENTS_INIT


### PR DESCRIPTION
- update core clock before configure systick
- add led task to easy confirm kernel is running

==================================
忘记调用 systemcoreclockupdate()函数， 导致systick中断频率太慢。
