### PR TITLE
[LWIP] Fix lwip 2.0.2 link status problem.

### DIFF
--- a/components/net/lwip-2.0.2/src/arch/sys_arch.c
+++ b/components/net/lwip-2.0.2/src/arch/sys_arch.c
@@ -114,7 +114,7 @@ static void tcpip_init_done_callback(void *arg)
             netif_set_up(ethif->netif);
 #endif
 
-            if (!(ethif->flags & ETHIF_LINK_PHYUP))
+            if (ethif->flags & ETHIF_LINK_PHYUP)
             {
                 netif_set_link_up(ethif->netif);
             }

--- a/components/net/lwip-2.0.2/src/netif/ethernetif.c
+++ b/components/net/lwip-2.0.2/src/netif/ethernetif.c
@@ -180,7 +180,7 @@ static err_t eth_netif_device_init(struct netif *netif)
         netif_set_up(ethif->netif);
 #endif
 
-        if (!(ethif->flags & ETHIF_LINK_PHYUP))
+        if (ethif->flags & ETHIF_LINK_PHYUP)
         {
             /* set link_up for this netif */
             netif_set_link_up(ethif->netif);


### PR DESCRIPTION
在 lwip 2.0.2 中，当未插入网线时对设备开机，存在 link 状态显示不正确的 Bug。