### PR TITLE
fix the end of module symbol bug and 	fix duplicate definitions when using dfs and iar compiler

### DIFF
--- a/components/dfs/include/dfs_def.h
+++ b/components/dfs/include/dfs_def.h
@@ -203,7 +203,7 @@
 #define DFS_F_ERR                0x08000000
 
 /* Seek flags */
-#if  (defined(__CC_ARM) || defined(__IAR_SYSTEMS_ICC__))
+#if (defined(__CC_ARM) || defined(__IAR_SYSTEMS_ICC__))
 #include <stdio.h>
 #define DFS_SEEK_SET             SEEK_SET
 #define DFS_SEEK_CUR             SEEK_CUR

--- a/components/dfs/include/dfs_def.h
+++ b/components/dfs/include/dfs_def.h
@@ -203,7 +203,7 @@
 #define DFS_F_ERR                0x08000000
 
 /* Seek flags */
-#ifdef __CC_ARM
+#if  (defined(__CC_ARM) || defined(__IAR_SYSTEMS_ICC__))
 #include <stdio.h>
 #define DFS_SEEK_SET             SEEK_SET
 #define DFS_SEEK_CUR             SEEK_CUR

--- a/src/module.c
+++ b/src/module.c
@@ -116,7 +116,7 @@ int rt_system_module_init(void)
     _rt_module_symtab_end   = (struct rt_module_symtab *)&RTMSymTab$$Limit;
 #elif defined (__IAR_SYSTEMS_ICC__)
     _rt_module_symtab_begin = __section_begin("RTMSymTab");
-    _rt_module_symtab_end   = __section_begin("RTMSymTab");
+    _rt_module_symtab_end   = __section_end("RTMSymTab");
 #endif
 
 #ifdef RT_USING_SLAB


### PR DESCRIPTION
fix the end of module symbol bug when use iar compiler