### PR TITLE
[bsp] Fix a CAN interrupt number macro definition bug for STM32F10X_LD,STM32F10X_MD and STM32F10X_XL series.

### DIFF
--- a/bsp/stm32f10x/drivers/bxcan.c
+++ b/bsp/stm32f10x/drivers/bxcan.c
@@ -15,9 +15,11 @@
 #include <rtdevice.h>
 #include <board.h>
 #include <bxcan.h>
+
 #ifdef RT_USING_COMPONENTS_INIT
 #include <components.h>
 #endif
+
 #ifdef RT_USING_CAN
 
 #ifndef STM32F10X_CL
@@ -27,12 +29,13 @@
 #define BX_CAN_FMRNUMBER 28
 #define BX_CAN2_FMRSTART 14
 #endif
-#ifdef STM32F10X_HD
-#undef USING_BXCAN2
 
+#if (defined (STM32F10X_LD)) || (defined (STM32F10X_MD)) || (defined (STM32F10X_HD)) || (defined (STM32F10X_XL))
+#undef USING_BXCAN2
 #define CAN1_RX0_IRQn USB_LP_CAN1_RX0_IRQn
 #define CAN1_TX_IRQn USB_HP_CAN1_TX_IRQn
 #endif
+
 #define BX_CAN_MAX_FILTERS (BX_CAN_FMRNUMBER * 4)
 #define BX_CAN_MAX_FILTER_MASKS BX_CAN_MAX_FILTERS
 #define BX_CAN_FILTER_MAX_ARRAY_SIZE ((BX_CAN_MAX_FILTERS + 32 - 1) / 32)

--- a/bsp/stm32f10x/drivers/bxcan.c
+++ b/bsp/stm32f10x/drivers/bxcan.c
@@ -16,6 +16,10 @@
 #include <board.h>
 #include <bxcan.h>
 
+#if (defined (STM32F10X_LD_VL)) || (defined (STM32F10X_MD_VL)) || (defined (STM32F10X_HD_VL))
+#undef RT_USING_CAN
+#endif
+
 #ifdef RT_USING_COMPONENTS_INIT
 #include <components.h>
 #endif


### PR DESCRIPTION
Fix a CAN interrupt number macro definition bug for STM32F10X_LD,STM32F10X_MD and STM32F10X_XL series.
Prevent compilation errors in bxcan.c when using STM32F10X_LD_VL,STM32F10X_MD_VL,STM32F10X_HD_VL incorrectly choose to use the RT_USING_CAN.