### PR TITLE
[Kernel] Fix rt_realloc issue when new size is 0.

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -24,6 +24,7 @@
  *                             fix memory check in rt_realloc function
  * 2010-07-13     Bernard      fix RT_ALIGN issue found by kuronca
  * 2010-10-14     Bernard      fix rt_realloc issue when realloc a NULL pointer.
+ * 2017-07-14     armink       fix rt_realloc issue when new size is 0
  */
 
 /*
@@ -400,6 +401,11 @@ void *rt_realloc(void *rmem, rt_size_t newsize)
 
         return RT_NULL;
     }
+    else if (newsize == 0)
+    {
+        rt_free(rmem);
+        return RT_NULL;
+    }
 
     /* allocate a new memory block */
     if (rmem == RT_NULL)
@@ -589,4 +595,3 @@ FINSH_FUNCTION_EXPORT(list_mem, list memory usage information)
 
 #endif /* end of RT_USING_HEAP */
 #endif /* end of RT_USING_MEMHEAP_AS_HEAP */
-


### PR DESCRIPTION
Free the old memory when new size is 0 in `rt_realloc`.