### PR TITLE
Update cortex m port

### DIFF
--- a/bsp/stm32f20x/stm32_rom.icf
+++ b/bsp/stm32f20x/stm32_rom.icf
@@ -28,8 +28,8 @@ do not initialize  { section .noinit };
 
 keep { section FSymTab };
 keep { section VSymTab };
+keep { section .rti_fn* };
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly, block RTT_INIT_FUNC };
-place in RAM_region   { readwrite,
-                        block CSTACK, block HEAP };
+place in RAM_region   { readwrite, block CSTACK, last block HEAP};

--- a/libcpu/arm/cortex-m0/context_gcc.S
+++ b/libcpu/arm/cortex-m0/context_gcc.S
@@ -181,7 +181,9 @@ rt_hw_context_switch_to:
     NOP
     MSR     MSP, R0
 
-    CPSIE   I                       /* enable interrupts at processor level */
+    /* enable interrupts at processor level */
+    CPSIE   F
+    CPSIE   I
 
     /* never reach here! */
 

--- a/libcpu/arm/cortex-m0/context_iar.S
+++ b/libcpu/arm/cortex-m0/context_iar.S
@@ -188,6 +188,7 @@ rt_hw_context_switch_to:
     MSR     msp, r0
 
     ; enable interrupts at processor level
+    CPSIE   F
     CPSIE   I
 
     ; never reach here!

--- a/libcpu/arm/cortex-m0/context_rvds.S
+++ b/libcpu/arm/cortex-m0/context_rvds.S
@@ -191,6 +191,7 @@ rt_hw_context_switch_to    PROC
     MSR     msp, r0
 
     ; enable interrupts at processor level
+    CPSIE   F
     CPSIE   I
 
     ; never reach here!

--- a/libcpu/arm/cortex-m3/context_gcc.S
+++ b/libcpu/arm/cortex-m3/context_gcc.S
@@ -162,7 +162,9 @@ rt_hw_context_switch_to:
     NOP
     MSR     msp, r0
 
-    CPSIE   I                       /* enable interrupts at processor level */
+    /* enable interrupts at processor level */
+    CPSIE   F
+    CPSIE   I
 
     /* never reach here! */
 

--- a/libcpu/arm/cortex-m3/context_iar.S
+++ b/libcpu/arm/cortex-m3/context_iar.S
@@ -161,7 +161,9 @@ rt_hw_context_switch_to:
     NOP
     MSR     msp, r0
 
-    CPSIE   I                       ; enable interrupts at processor level
+    ; enable interrupts at processor level
+    CPSIE   F
+    CPSIE   I
 
     ; never reach here!
 

--- a/libcpu/arm/cortex-m3/context_rvds.S
+++ b/libcpu/arm/cortex-m3/context_rvds.S
@@ -168,6 +168,7 @@ rt_hw_context_switch_to    PROC
     MSR     msp, r0
 
     ; enable interrupts at processor level
+    CPSIE   F
     CPSIE   I
 
     ; never reach here!

--- a/libcpu/arm/cortex-m4/context_gcc.S
+++ b/libcpu/arm/cortex-m4/context_gcc.S
@@ -203,7 +203,9 @@ rt_hw_context_switch_to:
     NOP
     MSR     msp, r0
 
-    CPSIE   I                       /* enable interrupts at processor level */
+    /* enable interrupts at processor level */
+    CPSIE   F
+    CPSIE   I
 
     /* never reach here! */
 

--- a/libcpu/arm/cortex-m4/context_iar.S
+++ b/libcpu/arm/cortex-m4/context_iar.S
@@ -207,7 +207,9 @@ rt_hw_context_switch_to:
     NOP
     MSR     msp, r0
 
-    CPSIE   I                       ; enable interrupts at processor level
+    ; enable interrupts at processor level
+    CPSIE   F
+    CPSIE   I
 
     ; never reach here!
 

--- a/libcpu/arm/cortex-m4/context_rvds.S
+++ b/libcpu/arm/cortex-m4/context_rvds.S
@@ -208,6 +208,7 @@ rt_hw_context_switch_to    PROC
     MSR     msp, r0
 
     ; enable interrupts at processor level
+    CPSIE   F
     CPSIE   I
 
     ; never reach here!

--- a/libcpu/arm/cortex-m7/context_gcc.S
+++ b/libcpu/arm/cortex-m7/context_gcc.S
@@ -203,7 +203,9 @@ rt_hw_context_switch_to:
     NOP
     MSR     msp, r0
 
-    CPSIE   I                       /* enable interrupts at processor level */
+    /* enable interrupts at processor level */
+    CPSIE   F
+    CPSIE   I
 
     /* never reach here! */
 

--- a/libcpu/arm/cortex-m7/context_iar.S
+++ b/libcpu/arm/cortex-m7/context_iar.S
@@ -207,7 +207,9 @@ rt_hw_context_switch_to:
     NOP
     MSR     msp, r0
 
-    CPSIE   I                       ; enable interrupts at processor level
+    ; enable interrupts at processor level
+    CPSIE   F
+    CPSIE   I
 
     ; never reach here!
 

--- a/libcpu/arm/cortex-m7/context_rvds.S
+++ b/libcpu/arm/cortex-m7/context_rvds.S
@@ -208,6 +208,7 @@ rt_hw_context_switch_to    PROC
     MSR     msp, r0
 
     ; enable interrupts at processor level
+    CPSIE   F
     CPSIE   I
 
     ; never reach here!


### PR DESCRIPTION
1. 部分芯片或bootloader启动后，fualt没开。
2. F2的IAR链接脚本没有把HEAP放最后。