### PR TITLE
[Libc] Remove `RT_USING_DLIBC` define on `dlib/SConscript`。

### DIFF
--- a/components/libc/dlib/SConscript
+++ b/components/libc/dlib/SConscript
@@ -6,7 +6,7 @@ cwd = GetCurrentDir()
 group = []
 
 CPPPATH = [cwd]
-CPPDEFINES = ['RT_USING_DLIBC']
+CPPDEFINES = []
 
 if rtconfig.PLATFORM == 'iar':
 


### PR DESCRIPTION
如题，因为在 rtconfig.h 已定义 `RT_USING_DLIBC`，所以 IAR 工程会报很多重复定义的警告。