### PR TITLE
x86: bring up share object module on i386 machine

### DIFF
--- a/bsp/x86/Makefile
+++ b/bsp/x86/Makefile
@@ -1,17 +1,45 @@
 
-all:floppy.img
-	scons
-	mkdir -p tmp
-	sudo mount -t vfat floppy.img tmp -o loop
-	sudo cp rtthread.elf tmp/boot/oskernel
-	sudo umount tmp
+CC = gcc -O0 -m32 -fno-builtin -fno-stack-protector -nostdinc -nostdlib
+LD = ld -melf_i386 -nostdlib
+
+all: rtthread rtsym exe dll floppy.img
+	@mkdir -p tmp
+	@sudo mount -t vfat floppy.img tmp -o loop
+	@sudo cp -fv rtthread.elf tmp/boot/oskernel
+	@sudo rm tmp/bin/* -fr
+	@sudo cp out/* tmp/bin/ -fv
+	@sudo umount tmp
+
+rtthread:
+	@scons
+
+rtsym:
+	@./src/extract.sh ./rtthread-ia32.map ./src/rt_thread_sym.h
+
+obj:
+	mkdir -p obj
+
+out:
+	mkdir -p out
+
+dll: obj out
+	$(CC) -shared -s -fPIC -e main -Isrc src/hello.c -o out/hello.mo
+
+disasm: obj out
+	$(CC) -shared -S -fPIC -Isrc src/hello.c -o obj/hello.s
+	cat obj/hello.s
+	objdump --disassemble out/hello.mo
+
+exe: obj out
+
 
 clean:
 	scons -c clean
-	rm -fr build rtthread*
+	rm -fr build rtthread* out obj
 
 floppy.img:
 	wget https://github.com/bajdcc/tinix/raw/master/floppy.img
 
+# https://en.wikibooks.org/wiki/QEMU/Devices/Network
 run:
-	qemu-system-i386 -fda floppy.img -boot a -m 64M -serial stdio
+	qemu-system-i386 -fda floppy.img -boot a -m 64M -serial stdio -net nic,model=ne2k_pci

--- a/bsp/x86/applications/application.c
+++ b/bsp/x86/applications/application.c
@@ -26,7 +26,12 @@
 
 #ifdef RT_USING_DFS
 #include <dfs_fs.h>
+#include <dfs_init.h>
 #include "floppy.h"
+#ifdef RT_USING_MODULE
+#include <rtm.h>
+#endif
+extern int elm_init(void);
 #endif
 
 /* components initialization for simulator */
@@ -40,6 +45,10 @@ void components_init(void)
 #ifdef RT_USING_DFS_ELMFAT
 	/* initialize the elm chan FatFS file system*/
 	elm_init();
+#endif
+
+#ifdef RT_USING_MODULE
+	rt_system_module_init();
 #endif
 #endif
 }

--- a/bsp/x86/drivers/console.c
+++ b/bsp/x86/drivers/console.c
@@ -29,7 +29,7 @@ extern void rt_serial_init(void);
 extern char rt_serial_getc(void);
 extern void rt_serial_putc(const char c);
 
-static void rt_console_putc(int c);
+void rt_console_putc(int c);
 
 /**
  * @addtogroup QEMU
@@ -127,7 +127,7 @@ static void rt_cga_putc(int c)
  *
  * @param c the char to write
  */
-static void rt_console_putc(int c)
+void rt_console_putc(int c)
 {
     rt_cga_putc(c);
     rt_serial_putc(c);

--- a/bsp/x86/rtconfig.h
+++ b/bsp/x86/rtconfig.h
@@ -17,7 +17,7 @@
 /* SECTION: RT_DEBUG */
 /* Thread Debug */
 #define RT_DEBUG
-#define RT_THREAD_DEBUG
+#define RT_DEBUG_MODULE 0
 
 #define RT_USING_OVERFLOW_CHECK
 
@@ -69,6 +69,8 @@
 
 /* SECTION: finsh, a C-Express shell */
 #define RT_USING_FINSH
+#define FINSH_USING_MSH
+#define FINSH_USING_MSH_ONLY
 /* Using symbol table */
 #define FINSH_USING_SYMTAB
 #define FINSH_USING_DESCRIPTION
@@ -175,4 +177,7 @@
 /* #define RTGUI_IMAGE_XPM */
 /* #define RTGUI_IMAGE_BMP */
 
+#define RT_USING_LIBDL
+#define RT_USING_MODULE
+#define MODULE_USING_386
 #endif

--- a/bsp/x86/rtconfig.py
+++ b/bsp/x86/rtconfig.py
@@ -33,7 +33,7 @@ BUILD = 'debug'
 if PLATFORM == 'gcc':
     # toolchains
     PREFIX = ''
-    CC = PREFIX + 'gcc -m32 -fno-builtin -fno-stack-protector'
+    CC = PREFIX + 'gcc -m32 -fno-builtin -fno-stack-protector -nostdinc'
     AS = PREFIX + 'gcc -m32'
     AR = PREFIX + 'ar'
     LINK = PREFIX + 'ld -melf_i386'

--- a/bsp/x86/src/extract.sh
+++ b/bsp/x86/src/extract.sh
@@ -1,0 +1,28 @@
+#! /bin/sh
+
+
+imap=$1
+iout=$2
+
+echo "!!! extract symbol from $imap to $iout !!!"
+
+symlist="rt_kprintf \
+rt_kputs \
+rt_vsprintf \
+rt_sprintf \
+rt_snprintf \
+rt_thread_create \
+"
+
+echo "#ifndef RT_THREAD_SYM_H_H" > $iout
+echo "#define RT_THREAD_SYM_H_H" >> $iout
+
+for sym in $symlist
+do
+dlim=`echo $sym | cut -b 1`
+addr=`cat $imap | grep $sym | head -n 1 | cut -d $dlim -f 1`
+
+echo "#define __abs_$sym $addr" >> $iout
+done
+
+echo "#endif /* RT_THREAD_SYM_H_H */" >> $iout

--- a/bsp/x86/src/hello.c
+++ b/bsp/x86/src/hello.c
@@ -1,0 +1,36 @@
+
+#include <stdio.h>
+const char* g_str = "Hello World!";
+
+static int a = 1234;
+int b = 5678;
+
+extern void rt_kprintf(const char* fmt,...);
+
+int add(int a, int b)
+{
+	return a+b;
+}
+
+int main(int argc, char* argv[])
+{
+	int i;
+	char str[32] = "Hello World\n";
+
+	for(i=0; i<argc; i++)
+	{
+		printf("argv[%d]='%s'\n", i, argv[i]);
+	}
+
+	printf(str);
+
+	printf("g_str address is %ph\n",g_str);
+	puts(g_str);
+
+	rt_kprintf("\nnative rt_kprintf a(%ph)=%d, b(%ph)=%d\n", &a, a, &b, b);
+
+	printf("%d+%d=%d\n", 4, 5, add(4, 5));
+
+	return 0xdeadbeef;
+}
+

--- a/bsp/x86/src/stdio.h
+++ b/bsp/x86/src/stdio.h
@@ -1,0 +1,18 @@
+#ifndef __STDIO_H_H
+#define __STDIO_H_H
+
+#include <rt_thread_sym.h>
+
+typedef unsigned int size_t;
+
+typedef int (*sprintf_fcn_t)(char *buf ,const char *format, ...);
+typedef int (*snprintf_fcn_t)(char *buf, size_t size, const char *format, ...);
+typedef void (*puts_fcn_t)(const char *str);
+typedef void (*printf_fcn_t)(const char *fmt, ...);
+
+#define printf ((printf_fcn_t)__abs_rt_kprintf)
+#define puts ((printf_fcn_t)__abs_rt_kputs)
+#define sprintf ((printf_fcn_t)__abs_rt_sprintf)
+#define snprintf ((printf_fcn_t)__abs_rt_snprintf)
+
+#endif

--- a/bsp/x86/x86_ram.lds
+++ b/bsp/x86/x86_ram.lds
@@ -21,10 +21,13 @@ SECTIONS
 		KEEP(*(VSymTab))
 		__vsymtab_end = .;
 		. = ALIGN(4);	
+		__rtmsymtab_start = .;
+		KEEP(*(RTMSymTab));
+		__rtmsymtab_end = .;
 	  }
 	
 	. = ALIGN(4);
-	.rodata : { *(.rodata) }
+	.rodata : { *(.rodata*) }
 
 	. = ALIGN(4);
 	.data : { *(.data) }

--- a/components/libc/libdl/dlopen.c
+++ b/components/libc/libdl/dlopen.c
@@ -27,7 +27,7 @@ void* dlopen(const char *filename, int flags)
 	/* check parameters */
 	RT_ASSERT(filename != RT_NULL);
 
-	if (filename[0] != '/') /* it's a absolute path, use it directly */
+	if (filename[0] != '/') /* it's a relative path, prefix with MODULE_ROOT_DIR */
 	{
 		fullpath = rt_malloc(strlen(def_path) + strlen(filename) + 2);
 
@@ -37,8 +37,7 @@ void* dlopen(const char *filename, int flags)
 	}
 	else
 	{
-		rt_kprintf("use absolute path\n");
-		return RT_NULL;
+		fullpath = (char*)filename; /* absolute path, use it directly */
 	}	
 
 	/* find in module list */
@@ -47,7 +46,11 @@ void* dlopen(const char *filename, int flags)
 	if(module != RT_NULL) module->nref++;
 	else module = rt_module_open(fullpath);
 
-	rt_free(fullpath);
+	if(fullpath != filename)
+	{
+		rt_free(fullpath);
+	}
+
 	return (void*)module;
 }
 

--- a/src/module.h
+++ b/src/module.h
@@ -208,6 +208,13 @@ typedef struct
 #define R_ARM_THM_JUMP24        30
 #define R_ARM_V4BX              40
 
+/*
+ * Relocation type for arm
+ */
+#define R_386_GLOB_DAT          6
+#define R_386_JUMP_SLOT         7
+#define R_386_RELATIVE          8
+
 /* Program Header */
 typedef struct
 {


### PR DESCRIPTION
1. upddate kernel module to support i386
2. update libdl to support open *.so by absolute path
3. new test case bsp/x86/src/hello.c to test i386 module feature

Signed-off-by: parai <parai@foxmail.com>