### PR TITLE
[Components]drivers can change txcompletion to sem

### DIFF
--- a/components/drivers/include/drivers/can.h
+++ b/components/drivers/include/drivers/can.h
@@ -280,7 +280,7 @@ struct rt_can_sndbxinx_list
 struct rt_can_tx_fifo
 {
     struct rt_can_sndbxinx_list *buffer;
-    struct rt_completion completion;
+    struct rt_semaphore sem;
     struct rt_list_node freelist;
 };
 


### PR DESCRIPTION
Because completion can only suspend one thread and muti-thread may suspend when hardware can not send can msg, so we use change completion to sem here!