### PR TITLE
修改包含LWIP_USING_DHCPD后产生的组名

### DIFF
--- a/components/net/lwip_dhcpd/SConscript
+++ b/components/net/lwip_dhcpd/SConscript
@@ -5,6 +5,6 @@ src = Glob('*.c')
 
 CPPPATH = [cwd]
 
-group = DefineGroup('LwIP', src, depend = ['RT_USING_LWIP', 'LWIP_USING_DHCPD'], CPPPATH = CPPPATH)
+group = DefineGroup('LwipDhcp', src, depend = ['RT_USING_LWIP', 'LWIP_USING_DHCPD'], CPPPATH = CPPPATH)
 
 Return('group')


### PR DESCRIPTION
使用lwip2.02在工程中的组名是lwIP，和本组件的组名几乎一致，会产生误解，应该修改一下组名。