### PR TITLE
update libcpu: cortex-m0 fault handlers always enable.

### DIFF
--- a/libcpu/arm/cortex-m0/context_gcc.S
+++ b/libcpu/arm/cortex-m0/context_gcc.S
@@ -182,7 +182,6 @@ rt_hw_context_switch_to:
     MSR     MSP, R0
 
     /* enable interrupts at processor level */
-    CPSIE   F
     CPSIE   I
 
     /* never reach here! */

--- a/libcpu/arm/cortex-m0/context_iar.S
+++ b/libcpu/arm/cortex-m0/context_iar.S
@@ -188,7 +188,6 @@ rt_hw_context_switch_to:
     MSR     msp, r0
 
     ; enable interrupts at processor level
-    CPSIE   F
     CPSIE   I
 
     ; never reach here!

--- a/libcpu/arm/cortex-m0/context_rvds.S
+++ b/libcpu/arm/cortex-m0/context_rvds.S
@@ -191,7 +191,6 @@ rt_hw_context_switch_to    PROC
     MSR     msp, r0
 
     ; enable interrupts at processor level
-    CPSIE   F
     CPSIE   I
 
     ; never reach here!


### PR DESCRIPTION
cortex-m0 没有 `CPSIE   F` 指令。
异常处理一直是打开状态。