### PR TITLE
根据代码格式文档约定 对src和include文件夹内部分不符合标准的代码进行格式化处理

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -92,105 +92,105 @@ typedef rt_base_t                       rt_off_t;       /**< Type for offset */
 
 /* Compiler Related Definitions */
 #ifdef __CC_ARM                         /* ARM Compiler */
-    #include <stdarg.h>
-    #define SECTION(x)                  __attribute__((section(x)))
-    #define RT_UNUSED                   __attribute__((unused))
-    #define RT_USED                     __attribute__((used))
-    #define ALIGN(n)                    __attribute__((aligned(n)))
-    #define WEAK						__weak
-    #define rt_inline                   static __inline
-    /* module compiling */
-    #ifdef RT_USING_MODULE
-        #define RTT_API                 __declspec(dllimport)
-    #else
-        #define RTT_API                 __declspec(dllexport)
-    #endif
+#include <stdarg.h>
+#define SECTION(x)                  __attribute__((section(x)))
+#define RT_UNUSED                   __attribute__((unused))
+#define RT_USED                     __attribute__((used))
+#define ALIGN(n)                    __attribute__((aligned(n)))
+#define WEAK                        __weak
+#define rt_inline                   static __inline
+/* module compiling */
+#ifdef RT_USING_MODULE
+#define RTT_API                 __declspec(dllimport)
+#else
+#define RTT_API                 __declspec(dllexport)
+#endif
 
 #elif defined (__IAR_SYSTEMS_ICC__)     /* for IAR Compiler */
-    #include <stdarg.h>
-    #define SECTION(x)                  @ x
-    #define RT_UNUSED
-    #define RT_USED                     __root
-    #define PRAGMA(x)                   _Pragma(#x)
-    #define ALIGN(n)                    PRAGMA(data_alignment=n)
-    #define WEAK                        __weak
-    #define rt_inline                   static inline
-    #define RTT_API
+#include <stdarg.h>
+#define SECTION(x)                  @ x
+#define RT_UNUSED
+#define RT_USED                     __root
+#define PRAGMA(x)                   _Pragma(#x)
+#define ALIGN(n)                    PRAGMA(data_alignment=n)
+#define WEAK                        __weak
+#define rt_inline                   static inline
+#define RTT_API
 
 #elif defined (__GNUC__)                /* GNU GCC Compiler */
-    #ifdef RT_USING_NEWLIB
-        #include <stdarg.h>
-    #else
-		/* the version of GNU GCC must be greater than 4.x */
-        typedef __builtin_va_list   __gnuc_va_list;
-        typedef __gnuc_va_list      va_list;
-        #define va_start(v,l)       __builtin_va_start(v,l)
-        #define va_end(v)           __builtin_va_end(v)
-        #define va_arg(v,l)         __builtin_va_arg(v,l)
-    #endif
-
-    #define SECTION(x)                  __attribute__((section(x)))
-    #define RT_UNUSED                   __attribute__((unused))
-    #define RT_USED                     __attribute__((used))
-    #define ALIGN(n)                    __attribute__((aligned(n)))
-    #define WEAK                        __attribute__((weak))
-    #define rt_inline                   static __inline
-    #define RTT_API
-#elif defined (__ADSPBLACKFIN__)        /* for VisualDSP++ Compiler */
-    #include <stdarg.h>
-    #define SECTION(x)                  __attribute__((section(x)))
-    #define RT_UNUSED                   __attribute__((unused))
-    #define RT_USED                     __attribute__((used))
-    #define ALIGN(n)                    __attribute__((aligned(n)))
-	#define WEAK                        __attribute__((weak))
-    #define rt_inline                   static inline
-    #define RTT_API
-#elif defined (_MSC_VER)
-    #include <stdarg.h>
-    #define SECTION(x)
-    #define RT_UNUSED
-    #define RT_USED
-    #define ALIGN(n)                    __declspec(align(n))
-	#define WEAK
-    #define rt_inline                   static __inline
-    #define RTT_API
-#elif defined (__TI_COMPILER_VERSION__)
-    #include <stdarg.h>
-    /* The way that TI compiler set section is different from other(at least
-     * GCC and MDK) compilers. See ARM Optimizing C/C++ Compiler 5.9.3 for more
-     * details. */
-    #define SECTION(x)
-    #define RT_UNUSED
-    #define RT_USED
-    #define PRAGMA(x)                   _Pragma(#x)
-    #define ALIGN(n)
-    #define WEAK
-    #define rt_inline                   static inline
-    #define RTT_API
+#ifdef RT_USING_NEWLIB
+#include <stdarg.h>
 #else
-    #error not supported tool chain
+/* the version of GNU GCC must be greater than 4.x */
+typedef __builtin_va_list   __gnuc_va_list;
+typedef __gnuc_va_list      va_list;
+#define va_start(v,l)       __builtin_va_start(v,l)
+#define va_end(v)           __builtin_va_end(v)
+#define va_arg(v,l)         __builtin_va_arg(v,l)
+#endif
+
+#define SECTION(x)                  __attribute__((section(x)))
+#define RT_UNUSED                   __attribute__((unused))
+#define RT_USED                     __attribute__((used))
+#define ALIGN(n)                    __attribute__((aligned(n)))
+#define WEAK                        __attribute__((weak))
+#define rt_inline                   static __inline
+#define RTT_API
+#elif defined (__ADSPBLACKFIN__)        /* for VisualDSP++ Compiler */
+#include <stdarg.h>
+#define SECTION(x)                  __attribute__((section(x)))
+#define RT_UNUSED                   __attribute__((unused))
+#define RT_USED                     __attribute__((used))
+#define ALIGN(n)                    __attribute__((aligned(n)))
+#define WEAK                        __attribute__((weak))
+#define rt_inline                   static inline
+#define RTT_API
+#elif defined (_MSC_VER)
+#include <stdarg.h>
+#define SECTION(x)
+#define RT_UNUSED
+#define RT_USED
+#define ALIGN(n)                    __declspec(align(n))
+#define WEAK
+#define rt_inline                   static __inline
+#define RTT_API
+#elif defined (__TI_COMPILER_VERSION__)
+#include <stdarg.h>
+/* The way that TI compiler set section is different from other(at least
+ * GCC and MDK) compilers. See ARM Optimizing C/C++ Compiler 5.9.3 for more
+ * details. */
+#define SECTION(x)
+#define RT_UNUSED
+#define RT_USED
+#define PRAGMA(x)                   _Pragma(#x)
+#define ALIGN(n)
+#define WEAK
+#define rt_inline                   static inline
+#define RTT_API
+#else
+#error not supported tool chain
 #endif
 
 /* initialization export */
 #ifdef RT_USING_COMPONENTS_INIT
 typedef int (*init_fn_t)(void);
 #ifdef _MSC_VER /* we do not support MS VC++ compiler */
-    #define INIT_EXPORT(fn, level)
+#define INIT_EXPORT(fn, level)
 #else
-	#if RT_DEBUG_INIT
-		struct rt_init_desc
-		{
-			const char* fn_name;
-			const init_fn_t fn;
-		};
-		#define INIT_EXPORT(fn, level)  		\
-			const char __rti_##fn##_name[] = #fn; \
-			const struct rt_init_desc __rt_init_desc_##fn SECTION(".rti_fn."level) = \
-			{ __rti_##fn##_name, fn};
-	#else
-    	#define INIT_EXPORT(fn, level)  \
-        	const init_fn_t __rt_init_##fn SECTION(".rti_fn."level) = fn
-	#endif
+#if RT_DEBUG_INIT
+struct rt_init_desc
+{
+    const char *fn_name;
+    const init_fn_t fn;
+};
+#define INIT_EXPORT(fn, level)          \
+          const char __rti_##fn##_name[] = #fn; \
+          const struct rt_init_desc __rt_init_desc_##fn SECTION(".rti_fn."level) = \
+          { __rti_##fn##_name, fn};
+#else
+#define INIT_EXPORT(fn, level)  \
+         const init_fn_t __rt_init_##fn SECTION(".rti_fn."level) = fn
+#endif
 #endif
 #else
 #define INIT_EXPORT(fn, level)
@@ -206,7 +206,7 @@ typedef int (*init_fn_t)(void);
 /* file system initialization (dfs-elm, dfs-rom, ...) */
 #define INIT_FS_EXPORT(fn)              INIT_EXPORT(fn, "4")
 /* environment initialization (mount disk, ...) */
-#define INIT_ENV_EXPORT(fn)				INIT_EXPORT(fn, "5")
+#define INIT_ENV_EXPORT(fn)             INIT_EXPORT(fn, "5")
 /* appliation initialization (rtgui application etc ...) */
 #define INIT_APP_EXPORT(fn)             INIT_EXPORT(fn, "6")
 
@@ -759,8 +759,8 @@ enum rt_device_class_type
     RT_Device_Class_Pipe,                               /**< Pipe device */
     RT_Device_Class_Portal,                             /**< Portal device */
     RT_Device_Class_Timer,                              /**< Timer device */
-	RT_Device_Class_Miscellaneous,                      /**< Miscellaneous device */
-	RT_Device_Class_Unknown                             /**< unknown device */
+    RT_Device_Class_Miscellaneous,                      /**< Miscellaneous device */
+    RT_Device_Class_Unknown                             /**< unknown device */
 };
 
 /**
@@ -778,9 +778,9 @@ enum rt_device_class_type
 #define RT_DEVICE_FLAG_SUSPENDED        0x020           /**< device is suspended */
 #define RT_DEVICE_FLAG_STREAM           0x040           /**< stream mode */
 
-#define RT_DEVICE_CTRL_CONFIG           0x03    	/* configure device */
-#define RT_DEVICE_CTRL_SET_INT          0x10    	/* enable receive irq */
-#define RT_DEVICE_CTRL_CLR_INT          0x11    	/* disable receive irq */
+#define RT_DEVICE_CTRL_CONFIG           0x03            /* configure device */
+#define RT_DEVICE_CTRL_SET_INT          0x10            /* enable receive irq */
+#define RT_DEVICE_CTRL_CLR_INT          0x11            /* disable receive irq */
 #define RT_DEVICE_CTRL_GET_INT          0x12
 
 #define RT_DEVICE_FLAG_INT_RX           0x100           /**< INT mode on Rx */
@@ -835,12 +835,12 @@ struct rt_device
     rt_err_t (*tx_complete)(rt_device_t dev, void *buffer);
 
     /* common device interface */
-    rt_err_t  (*init)   (rt_device_t dev);
-    rt_err_t  (*open)   (rt_device_t dev, rt_uint16_t oflag);
-    rt_err_t  (*close)  (rt_device_t dev);
-    rt_size_t (*read)   (rt_device_t dev, rt_off_t pos, void *buffer, rt_size_t size);
-    rt_size_t (*write)  (rt_device_t dev, rt_off_t pos, const void *buffer, rt_size_t size);
-    rt_err_t  (*control)(rt_device_t dev, rt_uint8_t cmd, void *args);
+    rt_err_t (*init)(rt_device_t dev);
+    rt_err_t (*open)(rt_device_t dev, rt_uint16_t oflag);
+    rt_err_t (*close)(rt_device_t dev);
+    rt_size_t (*read)(rt_device_t dev, rt_off_t pos, void *buffer, rt_size_t size);
+    rt_size_t (*write)(rt_device_t dev, rt_off_t pos, const void *buffer, rt_size_t size);
+    rt_err_t (*control)(rt_device_t dev, rt_uint8_t cmd, void *args);
 
     void                     *user_data;                /**< device private data */
 };
@@ -935,13 +935,13 @@ struct rt_device_rect_info
  */
 struct rt_device_graphic_ops
 {
-    void (*set_pixel) (const char *pixel, int x, int y);
-    void (*get_pixel) (char *pixel, int x, int y);
+    void (*set_pixel)(const char *pixel, int x, int y);
+    void (*get_pixel)(char *pixel, int x, int y);
 
     void (*draw_hline)(const char *pixel, int x1, int x2, int y);
     void (*draw_vline)(const char *pixel, int x, int y1, int y2);
 
-    void (*blit_line) (const char *pixel, int x, int y, rt_size_t size);
+    void (*blit_line)(const char *pixel, int x, int y, rt_size_t size);
 };
 #define rt_graphix_ops(device)          ((struct rt_device_graphic_ops *)(device->user_data))
 
@@ -976,8 +976,8 @@ struct rt_module
     void                        *module_entry;          /**< the entry address of module */
     rt_thread_t                  module_thread;         /**< the main thread of module */
 
-	rt_uint8_t*                  module_cmd_line;		/**< module command line */
-	rt_uint32_t                  module_cmd_size;		/**< the size of module command line */
+    rt_uint8_t                  *module_cmd_line;       /**< module command line */
+    rt_uint32_t                  module_cmd_size;       /**< the size of module command line */
 
 #ifdef RT_USING_SLAB
     /* module memory allocator */

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -156,8 +156,8 @@ void rt_thread_timeout(void *parameter);
 
 #ifdef RT_USING_HOOK
 void rt_thread_suspend_sethook(void (*hook)(rt_thread_t thread));
-void rt_thread_resume_sethook (void (*hook)(rt_thread_t thread));
-void rt_thread_inited_sethook (void (*hook)(rt_thread_t thread));
+void rt_thread_resume_sethook(void (*hook)(rt_thread_t thread));
+void rt_thread_inited_sethook(void (*hook)(rt_thread_t thread));
 #endif
 
 /*
@@ -262,8 +262,8 @@ rt_err_t rt_memheap_init(struct rt_memheap *memheap,
                          void              *start_addr,
                          rt_uint32_t        size);
 rt_err_t rt_memheap_detach(struct rt_memheap *heap);
-void* rt_memheap_alloc(struct rt_memheap *heap, rt_uint32_t size);
-void *rt_memheap_realloc(struct rt_memheap* heap, void* ptr, rt_size_t newsize);
+void *rt_memheap_alloc(struct rt_memheap *heap, rt_uint32_t size);
+void *rt_memheap_realloc(struct rt_memheap *heap, void *ptr, rt_size_t newsize);
 void rt_memheap_free(void *ptr);
 #endif
 
@@ -399,13 +399,13 @@ rt_err_t
 rt_device_set_tx_complete(rt_device_t dev,
                           rt_err_t (*tx_done)(rt_device_t dev, void *buffer));
 
-rt_err_t  rt_device_init (rt_device_t dev);
-rt_err_t  rt_device_open (rt_device_t dev, rt_uint16_t oflag);
+rt_err_t  rt_device_init(rt_device_t dev);
+rt_err_t  rt_device_open(rt_device_t dev, rt_uint16_t oflag);
 rt_err_t  rt_device_close(rt_device_t dev);
-rt_size_t rt_device_read (rt_device_t dev,
-                          rt_off_t    pos,
-                          void       *buffer,
-                          rt_size_t   size);
+rt_size_t rt_device_read(rt_device_t dev,
+                         rt_off_t    pos,
+                         void       *buffer,
+                         rt_size_t   size);
 rt_size_t rt_device_write(rt_device_t dev,
                           rt_off_t    pos,
                           const void *buffer,
@@ -429,7 +429,7 @@ rt_module_t rt_module_load(const char *name, void *module_ptr);
 rt_err_t rt_module_unload(rt_module_t module);
 #ifdef RT_USING_DFS
 rt_module_t rt_module_open(const char *filename);
-rt_module_t rt_module_exec_cmd(const char *path, const char* cmd_line, int size);
+rt_module_t rt_module_exec_cmd(const char *path, const char *cmd_line, int size);
 #endif
 void *rt_module_malloc(rt_size_t size);
 void *rt_module_realloc(void *ptr, rt_size_t size);
@@ -496,7 +496,7 @@ void rt_kputs(const char *str);
 #endif
 rt_int32_t rt_vsprintf(char *dest, const char *format, va_list arg_ptr);
 rt_int32_t rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list args);
-rt_int32_t rt_sprintf(char *buf ,const char *format, ...);
+rt_int32_t rt_sprintf(char *buf, const char *format, ...);
 rt_int32_t rt_snprintf(char *buf, rt_size_t size, const char *format, ...);
 
 #if defined(RT_USING_DEVICE) && defined(RT_USING_CONSOLE)
@@ -517,8 +517,8 @@ void *rt_memset(void *src, int c, rt_ubase_t n);
 void *rt_memcpy(void *dest, const void *src, rt_ubase_t n);
 
 rt_int32_t rt_strncmp(const char *cs, const char *ct, rt_ubase_t count);
-rt_int32_t rt_strcmp (const char *cs, const char *ct);
-rt_size_t rt_strlen (const char *src);
+rt_int32_t rt_strcmp(const char *cs, const char *ct);
+rt_size_t rt_strlen(const char *src);
 char *rt_strdup(const char *s);
 
 char *rt_strstr(const char *str1, const char *str2);
@@ -531,10 +531,10 @@ rt_uint32_t rt_strcasecmp(const char *a, const char *b);
 void rt_show_version(void);
 
 #ifdef RT_DEBUG
-extern void (*rt_assert_hook)(const char* ex, const char* func, rt_size_t line);
-void rt_assert_set_hook(void (*hook)(const char* ex, const char* func, rt_size_t line));
+extern void (*rt_assert_hook)(const char *ex, const char *func, rt_size_t line);
+void rt_assert_set_hook(void (*hook)(const char *ex, const char *func, rt_size_t line));
 
-void rt_assert_handler(const char* ex, const char* func, rt_size_t line);
+void rt_assert_handler(const char *ex, const char *func, rt_size_t line);
 #endif /* RT_DEBUG */
 
 /**@}*/

--- a/src/components.c
+++ b/src/components.c
@@ -41,7 +41,7 @@
 
 #ifdef RT_USING_COMPONENTS_INIT
 /*
- * Components Initialization will initialize some driver and components as following 
+ * Components Initialization will initialize some driver and components as following
  * order:
  * rti_start         --> 0
  * BOARD_EXPORT      --> 1
@@ -51,17 +51,17 @@
  * COMPONENT_EXPORT  --> 3
  * FS_EXPORT         --> 4
  * ENV_EXPORT        --> 5
- * APP_EXPORT        --> 6 
- * 
+ * APP_EXPORT        --> 6
+ *
  * rti_end           --> 6.end
  *
- * These automatically initializaiton, the driver or component initial function must 
+ * These automatically initializaiton, the driver or component initial function must
  * be defined with:
  * INIT_BOARD_EXPORT(fn);
  * INIT_DEVICE_EXPORT(fn);
  * ...
  * INIT_APP_EXPORT(fn);
- * etc. 
+ * etc.
  */
 static int rti_start(void)
 {
@@ -155,11 +155,11 @@ int $Sub$$main(void)
 #elif defined(__ICCARM__)
 extern int main(void);
 /* __low_level_init will auto called by IAR cstartup */
-extern void __iar_data_init3( void );
+extern void __iar_data_init3(void);
 int __low_level_init(void)
 {
-	// call IAR table copy function.
-	__iar_data_init3();
+    // call IAR table copy function.
+    __iar_data_init3();
     rt_hw_interrupt_disable();
     rtthread_startup();
     return 0;
@@ -221,7 +221,7 @@ void rt_application_init(void)
 
 int rtthread_startup(void)
 {
-	rt_hw_interrupt_disable();
+    rt_hw_interrupt_disable();
 
     /* board level initalization
      * NOTE: please initialize heap inside board initialization.

--- a/src/idle.c
+++ b/src/idle.c
@@ -55,7 +55,7 @@ static void (*rt_thread_idle_hook)();
 
 /**
  * @ingroup Hook
- * This function sets a hook function to idle thread loop. When the system performs 
+ * This function sets a hook function to idle thread loop. When the system performs
  * idle loop, this hook function should be invoked.
  *
  * @param hook the specified hook function
@@ -77,7 +77,7 @@ rt_inline int _has_defunct_thread(void)
      * into a "if".
      *
      * So add the volatile qualifier here. */
-    const volatile rt_list_t *l = (const volatile rt_list_t*)&rt_thread_defunct;
+    const volatile rt_list_t *l = (const volatile rt_list_t *)&rt_thread_defunct;
 
     return l->next != l;
 }
@@ -155,8 +155,8 @@ void rt_thread_idle_excute(void)
             rt_module_free((rt_module_t)thread->module_id, thread->stack_addr);
         else
 #endif
-        /* release thread's stack */
-        RT_KERNEL_FREE(thread->stack_addr);
+            /* release thread's stack */
+            RT_KERNEL_FREE(thread->stack_addr);
         /* delete thread object */
         rt_object_delete((rt_object_t)thread);
 #endif
@@ -168,7 +168,7 @@ void rt_thread_idle_excute(void)
 
             /* if sub thread list and main thread are all empty */
             if ((module->module_thread == RT_NULL) &&
-                rt_list_isempty(&module->module_object[RT_Object_Class_Thread].object_list))
+                    rt_list_isempty(&module->module_object[RT_Object_Class_Thread].object_list))
             {
                 module->nref --;
             }
@@ -185,12 +185,12 @@ static void rt_thread_idle_entry(void *parameter)
 {
     while (1)
     {
-    #ifdef RT_USING_IDLE_HOOK
+#ifdef RT_USING_IDLE_HOOK
         if (rt_thread_idle_hook != RT_NULL)
         {
             rt_thread_idle_hook();
         }
-    #endif
+#endif
 
         rt_thread_idle_excute();
     }

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -103,32 +103,32 @@ rt_inline rt_err_t rt_ipc_list_suspend(rt_list_t        *list,
         break;
 
     case RT_IPC_FLAG_PRIO:
+    {
+        struct rt_list_node *n;
+        struct rt_thread *sthread;
+
+        /* find a suitable position */
+        for (n = list->next; n != list; n = n->next)
         {
-            struct rt_list_node *n;
-            struct rt_thread *sthread;
+            sthread = rt_list_entry(n, struct rt_thread, tlist);
 
-            /* find a suitable position */
-            for (n = list->next; n != list; n = n->next)
+            /* find out */
+            if (thread->current_priority < sthread->current_priority)
             {
-                sthread = rt_list_entry(n, struct rt_thread, tlist);
-
-                /* find out */
-                if (thread->current_priority < sthread->current_priority)
-                {
-                    /* insert this thread before the sthread */
-                    rt_list_insert_before(&(sthread->tlist), &(thread->tlist));
-                    break;
-                }
+                /* insert this thread before the sthread */
+                rt_list_insert_before(&(sthread->tlist), &(thread->tlist));
+                break;
             }
-
-            /*
-             * not found a suitable position,
-             * append to the end of suspend_thread list
-             */
-            if (n == list)
-                rt_list_insert_before(list, &(thread->tlist));
         }
-        break;
+
+        /*
+         * not found a suitable position,
+         * append to the end of suspend_thread list
+         */
+        if (n == list)
+            rt_list_insert_before(list, &(thread->tlist));
+    }
+    break;
     }
 
     return RT_EOK;
@@ -1382,8 +1382,8 @@ rt_err_t rt_mb_delete(rt_mailbox_t mb)
     else
 #endif
 
-    /* free mailbox pool */
-    RT_KERNEL_FREE(mb->msg_pool);
+        /* free mailbox pool */
+        RT_KERNEL_FREE(mb->msg_pool);
 
     /* delete mailbox object */
     rt_object_delete(&(mb->parent.parent));
@@ -1775,7 +1775,7 @@ rt_err_t rt_mq_init(rt_mq_t     mq,
     for (temp = 0; temp < mq->max_msgs; temp ++)
     {
         head = (struct rt_mq_message *)((rt_uint8_t *)mq->msg_pool +
-            temp * (mq->msg_size + sizeof(struct rt_mq_message)));
+                                        temp * (mq->msg_size + sizeof(struct rt_mq_message)));
         head->next = mq->msg_queue_free;
         mq->msg_queue_free = head;
     }
@@ -1849,7 +1849,7 @@ rt_mq_t rt_mq_create(const char *name,
     mq->max_msgs = max_msgs;
 
     /* allocate message pool */
-    mq->msg_pool = RT_KERNEL_MALLOC((mq->msg_size + sizeof(struct rt_mq_message))* mq->max_msgs);
+    mq->msg_pool = RT_KERNEL_MALLOC((mq->msg_size + sizeof(struct rt_mq_message)) * mq->max_msgs);
     if (mq->msg_pool == RT_NULL)
     {
         rt_mq_delete(mq);
@@ -1866,7 +1866,7 @@ rt_mq_t rt_mq_create(const char *name,
     for (temp = 0; temp < mq->max_msgs; temp ++)
     {
         head = (struct rt_mq_message *)((rt_uint8_t *)mq->msg_pool +
-               temp * (mq->msg_size + sizeof(struct rt_mq_message)));
+                                        temp * (mq->msg_size + sizeof(struct rt_mq_message)));
         head->next = mq->msg_queue_free;
         mq->msg_queue_free = head;
     }
@@ -1902,8 +1902,8 @@ rt_err_t rt_mq_delete(rt_mq_t mq)
     else
 #endif
 
-    /* free message queue pool */
-    RT_KERNEL_FREE(mq->msg_pool);
+        /* free message queue pool */
+        RT_KERNEL_FREE(mq->msg_pool);
 
     /* delete message queue object */
     rt_object_delete(&(mq->parent.parent));
@@ -1942,7 +1942,7 @@ rt_err_t rt_mq_send(rt_mq_t mq, void *buffer, rt_size_t size)
     temp = rt_hw_interrupt_disable();
 
     /* get a free list, there must be an empty item */
-    msg = (struct rt_mq_message*)mq->msg_queue_free;
+    msg = (struct rt_mq_message *)mq->msg_queue_free;
     /* message queue is full */
     if (msg == RT_NULL)
     {

--- a/src/irq.c
+++ b/src/irq.c
@@ -34,7 +34,7 @@ static void (*rt_interrupt_leave_hook)(void);
 
 /**
  * @ingroup Hook
- * This function set a hook function when the system enter a interrupt 
+ * This function set a hook function when the system enter a interrupt
  *
  * @note the hook function must be simple and never be blocked or suspend.
  */
@@ -44,7 +44,7 @@ void rt_interrupt_enter_sethook(void (*hook)(void))
 }
 /**
  * @ingroup Hook
- * This function set a hook function when the system exit a interrupt. 
+ * This function set a hook function when the system exit a interrupt.
  *
  * @note the hook function must be simple and never be blocked or suspend.
  */
@@ -80,7 +80,7 @@ void rt_interrupt_enter(void)
 
     level = rt_hw_interrupt_disable();
     rt_interrupt_nest ++;
-    RT_OBJECT_HOOK_CALL(rt_interrupt_enter_hook,());
+    RT_OBJECT_HOOK_CALL(rt_interrupt_enter_hook, ());
     rt_hw_interrupt_enable(level);
 }
 RTM_EXPORT(rt_interrupt_enter);
@@ -101,7 +101,7 @@ void rt_interrupt_leave(void)
 
     level = rt_hw_interrupt_disable();
     rt_interrupt_nest --;
-    RT_OBJECT_HOOK_CALL(rt_interrupt_leave_hook,());
+    RT_OBJECT_HOOK_CALL(rt_interrupt_leave_hook, ());
     rt_hw_interrupt_enable(level);
 }
 RTM_EXPORT(rt_interrupt_leave);

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -118,7 +118,7 @@ int *_rt_errno(void)
 
     tid = rt_thread_self();
     if (tid != RT_NULL)
-        return (int *)&(tid->error);
+        return (int *) & (tid->error);
 
     return (int *)&_errno;
 }
@@ -415,7 +415,8 @@ char *rt_strncpy(char *dst, const char *src, rt_ubase_t n)
                     *d++ = 0;
                 break;
             }
-        } while (--n != 0);
+        }
+        while (--n != 0);
     }
 
     return (dst);
@@ -464,9 +465,9 @@ rt_int32_t rt_strcmp(const char *cs, const char *ct)
 RTM_EXPORT(rt_strcmp);
 /**
  * The  strnlen()  function  returns the number of characters in the
- * string pointed to by s, excluding the terminating null byte ('\0'), 
- * but at most maxlen.  In doing this, strnlen() looks only at the 
- * first maxlen characters in the string pointed to by s and never 
+ * string pointed to by s, excluding the terminating null byte ('\0'),
+ * but at most maxlen.  In doing this, strnlen() looks only at the
+ * first maxlen characters in the string pointed to by s and never
  * beyond s+maxlen.
  *
  * @param s the string
@@ -547,13 +548,13 @@ rt_inline rt_int32_t divide(rt_int32_t *n, rt_int32_t base)
     /* optimized for processor which does not support divide instructions. */
     if (base == 10)
     {
-        res = ((rt_uint32_t)*n) % 10U;
-        *n = ((rt_uint32_t)*n) / 10U;
+        res = ((rt_uint32_t) * n) % 10U;
+        *n = ((rt_uint32_t) * n) / 10U;
     }
     else
     {
-        res = ((rt_uint32_t)*n) % 16U;
-        *n = ((rt_uint32_t)*n) / 16U;
+        res = ((rt_uint32_t) * n) % 16U;
+        *n = ((rt_uint32_t) * n) / 16U;
     }
 
     return res;
@@ -561,7 +562,7 @@ rt_inline rt_int32_t divide(rt_int32_t *n, rt_int32_t base)
 
 rt_inline int skip_atoi(const char **s)
 {
-    register int i=0;
+    register int i = 0;
     while (isdigit(**s))
         i = i * 10 + *((*s)++) - '0';
 
@@ -640,7 +641,7 @@ static char *print_number(char *buf,
 
     i = 0;
     if (num == 0)
-        tmp[i++]='0';
+        tmp[i++] = '0';
     else
     {
         while (num != 0)
@@ -655,12 +656,12 @@ static char *print_number(char *buf,
     size -= i;
 #endif
 
-    if (!(type&(ZEROPAD | LEFT)))
+    if (!(type & (ZEROPAD | LEFT)))
     {
-        if ((sign)&&(size>0))
+        if ((sign) && (size > 0))
             size--;
 
-        while (size-->0)
+        while (size-- > 0)
         {
             if (buf <= end)
                 *buf = ' ';
@@ -681,7 +682,7 @@ static char *print_number(char *buf,
 #ifdef RT_PRINTF_SPECIAL
     if (type & SPECIAL)
     {
-        if (base==8)
+        if (base == 8)
         {
             if (buf <= end)
                 *buf = '0';
@@ -694,7 +695,7 @@ static char *print_number(char *buf,
             ++ buf;
             if (buf <= end)
             {
-                *buf = type & LARGE? 'X' : 'x';
+                *buf = type & LARGE ? 'X' : 'x';
             }
             ++ buf;
         }
@@ -768,7 +769,7 @@ rt_int32_t rt_vsnprintf(char       *buf,
     /* Make sure end is always >= buf */
     if (end < buf)
     {
-        end  = ((char *)-1);
+        end  = ((char *) - 1);
         size = end - buf;
     }
 
@@ -929,7 +930,7 @@ rt_int32_t rt_vsnprintf(char       *buf,
             ++ str;
             continue;
 
-            /* integer number formats - set up the flags and "break" */
+        /* integer number formats - set up the flags and "break" */
         case 'o':
             base = 8;
             break;
@@ -1028,7 +1029,7 @@ RTM_EXPORT(rt_snprintf);
  */
 rt_int32_t rt_vsprintf(char *buf, const char *format, va_list arg_ptr)
 {
-    return rt_vsnprintf(buf, (rt_size_t) -1, format, arg_ptr);
+    return rt_vsnprintf(buf, (rt_size_t) - 1, format, arg_ptr);
 }
 RTM_EXPORT(rt_vsprintf);
 
@@ -1044,7 +1045,7 @@ rt_int32_t rt_sprintf(char *buf, const char *format, ...)
     va_list arg_ptr;
 
     va_start(arg_ptr, format);
-    n = rt_vsprintf(buf ,format, arg_ptr);
+    n = rt_vsprintf(buf, format, arg_ptr);
     va_end(arg_ptr);
 
     return n;
@@ -1183,7 +1184,7 @@ RTM_EXPORT(rt_kprintf);
  *
  * @return the allocated memory block on successful, otherwise returns RT_NULL
  */
-void* rt_malloc_align(rt_size_t size, rt_size_t align)
+void *rt_malloc_align(rt_size_t size, rt_size_t align)
 {
     void *align_ptr;
     void *ptr;
@@ -1198,7 +1199,7 @@ void* rt_malloc_align(rt_size_t size, rt_size_t align)
     ptr = rt_malloc(align_size);
     if (ptr != RT_NULL)
     {
-         /* the allocated memory block is aligned */
+        /* the allocated memory block is aligned */
         if (((rt_uint32_t)ptr & (align - 1)) == 0)
         {
             align_ptr = (void *)((rt_uint32_t)ptr + align);
@@ -1228,7 +1229,7 @@ void rt_free_align(void *ptr)
 {
     void *real_ptr;
 
-    real_ptr = (void *)*(rt_uint32_t *)((rt_uint32_t)ptr - sizeof(void *));
+    real_ptr = (void *) * (rt_uint32_t *)((rt_uint32_t)ptr - sizeof(void *));
     rt_free(real_ptr);
 }
 RTM_EXPORT(rt_free_align);
@@ -1284,13 +1285,14 @@ rt_ubase_t __rt_ffs(rt_ubase_t value)
 
 #ifdef RT_DEBUG
 /* RT_ASSERT(EX)'s hook */
-void (*rt_assert_hook)(const char* ex, const char* func, rt_size_t line);
+void (*rt_assert_hook)(const char *ex, const char *func, rt_size_t line);
 /**
  * This function will set a hook function to RT_ASSERT(EX). It will run when the expression is false.
  *
  * @param hook the hook function
  */
-void rt_assert_set_hook(void (*hook)(const char* ex, const char* func, rt_size_t line)) {
+void rt_assert_set_hook(void (*hook)(const char *ex, const char *func, rt_size_t line))
+{
     rt_assert_hook = hook;
 }
 
@@ -1301,30 +1303,30 @@ void rt_assert_set_hook(void (*hook)(const char* ex, const char* func, rt_size_t
  * @param func the function name when assertion.
  * @param line the file line number when assertion.
  */
-void rt_assert_handler(const char* ex_string, const char* func, rt_size_t line)
+void rt_assert_handler(const char *ex_string, const char *func, rt_size_t line)
 {
     volatile char dummy = 0;
 
     if (rt_assert_hook == RT_NULL)
     {
 #ifdef RT_USING_MODULE
-		if (rt_module_self() != RT_NULL)
-		{
-			/* unload assertion module */
-			rt_module_unload(rt_module_self());
+        if (rt_module_self() != RT_NULL)
+        {
+            /* unload assertion module */
+            rt_module_unload(rt_module_self());
 
-			/* re-schedule */
-			rt_schedule();
-		}
-		else
+            /* re-schedule */
+            rt_schedule();
+        }
+        else
 #endif
-		{
-	        rt_kprintf("(%s) assertion failed at function:%s, line number:%d \n", ex_string, func, line);
-	        while (dummy == 0);
-		}
+        {
+            rt_kprintf("(%s) assertion failed at function:%s, line number:%d \n", ex_string, func, line);
+            while (dummy == 0);
+        }
     }
-	else
-	{
+    else
+    {
         rt_assert_hook(ex_string, func, line);
     }
 }
@@ -1339,7 +1341,7 @@ void *memmove(void *dest, const void *src, size_t n) __attribute__((weak, alias(
 int   memcmp(const void *s1, const void *s2, size_t n) __attribute__((weak, alias("rt_memcmp")));
 
 size_t strlen(const char *s) __attribute__((weak, alias("rt_strlen")));
-char *strstr(const char *s1,const char *s2) __attribute__((weak, alias("rt_strstr")));
+char *strstr(const char *s1, const char *s2) __attribute__((weak, alias("rt_strstr")));
 int strcasecmp(const char *a, const char *b) __attribute__((weak, alias("rt_strcasecmp")));
 char *strncpy(char *dest, const char *src, size_t n) __attribute__((weak, alias("rt_strncpy")));
 int strncmp(const char *cs, const char *ct, size_t count) __attribute__((weak, alias("rt_strncmp")));

--- a/src/mem.c
+++ b/src/mem.c
@@ -146,8 +146,8 @@ static void plug_holes(struct heap_mem *mem)
     /* plug hole forward */
     nmem = (struct heap_mem *)&heap_ptr[mem->next];
     if (mem != nmem &&
-        nmem->used == 0 &&
-        (rt_uint8_t *)nmem != (rt_uint8_t *)heap_end)
+            nmem->used == 0 &&
+            (rt_uint8_t *)nmem != (rt_uint8_t *)heap_end)
     {
         /* if mem->next is unused and not end of heap_ptr,
          * combine mem and mem->next
@@ -192,7 +192,7 @@ void rt_system_heap_init(void *begin_addr, void *end_addr)
 
     /* alignment addr */
     if ((end_align > (2 * SIZEOF_STRUCT_MEM)) &&
-        ((end_align - 2 * SIZEOF_STRUCT_MEM) >= begin_align))
+            ((end_align - 2 * SIZEOF_STRUCT_MEM) >= begin_align))
     {
         /* calculate the aligned memory size */
         mem_size_aligned = end_align - begin_align - 2 * SIZEOF_STRUCT_MEM;
@@ -278,8 +278,8 @@ void *rt_malloc(rt_size_t size)
     rt_sem_take(&heap_sem, RT_WAITING_FOREVER);
 
     for (ptr = (rt_uint8_t *)lfree - heap_ptr;
-         ptr < mem_size_aligned - size;
-         ptr = ((struct heap_mem *)&heap_ptr[ptr])->next)
+            ptr < mem_size_aligned - size;
+            ptr = ((struct heap_mem *)&heap_ptr[ptr])->next)
     {
         mem = (struct heap_mem *)&heap_ptr[ptr];
 
@@ -289,7 +289,7 @@ void *rt_malloc(rt_size_t size)
              * mem->next - (ptr + SIZEOF_STRUCT_MEM) gives us the 'user data size' of mem */
 
             if (mem->next - (ptr + SIZEOF_STRUCT_MEM) >=
-                (size + SIZEOF_STRUCT_MEM + MIN_SIZE_ALIGNED))
+                    (size + SIZEOF_STRUCT_MEM + MIN_SIZE_ALIGNED))
             {
                 /* (in addition to the above, we test if another struct heap_mem (SIZEOF_STRUCT_MEM) containing
                  * at least MIN_SIZE_ALIGNED of data also fits in the 'user data space' of 'mem')
@@ -335,7 +335,7 @@ void *rt_malloc(rt_size_t size)
                  */
                 mem->used = 1;
 #ifdef RT_MEM_STATS
-                used_mem += mem->next - ((rt_uint8_t*)mem - heap_ptr);
+                used_mem += mem->next - ((rt_uint8_t *)mem - heap_ptr);
                 if (max_mem < used_mem)
                     max_mem = used_mem;
 #endif
@@ -355,7 +355,7 @@ void *rt_malloc(rt_size_t size)
             rt_sem_release(&heap_sem);
             RT_ASSERT((rt_uint32_t)mem + SIZEOF_STRUCT_MEM + size <= (rt_uint32_t)heap_end);
             RT_ASSERT((rt_uint32_t)((rt_uint8_t *)mem + SIZEOF_STRUCT_MEM) % RT_ALIGN_SIZE == 0);
-            RT_ASSERT((((rt_uint32_t)mem) & (RT_ALIGN_SIZE-1)) == 0);
+            RT_ASSERT((((rt_uint32_t)mem) & (RT_ALIGN_SIZE - 1)) == 0);
 
             RT_DEBUG_LOG(RT_DEBUG_MEM,
                          ("allocate memory at 0x%x, size: %d\n",
@@ -414,7 +414,7 @@ void *rt_realloc(void *rmem, rt_size_t newsize)
     rt_sem_take(&heap_sem, RT_WAITING_FOREVER);
 
     if ((rt_uint8_t *)rmem < (rt_uint8_t *)heap_ptr ||
-        (rt_uint8_t *)rmem >= (rt_uint8_t *)heap_end)
+            (rt_uint8_t *)rmem >= (rt_uint8_t *)heap_end)
     {
         /* illegal memory */
         rt_sem_release(&heap_sem);
@@ -443,7 +443,7 @@ void *rt_realloc(void *rmem, rt_size_t newsize)
 
         ptr2 = ptr + SIZEOF_STRUCT_MEM + newsize;
         mem2 = (struct heap_mem *)&heap_ptr[ptr2];
-        mem2->magic= HEAP_MAGIC;
+        mem2->magic = HEAP_MAGIC;
         mem2->used = 0;
         mem2->next = mem->next;
         mem2->prev = ptr;
@@ -516,14 +516,14 @@ void rt_free(void *rmem)
 
     if (rmem == RT_NULL)
         return;
-    RT_ASSERT((((rt_uint32_t)rmem) & (RT_ALIGN_SIZE-1)) == 0);
+    RT_ASSERT((((rt_uint32_t)rmem) & (RT_ALIGN_SIZE - 1)) == 0);
     RT_ASSERT((rt_uint8_t *)rmem >= (rt_uint8_t *)heap_ptr &&
               (rt_uint8_t *)rmem < (rt_uint8_t *)heap_end);
 
     RT_OBJECT_HOOK_CALL(rt_free_hook, (rmem));
 
     if ((rt_uint8_t *)rmem < (rt_uint8_t *)heap_ptr ||
-        (rt_uint8_t *)rmem >= (rt_uint8_t *)heap_end)
+            (rt_uint8_t *)rmem >= (rt_uint8_t *)heap_end)
     {
         RT_DEBUG_LOG(RT_DEBUG_MEM, ("illegal memory\n"));
 
@@ -556,7 +556,7 @@ void rt_free(void *rmem)
     }
 
 #ifdef RT_MEM_STATS
-    used_mem -= (mem->next - ((rt_uint8_t*)mem - heap_ptr));
+    used_mem -= (mem->next - ((rt_uint8_t *)mem - heap_ptr));
 #endif
 
     /* finally, see if prev or next are free also */

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -90,19 +90,19 @@ static void _rt_scheduler_stack_check(struct rt_thread *thread)
     RT_ASSERT(thread != RT_NULL);
 
     if (*((rt_uint8_t *)thread->stack_addr) != '#' ||
-	(rt_uint32_t)thread->sp <= (rt_uint32_t)thread->stack_addr ||
-        (rt_uint32_t)thread->sp >
-        (rt_uint32_t)thread->stack_addr + (rt_uint32_t)thread->stack_size)
+            (rt_uint32_t)thread->sp <= (rt_uint32_t)thread->stack_addr ||
+            (rt_uint32_t)thread->sp >
+            (rt_uint32_t)thread->stack_addr + (rt_uint32_t)thread->stack_size)
     {
         rt_uint32_t level;
 
         rt_kprintf("thread:%s stack overflow\n", thread->name);
-        #ifdef RT_USING_FINSH
+#ifdef RT_USING_FINSH
         {
             extern long list_thread(void);
             list_thread();
         }
-        #endif
+#endif
         level = rt_hw_interrupt_disable();
         while (level);
     }

--- a/src/timer.c
+++ b/src/timer.c
@@ -28,7 +28,7 @@
  * 2010-05-12     Bernard      fix the timer check bug.
  * 2010-11-02     Charlie      re-implement tick overflow issue
  * 2012-12-15     Bernard      fix the next timeout issue in soft timer
- * 2014-07-12     Bernard      does not lock scheduler when invoking soft-timer 
+ * 2014-07-12     Bernard      does not lock scheduler when invoking soft-timer
  *                             timeout function.
  */
 
@@ -147,13 +147,13 @@ void rt_timer_dump(rt_list_t timer_heads[])
 {
     rt_list_t *list;
 
-    for (list = timer_heads[RT_TIMER_SKIP_LIST_LEVEL-1].next;
-         list != &timer_heads[RT_TIMER_SKIP_LIST_LEVEL-1];
-         list = list->next)
+    for (list = timer_heads[RT_TIMER_SKIP_LIST_LEVEL - 1].next;
+            list != &timer_heads[RT_TIMER_SKIP_LIST_LEVEL - 1];
+            list = list->next)
     {
         struct rt_timer *timer = rt_list_entry(list,
                                                struct rt_timer,
-                                               row[RT_TIMER_SKIP_LIST_LEVEL-1]);
+                                               row[RT_TIMER_SKIP_LIST_LEVEL - 1]);
         rt_kprintf("%d", rt_timer_count_height(timer));
     }
     rt_kprintf("\n");
@@ -303,9 +303,9 @@ rt_err_t rt_timer_start(rt_timer_t timer)
     /* timer check */
     RT_ASSERT(timer != RT_NULL);
 
-	/* stop timer firstly */
-	level = rt_hw_interrupt_disable();
-	/* remove timer from list */
+    /* stop timer firstly */
+    level = rt_hw_interrupt_disable();
+    /* remove timer from list */
     _rt_timer_remove(timer);
     /* change status of timer */
     timer->parent.flag &= ~RT_TIMER_FLAG_ACTIVATED;
@@ -339,8 +339,8 @@ rt_err_t rt_timer_start(rt_timer_t timer)
     row_head[0]  = &timer_list[0];
     for (row_lvl = 0; row_lvl < RT_TIMER_SKIP_LIST_LEVEL; row_lvl++)
     {
-        for (;row_head[row_lvl] != timer_list[row_lvl].prev;
-             row_head[row_lvl]  = row_head[row_lvl]->next)
+        for (; row_head[row_lvl] != timer_list[row_lvl].prev;
+                row_head[row_lvl]  = row_head[row_lvl]->next)
         {
             struct rt_timer *t;
             rt_list_t *p = row_head[row_lvl]->next;
@@ -363,7 +363,7 @@ rt_err_t rt_timer_start(rt_timer_t timer)
             }
         }
         if (row_lvl != RT_TIMER_SKIP_LIST_LEVEL - 1)
-            row_head[row_lvl+1] = row_head[row_lvl]+1;
+            row_head[row_lvl + 1] = row_head[row_lvl] + 1;
     }
 
     /* Interestingly, this super simple timer insert counter works very very
@@ -373,8 +373,8 @@ rt_err_t rt_timer_start(rt_timer_t timer)
     random_nr++;
     tst_nr = random_nr;
 
-    rt_list_insert_after(row_head[RT_TIMER_SKIP_LIST_LEVEL-1],
-                         &(timer->row[RT_TIMER_SKIP_LIST_LEVEL-1]));
+    rt_list_insert_after(row_head[RT_TIMER_SKIP_LIST_LEVEL - 1],
+                         &(timer->row[RT_TIMER_SKIP_LIST_LEVEL - 1]));
     for (row_lvl = 2; row_lvl <= RT_TIMER_SKIP_LIST_LEVEL; row_lvl++)
     {
         if (!(tst_nr & RT_TIMER_SKIP_LIST_MASK))
@@ -384,7 +384,7 @@ rt_err_t rt_timer_start(rt_timer_t timer)
             break;
         /* Shift over the bits we have tested. Works well with 1 bit and 2
          * bits. */
-        tst_nr >>= (RT_TIMER_SKIP_LIST_MASK+1)>>1;
+        tst_nr >>= (RT_TIMER_SKIP_LIST_MASK + 1) >> 1;
     }
 
     timer->parent.flag |= RT_TIMER_FLAG_ACTIVATED;
@@ -498,7 +498,7 @@ void rt_timer_check(void)
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
 
-    while (!rt_list_isempty(&rt_timer_list[RT_TIMER_SKIP_LIST_LEVEL-1]))
+    while (!rt_list_isempty(&rt_timer_list[RT_TIMER_SKIP_LIST_LEVEL - 1]))
     {
         t = rt_list_entry(rt_timer_list[RT_TIMER_SKIP_LIST_LEVEL - 1].next,
                           struct rt_timer, row[RT_TIMER_SKIP_LIST_LEVEL - 1]);
@@ -507,7 +507,7 @@ void rt_timer_check(void)
          * It supposes that the new tick shall less than the half duration of
          * tick max.
          */
-        if ((current_tick - t->timeout_tick) < RT_TICK_MAX/2)
+        if ((current_tick - t->timeout_tick) < RT_TICK_MAX / 2)
         {
             RT_OBJECT_HOOK_CALL(rt_timer_timeout_hook, (t));
 
@@ -523,7 +523,7 @@ void rt_timer_check(void)
             RT_DEBUG_LOG(RT_DEBUG_TIMER, ("current tick: %d\n", current_tick));
 
             if ((t->parent.flag & RT_TIMER_FLAG_PERIODIC) &&
-                (t->parent.flag & RT_TIMER_FLAG_ACTIVATED))
+                    (t->parent.flag & RT_TIMER_FLAG_ACTIVATED))
             {
                 /* start it */
                 t->parent.flag &= ~RT_TIMER_FLAG_ACTIVATED;
@@ -570,13 +570,13 @@ void rt_soft_timer_check(void)
 
     current_tick = rt_tick_get();
 
-	/* lock scheduler */
-	rt_enter_critical();
+    /* lock scheduler */
+    rt_enter_critical();
 
-    for (n = rt_soft_timer_list[RT_TIMER_SKIP_LIST_LEVEL-1].next;
-         n != &(rt_soft_timer_list[RT_TIMER_SKIP_LIST_LEVEL-1]);)
+    for (n = rt_soft_timer_list[RT_TIMER_SKIP_LIST_LEVEL - 1].next;
+            n != &(rt_soft_timer_list[RT_TIMER_SKIP_LIST_LEVEL - 1]);)
     {
-        t = rt_list_entry(n, struct rt_timer, row[RT_TIMER_SKIP_LIST_LEVEL-1]);
+        t = rt_list_entry(n, struct rt_timer, row[RT_TIMER_SKIP_LIST_LEVEL - 1]);
 
         /*
          * It supposes that the new tick shall less than the half duration of
@@ -592,8 +592,8 @@ void rt_soft_timer_check(void)
             /* remove timer from timer list firstly */
             _rt_timer_remove(t);
 
-			/* not lock scheduler when performing timeout function */
-			rt_exit_critical();
+            /* not lock scheduler when performing timeout function */
+            rt_exit_critical();
             /* call timeout function */
             t->timeout_func(t->parameter);
 
@@ -602,11 +602,11 @@ void rt_soft_timer_check(void)
 
             RT_DEBUG_LOG(RT_DEBUG_TIMER, ("current tick: %d\n", current_tick));
 
-			/* lock scheduler */
-			rt_enter_critical();
+            /* lock scheduler */
+            rt_enter_critical();
 
             if ((t->parent.flag & RT_TIMER_FLAG_PERIODIC) &&
-                (t->parent.flag & RT_TIMER_FLAG_ACTIVATED))
+                    (t->parent.flag & RT_TIMER_FLAG_ACTIVATED))
             {
                 /* start it */
                 t->parent.flag &= ~RT_TIMER_FLAG_ACTIVATED;
@@ -621,8 +621,8 @@ void rt_soft_timer_check(void)
         else break; /* not check anymore */
     }
 
-	/* unlock scheduler */
-	rt_exit_critical();
+    /* unlock scheduler */
+    rt_exit_critical();
 
     RT_DEBUG_LOG(RT_DEBUG_TIMER, ("software timer check leave\n"));
 }
@@ -649,7 +649,7 @@ static void rt_thread_timer_entry(void *parameter)
             /* get current tick */
             current_tick = rt_tick_get();
 
-            if ((next_timeout - current_tick) < RT_TICK_MAX/2)
+            if ((next_timeout - current_tick) < RT_TICK_MAX / 2)
             {
                 /* get the delta timeout tick */
                 next_timeout = next_timeout - current_tick;
@@ -672,9 +672,9 @@ void rt_system_timer_init(void)
 {
     int i;
 
-    for (i = 0; i < sizeof(rt_timer_list)/sizeof(rt_timer_list[0]); i++)
+    for (i = 0; i < sizeof(rt_timer_list) / sizeof(rt_timer_list[0]); i++)
     {
-        rt_list_init(rt_timer_list+i);
+        rt_list_init(rt_timer_list + i);
     }
 }
 
@@ -689,10 +689,10 @@ void rt_system_timer_thread_init(void)
     int i;
 
     for (i = 0;
-         i < sizeof(rt_soft_timer_list)/sizeof(rt_soft_timer_list[0]);
-         i++)
+            i < sizeof(rt_soft_timer_list) / sizeof(rt_soft_timer_list[0]);
+            i++)
     {
-        rt_list_init(rt_soft_timer_list+i);
+        rt_list_init(rt_soft_timer_list + i);
     }
 
     /* start software timer thread */


### PR DESCRIPTION
根据documentation/coding_style_cn.txt中第14条约定：
```
14. 用 astyle 自动格式化代码
参数：--style=allman
      --indent=spaces=4
      --pad-oper
      --pad-header
      --unpad-paren
      --suffix=none
      --align-pointer=name
      --lineend=linux
      --convert-tabs
      --verbose
```
对最外层的src和include文件夹内的文件进行格式化处理