### PR TITLE
在配置文件“rtconfig.h”中增加硬浮点FPU的配置项，

### DIFF
--- a/bsp/ls1cdev/drivers/board.c
+++ b/bsp/ls1cdev/drivers/board.c
@@ -94,8 +94,10 @@ void rt_hw_board_init(void)
 	/* init operating system timer */
 	rt_hw_timer_init();
 
+#ifdef RT_USING_FPU
     /* init hardware fpu */
     rt_hw_fpu_init();
+#endif
 
 	rt_kprintf("current sr: 0x%08x\n", read_c0_status());
 }

--- a/bsp/ls1cdev/rtconfig.h
+++ b/bsp/ls1cdev/rtconfig.h
@@ -75,6 +75,8 @@
 #define RT_UART_RX_BUFFER_SIZE	64
 // </section>
 
+#define RT_USING_FPU
+
 // <section name="RT_USING_CONSOLE" description="Using console" default="true" >
 #define RT_USING_CONSOLE
 // <integer name="RT_CONSOLEBUF_SIZE" description="The buffer size for console output" default="128" />

--- a/libcpu/mips/loongson_1c/context_gcc.S
+++ b/libcpu/mips/loongson_1c/context_gcc.S
@@ -57,12 +57,16 @@ rt_hw_interrupt_enable:
 rt_hw_context_switch:
     mtc0    ra, CP0_EPC
     SAVE_ALL
+#ifdef RT_USING_FPU
     SAVE_FPU
+#endif
 
     sw      sp, 0(a0)       /* store sp in preempted tasks TCB */
     lw      sp, 0(a1)       /* get new task stack pointer */
 
+#ifdef RT_USING_FPU
     RESTORE_FPU
+#endif
     RESTORE_ALL_AND_RET
 
 /*
@@ -73,7 +77,9 @@ rt_hw_context_switch:
 rt_hw_context_switch_to:
     lw      sp, 0(a0)       /* get new task stack pointer */
 
+#ifdef RT_USING_FPU
     RESTORE_FPU
+#endif
     RESTORE_ALL_AND_RET
 
 /*
@@ -107,7 +113,9 @@ _reswitch:
     .globl mips_irq_handle
 mips_irq_handle:
     SAVE_ALL
+#ifdef RT_USING_FPU
     SAVE_FPU
+#endif
 
     mfc0    t0, CP0_CAUSE
     and     t1, t0, 0xff
@@ -156,7 +164,9 @@ mips_irq_handle:
     nop
 
 spurious_interrupt:
+#ifdef RT_USING_FPU
     RESTORE_FPU
+#endif
     RESTORE_ALL_AND_RET
 
     .set reorder


### PR DESCRIPTION
浮点经常会用到，所以默认使用硬浮点。