### PR TITLE
增加硬浮点FPU的配置项和修改异常向量间隔

### DIFF
--- a/bsp/ls1cdev/applications/startup.c
+++ b/bsp/ls1cdev/applications/startup.c
@@ -51,9 +51,9 @@ void rtthread_startup(void)
     rt_hw_interrupt_init();
 
     /* copy vector */
-    rt_memcpy((void *)A_K0BASE, tlb_refill_exception, 0x20);
-    rt_memcpy((void *)(A_K0BASE + 0x180), general_exception, 0x20);
-    rt_memcpy((void *)(A_K0BASE + 0x200), irq_exception, 0x20);
+    rt_memcpy((void *)A_K0BASE, tlb_refill_exception, 0x80);
+    rt_memcpy((void *)(A_K0BASE + 0x180), general_exception, 0x80);
+    rt_memcpy((void *)(A_K0BASE + 0x200), irq_exception, 0x80);
 
     invalidate_writeback_dcache_all();
     invalidate_icache_all();

--- a/bsp/ls1cdev/drivers/board.c
+++ b/bsp/ls1cdev/drivers/board.c
@@ -94,8 +94,10 @@ void rt_hw_board_init(void)
 	/* init operating system timer */
 	rt_hw_timer_init();
 
+#ifdef RT_USING_FPU
     /* init hardware fpu */
     rt_hw_fpu_init();
+#endif
 
 	rt_kprintf("current sr: 0x%08x\n", read_c0_status());
 }

--- a/bsp/ls1cdev/rtconfig.h
+++ b/bsp/ls1cdev/rtconfig.h
@@ -75,6 +75,8 @@
 #define RT_UART_RX_BUFFER_SIZE	64
 // </section>
 
+#define RT_USING_FPU
+
 // <section name="RT_USING_CONSOLE" description="Using console" default="true" >
 #define RT_USING_CONSOLE
 // <integer name="RT_CONSOLEBUF_SIZE" description="The buffer size for console output" default="128" />

--- a/libcpu/mips/loongson_1c/stackframe_fpu.h
+++ b/libcpu/mips/loongson_1c/stackframe_fpu.h
@@ -37,6 +37,7 @@
     .macro SAVE_FPU
     .set push
     .set noreorder
+#ifdef RT_USING_FPU
     move k1, sp                     /* 保存现场 */
     and k0, k1, 0xFFFFFFF8          /* 8字节对齐 */    
     PTR_SUBU sp, k0, PT_FPU_SIZE    /* 计算栈底 */
@@ -57,6 +58,7 @@
     s.d $f28, PT_FPU_R28(sp)
     s.d $f30, PT_FPU_R30(sp)
     move sp, k1                     /* 恢复现场 */
+#endif
     .set reorder
     .set pop
     .endm
@@ -65,6 +67,7 @@
     .macro RESTORE_FPU
     .set push
     .set noreorder
+#ifdef RT_USING_FPU
     move k1, sp                     /* 保存现场 */
     and k0, k1, 0xFFFFFFF8          /* 8字节对齐 */
     PTR_SUBU sp, k0, PT_FPU_SIZE    /* 计算栈底*/
@@ -85,6 +88,7 @@
     l.d $f28, PT_FPU_R28(sp)
     l.d $f30, PT_FPU_R30(sp)
     move sp, k1                     /* 恢复现场 */
+#endif
     .set reorder
     .set pop
     .endm


### PR DESCRIPTION
浮点经常会用到，所以默认使用硬浮点。