### PR TITLE
Update rtconfig.py

### DIFF
--- a/bsp/frdm-k64f/rtconfig.py
+++ b/bsp/frdm-k64f/rtconfig.py
@@ -74,7 +74,7 @@ elif PLATFORM == 'armcc':
     EXEC_PATH += '/arm/bin40/'
 
     if BUILD == 'debug':
-        CFLAGS += ' -g -O0'
+        CFLAGS += ' --c99 -g -O0'
         AFLAGS += ' -g'
     else:
         CFLAGS += ' -O2'


### PR DESCRIPTION
when "PLATFORM  == armcc", the option "CFLAGS += '  -g -O0' " needs to change to "CFLAGS += ' --c99 -g -O0'" to support the keyword "inline"