### PR TITLE
修复无法重复使用finsh命令device_test进行驱动测试

### DIFF
--- a/examples/test/device_test.c
+++ b/examples/test/device_test.c
@@ -90,7 +90,7 @@ static rt_err_t _block_device_test(rt_device_t device)
 
         /* step 3:  R/W test */
         {
-            rt_uint32_t i,err_count, sector_no;
+            rt_uint32_t i, err_count, sector_no;
             rt_uint8_t * data_point;
 
             i = rt_device_read(device, 0, read_buffer, 1);
@@ -449,11 +449,13 @@ static rt_err_t _block_device_test(rt_device_t device)
             }
         } /* step 5: multiple sector speed test */
 
+        rt_device_close(device);
         return RT_EOK;
     }// device can read and write.
     else
     {
         // device read only
+        rt_device_close(device);
         return RT_EOK;
     }// device read only
 
@@ -466,6 +468,7 @@ __return:
     {
         rt_free(write_buffer);
     }
+    rt_device_close(device);
     return RT_ERROR;
 }
 


### PR DESCRIPTION
1. 该问题是打开设备后, 出错或者成功后没有关闭设备而导致.