### PR TITLE
[lwIP] Fix the lwIP 2.0.2 IAR compile error

### DIFF
--- a/components/net/lwip-2.0.2/src/include/lwip/arch.h
+++ b/components/net/lwip-2.0.2/src/include/lwip/arch.h
@@ -203,8 +203,7 @@ typedef uintptr_t mem_ptr_t;
  * \#define LWIP_DECLARE_MEMORY_ALIGNED(variable_name, size) u32_t variable_name[(size + sizeof(u32_t) - 1) / sizeof(u32_t)]
  */
 #ifndef LWIP_DECLARE_MEMORY_ALIGNED
-//#define LWIP_DECLARE_MEMORY_ALIGNED(variable_name, size) u8_t variable_name[LWIP_MEM_ALIGN_BUFFER(size)]
-#define LWIP_DECLARE_MEMORY_ALIGNED(variable_name, size) u8_t variable_name[size] __attribute__((aligned(4)))
+#define LWIP_DECLARE_MEMORY_ALIGNED(variable_name, size) u8_t variable_name[LWIP_MEM_ALIGN_BUFFER(size)]
 
 #endif
 


### PR DESCRIPTION
Fix the lwIP 2.0.2 IAR compile error when the `RT_LWIP_USING_RT_MEM` macro is not defined.