### PR TITLE
清理编译告警和错误。编译告警和错误的原因是删除了头文件“components.h”

### DIFF
--- a/bsp/ls1cdev/drivers/net/synopGMAC_network_interface.h
+++ b/bsp/ls1cdev/drivers/net/synopGMAC_network_interface.h
@@ -35,6 +35,9 @@
 #ifndef SYNOP_GMAC_NETWORK_INTERFACE_H
 #define SYNOP_GMAC_NETWORK_INTERFACE_H 1
 
+
+#include <lwip/sys.h>
+#include <netif/ethernetif.h>
 #include "synopGMAC_plat.h"
 #include "synopGMAC_Host.h"
 #include "synopGMAC_Dev.h"


### PR DESCRIPTION
如题