### PR TITLE
Pulls

### DIFF
--- a/bsp/beaglebone/beaglebone_ram.lds
+++ b/bsp/beaglebone/beaglebone_ram.lds
@@ -67,7 +67,7 @@ SECTIONS
     __data_end = .;
 
     . = ALIGN(4);
-    __bss_start = __data_end;
+    __bss_start = .;
     .bss       :
     {
     *(.bss)

--- a/bsp/imx6sx/cortex-a9/imx6.lds
+++ b/bsp/imx6sx/cortex-a9/imx6.lds
@@ -75,7 +75,7 @@ SECTIONS
     __data_end = .;
 
     . = ALIGN(4);
-    __bss_start = __data_end;
+    __bss_start = .;
     .bss       :
     {
     *(.bss)

--- a/bsp/zynq7000/zynq7000.ld
+++ b/bsp/zynq7000/zynq7000.ld
@@ -92,7 +92,7 @@ SECTIONS
     __data_end = .;
 
     . = ALIGN(4);
-    __bss_start = __data_end;
+    __bss_start = 0;
     .bss       :
     {
     *(.bss)

--- a/tools/building.py
+++ b/tools/building.py
@@ -695,15 +695,13 @@ def SrcRemove(src, remove):
     if not src:
         return
 
-    if type(src[0]) == type('str'):
-        for item in src:
+    for item in src:
+        if type(item) == type('str'):
             if os.path.basename(item) in remove:
                 src.remove(item)
-        return
-
-    for item in src:
-        if os.path.basename(item.rstr()) in remove:
-            src.remove(item)
+        else:
+            if os.path.basename(item.rstr()) in remove:
+                src.remove(item)
 
 def GetVersion():
     import SCons.cpp


### PR DESCRIPTION
1. __bss_start 取值有误，造成上面的对齐无效，会触发 clean bss时的数据非对齐异常
2. 以不同方式批量添加源文件时，删除时要单独判断每个项目类型。