### PR TITLE
[Finsh] Fix an auto complete history bug.

### DIFF
--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -372,7 +372,7 @@ static void shell_push_history(struct finsh_shell *shell)
         if (shell->history_count >= FINSH_HISTORY_LINES)
         {
             /* if current cmd is same as last cmd, don't push */
-            if (memcmp(&shell->cmd_history[FINSH_HISTORY_LINES - 1], shell->line, shell->line_position))
+            if (memcmp(&shell->cmd_history[FINSH_HISTORY_LINES - 1], shell->line, FINSH_CMD_SIZE))
             {
                 /* move history */
                 int index;
@@ -391,7 +391,7 @@ static void shell_push_history(struct finsh_shell *shell)
         else
         {
             /* if current cmd is same as last cmd, don't push */
-            if (shell->history_count == 0 || memcmp(&shell->cmd_history[shell->history_count - 1], shell->line, shell->line_position))
+            if (shell->history_count == 0 || memcmp(&shell->cmd_history[shell->history_count - 1], shell->line, FINSH_CMD_SIZE))
             {
                 shell->current_history = shell->history_count;
                 memset(&shell->cmd_history[shell->history_count][0], 0, FINSH_CMD_SIZE);


### PR DESCRIPTION
bug 复现

- 上次输入命令 `send 10`
- 当前输入命令 `send 1`
- 新命令未被加入到历史中