### PR TITLE
[lwip] : statement is unreachable

### DIFF
--- a/components/net/lwip-2.0.2/src/core/tcp.c
+++ b/components/net/lwip-2.0.2/src/core/tcp.c
@@ -358,7 +358,6 @@ tcp_close_shutdown_fin(struct tcp_pcb *pcb)
   default:
     /* Has already been closed, do nothing. */
     return ERR_OK;
-    break;
   }
 
   if (err == ERR_OK) {


### PR DESCRIPTION
..\..\components\net\lwip-2.0.2\src\core\tcp.c(361): warning:  #111-D: statement is unreachable