### PR TITLE
[lwip]判定eth_rx是否为空,为空不执行。

### DIFF
--- a/components/net/lwip-2.0.2/src/netif/ethernetif.c
+++ b/components/net/lwip-2.0.2/src/netif/ethernetif.c
@@ -391,6 +391,8 @@ static void eth_rx_thread_entry(void* parameter)
             /* receive all of buffer */
             while (1)
             {
+                if(device->eth_rx == RT_NULL) break;
+                
                 p = device->eth_rx(&(device->parent));
                 if (p != RT_NULL)
                 {


### PR DESCRIPTION
当eth_rx为空时，系统会宕机