### PR TITLE
[tools]menuconfig.py. Fix config line split error.

### DIFF
--- a/tools/menuconfig.py
+++ b/tools/menuconfig.py
@@ -33,7 +33,7 @@ def mk_rtconfig(filename):
             empty_line = 0
         else:
             empty_line = 0
-            setting = line.split('=')
+            setting = line.split('=', 1)
             if len(setting) >= 2:
                 if setting[0].startswith('CONFIG_'):
                     setting[0] = setting[0][7:]


### PR DESCRIPTION
Fix config line split error when config line contains more then one equal marks.