### PR TITLE
[bsp] remove old head file include for RTGUI

### DIFF
--- a/bsp/gd32450z-eval/applications/rtgui_demo.c
+++ b/bsp/gd32450z-eval/applications/rtgui_demo.c
@@ -31,7 +31,6 @@
 
 #include <rtgui/widgets/window.h>
 #include <rtgui/dc.h>
-//#include <rtgui/dc_hw.h>
 
 struct rtgui_win *main_win;
 rt_bool_t dc_event_handler(struct rtgui_object *object, rtgui_event_t *event);

--- a/bsp/stm32f429-apollo/applications/rtgui_demo.c
+++ b/bsp/stm32f429-apollo/applications/rtgui_demo.c
@@ -18,7 +18,6 @@
 
 #include <rtgui/widgets/window.h>
 #include <rtgui/dc.h>
-#include <rtgui/dc_hw.h>
 
 #include "finsh.h"
 #include "rtgui_demo.h"

--- a/bsp/stm32f429_armfly/applications/rtgui_demo.c
+++ b/bsp/stm32f429_armfly/applications/rtgui_demo.c
@@ -31,7 +31,6 @@
 
 #include <rtgui/widgets/window.h>
 #include <rtgui/dc.h>
-#include <rtgui/dc_hw.h>
 
 struct rtgui_win *main_win;
 rt_bool_t dc_event_handler(struct rtgui_object *object, rtgui_event_t *event);


### PR DESCRIPTION

<rtgui/dc_hw.h> 已经合并到<rtgui/dc_.h>