### PR TITLE
[Components][Drivers][USB]WinUSB And Core update

### DIFF
--- a/components/drivers/include/drivers/usb_common.h
+++ b/components/drivers/include/drivers/usb_common.h
@@ -422,6 +422,53 @@ struct usb_os_comp_id_descriptor
 };
 typedef struct usb_os_comp_id_descriptor * usb_os_comp_id_desc_t;
 
+struct usb_os_property_header
+{
+    rt_uint32_t dwLength;
+    rt_uint16_t bcdVersion;
+    rt_uint16_t wIndex;
+    rt_uint16_t wCount;
+};
+typedef struct usb_os_property_header * usb_os_property_header_t;
+struct usb_os_proerty
+{
+    rt_uint32_t dwSize;
+    rt_uint32_t dwPropertyDataType;
+    rt_uint16_t wPropertyNameLength;
+    const char * bPropertyName;
+    rt_uint32_t dwPropertyDataLength;
+    const char * bPropertyData;
+};
+typedef struct usb_os_proerty * usb_os_proerty_t;
+
+// Value	Description
+//  1	    A NULL-terminated Unicode String (REG_SZ)
+//  2	    A NULL-terminated Unicode String that includes environment variables (REG_EXPAND_SZ)
+//  3	    Free-form binary (REG_BINARY)
+//  4	    A little-endian 32-bit integer (REG_DWORD_LITTLE_ENDIAN)
+//  5	    A big-endian 32-bit integer (REG_DWORD_BIG_ENDIAN)
+//  6	    A NULL-terminated Unicode string that contains a symbolic link (REG_LINK)
+//  7	    Multiple NULL-terminated Unicode strings (REG_MULTI_SZ)
+#define USB_OS_PROERTY_TYPE_REG_SZ                      0x01UL
+#define USB_OS_PROERTY_TYPE_REG_EXPAND_SZ               0x02UL
+#define USB_OS_PROERTY_TYPE_REG_BINARY                  0x03UL
+#define USB_OS_PROERTY_TYPE_REG_DWORD_LITTLE_ENDIAN     0x04UL
+#define USB_OS_PROERTY_TYPE_REG_DWORD_BIG_ENDIAN        0x05UL
+#define USB_OS_PROERTY_TYPE_REG_LINK                    0x06UL
+#define USB_OS_PROERTY_TYPE_REG_MULTI_SZ                0x07UL
+
+#define USB_OS_PROERTY_DESC(PropertyDataType,PropertyName,PropertyData) \
+{\
+    .dwSize                 = sizeof(struct usb_os_proerty)-sizeof(const char *)*2\
+                            +sizeof(PropertyName)*2+sizeof(PropertyData)*2,\
+    .dwPropertyDataType     = PropertyDataType,\
+    .wPropertyNameLength    = sizeof(PropertyName)*2,\
+    .bPropertyName          = PropertyName,\
+    .dwPropertyDataLength   = sizeof(PropertyData)*2,\
+    .bPropertyData          = PropertyData\
+}
+
+
 #ifndef HID_SUB_DESCRIPTOR_MAX
 #define  HID_SUB_DESCRIPTOR_MAX        1
 #endif

--- a/components/drivers/usb/usbdevice/class/winusb.c
+++ b/components/drivers/usb/usbdevice/class/winusb.c
@@ -25,7 +25,7 @@ static struct udevice_descriptor dev_desc =
     USB_DESC_LENGTH_DEVICE,     //bLength;
     USB_DESC_TYPE_DEVICE,       //type;
     USB_BCD_VERSION,            //bcdUSB;
-    0x00,           //bDeviceClass;
+    0x00,                       //bDeviceClass;
     0x00,                       //bDeviceSubClass;
     0x00,                       //bDeviceProtocol;
     0x40,                       //bMaxPacketSize0;
@@ -100,6 +100,11 @@ const static char* _ustring[] =
     "Interface",
     USB_STRING_OS//must be
 };
+struct usb_os_proerty winusb_proerty[] = 
+{
+    USB_OS_PROERTY_DESC(USB_OS_PROERTY_TYPE_REG_SZ,"DeviceInterfaceGUID","{6860DC3C-C05F-4807-8807-1CA861CC1D66}"),
+};
+
 struct usb_os_function_comp_id_descriptor winusb_func_comp_id_desc = 
 {
     .bFirstInterfaceNumber = USB_DYNAMIC,
@@ -127,6 +132,18 @@ static rt_err_t _ep_in_handler(ufunction_t func, rt_size_t size)
 }
 static rt_err_t _interface_handler(ufunction_t func, ureq_t setup)
 {
+    switch(setup->bRequest)
+    {
+    case 'A':
+        switch(setup->wIndex)
+        {
+        case 0x05:
+            usbd_os_proerty_descriptor_send(func,setup,winusb_proerty,sizeof(winusb_proerty)/sizeof(winusb_proerty[0]));
+            break;
+        }
+        break;
+    }
+    
     return RT_EOK;
 }
 static rt_err_t _function_enable(ufunction_t func)

--- a/components/drivers/usb/usbdevice/class/winusb.h
+++ b/components/drivers/usb/usbdevice/class/winusb.h
@@ -20,18 +20,4 @@ struct winusb_descriptor
 };
 typedef struct winusb_descriptor* winusb_desc_t;
 
-
-struct winusb_os_header_properties_descriptor
-{
-    rt_uint32_t dwLength;
-    rt_uint16_t bcdVersion;
-    rt_uint16_t wIndex;
-    rt_uint16_t bCount;
-};
-typedef struct winusb_os_header_properties_descriptor * winusb_os_header_prop_desc_t;
-
-
-
-
-
 #endif

--- a/components/drivers/usb/usbdevice/core/core.c
+++ b/components/drivers/usb/usbdevice/core/core.c
@@ -669,6 +669,8 @@ static rt_err_t _vendor_request(udevice_t device, ureq_t setup)
     static rt_uint8_t * usb_comp_id_desc = RT_NULL;
     static rt_uint32_t  usb_comp_id_desc_size = 0;
     usb_os_func_comp_id_desc_t func_comp_id_desc;
+    uintf_t intf;
+    ufunction_t func;
     switch(setup->bRequest)
     {
         case 'A':
@@ -704,6 +706,13 @@ static rt_err_t _vendor_request(udevice_t device, ureq_t setup)
                 }
                 rt_usbd_ep0_write(device, (void*)usb_comp_id_desc, setup->wLength);
             break;
+            case 0x05:
+                intf = rt_usbd_find_interface(device, setup->wValue & 0xFF, &func);
+                if(intf != RT_NULL)
+                {
+                    intf->handler(func, setup);
+                }
+                break;
         }
             
         break;


### PR DESCRIPTION
协议栈增加允许class在windows环境下枚举时向系统注册附加属性。并在winusb class中提供范例（注册GUID信息）详细信息参见MicroSoft文档 《Extended Properties OS Feature Descriptor Specification》
https://technet.microsoft.com/zh-cn/library/ff537430