### PR TITLE
[LWIP] make sure lwip initialization order.

### DIFF
--- a/components/net/lwip-2.0.2/src/arch/sys_arch.c
+++ b/components/net/lwip-2.0.2/src/arch/sys_arch.c
@@ -136,10 +136,13 @@ static void tcpip_init_done_callback(void *arg)
 /**
  * LwIP system initialization
  */
+extern int eth_system_device_init_private(void);
 int lwip_system_init(void)
 {
     rt_err_t rc;
     struct rt_semaphore done_sem;
+	
+    eth_system_device_init_private();
 
     /* set default netif to NULL */
     netif_default = RT_NULL;
@@ -181,7 +184,7 @@ int lwip_system_init(void)
 
     return 0;
 }
-INIT_COMPONENT_EXPORT(lwip_system_init);
+INIT_PREV_EXPORT(lwip_system_init);
 
 void sys_init(void)
 {

--- a/components/net/lwip-2.0.2/src/netif/ethernetif.c
+++ b/components/net/lwip-2.0.2/src/netif/ethernetif.c
@@ -415,7 +415,16 @@ static void eth_rx_thread_entry(void* parameter)
 }
 #endif
 
+/* this function does not need, 
+ * use eth_system_device_init_private() 
+ * call by lwip_system_init(). 
+ */
 int eth_system_device_init(void)
+{
+    return 0;
+}
+
+int eth_system_device_init_private(void)
 {
     rt_err_t result = RT_EOK;
 
@@ -454,7 +463,6 @@ int eth_system_device_init(void)
 
     return (int)result;
 }
-INIT_PREV_EXPORT(eth_system_device_init);
 
 #ifdef RT_USING_FINSH
 #include <finsh.h>


### PR DESCRIPTION
取消 INIT_PREV_EXPORT(eth_system_device_init);

由 lwip_system_init 自动调用 eth_system_device_init_private

同时留空 eth_system_device_init 以兼容旧的代码。