### PR TITLE
[bsp] better use gcc to link instead of g++

### DIFF
--- a/bsp/qemu-vexpress-a9/rtconfig.py
+++ b/bsp/qemu-vexpress-a9/rtconfig.py
@@ -27,7 +27,7 @@ if PLATFORM == 'gcc':
     CXX = PREFIX + 'g++'
     AS = PREFIX + 'gcc'
     AR = PREFIX + 'ar'
-    LINK = PREFIX + 'g++'
+    LINK = PREFIX + 'gcc'
     TARGET_EXT = 'elf'
     SIZE = PREFIX + 'size'
     OBJDUMP = PREFIX + 'objdump'


### PR DESCRIPTION
on ubuntu, use g++ will add an additional linkflag "-lstdc++" and this will result link failed.