### PR TITLE
龙芯1C使用的libc初始化添加了dev的定义条件

### DIFF
--- a/components/libc/compilers/newlib/libc.c
+++ b/components/libc/compilers/newlib/libc.c
@@ -37,7 +37,7 @@
 
 int libc_system_init(void)
 {
-#ifdef RT_USING_DFS
+#if defined(RT_USING_DFS) & defined(RT_USING_DFS_DEVFS)
     rt_device_t dev_console;
 
     dev_console = rt_console_get_device();


### PR DESCRIPTION
以前是#if defined(RT_USING_DFS) 
修改成#if defined(RT_USING_DFS) & defined(RT_USING_DFS_DEVFS)
解决使用 dfs时组件初始化卡死