### PR TITLE
[sfud]sfud在没有检测到Flash时的Bug

### DIFF
--- a/components/drivers/spi/spi_flash_sfud.c
+++ b/components/drivers/spi/spi_flash_sfud.c
@@ -252,11 +252,11 @@ rt_spi_flash_device_t rt_sfud_flash_probe(const char *spi_flash_dev_name, const 
 
     /* initialize lock */
     if (rtt_dev) {
+		rt_memset(rtt_dev, 0, sizeof(struct spi_flash_device));
         rt_mutex_init(&(rtt_dev->lock), spi_flash_dev_name, RT_IPC_FLAG_FIFO);  
     }
     
-    if (rtt_dev && sfud_dev && spi_flash_dev_name_bak && spi_dev_name_bak) {
-        rt_memset(rtt_dev, 0, sizeof(struct spi_flash_device));
+    if (rtt_dev && sfud_dev && spi_flash_dev_name_bak && spi_dev_name_bak) {        
         rt_memset(sfud_dev, 0, sizeof(sfud_flash));
         rt_strncpy(spi_flash_dev_name_bak, spi_flash_dev_name, rt_strlen(spi_flash_dev_name));
         rt_strncpy(spi_dev_name_bak, spi_dev_name, rt_strlen(spi_dev_name));

--- a/components/drivers/spi/spi_flash_sfud.c
+++ b/components/drivers/spi/spi_flash_sfud.c
@@ -250,6 +250,11 @@ rt_spi_flash_device_t rt_sfud_flash_probe(const char *spi_flash_dev_name, const 
     spi_flash_dev_name_bak = (char *) rt_malloc(rt_strlen(spi_flash_dev_name) + 1);
     spi_dev_name_bak = (char *) rt_malloc(rt_strlen(spi_dev_name) + 1);
 
+    /* initialize lock */
+    if (rtt_dev) {
+        rt_mutex_init(&(rtt_dev->lock), spi_flash_dev_name, RT_IPC_FLAG_FIFO);  
+    }
+    
     if (rtt_dev && sfud_dev && spi_flash_dev_name_bak && spi_dev_name_bak) {
         rt_memset(rtt_dev, 0, sizeof(struct spi_flash_device));
         rt_memset(sfud_dev, 0, sizeof(sfud_flash));
@@ -268,8 +273,6 @@ rt_spi_flash_device_t rt_sfud_flash_probe(const char *spi_flash_dev_name, const 
             }
             sfud_dev->spi.name = spi_dev_name_bak;
             rt_spi_configure(rtt_dev->rt_spi_device, &cfg);
-            /* initialize lock */
-            rt_mutex_init(&(rtt_dev->lock), spi_flash_dev_name, RT_IPC_FLAG_FIFO);
         }
         /* SFUD flash device initialize */
         {
@@ -309,7 +312,9 @@ rt_spi_flash_device_t rt_sfud_flash_probe(const char *spi_flash_dev_name, const 
 
 error:
     /* may be one of objects memory was malloc success, so need free all */
-    rt_mutex_detach(&(rtt_dev->lock));
+    if (rtt_dev) {
+        rt_mutex_detach(&(rtt_dev->lock));
+    }
     rt_free(rtt_dev);
     rt_free(sfud_dev);
     rt_free(spi_flash_dev_name_bak);

--- a/components/drivers/spi/spi_flash_sfud.c
+++ b/components/drivers/spi/spi_flash_sfud.c
@@ -309,6 +309,7 @@ rt_spi_flash_device_t rt_sfud_flash_probe(const char *spi_flash_dev_name, const 
 
 error:
     /* may be one of objects memory was malloc success, so need free all */
+    rt_mutex_detach(&(rtt_dev->lock));
     rt_free(rtt_dev);
     rt_free(sfud_dev);
     rt_free(spi_flash_dev_name_bak);


### PR DESCRIPTION
[sfud]当没有检测到外部Flash时，释放内存前需要先脱离互斥量；否则会造成内存错误。