### PR TITLE
[dfs] add IN6_IS_ADDR_MULTICAST support

### DIFF
--- a/components/dfs/filesystems/net/netinet/in.h
+++ b/components/dfs/filesystems/net/netinet/in.h
@@ -27,4 +27,8 @@
 
 #include <lwip/sockets.h>
 
+#ifndef IN6_IS_ADDR_MULTICAST
+#define IN6_IS_ADDR_MULTICAST(a) (((uint8_t *) (a))[0] == 0xff)
+#endif
+
 #endif


### PR DESCRIPTION
in components/dfs/filesystems/net/netinet/in.h, add IN6_IS_ADDR_MULTICAST support