### PR TITLE
[Components][Drivers][USB]fix memory leak

### DIFF
--- a/components/drivers/usb/usbdevice/class/hid.c
+++ b/components/drivers/usb/usbdevice/class/hid.c
@@ -486,7 +486,10 @@ static rt_err_t _function_enable(ufunction_t func)
 //
 //    _vcom_reset_state(func);
 //
-    data->ep_out->buffer            = rt_malloc(HID_RX_BUFSIZE);
+    if(data->ep_out->buffer == RT_NULL)
+    {
+        data->ep_out->buffer        = rt_malloc(HID_RX_BUFSIZE);
+    }
     data->ep_out->request.buffer    = data->ep_out->buffer;
     data->ep_out->request.size      = EP_MAXPACKET(data->ep_out);
     data->ep_out->request.req_type  = UIO_REQUEST_READ_BEST;


### PR DESCRIPTION
修复一个 bug 该bug曾导致在设备不断电但主机重新枚举设备的情况下会导致内存泄漏并无法接收数据