### PR TITLE
[libcpu]: fixed #1196 FPU FPCA issue.

### DIFF
--- a/libcpu/arm/cortex-m4/context_gcc.S
+++ b/libcpu/arm/cortex-m4/context_gcc.S
@@ -145,15 +145,15 @@ switch_to_thread:
 
     MSR psp, r1                 /* update stack pointer */
 
-pendsv_exit:
-    /* restore interrupt */
-    MSR PRIMASK, r2
-
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
     ORR     lr, lr, #0x10       /* lr |=  (1 << 4), clean FPCA. */
     CMP     r3,  #0             /* if(flag_r3 != 0) */
     BICNE   lr, lr, #0x10       /* lr &= ~(1 << 4), set FPCA. */
 #endif
+
+pendsv_exit:
+    /* restore interrupt */
+    MSR PRIMASK, r2
 
     ORR lr, lr, #0x04
     BX  lr

--- a/libcpu/arm/cortex-m4/context_iar.S
+++ b/libcpu/arm/cortex-m4/context_iar.S
@@ -149,16 +149,16 @@ skip_pop_fpu
 
     MSR     psp, r1                 ; update stack pointer
 
-pendsv_exit
-    ; restore interrupt
-    MSR     PRIMASK, r2
-
 #if defined ( __ARMVFP__ )
     ORR     lr, lr, #0x10           ; lr |=  (1 << 4), clean FPCA.
     CBZ     r3, return_without_fpu  ; if(flag_r3 != 0)
     BIC     lr, lr, #0x10           ; lr &= ~(1 << 4), set FPCA.
 return_without_fpu
 #endif
+
+pendsv_exit
+    ; restore interrupt
+    MSR     PRIMASK, r2
 
     ORR     lr, lr, #0x04
     BX      lr

--- a/libcpu/arm/cortex-m4/context_rvds.S
+++ b/libcpu/arm/cortex-m4/context_rvds.S
@@ -147,15 +147,15 @@ switch_to_thread
 
     MSR     psp, r1                 ; update stack pointer
 
-pendsv_exit
-    ; restore interrupt
-    MSR     PRIMASK, r2
-
     IF      {FPU} != "SoftVFP"
     ORR     lr, lr, #0x10           ; lr |=  (1 << 4), clean FPCA.
     CMP     r3,  #0                 ; if(flag_r3 != 0)
     BICNE   lr, lr, #0x10           ; lr &= ~(1 << 4), set FPCA.
     ENDIF
+
+pendsv_exit
+    ; restore interrupt
+    MSR     PRIMASK, r2
 
     ORR     lr, lr, #0x04
     BX      lr

--- a/libcpu/arm/cortex-m7/context_gcc.S
+++ b/libcpu/arm/cortex-m7/context_gcc.S
@@ -145,15 +145,15 @@ switch_to_thread:
 
     MSR psp, r1                 /* update stack pointer */
 
-pendsv_exit:
-    /* restore interrupt */
-    MSR PRIMASK, r2
-
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
     ORR     lr, lr, #0x10       /* lr |=  (1 << 4), clean FPCA. */
     CMP     r3,  #0             /* if(flag_r3 != 0) */
     BICNE   lr, lr, #0x10       /* lr &= ~(1 << 4), set FPCA. */
 #endif
+
+pendsv_exit:
+    /* restore interrupt */
+    MSR PRIMASK, r2
 
     ORR lr, lr, #0x04
     BX  lr

--- a/libcpu/arm/cortex-m7/context_iar.S
+++ b/libcpu/arm/cortex-m7/context_iar.S
@@ -149,16 +149,16 @@ skip_pop_fpu
 
     MSR     psp, r1                 ; update stack pointer
 
-pendsv_exit
-    ; restore interrupt
-    MSR     PRIMASK, r2
-
 #if defined ( __ARMVFP__ )
     ORR     lr, lr, #0x10           ; lr |=  (1 << 4), clean FPCA.
     CBZ     r3, return_without_fpu  ; if(flag_r3 != 0)
     BIC     lr, lr, #0x10           ; lr &= ~(1 << 4), set FPCA.
 return_without_fpu
 #endif
+
+pendsv_exit
+    ; restore interrupt
+    MSR     PRIMASK, r2
 
     ORR     lr, lr, #0x04
     BX      lr

--- a/libcpu/arm/cortex-m7/context_rvds.S
+++ b/libcpu/arm/cortex-m7/context_rvds.S
@@ -147,15 +147,15 @@ switch_to_thread
 
     MSR     psp, r1                 ; update stack pointer
 
-pendsv_exit
-    ; restore interrupt
-    MSR     PRIMASK, r2
-
     IF      {FPU} != "SoftVFP"
     ORR     lr, lr, #0x10           ; lr |=  (1 << 4), clean FPCA.
     CMP     r3,  #0                 ; if(flag_r3 != 0)
     BICNE   lr, lr, #0x10           ; lr &= ~(1 << 4), set FPCA.
     ENDIF
+
+pendsv_exit
+    ; restore interrupt
+    MSR     PRIMASK, r2
 
     ORR     lr, lr, #0x04
     BX      lr


### PR DESCRIPTION
线程时，更新目标线程的FPU FPCA标致位的时机不合理，当不需要切换时，可能会引起目标线程寄存器错乱。
相关讨论详见 issus #1196 