### PR TITLE
[bsp] fix uart driver bug

### DIFF
--- a/bsp/imxrt1052-evk/drivers/usart.c
+++ b/bsp/imxrt1052-evk/drivers/usart.c
@@ -230,10 +230,10 @@ static rt_err_t imxrt_configure(struct rt_serial_device *serial, struct serial_c
     switch (cfg->stop_bits)
     {
     case STOP_BITS_2:
-        config.stopBitCount = kLPUART_OneStopBit;
+        config.stopBitCount = kLPUART_TwoStopBit;
         break;
     default:
-        config.stopBitCount = kLPUART_TwoStopBit;
+        config.stopBitCount = kLPUART_OneStopBit;
         break;
     }
 


### PR DESCRIPTION
修复uart配置的bug，错误的停止位会导致硬件同时接收多个数据出错。