### PR TITLE
stm32f10x enters external interrupt handler forever

### DIFF
--- a/bsp/stm32f10x/drivers/gpio.c
+++ b/bsp/stm32f10x/drivers/gpio.c
@@ -21,8 +21,8 @@
 
 #define STM32F10X_PIN_NUMBERS 100 //[48, 64, 100, 144 ]
 
-#define __STM32_PIN(index, rcc, gpio, gpio_index) { 0, RCC_##rcc##Periph_GPIO##gpio, GPIO##gpio, GPIO_Pin_##gpio_index}
-#define __STM32_PIN_DEFAULT {-1, 0, 0, 0}
+#define __STM32_PIN(index, rcc, gpio, gpio_index) { 0, RCC_##rcc##Periph_GPIO##gpio, GPIO##gpio, GPIO_Pin_##gpio_index, GPIO_PortSourceGPIO##gpio, GPIO_PinSource##gpio_index}
+#define __STM32_PIN_DEFAULT {-1, 0, 0, 0, 0, 0}
 
 /* STM32 GPIO driver */
 struct pin_index
@@ -31,6 +31,8 @@ struct pin_index
     uint32_t rcc;
     GPIO_TypeDef *gpio;
     uint32_t pin;
+    uint8_t port_source;
+    uint8_t pin_source;
 };
 
 static const struct pin_index pins[] =
@@ -695,6 +697,7 @@ rt_err_t stm32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
         NVIC_InitStructure.NVIC_IRQChannelCmd=ENABLE;
         NVIC_Init(&NVIC_InitStructure);
 
+        GPIO_EXTILineConfig(index->port_source, index->pin_source);
         EXTI_InitStructure.EXTI_Line = irqmap->irqbit;  
         EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
         switch(pin_irq_hdr_tab[irqindex].mode)


### PR DESCRIPTION
In function **stm32_pin_irq_enable**, missing **GPIO_EXTILineConfig** may cause that program enters interrupt handler forever. So, the following statement is necessary.

` GPIO_EXTILineConfig(index->port_source, index->pin_source);
`
