### PR TITLE
没用使用RT_USING_HEAP宏时，增加一条语句用于消除此警告

### DIFF
--- a/src/components.c
+++ b/src/components.c
@@ -214,6 +214,9 @@ void rt_application_init(void)
     result = rt_thread_init(tid, "main", main_thread_entry, RT_NULL,
                             main_stack, sizeof(main_stack), RT_THREAD_PRIORITY_MAX / 3, 20);
     RT_ASSERT(result == RT_EOK);
+	
+	/* if not define RT_USING_HEAP, using to eliminate the warning */
+	(void)result;
 #endif
 
     rt_thread_startup(tid);

--- a/src/components.c
+++ b/src/components.c
@@ -215,8 +215,8 @@ void rt_application_init(void)
                             main_stack, sizeof(main_stack), RT_THREAD_PRIORITY_MAX / 3, 20);
     RT_ASSERT(result == RT_EOK);
 	
-	/* if not define RT_USING_HEAP, using to eliminate the warning */
-	(void)result;
+    /* if not define RT_USING_HEAP, using to eliminate the warning */
+    (void)result;
 #endif
 
     rt_thread_startup(tid);


### PR DESCRIPTION
没用使用RT_USING_HEAP宏时，components.c文件第211行会报警告，增加一条语句用于消除此警告