### PR TITLE
[bsp] update uart driver and fixed typo

### DIFF
--- a/bsp/v2m-mps2/README.md
+++ b/bsp/v2m-mps2/README.md
@@ -24,7 +24,7 @@ V2M-MPS2板级包支持MDK5（已测试MDK5.23~MDK5.25）
 - [Windows 7: Enabling Telnet Client](https://social.technet.microsoft.com/wiki/contents/articles/910.windows-7-enabling-telnet-client.aspx)
 - [Windows 10: Enabling Telnet Client](https://social.technet.microsoft.com/wiki/contents/articles/38433.windows-10-enabling-telnet-client.aspx)
 
-打开project.uvprojx，编译，点击Debug->Start/Stop Seccion就可以进入仿真了。
+打开project.uvprojx，编译，点击Debug->Start/Stop Session就可以进入仿真了。
 
 ### 3.2 如何选择其他内核 
 
@@ -54,7 +54,7 @@ finsh />
 
 | 驱动 | 支持情况  |  备注  |
 | ------ | ----  | :------:  |
-| UART | 支持 | UART0/1/2/3 |
+| UART | 支持 | UART0/1/2 |
 | GPIO | 未支持 |  |
 | LED | 未支持 |  |
 | BUTTOM | 未支持 | |

--- a/bsp/v2m-mps2/project.uvoptx
+++ b/bsp/v2m-mps2/project.uvoptx
@@ -148,24 +148,7 @@
           <Name>UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000)</Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>150</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>2206</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\..\src\components.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\rtthread_v2m_mps2\../../src/components.c\150</Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <Tracepoint>
         <THDelay>0</THDelay>
       </Tracepoint>


### PR DESCRIPTION
将uart驱动改成使用serial方式，是为了可以打开RT_USING_POSIX选项，原来的实现并不支持POSXI方式的getchar。
- 更新uart驱动
- readme修复一些错误