### PR TITLE
[bsp][lpc824] fixed error: incomplete type is not allowed

### DIFF
--- a/bsp/lpc824/rtconfig.h
+++ b/bsp/lpc824/rtconfig.h
@@ -80,7 +80,7 @@
 // </c>
 // <c1>Using Mutex
 //  <i>Using Mutex
-//#define RT_USING_MUTEX
+#define RT_USING_MUTEX
 // </c>
 // <c1>Using Event
 //  <i>Using Event


### PR DESCRIPTION
默认不打开mutex会导致编译报错。