### PR TITLE
[BSP] fix pin drive bug and add interrupt mode. | 修复PIN驱动BUG并添加中断模式.

### DIFF
--- a/bsp/imxrt1052-evk/drivers/drv_pin.h
+++ b/bsp/imxrt1052-evk/drivers/drv_pin.h
@@ -10,6 +10,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-03-13     Liuguang     the first version. 
+ * 2018-03-19     Liuguang     add GPIO interrupt mode support.
  */
  
 #ifndef __DRV_PIN_H__


### PR DESCRIPTION
更新如下:
1. 修复GPIO5_0~2管脚复用调用错误(错误情况会影响SDRAM正常工作)。
2. 添加中断模式，支持上升沿、下降沿、双边沿、高电平、低电平触发中断模式。
3. 移除C99特性。