### PR TITLE
[bsp][v2m-mps2] fix "scons --target=mdk5" error

### DIFF
--- a/bsp/v2m-mps2/rtconfig.py
+++ b/bsp/v2m-mps2/rtconfig.py
@@ -5,9 +5,6 @@ ARCH='arm'
 CPU='cortex-m7'
 CROSS_TOOL='keil'
 
-if os.getenv('RTT_CC'):
-	CROSS_TOOL = os.getenv('RTT_CC')
-
 if CROSS_TOOL == 'keil':
 	PLATFORM 	= 'armcc'
 	EXEC_PATH 	= 'C:/Keil_v5'
@@ -48,7 +45,6 @@ if PLATFORM == 'armcc':
     CFLAGS += ' --c99'
 
     POST_ACTION = 'fromelf -z $TARGET'
-    # POST_ACTION = 'fromelf --bin $TARGET --output rtthread.bin \nfromelf -z $TARGET'
 else:
 	print("only support armcc in this bsp")
 	exit(-1)


### PR DESCRIPTION
在env里面会默认把RTT_CC设置为gcc。
仅仅支持keil的bsp就没必要从环境变量获取编译器类型了。