### PR TITLE
fix some bugs in lpc176x bsp

### DIFF
--- a/bsp/lpc176x/drivers/uart.h
+++ b/bsp/lpc176x/drivers/uart.h
@@ -2,5 +2,6 @@
 #define __UART_H__
 
 void rt_hw_uart_init(void);
+void rt_uart_precise_baudset(rt_uint32_t uartclk, rt_uint32_t bps, rt_uint8_t *m_fdr, rt_uint32_t *m_fdiv);
 
 #endif


### PR DESCRIPTION
1、添加波特率设置参数计算函数，修正因串口波特率不准造成的乱码问题。
2、修正结构体中计数器长度。