### PR TITLE
[BSP]fix rt1052 uart

### DIFF
--- a/bsp/imxrt1052-evk/drivers/board.c
+++ b/bsp/imxrt1052-evk/drivers/board.c
@@ -16,11 +16,9 @@
 #include <rtthread.h>
 
 #include "board.h"
-#include "drv_uart.h"
+//#include "drv_uart.h"
 
-#if defined(RT_USING_SDRAM) && defined(RT_USING_MEMHEAP_AS_HEAP)
-static struct rt_memheap system_heap;
-#endif
+//static struct rt_memheap system_heap;
 
 /* ARM PLL configuration for RUN mode */
 const clock_arm_pll_config_t armPllConfig = { .loopDivider = 100U };
@@ -48,40 +46,39 @@ static void BOARD_BootClockRUN(void)
     /* Boot ROM did initialize the XTAL, here we only sets external XTAL OSC freq */
     CLOCK_SetXtalFreq(24000000U);
     CLOCK_SetRtcXtalFreq(32768U);
-    
+
     CLOCK_SetMux(kCLOCK_PeriphClk2Mux, 0x1); /* Set PERIPH_CLK2 MUX to OSC */
-    CLOCK_SetMux(kCLOCK_PeriphMux, 0x1); /* Set PERIPH_CLK MUX to PERIPH_CLK2 */   
-    
+    CLOCK_SetMux(kCLOCK_PeriphMux, 0x1); /* Set PERIPH_CLK MUX to PERIPH_CLK2 */
+
     /* Setting the VDD_SOC to 1.5V. It is necessary to config AHB to 600Mhz */
     DCDC->REG3 = (DCDC->REG3 & (~DCDC_REG3_TRG_MASK)) | DCDC_REG3_TRG(0x12);
-    
+
     CLOCK_InitArmPll(&armPllConfig); /* Configure ARM PLL to 1200M */
 #ifndef SKIP_SYSCLK_INIT
     CLOCK_InitSysPll(&sysPllConfig); /* Configure SYS PLL to 528M */
 #endif
-#ifndef SKIP_USB_PLL_INIT    
+#ifndef SKIP_USB_PLL_INIT
     CLOCK_InitUsb1Pll(&usb1PllConfig); /* Configure USB1 PLL to 480M */
-#endif    
+#endif
     CLOCK_SetDiv(kCLOCK_ArmDiv, 0x1); /* Set ARM PODF to 0, divide by 2 */
-    CLOCK_SetDiv(kCLOCK_AhbDiv, 0x0); /* Set AHB PODF to 0, divide by 1 */ 
-    CLOCK_SetDiv(kCLOCK_IpgDiv, 0x3); /* Set IPG PODF to 3, divede by 4 */ 
-    
-    CLOCK_SetMux(kCLOCK_PrePeriphMux, 0x3); /* Set PRE_PERIPH_CLK to PLL1, 1200M */    
-    CLOCK_SetMux(kCLOCK_PeriphMux, 0x0); /* Set PERIPH_CLK MUX to PRE_PERIPH_CLK */       
-    
+    CLOCK_SetDiv(kCLOCK_AhbDiv, 0x0); /* Set AHB PODF to 0, divide by 1 */
+    CLOCK_SetDiv(kCLOCK_IpgDiv, 0x3); /* Set IPG PODF to 3, divede by 4 */
+
+    CLOCK_SetMux(kCLOCK_PrePeriphMux, 0x3); /* Set PRE_PERIPH_CLK to PLL1, 1200M */
+    CLOCK_SetMux(kCLOCK_PeriphMux, 0x0); /* Set PERIPH_CLK MUX to PRE_PERIPH_CLK */
+
     /* Disable unused clock */
-    BOARD_BootClockGate();    
-    
-    /* Power down all unused PLL */    
+    BOARD_BootClockGate();
+
+    /* Power down all unused PLL */
     CLOCK_DeinitAudioPll();
     CLOCK_DeinitVideoPll();
     CLOCK_DeinitEnetPll();
     CLOCK_DeinitUsb2Pll();
 
-    /* Configure UART divider to default */
-    CLOCK_SetMux(kCLOCK_UartMux, 0); /* Set UART source to PLL3 80M */
-    CLOCK_SetDiv(kCLOCK_UartDiv, 0); /* Set UART divider to 1 */    
-    
+    /* iomuxc clock (iomuxc_clk_enable): 0x03u */
+    CLOCK_EnableClock(kCLOCK_Iomuxc);
+
     /* Update core clock */
     SystemCoreClockUpdate();
 }
@@ -128,12 +125,12 @@ static void BOARD_ConfigMPU(void)
 
 #if defined(SDRAM_MPU_INIT)
     /* Region 7 setting */
-    MPU->RBAR = ARM_MPU_RBAR(7, 0x80000000U);
-    MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 0, 0, 1, 1, 0, ARM_MPU_REGION_SIZE_32MB);
+//    MPU->RBAR = ARM_MPU_RBAR(7, 0x80000000U);
+//    MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 0, 0, 1, 1, 0, ARM_MPU_REGION_SIZE_32MB);
 
-    /* Region 8 setting */
-    MPU->RBAR = ARM_MPU_RBAR(8, 0x81E00000U);
-    MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 1, 1, 0, 0, 0, ARM_MPU_REGION_SIZE_2MB);
+//    /* Region 8 setting */
+//    MPU->RBAR = ARM_MPU_RBAR(8, 0x81E00000U);
+//    MPU->RASR = ARM_MPU_RASR(0, ARM_MPU_AP_FULL, 1, 1, 0, 0, 0, ARM_MPU_REGION_SIZE_2MB);
 #endif
 
     /* Enable MPU */
@@ -164,63 +161,36 @@ void rt_lowlevel_init(void)
 {
     BOARD_ConfigMPU();
 
-#if defined(RT_USING_SDRAM) 
-    extern int imxrt_sdram_init(void);
-    imxrt_sdram_init();
-#endif
+    //extern int imxrt_sdram_init(void);
+    //imxrt_sdram_init();
 }
 
 /**
- * This function will initial rt1050 board.
+ * This function will initial LPC8XX board.
  */
 void rt_hw_board_init()
 {
     BOARD_BootClockRUN();
 
     SysTick_Config(SystemCoreClock / RT_TICK_PER_SECOND);
-    
+
 #ifdef RT_USING_COMPONENTS_INIT
     rt_components_board_init();
 #endif
-    
+
 #ifdef RT_USING_CONSOLE
     rt_console_set_device(RT_CONSOLE_DEVICE_NAME);
 #endif
-    
+
 #ifdef RT_USING_HEAP
-
-#if defined(RT_USING_SDRAM) && defined(RT_USING_MEMHEAP_AS_HEAP)
     rt_kprintf("sdram heap, begin: 0x%p, end: 0x%p\n", SDRAM_BEGIN, SDRAM_END);
-    rt_system_heap_init((void *)SDRAM_BEGIN, (void*)SDRAM_END); 
-    
-    rt_kprintf("sram heap, begin: 0x%p, end: 0x%p\n", HEAP_BEGIN, HEAP_END); 
-    rt_memheap_init(&system_heap, "sram", (void *)HEAP_BEGIN, HEAP_SIZE); 
-#else
-    rt_kprintf("sram heap, begin: 0x%p, end: 0x%p\n", HEAP_BEGIN, HEAP_END); 
-    rt_system_heap_init((void *)HEAP_BEGIN, (void*)HEAP_END); 
-#endif
-    
+//    rt_system_heap_init((void*)SDRAM_BEGIN, (void*)SDRAM_END);
+
+    rt_kprintf("sram heap, begin: 0x%p, end: 0x%p\n", HEAP_BEGIN, HEAP_END);
+    rt_system_heap_init((void *)HEAP_BEGIN, (void *)HEAP_END);
 #endif
 }
 
-#ifdef PKG_USING_GUIENGINE
-#include <rtgui/driver.h>
-#include "drv_lcd.h"
 
-/* initialize for gui driver */
-int rtgui_lcd_init(void)
-{
-    rt_device_t device;
-
-    imxrt_hw_lcd_init();
-
-    device = rt_device_find("lcd");
-    /* set graphic device */
-    rtgui_graphic_set_device(device);
-
-    return 0;
-}
-INIT_DEVICE_EXPORT(rtgui_lcd_init);
-#endif
 
 /*@}*/

--- a/bsp/imxrt1052-evk/drivers/drv_uart.c
+++ b/bsp/imxrt1052-evk/drivers/drv_uart.c
@@ -1,5 +1,5 @@
 /*
- * File      : drv_uart.c
+ * File      : drv_usart.c
  * This file is part of RT-Thread RTOS
  * COPYRIGHT (C) 2006-2013, RT-Thread Development Team
  *
@@ -21,7 +21,6 @@
 
 #ifdef RT_USING_SERIAL
 
-/* GPIO外设时钟会在LPUART_Init中自动配置, 如果定义了以下宏则不会自动配置 */
 #if defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL
 #error "Please don't define 'FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL'!"
 #endif
@@ -41,10 +40,10 @@
 /* imxrt uart driver */
 struct imxrt_uart
 {
-    LPUART_Type * uart_base;
+    LPUART_Type *uart_base;
     IRQn_Type irqn;
 
-    struct rt_serial_device * serial;
+    struct rt_serial_device *serial;
     char *device_name;
 };
 
@@ -129,7 +128,8 @@ void LPUART8_IRQHandler(void)
 
 #endif /* RT_USING_UART8 */
 
-static const struct imxrt_uart uarts[] = {
+static const struct imxrt_uart uarts[] =
+{
 #ifdef RT_USING_UART1
     {
         LPUART1,
@@ -196,9 +196,8 @@ static const struct imxrt_uart uarts[] = {
 #endif
 
 };
-
-/* Get debug console frequency. */
-uint32_t BOARD_DebugConsoleSrcFreq(void)
+/* Get uart frequency. */
+uint32_t GetUartSrcFreq(void)
 {
     uint32_t freq;
 
@@ -215,8 +214,6 @@ uint32_t BOARD_DebugConsoleSrcFreq(void)
 
     return freq;
 }
-
-
 /**
 * @brief UART MSP Initialization
 *        This function configures the hardware resources used in this example:
@@ -228,11 +225,9 @@ uint32_t BOARD_DebugConsoleSrcFreq(void)
 */
 void imxrt_uart_gpio_init(struct imxrt_uart *uart)
 {
-    if (uart->uart_base != RT_NULL)
+    if (uart->uart_base == LPUART1)
     {
-#ifdef RT_USING_UART1
-        CLOCK_EnableClock(kCLOCK_Iomuxc);           /* iomuxc clock (iomuxc_clk_enable): 0x03u */
-
+			CLOCK_EnableClock(kCLOCK_Iomuxc);           /* iomuxc clock (iomuxc_clk_enable): 0x03u */
         IOMUXC_SetPinMux(
             IOMUXC_GPIO_AD_B0_12_LPUART1_TX,        /* GPIO_AD_B0_12 is configured as LPUART1_TX */
             0U);                                    /* Software Input On Field: Input Path is determined by functionality */
@@ -259,10 +254,10 @@ void imxrt_uart_gpio_init(struct imxrt_uart *uart)
                                                      Pull / Keep Select Field: Keeper
                                                      Pull Up / Down Config. Field: 100K Ohm Pull Down
                                                      Hyst. Enable Field: Hysteresis Disabled */
-#endif
-#ifdef RT_USING_UART2
-        CLOCK_EnableClock(kCLOCK_Iomuxc);
-
+    }
+    else if (uart->uart_base == LPUART2)
+    {
+			CLOCK_EnableClock(kCLOCK_Iomuxc); 
         IOMUXC_SetPinMux(
             IOMUXC_GPIO_AD_B1_02_LPUART2_TX,
             0U);
@@ -272,16 +267,13 @@ void imxrt_uart_gpio_init(struct imxrt_uart *uart)
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_AD_B1_02_LPUART2_TX,
             0x10B0u);
-
-
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_AD_B1_03_LPUART2_RX,
             0x10B0u);
-
-#endif
-#ifdef RT_USING_UART3
-        CLOCK_EnableClock(kCLOCK_Iomuxc);
-
+    }
+    else if (uart->uart_base == LPUART3)
+    {
+			CLOCK_EnableClock(kCLOCK_Iomuxc); 
         IOMUXC_SetPinMux(
             IOMUXC_GPIO_AD_B1_06_LPUART3_TX,
             0U);
@@ -291,14 +283,13 @@ void imxrt_uart_gpio_init(struct imxrt_uart *uart)
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_AD_B1_06_LPUART3_TX,
             0x10B0u);
-
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_AD_B1_07_LPUART3_RX,
             0x10B0u);
-#endif
-#ifdef RT_USING_UART4
-        CLOCK_EnableClock(kCLOCK_Iomuxc);
-
+    }
+    else if (uart->uart_base == LPUART4)
+    {
+			CLOCK_EnableClock(kCLOCK_Iomuxc); 
         IOMUXC_SetPinMux(
             IOMUXC_GPIO_B1_00_LPUART4_TX,
             0U);
@@ -308,14 +299,13 @@ void imxrt_uart_gpio_init(struct imxrt_uart *uart)
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_B1_00_LPUART4_TX,
             0x10B0u);
-
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_B1_01_LPUART4_RX,
             0x10B0u);
-#endif
-#ifdef RT_USING_UART5
-        CLOCK_EnableClock(kCLOCK_Iomuxc);
-
+    }
+    else if (uart->uart_base == LPUART5)
+    {
+			CLOCK_EnableClock(kCLOCK_Iomuxc); 
         IOMUXC_SetPinMux(
             IOMUXC_GPIO_B1_12_LPUART5_TX,
             0U);
@@ -325,14 +315,12 @@ void imxrt_uart_gpio_init(struct imxrt_uart *uart)
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_B1_12_LPUART5_TX,
             0x10B0u);
-
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_B1_13_LPUART5_RX,
             0x10B0u);
-#endif
-#ifdef RT_USING_UART6
-        CLOCK_EnableClock(kCLOCK_Iomuxc);
-
+    }
+    else if (uart->uart_base == LPUART6)
+    {
         IOMUXC_SetPinMux(
             IOMUXC_GPIO_AD_B0_02_LPUART6_TX,
             0U);
@@ -342,14 +330,12 @@ void imxrt_uart_gpio_init(struct imxrt_uart *uart)
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_AD_B0_02_LPUART6_TX,
             0x10B0u);
-
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_AD_B0_03_LPUART6_RX,
             0x10B0u);
-#endif
-#ifdef RT_USING_UART7
-        CLOCK_EnableClock(kCLOCK_Iomuxc);
-
+    }
+    else if (uart->uart_base == LPUART7)
+    {
         IOMUXC_SetPinMux(
             IOMUXC_GPIO_EMC_31_LPUART7_TX,
             0U);
@@ -359,14 +345,12 @@ void imxrt_uart_gpio_init(struct imxrt_uart *uart)
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_EMC_31_LPUART7_TX,
             0x10B0u);
-
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_EMC_32_LPUART7_RX,
             0x10B0u);
-#endif
-#ifdef RT_USING_UART8
-        CLOCK_EnableClock(kCLOCK_Iomuxc);
-
+    }
+    else if (uart->uart_base == LPUART8)
+    {
         IOMUXC_SetPinMux(
             IOMUXC_GPIO_AD_B1_10_LPUART8_TX,
             0U);
@@ -376,11 +360,9 @@ void imxrt_uart_gpio_init(struct imxrt_uart *uart)
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_AD_B1_10_LPUART8_TX,
             0x10B0u);
-
         IOMUXC_SetPinConfig(
             IOMUXC_GPIO_AD_B1_11_LPUART8_RX,
             0x10B0u);
-#endif
     }
     else
     {
@@ -440,7 +422,7 @@ static rt_err_t imxrt_configure(struct rt_serial_device *serial, struct serial_c
     config.enableTx = true;
     config.enableRx = true;
 
-    LPUART_Init(uart->uart_base, &config, BOARD_DebugConsoleSrcFreq());
+    LPUART_Init(uart->uart_base, &config, GetUartSrcFreq());
 
 
     return RT_EOK;
@@ -481,7 +463,7 @@ static int imxrt_putc(struct rt_serial_device *serial, char ch)
     uart = (struct imxrt_uart *)serial->parent.user_data;
 
     LPUART_WriteByte(uart->uart_base, ch);
-    while(!(LPUART_GetStatusFlags(uart->uart_base) & kLPUART_TxDataRegEmptyFlag));
+    while (!(LPUART_GetStatusFlags(uart->uart_base) & kLPUART_TxDataRegEmptyFlag));
 
     return 1;
 }
@@ -496,7 +478,9 @@ static int imxrt_getc(struct rt_serial_device *serial)
 
     ch = -1;
     if (LPUART_GetStatusFlags(uart->uart_base) & kLPUART_RxDataRegFullFlag)
+    {
         ch = LPUART_ReadByte(uart->uart_base);
+    }
     return ch;
 }
 
@@ -546,16 +530,21 @@ static const struct rt_uart_ops imxrt_uart_ops =
     imxrt_getc,
 };
 
-int imxrt_hw_usart_init(void)
+int imxrt_hw_uart_init(void)
 {
     struct serial_configure config = RT_SERIAL_CONFIG_DEFAULT;
     int i;
+	
+    /* Configure UART divider to default */
+    CLOCK_SetMux(kCLOCK_UartMux, 0); /* Set UART source to PLL3 80M */
+    CLOCK_SetDiv(kCLOCK_UartDiv, 0); /* Set UART divider to 1 */
+
     for (i = 0; i < sizeof(uarts) / sizeof(uarts[0]); i++)
     {
         uarts[i].serial->ops    = &imxrt_uart_ops;
         uarts[i].serial->config = config;
 
-        /* register UART1 device */
+        /* register UART device */
         rt_hw_serial_register(uarts[i].serial,
                               uarts[i].device_name,
                               RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_INT_RX,
@@ -564,6 +553,6 @@ int imxrt_hw_usart_init(void)
 
     return 0;
 }
-INIT_BOARD_EXPORT(imxrt_hw_usart_init);
+INIT_BOARD_EXPORT(imxrt_hw_uart_init);
 
 #endif /*RT_USING_SERIAL */

--- a/bsp/imxrt1052-evk/drivers/drv_uart.h
+++ b/bsp/imxrt1052-evk/drivers/drv_uart.h
@@ -12,12 +12,10 @@
  * 2017-10-10     Tanek        the first version
  */
 
-#ifndef __DRV_USART_H__
-#define __DRV_USART_H__
+#ifndef __DRV_UART_H__
+#define __DRV_UART_H__
 
 #include <rthw.h>
 #include <rtthread.h>
-
-int rt_hw_usart_init(void);
 
 #endif


### PR DESCRIPTION
1. **将CLOCK_SetMux(kCLOCK_UartMux,_ 0);CLOCK_SetDiv(kCLOCK_UartDiv, 0);从board.c移到drv_usart.c的imxrt_hw_usart_initI()中.**

1. **将CLOCK_EnableClock(kCLOCK_Iomuxc);放入board.c的BOARD_BootClockRUN()中.而不是每次uart初始化都要重复操作.**
1. **修改 BOARD_DebugConsoleSrcFreq()函数名称为GetUartSrcFreq().**