### PR TITLE
Auto remove macro _DLIB_THREAD_SUPPORT when IAR version higher than 8.20.1

### DIFF
--- a/components/libc/compilers/dlib/SConscript
+++ b/components/libc/compilers/dlib/SConscript
@@ -1,4 +1,7 @@
 from building import *
+from distutils.version import LooseVersion
+from iar import IARVersion
+
 Import('rtconfig')
 
 src   = Glob('*.c')
@@ -11,7 +14,10 @@ CPPDEFINES = ['RT_USING_DLIBC']
 if rtconfig.PLATFORM == 'iar':
 
     if GetDepend('RT_USING_DFS'):
-        CPPDEFINES = CPPDEFINES + ['_DLIB_FILE_DESCRIPTOR', '_DLIB_THREAD_SUPPORT']
+        CPPDEFINES = CPPDEFINES + ['_DLIB_FILE_DESCRIPTOR']
+
+        if LooseVersion(IARVersion()) < LooseVersion("8.20.1"):
+            CPPDEFINES = CPPDEFINES + ['_DLIB_THREAD_SUPPORT']
 
     group = DefineGroup('dlib', src, depend = ['RT_USING_LIBC'], 
         CPPPATH = CPPPATH, CPPDEFINES = CPPDEFINES)

--- a/tools/iar.py
+++ b/tools/iar.py
@@ -156,3 +156,38 @@ def IARProject(target, script):
     out.close()
 
     IARWorkspace(target)
+    
+def IARVersion():
+    import subprocess
+    import re
+
+    def IARPath():
+        import rtconfig
+
+        # set environ
+        old_environ = os.environ
+        os.environ['RTT_CC'] = 'iar'
+        reload(rtconfig)
+
+        # get iar path
+        path = rtconfig.EXEC_PATH
+
+        # restore environ
+        os.environ = old_environ
+        reload(rtconfig)
+
+        return path
+
+    path = IARPath();
+
+    if os.path.exists(path):
+        cmd = os.path.join(path, 'iccarm.exe')
+    else:
+        print('Get IAR version error. Please update IAR installation path in rtconfig.h!')
+        return "0.0"
+
+    child = subprocess.Popen([cmd, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+    stdout, stderr = child.communicate()
+
+    # example stdout: IAR ANSI C/C++ Compiler V8.20.1.14183/W32 for ARM
+    return re.search('[\d\.]+', stdout).group(0)


### PR DESCRIPTION
- 添加获取IAR版本的函数
- 修复在高版本IAR下添加_DLIB_THREAD_SUPPORT宏的问题（该宏已经被遗弃，如果添加就报错）