### PR TITLE
[bsp] support get compiler path by environment variables for IAR

### DIFF
--- a/bsp/CME_M7/rtconfig.py
+++ b/bsp/CME_M7/rtconfig.py
@@ -16,7 +16,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keil'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'	
+	EXEC_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'	
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -106,7 +106,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M3' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
         
     AFLAGS = ''
@@ -120,5 +120,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --semihosting' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/asm9260t/rtconfig.py
+++ b/bsp/asm9260t/rtconfig.py
@@ -17,7 +17,7 @@ elif CROSS_TOOL == 'keil':
     EXEC_PATH   = 'C:/Keil_v5'
 elif CROSS_TOOL == 'iar':
     PLATFORM    = 'iar'
-    IAR_PATH    = 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.0'
+    EXEC_PATH    = 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.0'
 
 if os.getenv('RTT_EXEC_PATH'):
     EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -113,7 +113,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --endian=little'
     CFLAGS += ' -e'
     CFLAGS += ' --fpu=none'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
     CFLAGS += ' --silent'
 
     AFLAGS = '--cpu '+ DEVICE
@@ -135,5 +135,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --map ' + MAP_FILE
     LFLAGS += ' --silent'
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool  --silent --bin $TARGET ' + TARGET_NAME

--- a/bsp/at91sam9260/rtconfig.py
+++ b/bsp/at91sam9260/rtconfig.py
@@ -16,7 +16,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keil_v5'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.0'
+	EXEC_PATH 	= 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.0'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -111,7 +111,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --endian=little'
     CFLAGS += ' -e'
     CFLAGS += ' --fpu=none'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
     CFLAGS += ' --silent'
 
     AFLAGS = '--cpu '+ DEVICE
@@ -133,5 +133,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --map ' + MAP_FILE
     LFLAGS += ' --silent'
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool  --silent --bin $TARGET ' + TARGET_NAME

--- a/bsp/imxrt1052-evk/rtconfig.py
+++ b/bsp/imxrt1052-evk/rtconfig.py
@@ -18,7 +18,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keil_v5'
 elif CROSS_TOOL == 'iar':
     PLATFORM 	= 'iar'
-    IAR_PATH    = r'C:/Program Files (x86)/IAR Systems/Embedded Workbench 8.0'
+    EXEC_PATH    = r'C:/Program Files (x86)/IAR Systems/Embedded Workbench 8.0'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -121,7 +121,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M7'
     CFLAGS += ' -e'
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
     CFLAGS += ' -Ol'
     CFLAGS += ' --use_c++_inline'
 
@@ -137,5 +137,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall'
     LFLAGS += ' --entry __iar_program_start'
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/lpc176x/rtconfig.py
+++ b/bsp/lpc176x/rtconfig.py
@@ -16,7 +16,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keil'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
+	EXEC_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -105,7 +105,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M3' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -120,6 +120,6 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --semihosting' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     RT_USING_MINILIBC = False
     POST_ACTION = ''

--- a/bsp/lpc43xx/M0/rtconfig.py
+++ b/bsp/lpc43xx/M0/rtconfig.py
@@ -25,7 +25,7 @@ elif CROSS_TOOL == 'keil':
     EXEC_PATH = r'D:/Keil'
 elif CROSS_TOOL == 'iar':
     PLATFORM = 'iar'
-    IAR_PATH = r'C:/Program Files/IAR Systems/Embedded Workbench 6.0'
+    EXEC_PATH = r'C:/Program Files/IAR Systems/Embedded Workbench 6.0'
 
 if os.getenv('RTT_EXEC_PATH'):
         EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -113,7 +113,7 @@ elif PLATFORM == 'iar':
     else:
         CFLAGS += ' --cpu=Cortex-M0'
     CFLAGS += ' -e' 
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -132,5 +132,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/lpc43xx/M4/rtconfig.py
+++ b/bsp/lpc43xx/M4/rtconfig.py
@@ -29,7 +29,7 @@ elif CROSS_TOOL == 'keil':
     EXEC_PATH = r'D:/Keil'
 elif CROSS_TOOL == 'iar':
     PLATFORM = 'iar'
-    IAR_PATH = r'C:/Program Files/IAR Systems/Embedded Workbench 6.0'
+    EXEC_PATH = r'C:/Program Files/IAR Systems/Embedded Workbench 6.0'
 
 if os.getenv('RTT_EXEC_PATH'):
         EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -117,7 +117,7 @@ elif PLATFORM == 'iar':
     else:
         CFLAGS += ' --cpu=Cortex-M0'
     CFLAGS += ' -e' 
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -136,5 +136,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/lpc824/rtconfig.py
+++ b/bsp/lpc824/rtconfig.py
@@ -19,7 +19,7 @@ elif CROSS_TOOL == 'keil':
     EXEC_PATH 	= 'C:/keil_v5'
 elif CROSS_TOOL == 'iar':
     PLATFORM 	= 'iar'
-    IAR_PATH    = r'C:/Program Files (x86)/IAR Systems/Embedded Workbench 8.0'
+    EXEC_PATH    = r'C:/Program Files (x86)/IAR Systems/Embedded Workbench 8.0'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -105,7 +105,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M0'
     CFLAGS += ' -e'
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
     CFLAGS += ' -Ol'
     CFLAGS += ' --use_c++_inline'
 
@@ -121,5 +121,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall'
     LFLAGS += ' --entry __iar_program_start'
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/m16c62p/rtconfig.py
+++ b/bsp/m16c62p/rtconfig.py
@@ -14,7 +14,7 @@ if  CROSS_TOOL == 'gcc':
 	EXEC_PATH 	= 'C:/Program Files/Renesas/Hew/Tools/KPIT Cummins/GNUM16CM32C-ELF/v11.01/m32c-elf/bin'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH = 'C:/Program Files/IAR Systems/Embedded Workbench Evaluation 6.0'
+	EXEC_PATH = 'C:/Program Files/IAR Systems/Embedded Workbench Evaluation 6.0'
 #	EXEC_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench Evaluation 6.0'
 elif CROSS_TOOL == 'keil':
     print('================ERROR============================')
@@ -65,16 +65,14 @@ elif PLATFORM == 'iar':
     
     DEVICE = '--cpu M16C'
     
-    EXEC_PATH = IAR_PATH + '/m16c/bin'
-    
     AFLAGS = '-s+'
 #    AFLAGS += ' -M<>' 
     AFLAGS += ' -w+' 
     AFLAGS += ' -r' 
-    AFLAGS += ' -I"' + IAR_PATH + '/m16c/INC"'
+    AFLAGS += ' -I"' + EXEC_PATH + '/m16c/INC"'
         
     LFLAGS = '-xms'
-    LFLAGS += ' -I"' + IAR_PATH + '/m16c/LIB"' 
+    LFLAGS += ' -I"' + EXEC_PATH + '/m16c/LIB"' 
     LFLAGS += ' -rt' 
     LFLAGS += ' -s __program_start' 
     LFLAGS += ' -D_CSTACK_SIZE=80' 
@@ -82,7 +80,7 @@ elif PLATFORM == 'iar':
     LFLAGS += ' -D_DATA16_HEAP_SIZE=1000' 
     LFLAGS += ' -D_FAR_HEAP_SIZE=400'
     LFLAGS += ' -D_DATA20_HEAP_SIZE=400'
-    LFLAGS += ' "' + IAR_PATH + '/m16c/LIB/CLIB/clm16cfnffwc.r34"' 
+    LFLAGS += ' "' + EXEC_PATH + '/m16c/LIB/CLIB/clm16cfnffwc.r34"' 
     LFLAGS += ' -e_small_write=_formatted_write' 
     LFLAGS += ' -e_medium_read=_formatted_read'
     
@@ -95,13 +93,15 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --debug' 
     CFLAGS += ' -e' 
     CFLAGS += ' --align_func 1' 
-    CFLAGS += ' -I"' + IAR_PATH + '/m16c/INC"'
-    CFLAGS += ' -I"' + IAR_PATH + '/m16c/INC/CLIB"' 
+    CFLAGS += ' -I"' + EXEC_PATH + '/m16c/INC"'
+    CFLAGS += ' -I"' + EXEC_PATH + '/m16c/INC/CLIB"' 
     CFLAGS += ' -Ol' 
     CFLAGS += ' --no_cse' 
     CFLAGS += ' --no_unroll' 
     CFLAGS += ' --no_inline' 
     CFLAGS += ' --no_code_motion' 
     CFLAGS += ' --no_tbaa'    
+	
+	EXEC_PATH = EXEC_PATH + '/m16c/bin'
    
     POST_ACTION = ''

--- a/bsp/mb9bf500r/rtconfig.py
+++ b/bsp/mb9bf500r/rtconfig.py
@@ -19,7 +19,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keil'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
+	EXEC_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -102,7 +102,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M3' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'    
         
@@ -112,11 +112,11 @@ elif PLATFORM == 'iar':
     AFLAGS += ' -r' 
     AFLAGS += ' --cpu Cortex-M3' 
     AFLAGS += ' --fpu None' 
-    AFLAGS += ' -I"' + IAR_PATH + '/arm/INC"'
+    AFLAGS += ' -I"' + EXEC_PATH + '/arm/INC"'
 
     LFLAGS = ' --config mb9bf500r.icf'
     LFLAGS += ' --semihosting' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool.exe --srec --verbose $TARGET rtthread.srec'

--- a/bsp/mb9bf506r/rtconfig.py
+++ b/bsp/mb9bf506r/rtconfig.py
@@ -19,7 +19,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keil'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
+	EXEC_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -101,7 +101,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M3' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'    
         
@@ -111,11 +111,11 @@ elif PLATFORM == 'iar':
     AFLAGS += ' -r' 
     AFLAGS += ' --cpu Cortex-M3' 
     AFLAGS += ' --fpu None' 
-    AFLAGS += ' -I"' + IAR_PATH + '/arm/INC"'
+    AFLAGS += ' -I"' + EXEC_PATH + '/arm/INC"'
 
     LFLAGS = ' --config rtthread-mb9bf506.icf'
     LFLAGS += ' --semihosting' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool.exe --srec --verbose $TARGET rtthread.srec' 

--- a/bsp/mb9bf618s/rtconfig.py
+++ b/bsp/mb9bf618s/rtconfig.py
@@ -24,7 +24,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= r'E:/Keil'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= r'C:\Program Files\IAR Systems\Embedded Workbench 6.0 Evaluation'
+	EXEC_PATH 	= r'C:\Program Files\IAR Systems\Embedded Workbench 6.0 Evaluation'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -106,7 +106,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M3' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'    
         
@@ -116,11 +116,11 @@ elif PLATFORM == 'iar':
     AFLAGS += ' -r' 
     AFLAGS += ' --cpu Cortex-M3' 
     AFLAGS += ' --fpu None' 
-    AFLAGS += ' -I"' + IAR_PATH + '/arm/INC"'
+    AFLAGS += ' -I"' + EXEC_PATH + '/arm/INC"'
 
     LFLAGS = ' --config rtthread-fm3.icf'
     LFLAGS += ' --semihosting' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool.exe --srec --verbose $TARGET rtthread.srec' 

--- a/bsp/nuvoton_m05x/rtconfig.py
+++ b/bsp/nuvoton_m05x/rtconfig.py
@@ -103,7 +103,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M0' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -119,5 +119,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/nuvoton_m451/rtconfig.py
+++ b/bsp/nuvoton_m451/rtconfig.py
@@ -105,7 +105,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M4' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -121,5 +121,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/nuvoton_nuc472/rtconfig.py
+++ b/bsp/nuvoton_nuc472/rtconfig.py
@@ -19,7 +19,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:\Keil_v5'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.5'
+	EXEC_PATH 	= 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.5'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -105,7 +105,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M4' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -121,5 +121,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/nv32f100x/rtconfig.py
+++ b/bsp/nv32f100x/rtconfig.py
@@ -106,7 +106,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M0'
     CFLAGS += ' -e'
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
     CFLAGS += ' -Ol'
     CFLAGS += ' --use_c++_inline'
 
@@ -122,5 +122,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall'
     LFLAGS += ' --entry __iar_program_start'
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32f0x/rtconfig.py
+++ b/bsp/stm32f0x/rtconfig.py
@@ -107,7 +107,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M0' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -123,5 +123,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32f107/rtconfig.py
+++ b/bsp/stm32f107/rtconfig.py
@@ -19,7 +19,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keil'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
+	EXEC_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -105,7 +105,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M3' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
         
     AFLAGS = ''
@@ -118,5 +118,5 @@ elif PLATFORM == 'iar':
     LFLAGS = ' --config stm32_rom.icf'
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32f10x-HAL/rtconfig.py
+++ b/bsp/stm32f10x-HAL/rtconfig.py
@@ -20,7 +20,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keilv5'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
+	EXEC_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -106,7 +106,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M3' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -122,5 +122,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32f10x/rtconfig.py
+++ b/bsp/stm32f10x/rtconfig.py
@@ -31,7 +31,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keil'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
+	EXEC_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -117,7 +117,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M3' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -133,5 +133,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32f20x/rtconfig.py
+++ b/bsp/stm32f20x/rtconfig.py
@@ -16,7 +16,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keil'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'	
+	EXEC_PATH 	= 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation'	
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -101,7 +101,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M3' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
         
     AFLAGS = ''
@@ -115,5 +115,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --semihosting' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32f40x/rtconfig.py
+++ b/bsp/stm32f40x/rtconfig.py
@@ -106,7 +106,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M4' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -122,5 +122,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32f411-nucleo/rtconfig.py
+++ b/bsp/stm32f411-nucleo/rtconfig.py
@@ -23,7 +23,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keil_v5'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.2'
+	EXEC_PATH 	= 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.2'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -112,7 +112,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M4' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=VFPv4_sp'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' --silent'
         
     AFLAGS = DEVICE
@@ -133,5 +133,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --entry __iar_program_start'    
     #LFLAGS += ' --silent'
 	
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32f429-armfly/rtconfig.py
+++ b/bsp/stm32f429-armfly/rtconfig.py
@@ -112,7 +112,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M4'
     CFLAGS += ' -e'
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
     CFLAGS += ' -Ol'
     CFLAGS += ' --use_c++_inline'
 
@@ -128,5 +128,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall'
     LFLAGS += ' --entry __iar_program_start'
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32f429-disco/rtconfig.py
+++ b/bsp/stm32f429-disco/rtconfig.py
@@ -106,7 +106,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M4'
     CFLAGS += ' -e'
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
     CFLAGS += ' -Ol'
     CFLAGS += ' --use_c++_inline'
 
@@ -122,5 +122,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall'
     LFLAGS += ' --entry __iar_program_start'
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32f4xx-HAL/rtconfig.py
+++ b/bsp/stm32f4xx-HAL/rtconfig.py
@@ -23,7 +23,7 @@ elif CROSS_TOOL == 'keil':
 	EXEC_PATH 	= 'C:/Keil_v5'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.2'
+	EXEC_PATH 	= 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.2'
 
 if os.getenv('RTT_EXEC_PATH'):
 	EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -112,7 +112,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M4' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=VFPv4_sp'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' --silent'
         
     AFLAGS = DEVICE
@@ -133,5 +133,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --entry __iar_program_start'    
     #LFLAGS += ' --silent'
 	
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32f7-disco/rtconfig.py
+++ b/bsp/stm32f7-disco/rtconfig.py
@@ -20,7 +20,7 @@ elif CROSS_TOOL == 'keil':
     EXEC_PATH 	= r'C:/Keil_v5'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.2'
+	EXEC_PATH 	= 'C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.2'
 
 if os.getenv('RTT_EXEC_PATH'):
     EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -119,7 +119,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M7' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
     CFLAGS += ' --silent'
@@ -140,5 +140,5 @@ elif PLATFORM == 'iar':
 
     CXXFLAGS = CFLAGS
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32h743-nucleo/rtconfig.py
+++ b/bsp/stm32h743-nucleo/rtconfig.py
@@ -20,7 +20,7 @@ elif CROSS_TOOL == 'keil':
     EXEC_PATH 	= r'C:/Keil_v5'
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH 	= r'C:/Program Files (x86)/IAR Systems/Embedded Workbench 8.0'
+	EXEC_PATH 	= r'C:/Program Files (x86)/IAR Systems/Embedded Workbench 8.0'
 
 if os.getenv('RTT_EXEC_PATH'):
     EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -119,7 +119,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M7' 
     CFLAGS += ' -e' 
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
     CFLAGS += ' --silent'
@@ -140,5 +140,5 @@ elif PLATFORM == 'iar':
 
     CXXFLAGS = CFLAGS
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32l072/rtconfig.py
+++ b/bsp/stm32l072/rtconfig.py
@@ -108,7 +108,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M0'
     CFLAGS += ' -e'
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
     CFLAGS += ' -Ol'
     CFLAGS += ' --use_c++_inline'
 
@@ -124,5 +124,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall'
     LFLAGS += ' --entry __iar_program_start'
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32l475-iot-disco/rtconfig.py
+++ b/bsp/stm32l475-iot-disco/rtconfig.py
@@ -112,7 +112,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M4'
     CFLAGS += ' -e'
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
     CFLAGS += ' -Ol'
     CFLAGS += ' --use_c++_inline'
 
@@ -128,5 +128,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall'
     LFLAGS += ' --entry __iar_program_start'
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/stm32l476-nucleo/rtconfig.py
+++ b/bsp/stm32l476-nucleo/rtconfig.py
@@ -112,7 +112,7 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --cpu=Cortex-M4'
     CFLAGS += ' -e'
     CFLAGS += ' --fpu=None'
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'
     CFLAGS += ' -Ol'
     CFLAGS += ' --use_c++_inline'
 
@@ -128,5 +128,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall'
     LFLAGS += ' --entry __iar_program_start'
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/upd70f3454/rtconfig.py
+++ b/bsp/upd70f3454/rtconfig.py
@@ -16,7 +16,7 @@ if  CROSS_TOOL == 'gcc':
     exit(0)
 elif CROSS_TOOL == 'iar':
 	PLATFORM 	= 'iar'
-	IAR_PATH = 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation_0'
+	EXEC_PATH = 'C:/Program Files/IAR Systems/Embedded Workbench 6.0 Evaluation_0'
 elif CROSS_TOOL == 'keil':
     print('================ERROR============================')
     print('Not support keil yet!')
@@ -66,8 +66,6 @@ elif PLATFORM == 'iar':
 
     DEVICE = '--cpu V850'
 
-    EXEC_PATH = IAR_PATH + '/v850/bin'
-
     AFLAGS = '-s+'
     AFLAGS = ' -v1'
 #    AFLAGS += ' -M<>' 
@@ -76,17 +74,17 @@ elif PLATFORM == 'iar':
     AFLAGS += ' -DDATA_MODEL_TINY'
     AFLAGS += ' -w+'
     AFLAGS += ' -r'
-    AFLAGS += ' -I"' + IAR_PATH + '/v850/INC"'
+    AFLAGS += ' -I"' + EXEC_PATH + '/v850/INC"'
 
     LFLAGS = '-xms'
-    LFLAGS += ' -I"' + IAR_PATH + '/v850/LIB"' 
+    LFLAGS += ' -I"' + EXEC_PATH + '/v850/LIB"' 
     LFLAGS += ' -rt' 
     LFLAGS += ' -s __program_start' 
     LFLAGS += ' -D_CSTACK_SIZE=1000' 
-    LFLAGS += ' "' + IAR_PATH + '/v850/LIB/dl85nn1.r85"'
+    LFLAGS += ' "' + EXEC_PATH + '/v850/LIB/dl85nn1.r85"'
     LFLAGS += ' -D_HEAP_SIZE=0' 
 
-#    LFLAGS += ' "' + IAR_PATH + '/v850/lib/CLIB/clm16cfnffwc.r34"' 
+#    LFLAGS += ' "' + EXEC_PATH + '/v850/lib/CLIB/clm16cfnffwc.r34"' 
 #   LFLAGS += ' -e_small_write=_formatted_write' 
 #    LFLAGS += ' -e_medium_read=_formatted_read'
 
@@ -99,13 +97,15 @@ elif PLATFORM == 'iar':
     CFLAGS += ' --no_unroll' 
     CFLAGS += ' --no_inline' 
     CFLAGS += ' --no_code_motion' 
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/v850/LIB/dl85nn1.h"'
-    CFLAGS += ' -I"' + IAR_PATH + '/v850/INC"'
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/v850/LIB/dl85nn1.h"'
+    CFLAGS += ' -I"' + EXEC_PATH + '/v850/INC"'
     CFLAGS += ' --no_tbaa' 
     CFLAGS += ' --debug' 
     CFLAGS += ' --lock_regs 0' 
     CFLAGS += ' --migration_preprocessor_extensions' 
     CFLAGS += ' -e' 
     CFLAGS += ' -Ol'
+	
+	EXEC_PATH = EXEC_PATH + '/v850/bin'
 
     POST_ACTION = ''

--- a/bsp/xplorer4330/M0/rtconfig.py
+++ b/bsp/xplorer4330/M0/rtconfig.py
@@ -29,7 +29,7 @@ elif CROSS_TOOL == 'keil':
     EXEC_PATH = r'D:/Keil'
 elif CROSS_TOOL == 'iar':
     PLATFORM = 'iar'
-    IAR_PATH = r'C:/Program Files/IAR Systems/Embedded Workbench 6.0'
+    EXEC_PATH = r'C:/Program Files/IAR Systems/Embedded Workbench 6.0'
 
 if os.getenv('RTT_EXEC_PATH'):
         EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -116,7 +116,7 @@ elif PLATFORM == 'iar':
     else:
         CFLAGS += ' --cpu=Cortex-M0'
     CFLAGS += ' -e' 
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -135,5 +135,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''

--- a/bsp/xplorer4330/M4/rtconfig.py
+++ b/bsp/xplorer4330/M4/rtconfig.py
@@ -29,7 +29,7 @@ elif CROSS_TOOL == 'keil':
     EXEC_PATH = r'D:/Keil'
 elif CROSS_TOOL == 'iar':
     PLATFORM = 'iar'
-    IAR_PATH = r'C:/Program Files/IAR Systems/Embedded Workbench 6.0'
+    EXEC_PATH = r'C:/Program Files/IAR Systems/Embedded Workbench 6.0'
 
 if os.getenv('RTT_EXEC_PATH'):
         EXEC_PATH = os.getenv('RTT_EXEC_PATH')
@@ -116,7 +116,7 @@ elif PLATFORM == 'iar':
     else:
         CFLAGS += ' --cpu=Cortex-M0'
     CFLAGS += ' -e' 
-    CFLAGS += ' --dlib_config "' + IAR_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
+    CFLAGS += ' --dlib_config "' + EXEC_PATH + '/arm/INC/c/DLib_Config_Normal.h"'    
     CFLAGS += ' -Ol'    
     CFLAGS += ' --use_c++_inline'
         
@@ -135,5 +135,5 @@ elif PLATFORM == 'iar':
     LFLAGS += ' --redirect _Scanf=_ScanfSmall' 
     LFLAGS += ' --entry __iar_program_start'    
 
-    EXEC_PATH = IAR_PATH + '/arm/bin/'
+    EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = ''


### PR DESCRIPTION
如果使用IAR_PATH变量，那么通过设置环境变量的方式，来配置IAR编译器路径就会失败。