### PR TITLE
update scons script: strict SrcRemove() match rule.

### DIFF
--- a/bsp/sam7x/drivers/SConscript
+++ b/bsp/sam7x/drivers/SConscript
@@ -7,7 +7,7 @@ src = Glob('*.c')
 if GetDepend('RT_USING_LWIP') == False:
     SrcRemove(src, 'sam7x_emac.c')
 if GetDepend('RT_USING_DFS') == False:
-    SrcRemove(src, 'ssd.c')
+    SrcRemove(src, 'sd.c')
 
 CPPPATH = [cwd]
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -743,11 +743,20 @@ def SrcRemove(src, remove):
 
     for item in src:
         if type(item) == type('str'):
-            if os.path.basename(item) in remove:
+            item_str = item
+        else:
+            item_str = item.rstr()
+
+        if os.path.isabs(item_str):
+            item_str = os.path.relpath(item_str, GetCurrentDir())
+
+        if type(remove) == type('str'):
+            if item_str == remove:
                 src.remove(item)
         else:
-            if os.path.basename(item.rstr()) in remove:
-                src.remove(item)
+            for remove_item in remove:
+                if item_str == str(remove_item):
+                    src.remove(item)
 
 def GetVersion():
     import SCons.cpp


### PR DESCRIPTION
统一转换为相对路径后，再严格判断。

之前的版本无法区别   sd.c 和  test/sd.c