### PR TITLE
[Libc][dlib] fixed scons error: No module named iar

### DIFF
--- a/components/libc/compilers/dlib/SConscript
+++ b/components/libc/compilers/dlib/SConscript
@@ -1,5 +1,9 @@
+import sys
+
 from building import *
 from distutils.version import LooseVersion
+
+sys.path = sys.path + [os.path.join(os.path.normpath(os.getcwd()), '../../../../tools')]
 from iar import IARVersion
 
 Import('rtconfig')


### PR DESCRIPTION
如果bsp里面指定的RTT_ROOT是基于bsp的相对路径，例如../../tools，那么在其他地方（dlib）里面是找不到相应的tools目录的。所以需要在dlib里面再次添加一个。