### PR TITLE
[BSP][imxrt1052] add baudrate options, Delete simulate i2c . 

### DIFF
--- a/bsp/imxrt1052-evk/Kconfig
+++ b/bsp/imxrt1052-evk/Kconfig
@@ -267,56 +267,64 @@ menu "Select spi bus and dev drivers"
         depends on RT_USING_SPI_FLASH
 endmenu
 
-menu "Select i2c bus drivers"
+menu "Select iic bus drivers"
 
-    config LPI2C_CLOCK_SOURCE_DIVIDER
-        int "lpi2c bus clock source divider"
-        range 1 64
-        default 4
-        
-    config RT_USING_I2C1
-        bool "USING I2C1"
+    config RT_USING_HW_I2C1
+        bool "using hardware i2c1"
         select RT_USING_I2C
         default y 
-        if RT_USING_I2C1
-        config RT_USING_I2C1_BITOPS
-        select RT_USING_I2C_BITOPS
-        default n
-        bool "using simulate I2C1"
-        endif
-
-    config RT_USING_I2C2
-        bool "USING I2C2"
+    choice
+        prompt "i2c1 bus badurate choice"
+        default HW_I2C1_BADURATE_100kHZ
+        depends on RT_USING_HW_I2C1
+        config HW_I2C1_BADURATE_100kHZ
+            bool "100kHZ"
+        config HW_I2C1_BADURATE_400kHZ
+            bool "400kHZ"
+    endchoice
+	
+    config RT_USING_HW_I2C2
+        bool "using hardware i2c2"
         select RT_USING_I2C
         default n 
-        if RT_USING_I2C2
-        config RT_USING_I2C2_BITOPS
-        select RT_USING_I2C_BITOPS
-        default n
-        bool "using simulate I2C2"
-        endif
-
-    config RT_USING_I2C3
-        bool "USING I2C3"
+    choice
+        prompt "i2c2 bus badurate choice"
+        default HW_I2C2_BADURATE_100kHZ
+        depends on RT_USING_HW_I2C2
+        config HW_I2C2_BADURATE_100kHZ
+            bool "100kHZ"
+        config HW_I2C2_BADURATE_400kHZ
+            bool "400kHZ"
+    endchoice
+	
+    config RT_USING_HW_I2C3
+        bool "using hardware i2c3"
         select RT_USING_I2C
         default n 
-        if RT_USING_I2C3
-        config RT_USING_I2C3_BITOPS
-        select RT_USING_I2C_BITOPS
-        default n
-        bool "using simulate I2C3"
-        endif
-
-    config RT_USING_I2C4
-        bool "USING I2C4"
+    choice
+        prompt "i2c3 bus badurate choice"
+        default HW_I2C3_BADURATE_100kHZ
+        depends on RT_USING_HW_I2C3
+        config HW_I2C3_BADURATE_100kHZ
+            bool "100kHZ"
+        config HW_I2C3_BADURATE_400kHZ
+            bool "400kHZ"
+    endchoice
+	
+    config RT_USING_HW_I2C4
+        bool "using hardware i2c4"
         select RT_USING_I2C
         default n 
-        if RT_USING_I2C4
-        config RT_USING_I2C4_BITOPS
-        select RT_USING_I2C_BITOPS
-        default n
-        bool "using simulate I2C4"
-        endif
+    choice
+        prompt "i2c4 bus badurate choice"
+        default HW_I2C4_BADURATE_100kHZ
+        depends on RT_USING_HW_I2C4
+        config HW_I2C4_BADURATE_100kHZ
+            bool "100kHZ"
+        config HW_I2C4_BADURATE_400kHZ
+            bool "400kHZ"
+    endchoice
+
 endmenu
 
 menu "Select lcd driver"

--- a/bsp/imxrt1052-evk/drivers/drv_i2c.c
+++ b/bsp/imxrt1052-evk/drivers/drv_i2c.c
@@ -38,140 +38,44 @@
 #define I2C3BUS_NAME  "i2c3"
 #define I2C4BUS_NAME  "i2c4"
 
+#define LPI2C_CLOCK_SOURCE_DIVIDER 4
+
 /* Get frequency of lpi2c clock */
-#define LPI2C_CLOCK_FREQUENCY ((CLOCK_GetFreq(kCLOCK_Usb1PllClk) / 8) / (LPI2C_CLOCK_SOURCE_DIVIDER + 1U))
+#define LPI2C_CLOCK_FREQUENCY ((CLOCK_GetFreq(kCLOCK_Usb1PllClk) / 8) / (LPI2C_CLOCK_SOURCE_DIVIDER))
 
-#if defined(RT_USING_I2C_BITOPS) && (defined(RT_USING_I2C1_BITOPS) || defined(RT_USING_I2C2_BITOPS) || \
-                                     defined(RT_USING_I2C3_BITOPS) || defined(RT_USING_I2C4_BITOPS))
-
-struct rt1052_i2c_bit_data
-{
-    struct
-    {
-        GPIO_Type *base;
-        uint32_t pin;
-    } scl, sda;
-};
-
-static void gpio_udelay(rt_uint32_t us)
-{
-    volatile rt_int32_t i;
-    for (; us > 0; us--)
-    {
-        i = 100;
-        while (i--);
-    }
-}
-
-static void gpio_set_input(GPIO_Type *base, uint32_t pin)
-{
-    if (base->GDIR & (1 << pin))
-    {
-        base->GDIR &= ~(1 << pin);
-        gpio_udelay(5);
-    }
-}
-
-static void gpio_set_output(GPIO_Type *base, uint32_t pin)
-{
-    if (!(base->GDIR & (1 << pin)))
-    {
-        base->GDIR |= (1 << pin);
-        gpio_udelay(5);
-    }
-}
-
-static void gpio_set_sda(void *data, rt_int32_t state)
-{
-    struct rt1052_i2c_bit_data *bd = data;
-
-    gpio_set_output(bd->sda.base, bd->sda.pin);
-
-    GPIO_PinWrite(bd->sda.base, bd->sda.pin, !!state);
-}
-
-static void gpio_set_scl(void *data, rt_int32_t state)
-{
-    struct rt1052_i2c_bit_data *bd = data;
-
-    gpio_set_output(bd->scl.base, bd->scl.pin);
-
-    GPIO_PinWrite(bd->scl.base, bd->scl.pin, !!state);
-}
-
-static rt_int32_t gpio_get_sda(void *data)
-{
-    struct rt1052_i2c_bit_data *bd = data;
-
-    gpio_set_input(bd->sda.base, bd->sda.pin);
-
-    return GPIO_ReadPinInput(bd->sda.base, bd->sda.pin);
-}
-
-static rt_int32_t gpio_get_scl(void *data)
-{
-    struct rt1052_i2c_bit_data *bd = data;
-
-    gpio_set_input(bd->scl.base, bd->scl.pin);
-
-    return GPIO_ReadPinInput(bd->scl.base, bd->scl.pin);
-}
-
-#endif
-
-#ifdef RT_USING_I2C1
-#ifdef RT_USING_I2C1_BITOPS
-
-#else
+#ifdef RT_USING_HW_I2C1
 static struct rt1052_i2c_bus lpi2c1 =
 {
     .I2C = LPI2C1,
     .device_name = I2C1BUS_NAME,
 };
-#endif /* RT_USING_I2C1_BITOPS */
-#endif /* RT_USING_I2C1 */
+#endif /* RT_USING_HW_I2C1 */
 
-#ifdef RT_USING_I2C2
-#ifdef RT_USING_I2C2_BITOPS
-
-#else
+#ifdef RT_USING_HW_I2C2
 static struct rt1052_i2c_bus lpi2c2 =
 {
     .I2C = LPI2C2,
     .device_name = I2C2BUS_NAME,
 };
-#endif /* RT_USING_I2C2_BITOPS */
-#endif /* RT_USING_I2C2 */
+#endif /* RT_USING_HW_I2C2 */
 
-#ifdef RT_USING_I2C3
-#ifdef RT_USING_I2C3_BITOPS
-
-#else
+#ifdef RT_USING_HW_I2C3
 static struct rt1052_i2c_bus lpi2c3 =
 {
     .I2C = LPI2C3,
     .device_name = I2C3BUS_NAME,
 };
+#endif /* RT_USING_HW_I2C3 */
 
-#endif /* RT_USING_I2C3_BITOPS */
-#endif /* RT_USING_I2C3 */
-
-#ifdef RT_USING_I2C4
-
-#ifdef RT_USING_I2C4_BITOPS
-
-#else
+#ifdef RT_USING_HW_I2C4
 static struct rt1052_i2c_bus lpi2c4 =
 {
     .I2C = LPI2C4,
     .device_name = I2C4BUS_NAME,
 };
-#endif /* RT_USING_I2C1_BITOPS */
+#endif /* RT_USING_HW_I2C4 */
 
-#endif /* RT_USING_I2C4 */
-
-#if (defined(RT_USING_I2C1) || defined(RT_USING_I2C2) || \
-     defined(RT_USING_I2C3) || defined(RT_USING_I2C4))
+#if (defined(RT_USING_HW_I2C1) || defined(RT_USING_HW_I2C2) || defined(RT_USING_HW_I2C3) || defined(RT_USING_HW_I2C4))
 
 static rt_size_t imxrt_i2c_mst_xfer(struct rt_i2c_bus_device *bus,
                                     struct rt_i2c_msg msgs[],
@@ -189,9 +93,6 @@ static const struct rt_i2c_bus_device_ops imxrt_i2c_ops =
     imxrt_i2c_slv_xfer,
     imxrt_i2c_bus_control,
 };
-
-#if !defined(RT_USING_I2C_BITOPS) || (!defined(RT_USING_I2C1_BITOPS) || !defined(RT_USING_I2C2_BITOPS) || \
-                                      !defined(RT_USING_I2C3_BITOPS) || !defined(RT_USING_I2C4_BITOPS))
 
 void imxrt_lpi2c_gpio_init(struct rt1052_i2c_bus *bus)
 {
@@ -272,15 +173,85 @@ static rt_err_t imxrt_lpi2c_configure(struct rt1052_i2c_bus *bus, lpi2c_master_c
     return RT_EOK;
 }
 
-#endif
+status_t LPI2C_MasterCheck(LPI2C_Type *base, uint32_t status)
+{
+    status_t result = kStatus_Success;
+
+    /* Check for error. These errors cause a stop to automatically be sent. We must */
+    /* clear the errors before a new transfer can start. */
+    status &= 0x3c00;
+    if (status)
+    {
+        /* Select the correct error code. Ordered by severity, with bus issues first. */
+        if (status & kLPI2C_MasterPinLowTimeoutFlag)
+        {
+            result = kStatus_LPI2C_PinLowTimeout;
+        }
+        else if (status & kLPI2C_MasterArbitrationLostFlag)
+        {
+            result = kStatus_LPI2C_ArbitrationLost;
+        }
+        else if (status & kLPI2C_MasterNackDetectFlag)
+        {
+            result = kStatus_LPI2C_Nak;
+        }
+        else if (status & kLPI2C_MasterFifoErrFlag)
+        {
+            result = kStatus_LPI2C_FifoError;
+        }
+        else
+        {
+            assert(false);
+        }
+
+        /* Clear the flags. */
+        LPI2C_MasterClearStatusFlags(base, status);
+
+        /* Reset fifos. These flags clear automatically. */
+        base->MCR |= LPI2C_MCR_RRF_MASK | LPI2C_MCR_RTF_MASK;
+    }
+
+    return result;
+}
+
+/*!
+ * @brief Wait until the tx fifo all empty.
+ * @param base The LPI2C peripheral base address.
+ * @retval #kStatus_Success
+ * @retval #kStatus_LPI2C_PinLowTimeout
+ * @retval #kStatus_LPI2C_ArbitrationLost
+ * @retval #kStatus_LPI2C_Nak
+ * @retval #kStatus_LPI2C_FifoError
+ */
+static status_t LPI2C_MasterWaitForTxFifoAllEmpty(LPI2C_Type *base)
+{
+    uint32_t status;
+    size_t txCount;
+    do
+    {
+        status_t result;
+
+        /* Get the number of words in the tx fifo and compute empty slots. */
+        LPI2C_MasterGetFifoCounts(base, NULL, &txCount);
+
+        /* Check for error flags. */
+        status = LPI2C_MasterGetStatusFlags(base);
+        result = LPI2C_MasterCheck(base, status);
+        if (result)
+        {
+            return result;
+        }
+    }
+    while (txCount);
+    return kStatus_Success;
+}
 
 static rt_size_t imxrt_i2c_mst_xfer(struct rt_i2c_bus_device *bus,
                                     struct rt_i2c_msg msgs[],
                                     rt_uint32_t num)
 {
     struct rt1052_i2c_bus *rt1052_i2c;
-    rt_uint32_t numbak;
-    rt_uint16_t i;
+    rt_size_t i;
     RT_ASSERT(bus != RT_NULL);
     rt1052_i2c = (struct rt1052_i2c_bus *) bus;
 
@@ -293,8 +264,22 @@ static rt_size_t imxrt_i2c_mst_xfer(struct rt_i2c_bus_device *bus,
     {
         if (rt1052_i2c->msg[i].flags & RT_I2C_RD)
         {
-            LPI2C_MasterStart(rt1052_i2c->I2C, rt1052_i2c->msg[i].addr, kLPI2C_Read);
-            if (LPI2C_MasterReceive(rt1052_i2c->I2C, rt1052_i2c->msg[i].buf, rt1052_i2c->msg[i].len) == kStatus_LPI2C_Nak)
+            if (LPI2C_MasterStart(rt1052_i2c->I2C, rt1052_i2c->msg[i].addr, kLPI2C_Read) != kStatus_Success)
+            {
+                i = 0;
+                break;
+            }
+            if (LPI2C_MasterWaitForTxFifoAllEmpty(rt1052_i2c->I2C) != kStatus_Success)
+            {
+                i = 0;
+                break;
+            }
+            if (LPI2C_MasterReceive(rt1052_i2c->I2C, rt1052_i2c->msg[i].buf, rt1052_i2c->msg[i].len) != kStatus_Success)
+            {
+                i = 0;
+                break;
+            }
+            if (LPI2C_MasterWaitForTxFifoAllEmpty(rt1052_i2c->I2C) != kStatus_Success)
             {
                 i = 0;
                 break;
@@ -302,25 +287,41 @@ static rt_size_t imxrt_i2c_mst_xfer(struct rt_i2c_bus_device *bus,
         }
         else
         {
-            LPI2C_MasterStart(rt1052_i2c->I2C, rt1052_i2c->msg[i].addr, kLPI2C_Write);
-            if (LPI2C_MasterSend(rt1052_i2c->I2C, rt1052_i2c->msg[i].buf, rt1052_i2c->msg[i].len) == kStatus_LPI2C_Nak)
+            if (LPI2C_MasterStart(rt1052_i2c->I2C, rt1052_i2c->msg[i].addr, kLPI2C_Write) != kStatus_Success)
+            {
+                i = 0;
+                break;
+            }
+            if (LPI2C_MasterWaitForTxFifoAllEmpty(rt1052_i2c->I2C) != kStatus_Success)
+            {
+                i = 0;
+                break;
+            }
+            if (LPI2C_MasterSend(rt1052_i2c->I2C, rt1052_i2c->msg[i].buf, rt1052_i2c->msg[i].len) != kStatus_Success)
+            {
+                i = 0;
+                break;
+            }
+            if (LPI2C_MasterWaitForTxFifoAllEmpty(rt1052_i2c->I2C) != kStatus_Success)
             {
                 i = 0;
                 break;
             }
         }
     }
-
     i2c_dbg("send stop condition\n");
-    LPI2C_MasterStop(rt1052_i2c->I2C);
+    if (LPI2C_MasterStop(rt1052_i2c->I2C) != kStatus_Success)
+    {
+        i = 0;
+    }
 
-    numbak = i;
     rt1052_i2c->msg = RT_NULL;
     rt1052_i2c->msg_ptr = 0;
     rt1052_i2c->msg_cnt = 0;
     rt1052_i2c->dptr = 0;
-    return numbak;
+    return i;
 }
+
 static rt_size_t imxrt_i2c_slv_xfer(struct rt_i2c_bus_device *bus,
                                     struct rt_i2c_msg msgs[],
                                     rt_uint32_t num)
@@ -338,206 +339,59 @@ static rt_err_t imxrt_i2c_bus_control(struct rt_i2c_bus_device *bus,
 
 int rt_hw_i2c_init(void)
 {
-#if !defined(RT_USING_I2C_BITOPS) || (!defined(RT_USING_I2C1_BITOPS) || !defined(RT_USING_I2C2_BITOPS) || \
-                                      !defined(RT_USING_I2C3_BITOPS) || !defined(RT_USING_I2C4_BITOPS))
+#if (defined(RT_USING_HW_I2C1) || defined(RT_USING_HW_I2C2) || defined(RT_USING_HW_I2C3) || defined(RT_USING_HW_I2C4))
 
     lpi2c_master_config_t masterConfig = {0};
 
     /*Clock setting for LPI2C*/
     CLOCK_SetMux(kCLOCK_Lpi2cMux, 0);
-    CLOCK_SetDiv(kCLOCK_Lpi2cDiv, LPI2C_CLOCK_SOURCE_DIVIDER);
+    CLOCK_SetDiv(kCLOCK_Lpi2cDiv, LPI2C_CLOCK_SOURCE_DIVIDER - 1);
 
 #endif
 
-#if defined(RT_USING_I2C_BITOPS) && (defined(RT_USING_I2C1_BITOPS) || defined(RT_USING_I2C2_BITOPS) || \
-                                     defined(RT_USING_I2C3_BITOPS) || defined(RT_USING_I2C4_BITOPS))
-    gpio_pin_config_t pin_config =
-    {
-        kGPIO_DigitalOutput,
-        0,
-    };
-#endif /* RT_USING_I2C_BITOPS= RT_USING_I2C1_BITOPS RT_USING_I2C2_BITOPS RT_USING_I2C3_BITOPS RT_USING_I2C4_BITOPS */
-#if defined(RT_USING_I2C1) && defined(RT_USING_I2C1_BITOPS)
-
-    static struct rt_i2c_bus_device i2c1_device;
-
-    static const struct rt1052_i2c_bit_data _i2c1_bdata =
-    {
-        /* SCL */ {GPIO1, 16},
-        /* SDA */ {GPIO1, 17},
-    };
-
-    static const struct rt_i2c_bit_ops _i2c1_bit_ops =
-    {
-        (void *) &_i2c1_bdata,
-        gpio_set_sda,
-        gpio_set_scl,
-        gpio_get_sda,
-        gpio_get_scl,
-
-        gpio_udelay,
-
-        50,
-        1000
-    };
-
-    IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B1_00_GPIO1_IO16, 1U);
-    IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B1_00_GPIO1_IO16, 0xD8B0u);
-    IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B1_01_GPIO1_IO17, 1U);
-    IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B1_01_GPIO1_IO17, 0xD8B0u);
-
-    /* Enable touch panel controller */
-    GPIO_PinInit(_i2c1_bdata.sda.base, _i2c1_bdata.sda.pin, &pin_config);
-    GPIO_PinInit(_i2c1_bdata.scl.base, _i2c1_bdata.scl.pin, &pin_config);
-
-    GPIO_PortSet(_i2c1_bdata.sda.base, _i2c1_bdata.sda.pin);
-    GPIO_PortSet(_i2c1_bdata.scl.base, _i2c1_bdata.scl.pin);
-
-    i2c1_device.priv = (void *) &_i2c1_bit_ops;
-    rt_i2c_bit_add_bus(&i2c1_device, I2C1BUS_NAME);
-
-#elif   defined(RT_USING_I2C1) && !defined(RT_USING_I2C1_BITOPS)
+#if   defined(RT_USING_HW_I2C1)
     LPI2C_MasterGetDefaultConfig(&masterConfig);
+#if   defined(HW_I2C1_BADURATE_400kHZ)
+    masterConfig.baudRate_Hz = 400000U;
+#elif defined(HW_I2C1_BADURATE_100kHZ)
+    masterConfig.baudRate_Hz = 100000U;
+#endif
     imxrt_lpi2c_configure(&lpi2c1, &masterConfig);
     rt_i2c_bus_device_register(&lpi2c1.parent, lpi2c1.device_name);
 #endif
-#if defined(RT_USING_I2C2) && defined(RT_USING_I2C2_BITOPS)
 
-    static struct rt_i2c_bus_device i2c2_device;
-
-    static const struct rt1052_i2c_bit_data _i2c2_bdata =
-    {
-        /* SCL */ {GPIO2, 4},
-        /* SDA */ {GPIO2, 5},
-    };
-
-    static const struct rt_i2c_bit_ops _i2c2_bit_ops =
-    {
-        (void *) &_i2c2_bdata,
-        gpio_set_sda,
-        gpio_set_scl,
-        gpio_get_sda,
-        gpio_get_scl,
-
-        gpio_udelay,
-
-        50,
-        1000
-    };
-
-    IOMUXC_SetPinMux(IOMUXC_GPIO_B0_04_GPIO2_IO04, 1U);
-    IOMUXC_SetPinConfig(IOMUXC_GPIO_B0_04_GPIO2_IO04, 0xD8B0u);
-    IOMUXC_SetPinMux(IOMUXC_GPIO_B0_05_GPIO2_IO05, 1U);
-    IOMUXC_SetPinConfig(IOMUXC_GPIO_B0_05_GPIO2_IO05, 0xD8B0u);
-
-    /* Enable touch panel controller */
-    GPIO_PinInit(_i2c2_bdata.sda.base, _i2c2_bdata.sda.pin, &pin_config);
-    GPIO_PinInit(_i2c2_bdata.scl.base, _i2c2_bdata.scl.pin, &pin_config);
-
-    GPIO_PortSet(_i2c2_bdata.sda.base, _i2c2_bdata.sda.pin);
-    GPIO_PortSet(_i2c2_bdata.scl.base, _i2c2_bdata.scl.pin);
-
-
-    i2c2_device.priv = (void *) &_i2c2_bit_ops;
-    rt_i2c_bit_add_bus(&i2c2_device, I2C2BUS_NAME);
-
-#elif   defined(RT_USING_I2C2) && !defined(RT_USING_I2C2_BITOPS)
+#if   defined(RT_USING_HW_I2C2)
     LPI2C_MasterGetDefaultConfig(&masterConfig);
+#if   defined(HW_I2C2_BADURATE_400kHZ)
+    masterConfig.baudRate_Hz = 400000U;
+#elif defined(HW_I2C2_BADURATE_100kHZ)
+    masterConfig.baudRate_Hz = 100000U;
+#endif
     imxrt_lpi2c_configure(&lpi2c2, &masterConfig);
     rt_i2c_bus_device_register(&lpi2c2.parent, lpi2c2.device_name);
 #endif
-#if defined(RT_USING_I2C3) && defined(RT_USING_I2C3_BITOPS)
 
-    static struct rt_i2c_bus_device i2c3_device;
-
-    static const struct rt1052_i2c_bit_data _i2c3_bdata =
-    {
-        /* SCL */ {GPIO1, 23},
-        /* SDA */ {GPIO1, 22},
-    };
-
-    static const struct rt_i2c_bit_ops _i2c3_bit_ops =
-    {
-        (void *) &_i2c3_bdata,
-        gpio_set_sda,
-        gpio_set_scl,
-        gpio_get_sda,
-        gpio_get_scl,
-
-        gpio_udelay,
-
-        50,
-        1000
-    };
-
-    IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B1_07_GPIO1_IO23, 1U);
-    IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B1_07_GPIO1_IO23, 0xD8B0u);
-    IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B1_06_GPIO1_IO22, 1U);
-    IOMUXC_SetPinConfig(IOMUXC_GPIO_AD_B1_06_GPIO1_IO22, 0xD8B0u);
-
-    /* Enable touch panel controller */
-    GPIO_PinInit(_i2c3_bdata.sda.base, _i2c3_bdata.sda.pin, &pin_config);
-    GPIO_PinInit(_i2c3_bdata.scl.base, _i2c3_bdata.scl.pin, &pin_config);
-
-    GPIO_PortSet(_i2c3_bdata.sda.base, _i2c3_bdata.sda.pin);
-    GPIO_PortSet(_i2c3_bdata.scl.base, _i2c3_bdata.scl.pin);
-
-
-    i2c3_device.priv = (void *) &_i2c3_bit_ops;
-    rt_i2c_bit_add_bus(&i2c3_device, I2C3BUS_NAME);
-
-#elif   defined(RT_USING_I2C3) && !defined(RT_USING_I2C3_BITOPS)
+#if   defined(RT_USING_HW_I2C3)
     LPI2C_MasterGetDefaultConfig(&masterConfig);
+#if   defined(HW_I2C3_BADURATE_400kHZ)
+    masterConfig.baudRate_Hz = 400000U;
+#elif defined(HW_I2C3_BADURATE_100kHZ)
+    masterConfig.baudRate_Hz = 100000U;
+#endif
     imxrt_lpi2c_configure(&lpi2c3, &masterConfig);
     rt_i2c_bus_device_register(&lpi2c3.parent, lpi2c3.device_name);
 #endif
-#if defined(RT_USING_I2C4) && defined(RT_USING_I2C4_BITOPS)
 
-    static struct rt_i2c_bus_device i2c4_device;
-
-    static const struct rt1052_i2c_bit_data _i2c4_bdata =
-    {
-        /* SCL */ {GPIO4, 12},
-        /* SDA */ {GPIO4, 11},
-    };
-
-    static const struct rt_i2c_bit_ops _i2c4_bit_ops =
-    {
-        (void *) &_i2c4_bdata,
-        gpio_set_sda,
-        gpio_set_scl,
-        gpio_get_sda,
-        gpio_get_scl,
-
-        gpio_udelay,
-
-        50,
-        1000
-    };
-
-    IOMUXC_SetPinMux(IOMUXC_GPIO_EMC_12_GPIO4_IO12, 1U);
-    IOMUXC_SetPinConfig(IOMUXC_GPIO_EMC_12_GPIO4_IO12, 0xD8B0u);
-    IOMUXC_SetPinMux(IOMUXC_GPIO_EMC_11_GPIO4_IO11, 1U);
-    IOMUXC_SetPinConfig(IOMUXC_GPIO_EMC_11_GPIO4_IO11, 0xD8B0u);
-
-    /* Enable touch panel controller */
-    GPIO_PinInit(_i2c4_bdata.sda.base, _i2c4_bdata.sda.pin, &pin_config);
-    GPIO_PinInit(_i2c4_bdata.scl.base, _i2c4_bdata.scl.pin, &pin_config);
-
-    GPIO_PortSet(_i2c4_bdata.sda.base, _i2c4_bdata.sda.pin);
-    GPIO_PortSet(_i2c4_bdata.scl.base, _i2c4_bdata.scl.pin);
-
-
-    i2c4_device.priv = (void *) &_i2c4_bit_ops;
-    rt_i2c_bit_add_bus(&i2c4_device, I2C4BUS_NAME);
-
-#elif   defined(RT_USING_I2C4) && !defined(RT_USING_I2C4_BITOPS)
+#if   defined(RT_USING_HW_I2C4)
     LPI2C_MasterGetDefaultConfig(&masterConfig);
+#if   defined(HW_I2C4_BADURATE_400kHZ)
+    masterConfig.baudRate_Hz = 400000U;
+#elif defined(HW_I2C4_BADURATE_100kHZ)
+    masterConfig.baudRate_Hz = 100000U;
+#endif
     imxrt_lpi2c_configure(&lpi2c4, &masterConfig);
     rt_i2c_bus_device_register(&lpi2c4.parent, lpi2c4.device_name);
 #endif
-
-
 
     return 0;
 }
@@ -602,6 +456,7 @@ static void _search_i2c_device(rt_device_t dev, uint8_t cmd)
 static int i2c_test(const char *name, uint8_t cmd)
 {
     rt_device_t dev = _i2c_find(name);
+
     if (dev == RT_NULL)
     {
         rt_kprintf("search i2c device faild\n");
@@ -609,14 +464,12 @@ static int i2c_test(const char *name, uint8_t cmd)
     }
 
     _search_i2c_device(dev, cmd);
-
     rt_device_close(dev);
 
     return 0;
 }
 FINSH_FUNCTION_EXPORT(i2c_test, e.g: i2c_test("i2c1", 0xA3));
+
 #endif
 
 #endif /* RT_USING_I2C */
-
-

--- a/bsp/imxrt1052-evk/drivers/drv_pin.c
+++ b/bsp/imxrt1052-evk/drivers/drv_pin.c
@@ -392,7 +392,6 @@ void GPIO5_Combined_0_15_IRQHandler(void)
 #if defined __CORTEX_M && (__CORTEX_M == 4U)
     __DSB();
 #endif
-    
     rt_interrupt_leave();
 }
 
@@ -473,13 +472,13 @@ static void rt1052_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     {
         CLOCK_EnableClock(kCLOCK_Iomuxc); 
         
-        IOMUXC_SetPinMux(0x401F8010U + pin*4, 0x5U, 0, 0, 0, 0); 
+        IOMUXC_SetPinMux(0x401F8010U + pin*4, 0x5U, 0, 0, 0, 1); 
     }
     else
     {
         CLOCK_EnableClock(kCLOCK_IomuxcSnvs); 
         
-        IOMUXC_SetPinMux(0x401F8000U + (pin-125)*4, 0x5U, 0, 0, 0, 0); 
+        IOMUXC_SetPinMux(0x401F8000U + (pin-125)*4, 0x5U, 0, 0, 0, 1); 
     }
     
     gpio.outputLogic = 0; 
@@ -530,7 +529,7 @@ static void rt1052_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
 
 static int rt1052_pin_read(rt_device_t dev, rt_base_t pin)
 {
-    return GPIO_PinRead(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin); 
+    return GPIO_PinReadPadStatus(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin); 
 }
 
 static void rt1052_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)

--- a/bsp/imxrt1052-evk/rtconfig.h
+++ b/bsp/imxrt1052-evk/rtconfig.h
@@ -210,10 +210,10 @@
 #define LPSPI4_SDO_GPIO_1
 #define LPSPI4_SDI_GPIO_1
 
-/* Select i2c bus drivers */
+/* Select iic bus drivers */
 
-#define LPI2C_CLOCK_SOURCE_DIVIDER 4
-#define RT_USING_I2C1
+#define RT_USING_HW_I2C1
+#define HW_I2C1_BADURATE_100kHZ
 
 /* Select lcd driver */
 


### PR DESCRIPTION
1.drv_pin.c中

1. SION位置1.

1. rt1052_pin_read()函数 改为直接从PSR寄存器读取,不再是从DR寄存器读取.


`.....................`

1. 在menuconfig中增加波特率选项. 

1. 移除软件i2c.

1. 修复之前,micropython下i2c无法正确扫描设备的问题.