### PR TITLE
update enc28j60 driver: ensure enable PHY link changed interrupt.

### DIFF
--- a/components/drivers/spi/enc28j60.c
+++ b/components/drivers/spi/enc28j60.c
@@ -321,6 +321,8 @@ static rt_err_t enc28j60_init(rt_device_t dev)
     enc28j60_phy_write(spi_device, PHCON1, PHCON1_PDPXMD); // full duplex
     // no loopback of transmitted frames
     enc28j60_phy_write(spi_device, PHCON2, PHCON2_HDLDIS);
+    /* enable PHY link changed interrupt. */
+    enc28j60_phy_write(spi_device, PHIE, PHIE_PGEIE | PHIE_PLNKIE);
 
     enc28j60_set_bank(spi_device, ECON2);
     spi_write_op(spi_device, ENC28J60_BIT_FIELD_SET, ECON2, ECON2_AUTOINC);

--- a/components/drivers/spi/enc28j60.c
+++ b/components/drivers/spi/enc28j60.c
@@ -5,40 +5,40 @@
 #define ETH_TX_DUMP
 
 #ifdef NET_TRACE
-#define NET_DEBUG         rt_kprintf
+    #define NET_DEBUG         rt_kprintf
 #else
-#define NET_DEBUG(...)
+    #define NET_DEBUG(...)
 #endif /* #ifdef NET_TRACE */
 
 struct enc28j60_tx_list_typedef
 {
-    struct enc28j60_tx_list_typedef * prev;
-    struct enc28j60_tx_list_typedef * next;
+    struct enc28j60_tx_list_typedef *prev;
+    struct enc28j60_tx_list_typedef *next;
     rt_uint32_t addr; /* pkt addr in buffer */
     rt_uint32_t len;  /* pkt len */
     volatile rt_bool_t free; /* 0:busy, 1:free */
 };
 static struct enc28j60_tx_list_typedef enc28j60_tx_list[2];
-static volatile struct enc28j60_tx_list_typedef * tx_current;
-static volatile struct enc28j60_tx_list_typedef * tx_ack;
+static volatile struct enc28j60_tx_list_typedef *tx_current;
+static volatile struct enc28j60_tx_list_typedef *tx_ack;
 static struct rt_event tx_event;
 
 /* private enc28j60 define */
 /* enc28j60 spi interface function */
-static uint8_t spi_read_op(struct rt_spi_device * spi_device, uint8_t op, uint8_t address);
-static void spi_write_op(struct rt_spi_device * spi_device, uint8_t op, uint8_t address, uint8_t data);
+static uint8_t spi_read_op(struct rt_spi_device *spi_device, uint8_t op, uint8_t address);
+static void spi_write_op(struct rt_spi_device *spi_device, uint8_t op, uint8_t address, uint8_t data);
 
-static uint8_t spi_read(struct rt_spi_device * spi_device, uint8_t address);
-static void spi_write(struct rt_spi_device * spi_device, rt_uint8_t address, rt_uint8_t data);
+static uint8_t spi_read(struct rt_spi_device *spi_device, uint8_t address);
+static void spi_write(struct rt_spi_device *spi_device, rt_uint8_t address, rt_uint8_t data);
 
-static void enc28j60_clkout(struct rt_spi_device * spi_device, rt_uint8_t clk);
-static void enc28j60_set_bank(struct rt_spi_device * spi_device, uint8_t address);
-static uint32_t enc28j60_interrupt_disable(struct rt_spi_device * spi_device);
-static void enc28j60_interrupt_enable(struct rt_spi_device * spi_device, uint32_t level);
+static void enc28j60_clkout(struct rt_spi_device *spi_device, rt_uint8_t clk);
+static void enc28j60_set_bank(struct rt_spi_device *spi_device, uint8_t address);
+static uint32_t enc28j60_interrupt_disable(struct rt_spi_device *spi_device);
+static void enc28j60_interrupt_enable(struct rt_spi_device *spi_device, uint32_t level);
 
-static uint16_t enc28j60_phy_read(struct rt_spi_device * spi_device, rt_uint8_t address);
-static void enc28j60_phy_write(struct rt_spi_device * spi_device, rt_uint8_t address, uint16_t data);
-static rt_bool_t enc28j60_check_link_status(struct rt_spi_device * spi_device);
+static uint16_t enc28j60_phy_read(struct rt_spi_device *spi_device, rt_uint8_t address);
+static void enc28j60_phy_write(struct rt_spi_device *spi_device, rt_uint8_t address, uint16_t data);
+static rt_bool_t enc28j60_check_link_status(struct rt_spi_device *spi_device);
 
 #define enc28j60_lock(dev)      rt_mutex_take(&((struct net_device*)dev)->lock, RT_WAITING_FOREVER);
 #define enc28j60_unlock(dev)    rt_mutex_release(&((struct net_device*)dev)->lock);
@@ -52,11 +52,11 @@ static void _delay_us(uint32_t us)
 {
     volatile uint32_t len;
     for (; us > 0; us --)
-        for (len = 0; len < 20; len++ );
+        for (len = 0; len < 20; len++);
 }
 
 /* enc28j60 spi interface function */
-static uint8_t spi_read_op(struct rt_spi_device * spi_device, uint8_t op, uint8_t address)
+static uint8_t spi_read_op(struct rt_spi_device *spi_device, uint8_t op, uint8_t address)
 {
     uint8_t send_buffer[2];
     uint8_t recv_buffer[1];
@@ -66,7 +66,7 @@ static uint8_t spi_read_op(struct rt_spi_device * spi_device, uint8_t op, uint8_
     send_buffer[1] = 0xFF;
 
     /* do dummy read if needed (for mac and mii, see datasheet page 29). */
-    if(address & 0x80)
+    if (address & 0x80)
     {
         send_size = 2;
     }
@@ -75,7 +75,7 @@ static uint8_t spi_read_op(struct rt_spi_device * spi_device, uint8_t op, uint8_
     return (recv_buffer[0]);
 }
 
-static void spi_write_op(struct rt_spi_device * spi_device, uint8_t op, uint8_t address, uint8_t data)
+static void spi_write_op(struct rt_spi_device *spi_device, uint8_t op, uint8_t address, uint8_t data)
 {
     uint32_t level;
     uint8_t buffer[2];
@@ -90,25 +90,25 @@ static void spi_write_op(struct rt_spi_device * spi_device, uint8_t op, uint8_t 
 }
 
 /* enc28j60 function */
-static void enc28j60_clkout(struct rt_spi_device * spi_device, rt_uint8_t clk)
+static void enc28j60_clkout(struct rt_spi_device *spi_device, rt_uint8_t clk)
 {
     /* setup clkout: 2 is 12.5MHz: */
     spi_write(spi_device, ECOCON, clk & 0x7);
 }
 
-static void enc28j60_set_bank(struct rt_spi_device * spi_device, uint8_t address)
+static void enc28j60_set_bank(struct rt_spi_device *spi_device, uint8_t address)
 {
     /* set the bank (if needed) .*/
-    if((address & BANK_MASK) != Enc28j60Bank)
+    if ((address & BANK_MASK) != Enc28j60Bank)
     {
         /* set the bank. */
-        spi_write_op(spi_device, ENC28J60_BIT_FIELD_CLR, ECON1, (ECON1_BSEL1|ECON1_BSEL0));
-        spi_write_op(spi_device, ENC28J60_BIT_FIELD_SET, ECON1, (address & BANK_MASK)>>5);
+        spi_write_op(spi_device, ENC28J60_BIT_FIELD_CLR, ECON1, (ECON1_BSEL1 | ECON1_BSEL0));
+        spi_write_op(spi_device, ENC28J60_BIT_FIELD_SET, ECON1, (address & BANK_MASK) >> 5);
         Enc28j60Bank = (address & BANK_MASK);
     }
 }
 
-static uint8_t spi_read(struct rt_spi_device * spi_device, uint8_t address)
+static uint8_t spi_read(struct rt_spi_device *spi_device, uint8_t address)
 {
     /* set the bank. */
     enc28j60_set_bank(spi_device, address);
@@ -116,7 +116,7 @@ static uint8_t spi_read(struct rt_spi_device * spi_device, uint8_t address)
     return spi_read_op(spi_device, ENC28J60_READ_CTRL_REG, address);
 }
 
-static void spi_write(struct rt_spi_device * spi_device, rt_uint8_t address, rt_uint8_t data)
+static void spi_write(struct rt_spi_device *spi_device, rt_uint8_t address, rt_uint8_t data)
 {
     /* set the bank. */
     enc28j60_set_bank(spi_device, address);
@@ -124,7 +124,7 @@ static void spi_write(struct rt_spi_device * spi_device, rt_uint8_t address, rt_
     spi_write_op(spi_device, ENC28J60_WRITE_CTRL_REG, address, data);
 }
 
-static uint16_t enc28j60_phy_read(struct rt_spi_device * spi_device, rt_uint8_t address)
+static uint16_t enc28j60_phy_read(struct rt_spi_device *spi_device, rt_uint8_t address)
 {
     uint16_t value;
 
@@ -135,33 +135,33 @@ static uint16_t enc28j60_phy_read(struct rt_spi_device * spi_device, rt_uint8_t 
     _delay_us(15);
 
     /* wait until the PHY read completes. */
-    while(spi_read(spi_device, MISTAT) & MISTAT_BUSY);
+    while (spi_read(spi_device, MISTAT) & MISTAT_BUSY);
 
     /* reset reading bit */
     spi_write(spi_device, MICMD, 0x00);
 
-    value = spi_read(spi_device, MIRDL) | spi_read(spi_device, MIRDH)<<8;
+    value = spi_read(spi_device, MIRDL) | spi_read(spi_device, MIRDH) << 8;
 
     return (value);
 }
 
-static void enc28j60_phy_write(struct rt_spi_device * spi_device, rt_uint8_t address, uint16_t data)
+static void enc28j60_phy_write(struct rt_spi_device *spi_device, rt_uint8_t address, uint16_t data)
 {
     /* set the PHY register address. */
     spi_write(spi_device, MIREGADR, address);
 
     /* write the PHY data. */
     spi_write(spi_device, MIWRL, data);
-    spi_write(spi_device, MIWRH, data>>8);
+    spi_write(spi_device, MIWRH, data >> 8);
 
     /* wait until the PHY write completes. */
-    while(spi_read(spi_device, MISTAT) & MISTAT_BUSY)
+    while (spi_read(spi_device, MISTAT) & MISTAT_BUSY)
     {
         _delay_us(15);
     }
 }
 
-static uint32_t enc28j60_interrupt_disable(struct rt_spi_device * spi_device)
+static uint32_t enc28j60_interrupt_disable(struct rt_spi_device *spi_device)
 {
     uint32_t level;
 
@@ -176,7 +176,7 @@ static uint32_t enc28j60_interrupt_disable(struct rt_spi_device * spi_device)
     return level;
 }
 
-static void enc28j60_interrupt_enable(struct rt_spi_device * spi_device, uint32_t level)
+static void enc28j60_interrupt_enable(struct rt_spi_device *spi_device, uint32_t level)
 {
     /* switch to bank 0 */
     enc28j60_set_bank(spi_device, EIE);
@@ -186,7 +186,7 @@ static void enc28j60_interrupt_enable(struct rt_spi_device * spi_device, uint32_
 /*
  * Access the PHY to determine link status
  */
-static rt_bool_t enc28j60_check_link_status(struct rt_spi_device * spi_device)
+static rt_bool_t enc28j60_check_link_status(struct rt_spi_device *spi_device)
 {
     uint16_t reg;
     int duplex;
@@ -235,8 +235,8 @@ static void _tx_chain_init(void)
 /* initialize the interface */
 static rt_err_t enc28j60_init(rt_device_t dev)
 {
-    struct net_device * enc28j60 = (struct net_device *)dev;
-    struct rt_spi_device * spi_device = enc28j60->spi_device;
+    struct net_device *enc28j60 = (struct net_device *)dev;
+    struct rt_spi_device *spi_device = enc28j60->spi_device;
 
     enc28j60_lock(dev);
 
@@ -244,29 +244,29 @@ static rt_err_t enc28j60_init(rt_device_t dev)
 
     // perform system reset
     spi_write_op(spi_device, ENC28J60_SOFT_RESET, 0, ENC28J60_SOFT_RESET);
-    rt_thread_delay(RT_TICK_PER_SECOND/50); /* delay 20ms */
+    rt_thread_delay(RT_TICK_PER_SECOND / 50); /* delay 20ms */
 
     NextPacketPtr = RXSTART_INIT;
 
     // Rx start
-    spi_write(spi_device, ERXSTL, RXSTART_INIT&0xFF);
-    spi_write(spi_device, ERXSTH, RXSTART_INIT>>8);
+    spi_write(spi_device, ERXSTL, RXSTART_INIT & 0xFF);
+    spi_write(spi_device, ERXSTH, RXSTART_INIT >> 8);
     // set receive pointer address
-    spi_write(spi_device, ERXRDPTL, RXSTOP_INIT&0xFF);
-    spi_write(spi_device, ERXRDPTH, RXSTOP_INIT>>8);
+    spi_write(spi_device, ERXRDPTL, RXSTOP_INIT & 0xFF);
+    spi_write(spi_device, ERXRDPTH, RXSTOP_INIT >> 8);
     // RX end
-    spi_write(spi_device, ERXNDL, RXSTOP_INIT&0xFF);
-    spi_write(spi_device, ERXNDH, RXSTOP_INIT>>8);
+    spi_write(spi_device, ERXNDL, RXSTOP_INIT & 0xFF);
+    spi_write(spi_device, ERXNDH, RXSTOP_INIT >> 8);
 
     // TX start
-    spi_write(spi_device, ETXSTL, TXSTART_INIT&0xFF);
-    spi_write(spi_device, ETXSTH, TXSTART_INIT>>8);
+    spi_write(spi_device, ETXSTL, TXSTART_INIT & 0xFF);
+    spi_write(spi_device, ETXSTH, TXSTART_INIT >> 8);
     // set transmission pointer address
-    spi_write(spi_device, EWRPTL, TXSTART_INIT&0xFF);
-    spi_write(spi_device, EWRPTH, TXSTART_INIT>>8);
+    spi_write(spi_device, EWRPTL, TXSTART_INIT & 0xFF);
+    spi_write(spi_device, EWRPTH, TXSTART_INIT >> 8);
     // TX end
-    spi_write(spi_device, ETXNDL, TXSTOP_INIT&0xFF);
-    spi_write(spi_device, ETXNDH, TXSTOP_INIT>>8);
+    spi_write(spi_device, ETXNDL, TXSTOP_INIT & 0xFF);
+    spi_write(spi_device, ETXNDH, TXSTOP_INIT >> 8);
 
     // do bank 1 stuff, packet filter:
     // For broadcast packets we allow only ARP packtets
@@ -278,11 +278,11 @@ static rt_err_t enc28j60_init(rt_device_t dev)
     // 06 08 -- ff ff ff ff ff ff -> ip checksum for theses bytes=f7f9
     // in binary these poitions are:11 0000 0011 1111
     // This is hex 303F->EPMM0=0x3f,EPMM1=0x30
-    spi_write(spi_device, ERXFCON, ERXFCON_UCEN|ERXFCON_CRCEN|ERXFCON_BCEN);
+    spi_write(spi_device, ERXFCON, ERXFCON_UCEN | ERXFCON_CRCEN | ERXFCON_BCEN);
 
     // do bank 2 stuff
     // enable MAC receive
-    spi_write(spi_device, MACON1, MACON1_MARXEN|MACON1_TXPAUS|MACON1_RXPAUS);
+    spi_write(spi_device, MACON1, MACON1_MARXEN | MACON1_TXPAUS | MACON1_RXPAUS);
     // enable automatic padding to 60bytes and CRC operations
     // spi_write_op(ENC28J60_BIT_FIELD_SET, MACON3, MACON3_PADCFG0|MACON3_TXCRCEN|MACON3_FRMLNEN);
     spi_write_op(spi_device, ENC28J60_BIT_FIELD_SET, MACON3, MACON3_PADCFG0 | MACON3_TXCRCEN | MACON3_FRMLNEN | MACON3_FULDPX);
@@ -301,8 +301,8 @@ static rt_err_t enc28j60_init(rt_device_t dev)
 
     // Set the maximum packet size which the controller will accept
     // Do not send packets longer than MAX_FRAMELEN:
-    spi_write(spi_device, MAMXFLL, MAX_FRAMELEN&0xFF);
-    spi_write(spi_device, MAMXFLH, MAX_FRAMELEN>>8);
+    spi_write(spi_device, MAMXFLL, MAX_FRAMELEN & 0xFF);
+    spi_write(spi_device, MAMXFLH, MAX_FRAMELEN >> 8);
 
     // do bank 3 stuff
     // write MAC address
@@ -335,8 +335,8 @@ static rt_err_t enc28j60_init(rt_device_t dev)
     /* clock out */
     enc28j60_clkout(spi_device, 2);
 
-    enc28j60_phy_write(spi_device, PHLCON, 0xD76);	//0x476
-    rt_thread_delay(RT_TICK_PER_SECOND/50); /* delay 20ms */
+    enc28j60_phy_write(spi_device, PHLCON, 0xD76);  //0x476
+    rt_thread_delay(RT_TICK_PER_SECOND / 50); /* delay 20ms */
 
     enc28j60_unlock(dev);
     return RT_EOK;
@@ -345,12 +345,12 @@ static rt_err_t enc28j60_init(rt_device_t dev)
 /* control the interface */
 static rt_err_t enc28j60_control(rt_device_t dev, int cmd, void *args)
 {
-    struct net_device * enc28j60 = (struct net_device *)dev;
-    switch(cmd)
+    struct net_device *enc28j60 = (struct net_device *)dev;
+    switch (cmd)
     {
     case NIOCTL_GADDR:
         /* get mac address */
-        if(args) rt_memcpy(args, enc28j60->dev_addr, 6);
+        if (args) rt_memcpy(args, enc28j60->dev_addr, 6);
         else return -RT_ERROR;
         break;
 
@@ -374,14 +374,14 @@ static rt_err_t enc28j60_close(rt_device_t dev)
 }
 
 /* Read */
-static rt_size_t enc28j60_read(rt_device_t dev, rt_off_t pos, void* buffer, rt_size_t size)
+static rt_size_t enc28j60_read(rt_device_t dev, rt_off_t pos, void *buffer, rt_size_t size)
 {
     rt_set_errno(-RT_ENOSYS);
     return RT_EOK;
 }
 
 /* Write */
-static rt_size_t enc28j60_write(rt_device_t dev, rt_off_t pos, const void* buffer, rt_size_t size)
+static rt_size_t enc28j60_write(rt_device_t dev, rt_off_t pos, const void *buffer, rt_size_t size)
 {
     rt_set_errno(-RT_ENOSYS);
     return 0;
@@ -389,22 +389,22 @@ static rt_size_t enc28j60_write(rt_device_t dev, rt_off_t pos, const void* buffe
 
 /* ethernet device interface */
 /* Transmit packet. */
-static rt_err_t enc28j60_tx( rt_device_t dev, struct pbuf* p)
+static rt_err_t enc28j60_tx(rt_device_t dev, struct pbuf *p)
 {
-    struct net_device * enc28j60 = (struct net_device *)dev;
-    struct rt_spi_device * spi_device = enc28j60->spi_device;
-    struct pbuf* q;
+    struct net_device *enc28j60 = (struct net_device *)dev;
+    struct rt_spi_device *spi_device = enc28j60->spi_device;
+    struct pbuf *q;
     rt_uint32_t level;
 #ifdef ETH_TX_DUMP
     rt_size_t dump_count = 0;
-    rt_uint8_t * dump_ptr;
+    rt_uint8_t *dump_ptr;
     rt_size_t dump_i;
 #endif
 
-    if(tx_current->free == RT_FALSE)
+    if (tx_current->free == RT_FALSE)
     {
         NET_DEBUG("[Tx] no empty buffer!\r\n");
-        while(tx_current->free == RT_FALSE)
+        while (tx_current->free == RT_FALSE)
         {
             rt_err_t result;
             rt_uint32_t recved;
@@ -426,8 +426,8 @@ static rt_err_t enc28j60_tx( rt_device_t dev, struct pbuf* p)
     // Set the write pointer to start of transmit buffer area
 //    spi_write(EWRPTL, TXSTART_INIT&0xFF);
 //    spi_write(EWRPTH, TXSTART_INIT>>8);
-    spi_write(spi_device, EWRPTL, (tx_current->addr)&0xFF);
-    spi_write(spi_device, EWRPTH, (tx_current->addr)>>8);
+    spi_write(spi_device, EWRPTL, (tx_current->addr) & 0xFF);
+    spi_write(spi_device, EWRPTH, (tx_current->addr) >> 8);
     // Set the TXND pointer to correspond to the packet size given
     tx_current->len = p->tot_len;
 //    spi_write(ETXNDL, (TXSTART_INIT+ p->tot_len + 1)&0xFF);
@@ -445,14 +445,14 @@ static rt_err_t enc28j60_tx( rt_device_t dev, struct pbuf* p)
         rt_spi_send_then_send(enc28j60->spi_device, &cmd, 1, q->payload, q->len);
 #ifdef ETH_RX_DUMP
         dump_ptr = q->payload;
-        for(dump_i=0; dump_i<q->len; dump_i++)
+        for (dump_i = 0; dump_i < q->len; dump_i++)
         {
             NET_DEBUG("%02x ", *dump_ptr);
-            if( ((dump_count+1)%8) == 0 )
+            if (((dump_count + 1) % 8) == 0)
             {
                 NET_DEBUG("  ");
             }
-            if( ((dump_count+1)%16) == 0 )
+            if (((dump_count + 1) % 16) == 0)
             {
                 NET_DEBUG("\r\n");
             }
@@ -466,15 +466,15 @@ static rt_err_t enc28j60_tx( rt_device_t dev, struct pbuf* p)
 #endif
 
     // send the contents of the transmit buffer onto the network
-    if(tx_current == tx_ack)
+    if (tx_current == tx_ack)
     {
         NET_DEBUG("[Tx] stop, restart!\r\n");
         // TX start
-        spi_write(spi_device, ETXSTL, (tx_current->addr)&0xFF);
-        spi_write(spi_device, ETXSTH, (tx_current->addr)>>8);
+        spi_write(spi_device, ETXSTL, (tx_current->addr) & 0xFF);
+        spi_write(spi_device, ETXSTH, (tx_current->addr) >> 8);
         // TX end
-        spi_write(spi_device, ETXNDL, (tx_current->addr + tx_current->len)&0xFF);
-        spi_write(spi_device, ETXNDH, (tx_current->addr + tx_current->len)>>8);
+        spi_write(spi_device, ETXNDL, (tx_current->addr + tx_current->len) & 0xFF);
+        spi_write(spi_device, ETXNDH, (tx_current->addr + tx_current->len) >> 8);
 
         spi_write_op(spi_device, ENC28J60_BIT_FIELD_SET, ECON1, ECON1_TXRTS);
     }
@@ -487,7 +487,7 @@ static rt_err_t enc28j60_tx( rt_device_t dev, struct pbuf* p)
     tx_current = tx_current->next;
 
     /* Reset the transmit logic problem. See Rev. B4 Silicon Errata point 12. */
-    if( (spi_read(spi_device, EIR) & EIR_TXERIF) )
+    if ((spi_read(spi_device, EIR) & EIR_TXERIF))
     {
         spi_write_op(spi_device, ENC28J60_BIT_FIELD_CLR, ECON1, ECON1_TXRST);
     }
@@ -503,9 +503,9 @@ static rt_err_t enc28j60_tx( rt_device_t dev, struct pbuf* p)
 /* recv packet. */
 static struct pbuf *enc28j60_rx(rt_device_t dev)
 {
-    struct net_device * enc28j60 = (struct net_device *)dev;
-    struct rt_spi_device * spi_device = enc28j60->spi_device;
-    struct pbuf* p = RT_NULL;
+    struct net_device *enc28j60 = (struct net_device *)dev;
+    struct rt_spi_device *spi_device = enc28j60->spi_device;
+    struct pbuf *p = RT_NULL;
 
     uint8_t eir, eir_clr;
     uint32_t pk_counter;
@@ -521,7 +521,7 @@ static struct pbuf *enc28j60_rx(rt_device_t dev)
     /* get EIR */
     eir = spi_read(spi_device, EIR);
 
-    while(eir & ~EIR_PKTIF)
+    while (eir & ~EIR_PKTIF)
     {
         eir_clr = 0;
 
@@ -549,7 +549,7 @@ static struct pbuf *enc28j60_rx(rt_device_t dev)
         }
 
         /* LINK changed handler */
-        if ( eir & EIR_LINKIF)
+        if (eir & EIR_LINKIF)
         {
             rt_bool_t link_status;
 
@@ -573,15 +573,15 @@ static struct pbuf *enc28j60_rx(rt_device_t dev)
 
             tx_ack->free = RT_TRUE;
             tx_ack = tx_ack->next;
-            if(tx_ack->free == RT_FALSE)
+            if (tx_ack->free == RT_FALSE)
             {
                 NET_DEBUG("[tx isr] Tx chain not empty, continue send the next pkt!\r\n");
                 // TX start
-                spi_write(spi_device, ETXSTL, (tx_ack->addr)&0xFF);
-                spi_write(spi_device, ETXSTH, (tx_ack->addr)>>8);
+                spi_write(spi_device, ETXSTL, (tx_ack->addr) & 0xFF);
+                spi_write(spi_device, ETXSTH, (tx_ack->addr) >> 8);
                 // TX end
-                spi_write(spi_device, ETXNDL, (tx_ack->addr + tx_ack->len)&0xFF);
-                spi_write(spi_device, ETXNDH, (tx_ack->addr + tx_ack->len)>>8);
+                spi_write(spi_device, ETXNDL, (tx_ack->addr + tx_ack->len) & 0xFF);
+                spi_write(spi_device, ETXNDH, (tx_ack->addr + tx_ack->len) >> 8);
 
                 spi_write_op(spi_device, ENC28J60_BIT_FIELD_SET, ECON1, ECON1_TXRTS);
             }
@@ -595,7 +595,7 @@ static struct pbuf *enc28j60_rx(rt_device_t dev)
         }
 
         /* wake up handler */
-        if ( eir & EIR_WOLIF)
+        if (eir & EIR_WOLIF)
         {
             NET_DEBUG("EIR_WOLIF\r\n");
             eir_clr |= EIR_WOLIF;
@@ -644,33 +644,33 @@ static struct pbuf *enc28j60_rx(rt_device_t dev)
 
     /* read pkt */
     pk_counter = spi_read(spi_device, EPKTCNT);
-    if(pk_counter)
+    if (pk_counter)
     {
         /* Set the read pointer to the start of the received packet. */
         spi_write(spi_device, ERDPTL, (NextPacketPtr));
-        spi_write(spi_device, ERDPTH, (NextPacketPtr)>>8);
+        spi_write(spi_device, ERDPTH, (NextPacketPtr) >> 8);
 
         /* read the next packet pointer. */
         NextPacketPtr  = spi_read_op(spi_device, ENC28J60_READ_BUF_MEM, 0);
-        NextPacketPtr |= spi_read_op(spi_device, ENC28J60_READ_BUF_MEM, 0)<<8;
+        NextPacketPtr |= spi_read_op(spi_device, ENC28J60_READ_BUF_MEM, 0) << 8;
 
         /* read the packet length (see datasheet page 43). */
-        len  = spi_read_op(spi_device, ENC28J60_READ_BUF_MEM, 0);	    //0x54
-        len |= spi_read_op(spi_device, ENC28J60_READ_BUF_MEM, 0)<<8;	//5554
+        len  = spi_read_op(spi_device, ENC28J60_READ_BUF_MEM, 0);       //0x54
+        len |= spi_read_op(spi_device, ENC28J60_READ_BUF_MEM, 0) << 8;  //5554
 
-        len-=4; //remove the CRC count
+        len -= 4; //remove the CRC count
 
         // read the receive status (see datasheet page 43)
         rxstat  = spi_read_op(spi_device, ENC28J60_READ_BUF_MEM, 0);
-        rxstat |= ((rt_uint16_t)spi_read_op(spi_device, ENC28J60_READ_BUF_MEM, 0))<<8;
+        rxstat |= ((rt_uint16_t)spi_read_op(spi_device, ENC28J60_READ_BUF_MEM, 0)) << 8;
 
         // check CRC and symbol errors (see datasheet page 44, table 7-3):
         // The ERXFCON.CRCEN is set by default. Normally we should not
         // need to check this.
-        if ((rxstat & 0x80)==0)
+        if ((rxstat & 0x80) == 0)
         {
             // invalid
-            len=0;
+            len = 0;
         }
         else
         {
@@ -678,27 +678,27 @@ static struct pbuf *enc28j60_rx(rt_device_t dev)
             p = pbuf_alloc(PBUF_LINK, len, PBUF_POOL);
             if (p != RT_NULL)
             {
-                struct pbuf* q;
+                struct pbuf *q;
 #ifdef ETH_RX_DUMP
                 rt_size_t dump_count = 0;
-                rt_uint8_t * dump_ptr;
+                rt_uint8_t *dump_ptr;
                 rt_size_t dump_i;
                 NET_DEBUG("rx_dump, size:%d\r\n", len);
 #endif
-                for (q = p; q != RT_NULL; q= q->next)
+                for (q = p; q != RT_NULL; q = q->next)
                 {
                     uint8_t cmd = ENC28J60_READ_BUF_MEM;
                     rt_spi_send_then_recv(spi_device, &cmd, 1, q->payload, q->len);
 #ifdef ETH_RX_DUMP
                     dump_ptr = q->payload;
-                    for(dump_i=0; dump_i<q->len; dump_i++)
+                    for (dump_i = 0; dump_i < q->len; dump_i++)
                     {
                         NET_DEBUG("%02x ", *dump_ptr);
-                        if( ((dump_count+1)%8) == 0 )
+                        if (((dump_count + 1) % 8) == 0)
                         {
                             NET_DEBUG("  ");
                         }
-                        if( ((dump_count+1)%16) == 0 )
+                        if (((dump_count + 1) % 16) == 0)
                         {
                             NET_DEBUG("\r\n");
                         }
@@ -716,7 +716,7 @@ static struct pbuf *enc28j60_rx(rt_device_t dev)
         /* Move the RX read pointer to the start of the next received packet. */
         /* This frees the memory we just read out. */
         spi_write(spi_device, ERXRDPTL, (NextPacketPtr));
-        spi_write(spi_device, ERXRDPTH, (NextPacketPtr)>>8);
+        spi_write(spi_device, ERXRDPTH, (NextPacketPtr) >> 8);
 
         /* decrement the packet counter indicate we are done with this packet. */
         spi_write_op(spi_device, ENC28J60_BIT_FIELD_SET, ECON2, ECON2_PKTDEC);
@@ -739,12 +739,12 @@ static struct pbuf *enc28j60_rx(rt_device_t dev)
     return p;
 }
 
-rt_err_t enc28j60_attach(const char * spi_device_name)
+rt_err_t enc28j60_attach(const char *spi_device_name)
 {
-    struct rt_spi_device * spi_device;
+    struct rt_spi_device *spi_device;
 
     spi_device = (struct rt_spi_device *)rt_device_find(spi_device_name);
-    if(spi_device == RT_NULL)
+    if (spi_device == RT_NULL)
     {
         NET_DEBUG("spi device %s not found!\r\n", spi_device_name);
         return -RT_ENOSYS;
@@ -774,11 +774,11 @@ rt_err_t enc28j60_attach(const char * spi_device_name)
 
         enc28j60_dev.emac_rev = spi_read(spi_device, EREVID);
         value = enc28j60_phy_read(spi_device, PHHID2);
-        enc28j60_dev.phy_rev = value&0x0F;
-        enc28j60_dev.phy_pn = (value>>4)&0x3F;
-        enc28j60_dev.phy_id = (enc28j60_phy_read(spi_device, PHHID1) | ((value>>10)<<16))<<3;
+        enc28j60_dev.phy_rev = value & 0x0F;
+        enc28j60_dev.phy_pn = (value >> 4) & 0x3F;
+        enc28j60_dev.phy_id = (enc28j60_phy_read(spi_device, PHHID1) | ((value >> 10) << 16)) << 3;
 
-        if(enc28j60_dev.phy_id != 0x00280418)
+        if (enc28j60_dev.phy_id != 0x00280418)
         {
             NET_DEBUG("ENC28J60 PHY ID not correct!\r\n");
             NET_DEBUG("emac_rev:%d\r\n", enc28j60_dev.emac_rev);
@@ -825,7 +825,7 @@ rt_err_t enc28j60_attach(const char * spi_device_name)
  */
 static void enc28j60(void)
 {
-    struct rt_spi_device * spi_device = enc28j60_dev.spi_device;
+    struct rt_spi_device *spi_device = enc28j60_dev.spi_device;
     enc28j60_lock(&enc28j60_dev);
 
     rt_kprintf("-- enc28j60 registers:\n");

--- a/components/drivers/spi/enc28j60.h
+++ b/components/drivers/spi/enc28j60.h
@@ -121,112 +121,112 @@
 #define PHLCON           0x14
 
 // ENC28J60 ERXFCON Register Bit Definitions
-#define ERXFCON_UCEN     0x80
-#define ERXFCON_ANDOR    0x40
-#define ERXFCON_CRCEN    0x20
-#define ERXFCON_PMEN     0x10
-#define ERXFCON_MPEN     0x08
-#define ERXFCON_HTEN     0x04
-#define ERXFCON_MCEN     0x02
-#define ERXFCON_BCEN     0x01
+#define ERXFCON_UCEN        0x80
+#define ERXFCON_ANDOR       0x40
+#define ERXFCON_CRCEN       0x20
+#define ERXFCON_PMEN        0x10
+#define ERXFCON_MPEN        0x08
+#define ERXFCON_HTEN        0x04
+#define ERXFCON_MCEN        0x02
+#define ERXFCON_BCEN        0x01
 // ENC28J60 EIE Register Bit Definitions
-#define EIE_INTIE        0x80
-#define EIE_PKTIE        0x40
-#define EIE_DMAIE        0x20
-#define EIE_LINKIE       0x10
-#define EIE_TXIE         0x08
-#define EIE_WOLIE        0x04
-#define EIE_TXERIE       0x02
-#define EIE_RXERIE       0x01
+#define EIE_INTIE           0x80
+#define EIE_PKTIE           0x40
+#define EIE_DMAIE           0x20
+#define EIE_LINKIE          0x10
+#define EIE_TXIE            0x08
+#define EIE_WOLIE           0x04
+#define EIE_TXERIE          0x02
+#define EIE_RXERIE          0x01
 // ENC28J60 EIR Register Bit Definitions
-#define EIR_PKTIF        0x40
-#define EIR_DMAIF        0x20
-#define EIR_LINKIF       0x10
-#define EIR_TXIF         0x08
-#define EIR_WOLIF        0x04
-#define EIR_TXERIF       0x02
-#define EIR_RXERIF       0x01
+#define EIR_PKTIF           0x40
+#define EIR_DMAIF           0x20
+#define EIR_LINKIF          0x10
+#define EIR_TXIF            0x08
+#define EIR_WOLIF           0x04
+#define EIR_TXERIF          0x02
+#define EIR_RXERIF          0x01
 // ENC28J60 ESTAT Register Bit Definitions
-#define ESTAT_INT        0x80
-#define ESTAT_LATECOL    0x10
-#define ESTAT_RXBUSY     0x04
-#define ESTAT_TXABRT     0x02
-#define ESTAT_CLKRDY     0x01
+#define ESTAT_INT           0x80
+#define ESTAT_LATECOL       0x10
+#define ESTAT_RXBUSY        0x04
+#define ESTAT_TXABRT        0x02
+#define ESTAT_CLKRDY        0x01
 // ENC28J60 ECON2 Register Bit Definitions
-#define ECON2_AUTOINC    0x80
-#define ECON2_PKTDEC     0x40
-#define ECON2_PWRSV      0x20
-#define ECON2_VRPS       0x08
+#define ECON2_AUTOINC       0x80
+#define ECON2_PKTDEC        0x40
+#define ECON2_PWRSV         0x20
+#define ECON2_VRPS          0x08
 // ENC28J60 ECON1 Register Bit Definitions
-#define ECON1_TXRST      0x80
-#define ECON1_RXRST      0x40
-#define ECON1_DMAST      0x20
-#define ECON1_CSUMEN     0x10
-#define ECON1_TXRTS      0x08
-#define ECON1_RXEN       0x04
-#define ECON1_BSEL1      0x02
-#define ECON1_BSEL0      0x01
+#define ECON1_TXRST         0x80
+#define ECON1_RXRST         0x40
+#define ECON1_DMAST         0x20
+#define ECON1_CSUMEN        0x10
+#define ECON1_TXRTS         0x08
+#define ECON1_RXEN          0x04
+#define ECON1_BSEL1         0x02
+#define ECON1_BSEL0         0x01
 // ENC28J60 MACON1 Register Bit Definitions
-#define MACON1_LOOPBK    0x10
-#define MACON1_TXPAUS    0x08
-#define MACON1_RXPAUS    0x04
-#define MACON1_PASSALL   0x02
-#define MACON1_MARXEN    0x01
+#define MACON1_LOOPBK       0x10
+#define MACON1_TXPAUS       0x08
+#define MACON1_RXPAUS       0x04
+#define MACON1_PASSALL      0x02
+#define MACON1_MARXEN       0x01
 // ENC28J60 MACON2 Register Bit Definitions
-#define MACON2_MARST     0x80
-#define MACON2_RNDRST    0x40
-#define MACON2_MARXRST   0x08
-#define MACON2_RFUNRST   0x04
-#define MACON2_MATXRST   0x02
-#define MACON2_TFUNRST   0x01
+#define MACON2_MARST        0x80
+#define MACON2_RNDRST       0x40
+#define MACON2_MARXRST      0x08
+#define MACON2_RFUNRST      0x04
+#define MACON2_MATXRST      0x02
+#define MACON2_TFUNRST      0x01
 // ENC28J60 MACON3 Register Bit Definitions
-#define MACON3_PADCFG2   0x80
-#define MACON3_PADCFG1   0x40
-#define MACON3_PADCFG0   0x20
-#define MACON3_TXCRCEN   0x10
-#define MACON3_PHDRLEN   0x08
-#define MACON3_HFRMLEN   0x04
-#define MACON3_FRMLNEN   0x02
-#define MACON3_FULDPX    0x01
+#define MACON3_PADCFG2      0x80
+#define MACON3_PADCFG1      0x40
+#define MACON3_PADCFG0      0x20
+#define MACON3_TXCRCEN      0x10
+#define MACON3_PHDRLEN      0x08
+#define MACON3_HFRMLEN      0x04
+#define MACON3_FRMLNEN      0x02
+#define MACON3_FULDPX       0x01
 // ENC28J60 MACON4 Register Bit Definitions
-#define	MACON4_DEFER	(1<<6)
-#define	MACON4_BPEN		(1<<5)
-#define	MACON4_NOBKOFF	(1<<4)
+#define MACON4_DEFER        (1<<6)
+#define MACON4_BPEN         (1<<5)
+#define MACON4_NOBKOFF      (1<<4)
 // ENC28J60 MICMD Register Bit Definitions
-#define MICMD_MIISCAN    0x02
-#define MICMD_MIIRD      0x01
+#define MICMD_MIISCAN       0x02
+#define MICMD_MIIRD         0x01
 // ENC28J60 MISTAT Register Bit Definitions
-#define MISTAT_NVALID    0x04
-#define MISTAT_SCAN      0x02
-#define MISTAT_BUSY      0x01
+#define MISTAT_NVALID       0x04
+#define MISTAT_SCAN         0x02
+#define MISTAT_BUSY         0x01
 // ENC28J60 PHY PHCON1 Register Bit Definitions
-#define PHCON1_PRST      0x8000
-#define PHCON1_PLOOPBK   0x4000
-#define PHCON1_PPWRSV    0x0800
-#define PHCON1_PDPXMD    0x0100
+#define PHCON1_PRST         0x8000
+#define PHCON1_PLOOPBK      0x4000
+#define PHCON1_PPWRSV       0x0800
+#define PHCON1_PDPXMD       0x0100
 // ENC28J60 PHY PHSTAT1 Register Bit Definitions
-#define PHSTAT1_PFDPX    0x1000
-#define PHSTAT1_PHDPX    0x0800
-#define PHSTAT1_LLSTAT   0x0004
-#define PHSTAT1_JBSTAT   0x0002
+#define PHSTAT1_PFDPX       0x1000
+#define PHSTAT1_PHDPX       0x0800
+#define PHSTAT1_LLSTAT      0x0004
+#define PHSTAT1_JBSTAT      0x0002
 /* ENC28J60 PHY PHSTAT2 Register Bit Definitions */
-#define PHSTAT2_TXSTAT	(1 << 13)
-#define PHSTAT2_RXSTAT	(1 << 12)
-#define PHSTAT2_COLSTAT	(1 << 11)
-#define PHSTAT2_LSTAT	(1 << 10)
-#define PHSTAT2_DPXSTAT	(1 << 9)
-#define PHSTAT2_PLRITY	(1 << 5)
+#define PHSTAT2_TXSTAT      (1 << 13)
+#define PHSTAT2_RXSTAT      (1 << 12)
+#define PHSTAT2_COLSTAT     (1 << 11)
+#define PHSTAT2_LSTAT       (1 << 10)
+#define PHSTAT2_DPXSTAT     (1 << 9)
+#define PHSTAT2_PLRITY      (1 << 5)
 // ENC28J60 PHY PHCON2 Register Bit Definitions
-#define PHCON2_FRCLINK   0x4000
-#define PHCON2_TXDIS     0x2000
-#define PHCON2_JABBER    0x0400
-#define PHCON2_HDLDIS    0x0100
+#define PHCON2_FRCLINK      0x4000
+#define PHCON2_TXDIS        0x2000
+#define PHCON2_JABBER       0x0400
+#define PHCON2_HDLDIS       0x0100
 
 // ENC28J60 Packet Control Byte Bit Definitions
-#define PKTCTRL_PHUGEEN  0x08
-#define PKTCTRL_PPADEN   0x04
-#define PKTCTRL_PCRCEN   0x02
-#define PKTCTRL_POVERRIDE 0x01
+#define PKTCTRL_PHUGEEN     0x08
+#define PKTCTRL_PPADEN      0x04
+#define PKTCTRL_PCRCEN      0x02
+#define PKTCTRL_POVERRIDE   0x01
 
 /* ENC28J60 Transmit Status Vector */
 #define TSV_TXBYTECNT           0
@@ -290,40 +290,40 @@
 #define MAX_TX_PACKAGE_SIZE    (1536)
 
 // start with recbuf at 0/
-#define RXSTART_INIT	0x0
+#define RXSTART_INIT    0x0
 // receive buffer end
-#define RXSTOP_INIT		(0x1FFF - MAX_TX_PACKAGE_SIZE*2) - 1
+#define RXSTOP_INIT     (0x1FFF - MAX_TX_PACKAGE_SIZE*2) - 1
 // start TX buffer at 0x1FFF-0x0600, pace for one full ethernet frame (~1500 bytes)
 
-#define TXSTART_INIT	(0x1FFF - MAX_TX_PACKAGE_SIZE*2)
+#define TXSTART_INIT    (0x1FFF - MAX_TX_PACKAGE_SIZE*2)
 // stp TX buffer at end of mem
-#define TXSTOP_INIT		0x1FFF
+#define TXSTOP_INIT     0x1FFF
 
 // max frame length which the conroller will accept:
-#define MAX_FRAMELEN	1518
+#define MAX_FRAMELEN    1518
 
 #define MAX_ADDR_LEN    6
 
 struct net_device
 {
-	/* inherit from ethernet device */
-	struct eth_device parent;
+    /* inherit from ethernet device */
+    struct eth_device parent;
 
-	/* interface address info. */
-	rt_uint8_t  dev_addr[MAX_ADDR_LEN]; /* hw address	*/
+    /* interface address info. */
+    rt_uint8_t  dev_addr[MAX_ADDR_LEN]; /* hw address   */
 
-	rt_uint8_t emac_rev;
-	rt_uint8_t phy_rev;
-	rt_uint8_t phy_pn;
-	rt_uint32_t phy_id;
+    rt_uint8_t emac_rev;
+    rt_uint8_t phy_rev;
+    rt_uint8_t phy_pn;
+    rt_uint32_t phy_id;
 
-	/* spi device */
-	struct rt_spi_device * spi_device;
-	struct rt_mutex lock;
+    /* spi device */
+    struct rt_spi_device *spi_device;
+    struct rt_mutex lock;
 };
 
 /* export function */
-extern rt_err_t enc28j60_attach(const char * spi_device_name);
+extern rt_err_t enc28j60_attach(const char *spi_device_name);
 extern void enc28j60_isr(void);
 
 #endif // EN28J60_H_INCLUDED

--- a/components/drivers/spi/enc28j60.h
+++ b/components/drivers/spi/enc28j60.h
@@ -221,6 +221,12 @@
 #define PHCON2_TXDIS        0x2000
 #define PHCON2_JABBER       0x0400
 #define PHCON2_HDLDIS       0x0100
+/* ENC28J60 PHY PHIE Register Bit Definitions */
+#define PHIE_PLNKIE         (1 << 4)
+#define PHIE_PGEIE          (1 << 1)
+/* ENC28J60 PHY PHIR Register Bit Definitions */
+#define PHIR_PLNKIF         (1 << 4)
+#define PHIR_PGEIF          (1 << 1)
 
 // ENC28J60 Packet Control Byte Bit Definitions
 #define PKTCTRL_PHUGEEN     0x08


### PR DESCRIPTION
ENC28J60的LINK中断，除中断控制寄存EIE外，还受PHY里面的PHIE寄存器控制，需要明确使能。