### PR TITLE
[bsp][imxrt1052]update ctors/dtors sections to fix link error with RT_USING_CPLUSPLUS

### DIFF
--- a/bsp/imxrt1052-evk/Libraries/gcc/MIMXRT1052xxxxx_flexspi_nor.ld
+++ b/bsp/imxrt1052-evk/Libraries/gcc/MIMXRT1052xxxxx_flexspi_nor.ld
@@ -139,7 +139,8 @@ SECTIONS
 
  .ctors :
   {
-    __CTOR_LIST__ = .;
+    PROVIDE(__ctors_start__ = .);
+    /* __CTOR_LIST__ = .; */
     /* gcc uses crtbegin.o to find the start of
        the constructors, so we make sure it is
        first.  Because this is a wildcard, it
@@ -158,18 +159,21 @@ SECTIONS
     KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
     KEEP (*(SORT(.ctors.*)))
     KEEP (*(.ctors))
-    __CTOR_END__ = .;
+    /* __CTOR_END__ = .; */
+    PROVIDE(__ctors_end__ = .);
   } > m_text
 
   .dtors :
   {
-    __DTOR_LIST__ = .;
+    PROVIDE(__dtors_start__ = .);
+    /* __DTOR_LIST__ = .; */
     KEEP (*crtbegin.o(.dtors))
     KEEP (*crtbegin?.o(.dtors))
     KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
     KEEP (*(SORT(.dtors.*)))
     KEEP (*(.dtors))
-    __DTOR_END__ = .;
+    /* __DTOR_END__ = .; */
+    PROVIDE(__dtors_end__ = .);
   } > m_text
 
   .preinit_array :

--- a/bsp/imxrt1052-evk/Libraries/gcc/MIMXRT1052xxxxx_ram.ld
+++ b/bsp/imxrt1052-evk/Libraries/gcc/MIMXRT1052xxxxx_ram.ld
@@ -126,7 +126,8 @@ SECTIONS
 
  .ctors :
   {
-    __CTOR_LIST__ = .;
+    PROVIDE(__ctors_start__ = .);
+    /* __CTOR_LIST__ = .; */
     /* gcc uses crtbegin.o to find the start of
        the constructors, so we make sure it is
        first.  Because this is a wildcard, it
@@ -145,18 +146,21 @@ SECTIONS
     KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
     KEEP (*(SORT(.ctors.*)))
     KEEP (*(.ctors))
-    __CTOR_END__ = .;
+    /* __CTOR_END__ = .; */
+    PROVIDE(__ctors_end__ = .);
   } > m_text
 
   .dtors :
   {
-    __DTOR_LIST__ = .;
+    PROVIDE(__dtors_start__ = .);
+    /* __DTOR_LIST__ = .; */
     KEEP (*crtbegin.o(.dtors))
     KEEP (*crtbegin?.o(.dtors))
     KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
     KEEP (*(SORT(.dtors.*)))
     KEEP (*(.dtors))
-    __DTOR_END__ = .;
+    /* __DTOR_END__ = .; */
+    PROVIDE(__dtors_end__ = .);
   } > m_text
 
   .preinit_array :

--- a/bsp/imxrt1052-evk/Libraries/gcc/MIMXRT1052xxxxx_sdram.ld
+++ b/bsp/imxrt1052-evk/Libraries/gcc/MIMXRT1052xxxxx_sdram.ld
@@ -104,7 +104,8 @@ SECTIONS
 
  .ctors :
   {
-    __CTOR_LIST__ = .;
+    PROVIDE(__ctors_start__ = .);
+    /* __CTOR_LIST__ = .; */
     /* gcc uses crtbegin.o to find the start of
        the constructors, so we make sure it is
        first.  Because this is a wildcard, it
@@ -123,18 +124,21 @@ SECTIONS
     KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
     KEEP (*(SORT(.ctors.*)))
     KEEP (*(.ctors))
-    __CTOR_END__ = .;
+    /* __CTOR_END__ = .; */
+    PROVIDE(__ctors_end__ = .);
   } > m_text
 
   .dtors :
   {
-    __DTOR_LIST__ = .;
+    PROVIDE(__dtors_start__ = .);
+    /* __DTOR_LIST__ = .; */
     KEEP (*crtbegin.o(.dtors))
     KEEP (*crtbegin?.o(.dtors))
     KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
     KEEP (*(SORT(.dtors.*)))
     KEEP (*(.dtors))
-    __DTOR_END__ = .;
+    /* __DTOR_END__ = .; */
+    PROVIDE(__dtors_end__ = .);
   } > m_text
 
   .preinit_array :

--- a/bsp/imxrt1052-evk/Libraries/gcc/MIMXRT1052xxxxx_sdram_txt.ld
+++ b/bsp/imxrt1052-evk/Libraries/gcc/MIMXRT1052xxxxx_sdram_txt.ld
@@ -104,7 +104,8 @@ SECTIONS
 
  .ctors :
   {
-    __CTOR_LIST__ = .;
+    PROVIDE(__ctors_start__ = .);
+    /* __CTOR_LIST__ = .; */
     /* gcc uses crtbegin.o to find the start of
        the constructors, so we make sure it is
        first.  Because this is a wildcard, it
@@ -123,18 +124,21 @@ SECTIONS
     KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors))
     KEEP (*(SORT(.ctors.*)))
     KEEP (*(.ctors))
-    __CTOR_END__ = .;
+    /* __CTOR_END__ = .; */
+    PROVIDE(__ctors_end__ = .);
   } > m_text
 
   .dtors :
   {
-    __DTOR_LIST__ = .;
+    PROVIDE(__dtors_start__ = .);
+    /* __DTOR_LIST__ = .; */
     KEEP (*crtbegin.o(.dtors))
     KEEP (*crtbegin?.o(.dtors))
     KEEP (*(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors))
     KEEP (*(SORT(.dtors.*)))
     KEEP (*(.dtors))
-    __DTOR_END__ = .;
+    /* __DTOR_END__ = .; */
+    PROVIDE(__dtors_end__ = .);
   } > m_text
 
   .preinit_array :


### PR DESCRIPTION
When using gcc compiler and configuring RT-Thread with "Support C++ features" (RT_USING_CPLUSPLUS), the final link step will report errors as below:

LINK rtthread-imxrt.elf
build\kernel\components\cplusplus\crt_init.o: In function 'cplusplus_system_init':
crt_init.c:(.text.cplusplus_system_init+0x18): undefined reference to '__ctors_start__'
crt_init.c:(.text.cplusplus_system_init+0x1c): undefined reference to '__ctors_end__'
collect2.exe: error: ld returned 1 exit status
scons: *** [rtthread-imxrt.elf] Error 1

According to the RT-Thread C++ rules defined in 'crt_init.c', we should supply these symbols in link script files.