### PR TITLE
[BSP][RT1050] improve sdio stability and speed. | 优化SDIO接口稳定性和速度.

### DIFF
--- a/bsp/imxrt1052-evk/drivers/drv_sdio.c
+++ b/bsp/imxrt1052-evk/drivers/drv_sdio.c
@@ -20,6 +20,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2017-10-10     Tanek        first version
+ * 2018-05-07     Liu2guang    Improve sdio stability and speed
  */
 
 #include <rtthread.h>
@@ -51,13 +52,13 @@ static int enable_log = 1;
 #else
 #define MMCSD_DGB(fmt, ...)
 #endif
-        
+
 #define CACHE_LINESIZE              (32)
 
 #define USDHC_ADMA_TABLE_WORDS      (8U)        /* define the ADMA descriptor table length */
 #define USDHC_ADMA2_ADDR_ALIGN      (4U)        /* define the ADMA2 descriptor table addr align size */
-#define IMXRT_MAX_FREQ              (25UL * 1000UL * 1000UL)
-    
+#define IMXRT_MAX_FREQ              (30 * 1000UL * 1000UL)
+
 #define USDHC_ADMA_TABLE_WORDS      (8U)        /* define the ADMA descriptor table length */
 #define USDHC_ADMA2_ADDR_ALIGN      (4U)        /* define the ADMA2 descriptor table addr align size */
 #define USDHC_READ_BURST_LEN        (8U)        /*!< number of words USDHC read in a single burst */
@@ -73,32 +74,33 @@ static int enable_log = 1;
 
 /* Endian mode. */
 #define USDHC_ENDIAN_MODE kUSDHC_EndianModeLittle
-        
+
 ALIGN(USDHC_ADMA2_ADDR_ALIGN) uint32_t g_usdhcAdma2Table[USDHC_ADMA_TABLE_WORDS] SECTION("NonCacheable");
 
-struct imxrt_mmcsd {
-	struct rt_mmcsd_host *host;
-	struct rt_mmcsd_req *req;
-	struct rt_mmcsd_cmd *cmd;
-    
-	struct rt_timer timer;
-    
-	rt_uint32_t *buf;
-    
+struct imxrt_mmcsd
+{
+    struct rt_mmcsd_host *host;
+    struct rt_mmcsd_req *req;
+    struct rt_mmcsd_cmd *cmd;
+
+    struct rt_timer timer;
+
+    rt_uint32_t *buf;
+
     //USDHC_Type *base;
     usdhc_host_t usdhc_host;
     clock_div_t usdhc_div;
     clock_ip_name_t ip_clock;
-    
+
     uint32_t *usdhc_adma2_table;
 };
 
-static void _mmcsd_gpio_init(struct imxrt_mmcsd * mmcsd)
+static void _mmcsd_gpio_init(struct imxrt_mmcsd *mmcsd)
 {
     gpio_pin_config_t sw_config;
 
     CLOCK_EnableClock(kCLOCK_Iomuxc);          /* iomuxc clock (iomuxc_clk_enable): 0x03u */
-    
+
 #ifdef RT_USING_SDIO1
     if (mmcsd->usdhc_host.base == USDHC1)
     {
@@ -112,55 +114,55 @@ static void _mmcsd_gpio_init(struct imxrt_mmcsd * mmcsd)
         /* voltage select PIN */
         IOMUXC_SetPinMux(IOMUXC_GPIO_B1_14_USDHC1_VSELECT, 0);
 
-         /* card detect PIN */
+        /* card detect PIN */
         IOMUXC_SetPinMux(IOMUXC_GPIO_B1_12_GPIO2_IO28, 0);
         /* power reset pin */
         IOMUXC_SetPinMux(IOMUXC_GPIO_AD_B0_05_GPIO1_IO05, 0);
 
         IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B0_00_USDHC1_CMD, IOMUXC_SW_PAD_CTL_PAD_SRE_MASK | IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
-                                                           IOMUXC_SW_PAD_CTL_PAD_PUE_MASK | IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
-                                                           IOMUXC_SW_PAD_CTL_PAD_SPEED(2) | IOMUXC_SW_PAD_CTL_PAD_PUS(1) |
-                                                           IOMUXC_SW_PAD_CTL_PAD_DSE(1));
+                            IOMUXC_SW_PAD_CTL_PAD_PUE_MASK | IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_SPEED(2) | IOMUXC_SW_PAD_CTL_PAD_PUS(1) |
+                            IOMUXC_SW_PAD_CTL_PAD_DSE(1));
         IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B0_01_USDHC1_CLK, IOMUXC_SW_PAD_CTL_PAD_SRE_MASK | IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
-                                                           IOMUXC_SW_PAD_CTL_PAD_SPEED(1) | IOMUXC_SW_PAD_CTL_PAD_PUS(1) |
-                                                           IOMUXC_SW_PAD_CTL_PAD_DSE(1));
+                            IOMUXC_SW_PAD_CTL_PAD_SPEED(1) | IOMUXC_SW_PAD_CTL_PAD_PUS(1) |
+                            IOMUXC_SW_PAD_CTL_PAD_DSE(1));
         IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B0_02_USDHC1_DATA0, IOMUXC_SW_PAD_CTL_PAD_SRE_MASK | IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(1));
+                            IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
+                            IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(1));
 
         IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B0_03_USDHC1_DATA1, IOMUXC_SW_PAD_CTL_PAD_SRE_MASK | IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(1));
+                            IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
+                            IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(1));
 
         IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B0_04_USDHC1_DATA2, IOMUXC_SW_PAD_CTL_PAD_SRE_MASK | IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(1));
+                            IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
+                            IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(1));
 
         IOMUXC_SetPinConfig(IOMUXC_GPIO_SD_B0_05_USDHC1_DATA3, IOMUXC_SW_PAD_CTL_PAD_SRE_MASK | IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(1));
+                            IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
+                            IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(1));
 
         /*voltage select pin*/
         IOMUXC_SetPinConfig(IOMUXC_GPIO_B1_14_USDHC1_VSELECT, IOMUXC_SW_PAD_CTL_PAD_SRE_MASK | IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(4));
+                            IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
+                            IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(4));
 
         IOMUXC_SetPinConfig(IOMUXC_GPIO_B1_12_GPIO2_IO28, IOMUXC_SW_PAD_CTL_PAD_SRE_MASK | IOMUXC_SW_PAD_CTL_PAD_PKE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
-                                                               IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
-                                                               IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(1));
-        
+                            IOMUXC_SW_PAD_CTL_PAD_PUE_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_HYS_MASK |
+                            IOMUXC_SW_PAD_CTL_PAD_SPEED(2) |
+                            IOMUXC_SW_PAD_CTL_PAD_PUS(1) | IOMUXC_SW_PAD_CTL_PAD_DSE(1));
+
         sw_config.direction = kGPIO_DigitalOutput;
         sw_config.outputLogic = 0;
         sw_config.interruptMode = kGPIO_NoIntmode;
@@ -172,12 +174,12 @@ static void _mmcsd_gpio_init(struct imxrt_mmcsd * mmcsd)
 #endif
 
 #ifdef RT_USING_SDIO2
-    if (mmcsd->usdhc_host.base == USDHC2)
-    {
-        // todo
-    }
+        if (mmcsd->usdhc_host.base == USDHC2)
+        {
+            // todo
+        }
 #endif
-    
+
 }
 
 static void SDMMCHOST_ErrorRecovery(USDHC_Type *base)
@@ -199,10 +201,10 @@ static void SDMMCHOST_ErrorRecovery(USDHC_Type *base)
     }
 }
 
-static void _mmcsd_host_init(struct imxrt_mmcsd * mmcsd)
+static void _mmcsd_host_init(struct imxrt_mmcsd *mmcsd)
 {
     usdhc_host_t *usdhc_host = &mmcsd->usdhc_host;
-    
+
     /* Initializes SDHC. */
     usdhc_host->config.dataTimeout = USDHC_DATA_TIMEOUT;
     usdhc_host->config.endianMode = USDHC_ENDIAN_MODE;
@@ -214,57 +216,57 @@ static void _mmcsd_host_init(struct imxrt_mmcsd * mmcsd)
     USDHC_Init(usdhc_host->base, &(usdhc_host->config));
 }
 
-static void _mmcsd_clk_init(struct imxrt_mmcsd * mmcsd)
+static void _mmcsd_clk_init(struct imxrt_mmcsd *mmcsd)
 {
     CLOCK_EnableClock(mmcsd->ip_clock);
-    CLOCK_SetDiv(mmcsd->usdhc_div, 0U);
+    CLOCK_SetDiv(mmcsd->usdhc_div, 5U);
 }
 
-static void _mmcsd_isr_init(struct imxrt_mmcsd * mmcsd)
+static void _mmcsd_isr_init(struct imxrt_mmcsd *mmcsd)
 {
     //NVIC_SetPriority(USDHC1_IRQn, 5U);
 }
 
 static void _mmc_request(struct rt_mmcsd_host *host, struct rt_mmcsd_req *req)
 {
-    struct imxrt_mmcsd * mmcsd;
-    struct rt_mmcsd_cmd * cmd;
-    struct rt_mmcsd_data * data;
+    struct imxrt_mmcsd *mmcsd;
+    struct rt_mmcsd_cmd *cmd;
+    struct rt_mmcsd_data *data;
     status_t error;
     usdhc_adma_config_t dmaConfig;
     usdhc_transfer_t fsl_content = {0};
     usdhc_command_t fsl_command = {0};
     usdhc_data_t fsl_data = {0};
-    rt_uint32_t * buf = NULL;
+    rt_uint32_t *buf = NULL;
 
     RT_ASSERT(host != RT_NULL);
     RT_ASSERT(req != RT_NULL);
-    
+
     mmcsd = (struct imxrt_mmcsd *)host->private_data;
     RT_ASSERT(mmcsd != RT_NULL);
-    
+
     cmd = req->cmd;
     RT_ASSERT(cmd != RT_NULL);
-    
+
     MMCSD_DGB("\tcmd->cmd_code: %02d, cmd->arg: %08x, cmd->flags: %08x --> ", cmd->cmd_code, cmd->arg, cmd->flags);
-    
+
     data = cmd->data;
-        
+
     memset(&dmaConfig, 0, sizeof(usdhc_adma_config_t));
     /* config adma */
     dmaConfig.dmaMode = USDHC_DMA_MODE;
     dmaConfig.burstLen = kUSDHC_EnBurstLenForINCR;
     dmaConfig.admaTable = mmcsd->usdhc_adma2_table;
     dmaConfig.admaTableWords = USDHC_ADMA_TABLE_WORDS;
-    
+
     fsl_command.index = cmd->cmd_code;
     fsl_command.argument = cmd->arg;
-    
+
     if (cmd->cmd_code == STOP_TRANSMISSION)
         fsl_command.type = kCARD_CommandTypeAbort;
     else
         fsl_command.type = kCARD_CommandTypeNormal;
-    
+
     switch (cmd->flags & RESP_MASK)
     {
     case RESP_NONE:
@@ -294,16 +296,16 @@ static void _mmc_request(struct rt_mmcsd_host *host, struct rt_mmcsd_req *req)
     case RESP_R5:
         fsl_command.responseType = kCARD_ResponseTypeR5;
         break;
-    /*
-    case RESP_R5B:
-        fsl_command.responseType = kCARD_ResponseTypeR5b;
-        break;
-    */
+        /*
+        case RESP_R5B:
+            fsl_command.responseType = kCARD_ResponseTypeR5b;
+            break;
+        */
     default:
         RT_ASSERT(NULL);
     }
-    
-    // command type 
+
+    // command type
     /*
     switch (cmd->flags & CMD_MASK)
     {
@@ -317,13 +319,13 @@ static void _mmc_request(struct rt_mmcsd_host *host, struct rt_mmcsd_req *req)
         break;
     }
     */
-    
+
     fsl_command.flags = 0;
     //fsl_command.response
     //fsl_command.responseErrorFlags
-    
+
     fsl_content.command = &fsl_command;
-    
+
     if (data)
     {
         if (req->stop != NULL)
@@ -335,23 +337,23 @@ static void _mmc_request(struct rt_mmcsd_host *host, struct rt_mmcsd_req *req)
 
         fsl_data.enableIgnoreError = false;
         fsl_data.dataType = kUSDHC_TransferDataNormal;  //todo : update data type
-        fsl_data.blockSize = data->blksize;  
+        fsl_data.blockSize = data->blksize;
         fsl_data.blockCount = data->blks;
-        
+
         MMCSD_DGB(" blksize:%d, blks:%d ", fsl_data.blockSize, fsl_data.blockCount);
-        
+
         if (((rt_uint32_t)data->buf & (CACHE_LINESIZE - 1)) ||         // align cache(32byte)
-            ((rt_uint32_t)data->buf >  0x00000000 && (rt_uint32_t)data->buf < 0x00080000) /*||  // ITCM
+                ((rt_uint32_t)data->buf >  0x00000000 && (rt_uint32_t)data->buf < 0x00080000) /*||  // ITCM
             ((rt_uint32_t)data->buf >= 0x20000000 && (rt_uint32_t)data->buf < 0x20080000)*/)    // DTCM
         {
-            
+
             buf = rt_malloc_align(fsl_data.blockSize * fsl_data.blockCount, CACHE_LINESIZE);
             RT_ASSERT(buf != RT_NULL);
-            
+
             MMCSD_DGB(" malloc buf: %p, data->buf:%p, %d ", buf, data->buf, fsl_data.blockSize * fsl_data.blockCount);
         }
 
-        
+
         if ((cmd->cmd_code == WRITE_BLOCK) || (cmd->cmd_code == WRITE_MULTIPLE_BLOCK))
         {
             if (buf)
@@ -364,8 +366,8 @@ static void _mmc_request(struct rt_mmcsd_host *host, struct rt_mmcsd_req *req)
             {
                 fsl_data.txData = (uint32_t const *)data->buf;
             }
-            
-            fsl_data.rxData = NULL;            
+
+            fsl_data.rxData = NULL;
         }
         else
         {
@@ -377,17 +379,17 @@ static void _mmc_request(struct rt_mmcsd_host *host, struct rt_mmcsd_req *req)
             {
                 fsl_data.rxData = (uint32_t *)data->buf;
             }
-            
+
             fsl_data.txData = NULL;
         }
-        
+
         fsl_content.data = &fsl_data;
-    } 
+    }
     else
     {
         fsl_content.data = NULL;
     }
-    
+
     error = USDHC_TransferBlocking(mmcsd->usdhc_host.base, &dmaConfig, &fsl_content);
     if (error == kStatus_Fail)
     {
@@ -395,7 +397,7 @@ static void _mmc_request(struct rt_mmcsd_host *host, struct rt_mmcsd_req *req)
         MMCSD_DGB(" ***USDHC_TransferBlocking error: %d*** --> \n", error);
         cmd->err = -RT_ERROR;
     }
-    
+
     if (buf)
     {
         if (fsl_data.rxData)
@@ -403,57 +405,57 @@ static void _mmc_request(struct rt_mmcsd_host *host, struct rt_mmcsd_req *req)
             MMCSD_DGB("read copy buf to data->buf ");
             rt_memcpy(data->buf, buf, fsl_data.blockSize * fsl_data.blockCount);
         }
-    
+
         rt_free_align(buf);
     }
-    
-    if ((cmd->flags & RESP_MASK) == RESP_R2) 
+
+    if ((cmd->flags & RESP_MASK) == RESP_R2)
     {
         cmd->resp[3] = fsl_command.response[0];
         cmd->resp[2] = fsl_command.response[1];
         cmd->resp[1] = fsl_command.response[2];
         cmd->resp[0] = fsl_command.response[3];
         MMCSD_DGB(" resp 0x%08X 0x%08X 0x%08X 0x%08X\n",
-            cmd->resp[0], cmd->resp[1], cmd->resp[2], cmd->resp[3]);
-    } 
+                  cmd->resp[0], cmd->resp[1], cmd->resp[2], cmd->resp[3]);
+    }
     else
     {
         cmd->resp[0] = fsl_command.response[0];
         MMCSD_DGB(" resp 0x%08X\n", cmd->resp[0]);
     }
-    
+
     mmcsd_req_complete(host);
-    
+
     return;
 }
 
 static void _mmc_set_iocfg(struct rt_mmcsd_host *host, struct rt_mmcsd_io_cfg *io_cfg)
 {
-    
-    struct imxrt_mmcsd * mmcsd;
+
+    struct imxrt_mmcsd *mmcsd;
     unsigned int usdhc_clk;
     unsigned int bus_width;
     uint32_t src_clk;
-    
+
     RT_ASSERT(host != RT_NULL);
     RT_ASSERT(host->private_data != RT_NULL);
     RT_ASSERT(io_cfg != RT_NULL);
-    
+
     mmcsd = (struct imxrt_mmcsd *)host->private_data;
     usdhc_clk = io_cfg->clock;
-	bus_width = io_cfg->bus_width;
-    
-    if(usdhc_clk > IMXRT_MAX_FREQ)
-        usdhc_clk = IMXRT_MAX_FREQ;    
+    bus_width = io_cfg->bus_width;
+
+    if (usdhc_clk > IMXRT_MAX_FREQ)
+        usdhc_clk = IMXRT_MAX_FREQ;
     src_clk = (CLOCK_GetSysPfdFreq(kCLOCK_Pfd2) / (CLOCK_GetDiv(mmcsd->usdhc_div) + 1U));
-    
+
     MMCSD_DGB("\tsrc_clk: %d, usdhc_clk: %d, bus_width: %d\n", src_clk, usdhc_clk, bus_width);
-    
+
     if (usdhc_clk)
     {
         USDHC_SetSdClock(mmcsd->usdhc_host.base, src_clk, usdhc_clk);
         //CLOCK_EnableClock(mmcsd->ip_clock);
-        
+
         /* Change bus width */
         if (bus_width == MMCSD_BUS_WIDTH_8)
             USDHC_SetDataBusWidth(mmcsd->usdhc_host.base, kUSDHC_DataBusWidth8Bit);
@@ -468,7 +470,7 @@ static void _mmc_set_iocfg(struct rt_mmcsd_host *host, struct rt_mmcsd_io_cfg *i
     {
         //CLOCK_DisableClock(mmcsd->ip_clock);
     }
-    
+
 }
 
 #ifdef DEBUG
@@ -483,7 +485,7 @@ FINSH_FUNCTION_EXPORT(log_toggle, toglle log dumple);
 //{
 //    MMCSD_DGB("%s, start\n", __func__);
 //    MMCSD_DGB("%s, end\n", __func__);
-//    
+//
 //    return 0;
 //}
 //
@@ -492,71 +494,72 @@ FINSH_FUNCTION_EXPORT(log_toggle, toglle log dumple);
 //
 //}
 
-static const struct rt_mmcsd_host_ops ops = {
-	_mmc_request,
-	_mmc_set_iocfg,
+static const struct rt_mmcsd_host_ops ops =
+{
+    _mmc_request,
+    _mmc_set_iocfg,
     RT_NULL,//_mmc_get_card_status,
-	RT_NULL,//_mmc_enable_sdio_irq,
+    RT_NULL,//_mmc_enable_sdio_irq,
 };
 
 rt_int32_t _imxrt_mci_init(void)
 {
-	struct rt_mmcsd_host *host;
-	struct imxrt_mmcsd *mmcsd;
+    struct rt_mmcsd_host *host;
+    struct imxrt_mmcsd *mmcsd;
 
-	host = mmcsd_alloc_host();
-	if (!host) 
-	{
-		return -RT_ERROR;
-	}
+    host = mmcsd_alloc_host();
+    if (!host)
+    {
+        return -RT_ERROR;
+    }
 
-	mmcsd = rt_malloc(sizeof(struct imxrt_mmcsd));
-	if (!mmcsd) 
-	{
-		rt_kprintf("alloc mci failed\n");
-		goto err;
-	}
+    mmcsd = rt_malloc(sizeof(struct imxrt_mmcsd));
+    if (!mmcsd)
+    {
+        rt_kprintf("alloc mci failed\n");
+        goto err;
+    }
 
-	rt_memset(mmcsd, 0, sizeof(struct imxrt_mmcsd));
+    rt_memset(mmcsd, 0, sizeof(struct imxrt_mmcsd));
     mmcsd->usdhc_host.base = USDHC1;
     mmcsd->usdhc_div = kCLOCK_Usdhc1Div;
     mmcsd->usdhc_adma2_table = g_usdhcAdma2Table;
 
-	host->ops = &ops;
-	host->freq_min = 375000;
-	host->freq_max = 25000000;
-	host->valid_ocr = VDD_32_33 | VDD_33_34;
-	host->flags = MMCSD_BUSWIDTH_4 | MMCSD_MUTBLKWRITE | \
-				MMCSD_SUP_HIGHSPEED | MMCSD_SUP_SDIO_IRQ;
-	host->max_seg_size = 65535;
-	host->max_dma_segs = 2;
-	host->max_blk_size = 512;
-	host->max_blk_count = 4096;
+    host->ops = &ops;
+    host->freq_min = 375000;
+    host->freq_max = 30000000;
+    host->valid_ocr = VDD_32_33 | VDD_33_34;
+    host->flags = MMCSD_BUSWIDTH_4 | MMCSD_MUTBLKWRITE | \
+                  MMCSD_SUP_HIGHSPEED | MMCSD_SUP_SDIO_IRQ;
+    host->max_seg_size = 65535;
+    host->max_dma_segs = 2;
+    host->max_blk_size = 512;
+    host->max_blk_count = 4096;
 
-	mmcsd->host = host;
+    mmcsd->host = host;
 
     _mmcsd_clk_init(mmcsd);
     _mmcsd_isr_init(mmcsd);
-	_mmcsd_gpio_init(mmcsd);
+    _mmcsd_gpio_init(mmcsd);
     _mmcsd_host_init(mmcsd);
 
-	host->private_data = mmcsd;
+    host->private_data = mmcsd;
 
-	mmcsd_change(host);
+    mmcsd_change(host);
 
-	return 0;
+    return 0;
 
 err:
-	mmcsd_free_host(host);
+    mmcsd_free_host(host);
 
-	return -RT_ENOMEM;
+    return -RT_ENOMEM;
 }
 
 int imxrt_mci_init(void)
 {
     /* initilize sd card */
     _imxrt_mci_init();
-    
+
     return 0;
 }
 INIT_DEVICE_EXPORT(imxrt_mci_init);


### PR DESCRIPTION
1. 格式化代码.
2. 优化SDIO接口稳定性和速度: 将SDIO时钟树中分频数增大, 提高内部时钟的稳定性, 同时SDIO速度提高到30M. 并且通过USB拷贝12M MP3文件测试, 多次拷贝数据稳定.