### PR TITLE
[libc/armlibc] Remove time() on stubs.c.

### DIFF
--- a/components/libc/compilers/armlibc/stubs.c
+++ b/components/libc/compilers/armlibc/stubs.c
@@ -327,12 +327,3 @@ int fgetc(FILE *f)
     return -1;
 }
 #endif
-
-#ifndef RT_USING_RTC
-time_t time(time_t *t)
-{
-	time_t time_now = 0;
-	
-	return time_now;
-}
-#endif


### PR DESCRIPTION
统一定义 time() 到 time.c 中

https://github.com/RT-Thread/rt-thread/blob/a00cdcd7506489ad986d2b684b126fce6323349b/components/libc/compilers/armlibc/time.c#L40