### PR TITLE
[bsp][qemu]更改中断栈大小为2048

### DIFF
--- a/bsp/qemu-vexpress-a9/cpu/start_gcc.S
+++ b/bsp/qemu-vexpress-a9/cpu/start_gcc.S
@@ -34,11 +34,11 @@
 .equ F_Bit,           0x40            @ when F bit is set, FIQ is disabled
 
 .equ UND_Stack_Size,     0x00000000
-.equ SVC_Stack_Size,     0x00000100
+.equ SVC_Stack_Size,     0x00000400
 .equ ABT_Stack_Size,     0x00000000
 .equ RT_FIQ_STACK_PGSZ,  0x00000000
-.equ RT_IRQ_STACK_PGSZ,  0x00000100
-.equ USR_Stack_Size,     0x00000100
+.equ RT_IRQ_STACK_PGSZ,  0x00000800
+.equ USR_Stack_Size,     0x00000400
 
 #define ISR_Stack_Size  (UND_Stack_Size + SVC_Stack_Size + ABT_Stack_Size + \
                  RT_FIQ_STACK_PGSZ + RT_IRQ_STACK_PGSZ)


### PR DESCRIPTION
之前中断栈有点小，只有256，一不小心就溢出了