### PR TITLE
解决get_week的有效值与IS_RTC_WEEKDAY判断有效值不一致的问题。

### DIFF
--- a/bsp/stm32f40x/drivers/stm32f4_rtc.c
+++ b/bsp/stm32f40x/drivers/stm32f4_rtc.c
@@ -23,7 +23,7 @@ static int get_week(int year, int month, int day)
 		year -=1;
 		month +=12;
 	}
-	return (day+1+2*month+3*(month+1)/5+year+(year/4)-year/100+year/400)%7;
+	return (day+1+2*month+3*(month+1)/5+year+(year/4)-year/100+year/400)%7+1;
 }
 
 static struct rt_device rtc;


### PR DESCRIPTION
get_week获取的值是0-6.而stm32f4xx_rtc.h中IS_RTC_WEEKDAY中判断的有效值是1-7.当设置日期是周日时，会有问题。