### PR TITLE
to be able debug trace bit  before use DWT.

### DIFF
--- a/components/drivers/cputime/cputime_cortexm.c
+++ b/components/drivers/cputime/cputime_cortexm.c
@@ -54,6 +54,9 @@ int cortexm_cputime_init(void)
     /* check support bit */
     if ((DWT->CTRL & (1UL << DWT_CTRL_NOCYCCNT_Pos)) == 0) 
     {
+        /* enable trace*/
+        CoreDebug->DEMCR |= (1UL << CoreDebug_DEMCR_TRCENA_Pos);
+        
         /* whether cycle counter not enabled */
         if ((DWT->CTRL & (1UL << DWT_CTRL_CYCCNTENA_Pos)) == 0) 
         {


### PR DESCRIPTION
使用 DWT 之前必须先使能跟踪系统.