### PR TITLE
Fix the SD Card and EMAC issue:

### DIFF
--- a/bsp/lpc54608-LPCXpresso/drivers/drv_sd.c
+++ b/bsp/lpc54608-LPCXpresso/drivers/drv_sd.c
@@ -407,6 +407,22 @@ rt_err_t mci_hw_init(const char *device_name)
         rt_kprintf("SD_Init failed!\n");
         return -RT_ERROR;
     }
+	
+	/*
+	follow the page: https://community.nxp.com/thread/454769
+	
+	The issue concerns sdmmc library bug (I finally solved) in SD_Init() in the file sdmmc/src/fsl_sd.c:SD_SelectBusTiming() 
+	calls SD_SwitchFunction() which sets block size to 64bytes (512bits).Therefore SD_SetBlockSize(card, FSL_SDMMC_DEFAULT_BLOCK_SIZE)
+	should be called again before SD_Init() exits.
+	*/
+	
+	if (kStatus_Success != SDMMC_SetBlockSize(_mci_device->card.host.base, _mci_device->card.host.transfer, FSL_SDMMC_DEFAULT_BLOCK_SIZE))
+	{
+        SD_Deinit(&_mci_device->card);
+        memset(&_mci_device->card, 0U, sizeof(_mci_device->card));
+        rt_kprintf("SD_Init failed!\n");
+        return -RT_ERROR;		
+	}
 
     /* initialize mutex lock */
     rt_mutex_init(&_mci_device->lock, device_name, RT_IPC_FLAG_FIFO);


### PR DESCRIPTION
1. The issue concerns sdmmc library bug (I finally solved) in SD_Init() in the file sdmmc/src/fsl_sd.c:SD_SelectBusTiming()
calls SD_SwitchFunction() which sets block size to 64bytes (512bits).Therefore SD_SetBlockSize(card, FSL_SDMMC_DEFAULT_BLOCK_SIZE)
should be called again before SD_Init() exits.
2. The issue is wrong variable in drv_emac.c:lpc_emac_tx(), and the wrong data length of send packet
to cause the send failure.

Signed-off-by: zheng-chow <sernia.zhou@foxmail.com>