### PR TITLE
[components][dfs][elmfat] Add RT_USING_LIBC selected to ELMFAT Kconfig.

### DIFF
--- a/components/dfs/Kconfig
+++ b/components/dfs/Kconfig
@@ -28,6 +28,7 @@ if RT_USING_DFS
 
     config RT_USING_DFS_ELMFAT
         bool "Enable elm-chan fatfs"
+        selsect RT_USING_LIBC
         default y
         help
             FatFs is a generic FAT/exFAT file system module for small embedded systems.


### PR DESCRIPTION
fatfs 的 mkfs 、 mkdir 等函数都会使用 libc 的 time() 

https://github.com/RT-Thread/rt-thread/blob/a2e08706334aa77a87fc275f17517c202f0ab4e2/components/dfs/filesystems/elmfat/dfs_elm.c#L933