### PR TITLE
[components][dfs][fatfs] Add return 0 to get_fattime when RT_USING_LI…

### DIFF
--- a/components/dfs/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/filesystems/elmfat/dfs_elm.c
@@ -924,10 +924,12 @@ DRESULT disk_ioctl(BYTE drv, BYTE ctrl, void *buff)
 
 DWORD get_fattime(void)
 {
+    DWORD fat_time = 0;
+
+#ifdef RT_USING_LIBC 
     time_t now;
     struct tm *p_tm;
     struct tm tm_now;
-    DWORD fat_time;
 
     /* get current time */
     now = time(RT_NULL);
@@ -947,6 +949,7 @@ DWORD get_fattime(void)
                 (DWORD)tm_now.tm_hour        << 11 |
                 (DWORD)tm_now.tm_min         <<  5 |
                 (DWORD)tm_now.tm_sec / 2 ;
+#endif /* RT_USING_LIBC  */
 
     return fat_time;
 }


### PR DESCRIPTION
…BC not enable.

see #1518