### PR TITLE
Update usart.c

### DIFF
--- a/bsp/stm32f429-apollo/drivers/usart.c
+++ b/bsp/stm32f429-apollo/drivers/usart.c
@@ -692,4 +692,4 @@ int stm32_hw_usart_init(void)
 #endif /* RT_USING_UART5 */
     return 0;
 }
-INIT_BOARD_EXPORT(stm32_hw_usart_init);
+/*INIT_BOARD_EXPORT(stm32_hw_usart_init);*/


### PR DESCRIPTION
取消/*INIT_BOARD_EXPORT(stm32_hw_usart_init);*/自动初始化。
原因如下：
1.如果组建初始化需要debug，board.c中已经手动初始化uart_init，此时如果再组件自动初始化uart_int导致uart初始化了两次
2.如果组件初始化不需要debug，那么uart_init可以进行INIT_BOARD_EXPORT(stm32_hw_usart_init);但是此时需要将rt_console_set_device(RT_CONSOLE_DEVICE_NAME);放在rt_components_board_init();后面
综上所述：一般需要开debug便于调试，因此uart使用手动初始化，去掉组件自动初始化