### PR TITLE
[components][drivers]wlan打印ap信息更加友好

### DIFF
--- a/components/drivers/wlan/wlan_cmd.c
+++ b/components/drivers/wlan/wlan_cmd.c
@@ -426,13 +426,22 @@ int wifi(int argc, char **argv)
             int index, num;
 
             num = scan_result->ap_num;
-            rt_kprintf("----Wi-Fi APInformation----\n");
+            rt_kprintf("             SSID                      MAC            rssi   chn    Mbps\n");
+            rt_kprintf("------------------------------- -----------------     ----   ---    ----\n");
             for (index = 0; index < num; index ++)
             {
-                rt_kprintf("SSID:%-.32s, ", scan_result->ap_table[index].ssid);
-                rt_kprintf("rssi:%d, ", scan_result->ap_table[index].rssi);
-                rt_kprintf("chn:%d, ", scan_result->ap_table[index].channel);
-                rt_kprintf("rate:%d\n", scan_result->ap_table[index].datarate);
+                rt_kprintf("%-32.32s", scan_result->ap_table[index].ssid);
+                rt_kprintf("%02x:%02x:%02x:%02x:%02x:%02x     ", 
+                    scan_result->ap_table[index].bssid[0],
+                    scan_result->ap_table[index].bssid[1],
+                    scan_result->ap_table[index].bssid[2],
+                    scan_result->ap_table[index].bssid[3],
+                    scan_result->ap_table[index].bssid[4],
+                    scan_result->ap_table[index].bssid[5]
+                );
+                rt_kprintf("%4d    ", scan_result->ap_table[index].rssi);
+                rt_kprintf("%2d    ", scan_result->ap_table[index].channel);
+                rt_kprintf("%d\n", scan_result->ap_table[index].datarate / 1000000);
             }
         }
         rt_wlan_release_scan_result(&scan_result);
@@ -502,7 +511,7 @@ int wifi(int argc, char **argv)
                        wlan->info->bssid[4],
                        wlan->info->bssid[5]);
             rt_kprintf(" Channel: %d\n", wlan->info->channel);
-            rt_kprintf("DataRate: %dMbps\n", wlan->info->datarate / 1000);
+            rt_kprintf("DataRate: %dMbps\n", wlan->info->datarate / 1000000);
             rt_kprintf("    RSSI: %d\n", rssi);
         }
         else


### PR DESCRIPTION
## 现在

```
download firmware done!                                                   
             SSID                      MAC             rssi   chn    rate 
------------------------------- -----------------     ----   ---    ------
Zero                            ec:88:8f:88:aa:9a      -37     6    300000
AI-THINKER_23C19D               b6:e6:2d:23:c1:9d      -60     9    54000 
ubnt                            00:15:6d:20:91:68      -69     7    300000
NEO-shanghai-ap2                58:66:ba:a1:ee:71      -61    11    54000 
KVIP                            70:65:82:3b:75:43      -70    11    72200 
Xiaomi_3F                       78:11:dc:1b:9f:cc      -71    11    144400
WQ1                             88:25:93:94:51:54      -65    13    144400
YST2016                         88:25:93:c6:67:d1      -70    13    54000 
```

## 之前

```
download firmware done!                            
----Wi-Fi APInformation----                        
SSID:Zero, rssi:-20, chn:6, rate:300000            
SSID:AI-THINKER_23C19D, rssi:-57, chn:9, rate:54000
SSID:kongzhong, rssi:-69, chn:11, rate:72200        
SSID:Xiaomi_3F, rssi:-73, chn:11, rate:144400       
SSID:KVIP, rssi:-75, chn:11, rate:72200             
SSID:WQ3, rssi:-76, chn:13, rate:144400  
```
