### PR TITLE
Fix scons

### DIFF
--- a/tools/iar.py
+++ b/tools/iar.py
@@ -164,7 +164,7 @@ def IARVersion():
     def IARPath():
         import rtconfig
 
-        # set environ
+        # backup environ
         old_environ = os.environ
         os.environ['RTT_CC'] = 'iar'
         reload(rtconfig)
@@ -178,12 +178,21 @@ def IARVersion():
 
         return path
 
+    # get the IAR path in 'RTT_EXEC_PATH'
     path = IARPath();
+
+    # retry to get IAR path on 'rtconfig.py'
+    if not os.path.exists(path):
+        rtt_exec_path = os.environ['RTT_EXEC_PATH']
+        if rtt_exec_path:
+            del os.environ['RTT_EXEC_PATH']
+            path = IARPath();
+            os.environ['RTT_EXEC_PATH'] = rtt_exec_path
 
     if os.path.exists(path):
         cmd = os.path.join(path, 'iccarm.exe')
     else:
-        print('Get IAR version error. Please update IAR installation path in rtconfig.h!')
+        print('Get IAR version error. Please update IAR installation path in rtconfig.py!')
         return "0.0"
 
     child = subprocess.Popen([cmd, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)

--- a/tools/iar.py
+++ b/tools/iar.py
@@ -178,21 +178,12 @@ def IARVersion():
 
         return path
 
-    # get the IAR path in 'RTT_EXEC_PATH'
     path = IARPath();
-
-    # retry to get IAR path on 'rtconfig.py'
-    if not os.path.exists(path):
-        rtt_exec_path = os.environ['RTT_EXEC_PATH']
-        if rtt_exec_path:
-            del os.environ['RTT_EXEC_PATH']
-            path = IARPath();
-            os.environ['RTT_EXEC_PATH'] = rtt_exec_path
 
     if os.path.exists(path):
         cmd = os.path.join(path, 'iccarm.exe')
     else:
-        print('Get IAR version error. Please update IAR installation path in rtconfig.py!')
+        print('Error: get IAR version failed. Please update the IAR installation path in rtconfig.py!')
         return "0.0"
 
     child = subprocess.Popen([cmd, '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)


### PR DESCRIPTION
## 修复 scons 在 env 中生成工程后，编译工程可能出错的问题：

- **错误1**：无法识别 IAR 版本，导致每次生成 RT1050 的 IAR 工程，需要手动删除 `_DLIB_THREAD_SUPPORT` 选项
- **错误2**：近期新增了 cconfig.h 功能，由于 Env 中默认使用的 gcc 编译器，如果不重新设定 `RTT_CC` ，直接生成新工程，编译时会出现 `select` 相关的头文件路径未被加入的问题

## 目前的修复方法是：

- 根据 `scons --target=cc` 命令中的 `cc` 类型，自动修改环境变量中的 `RTT_CC` 为对应的工具链类型
- BSP 中默认的 `rtconfig.EXEC_PATH` 一般会使用环境变量中的 `RTT_EXEC_PATH` ，如果检测到该路径不正确，还会继续尝试使用 `rtconfig.py` 中配置的 `EXEC_PATH`