### PR TITLE
[rtservice] Add `rt_slist_first` and `rt_slist_next` API to slist.

### DIFF
--- a/include/rtservice.h
+++ b/include/rtservice.h
@@ -230,6 +230,16 @@ rt_inline rt_slist_t *rt_slist_remove(rt_slist_t *l, rt_slist_t *n)
     return l;
 }
 
+rt_inline rt_slist_t *rt_slist_first(rt_slist_t *l)
+{
+    return l->next;
+}
+
+rt_inline rt_slist_t *rt_slist_next(rt_slist_t *n)
+{
+    return n->next;
+}
+
 rt_inline int rt_slist_isempty(rt_slist_t *l)
 {
     return l->next == RT_NULL;


### PR DESCRIPTION
增加这两个 API 使得 slist 的迭代循环可以改为如下方式

```C
for (node = rt_slist_first(rlist); node; node = rt_slist_next(node))
{
    ...
}
```