### PR TITLE
[BSP][RT1050] Improve pin drive stability. | 提高PIN驱动稳定性.

### DIFF
--- a/bsp/imxrt1052-evk/drivers/drv_pin.c
+++ b/bsp/imxrt1052-evk/drivers/drv_pin.c
@@ -436,13 +436,11 @@ static void rt1052_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     if(rt1052_pin_map[pin].gpio != GPIO5)
     {
         CLOCK_EnableClock(kCLOCK_Iomuxc); 
-        
         IOMUXC_SetPinMux(0x401F8010U + pin*4, 0x5U, 0, 0, 0, 1); 
     }
     else
     {
         CLOCK_EnableClock(kCLOCK_IomuxcSnvs); 
-        
         IOMUXC_SetPinMux(0x400A8000U + (pin-125)*4, 0x5U, 0, 0, 0, 1); 
     }
     
@@ -566,6 +564,7 @@ static rt_err_t rt1052_pin_irq_enable(struct rt_device *device, rt_base_t pin, r
 {
     gpio_pin_config_t gpio; 
     IRQn_Type irq_num;
+    rt_uint32_t config_value = 0x1b0a0; 
     
     struct rt1052_pin* pin_map = RT_NULL; 
     struct rt1052_irq* irq_map = RT_NULL; 
@@ -639,6 +638,15 @@ static rt_err_t rt1052_pin_irq_enable(struct rt_device *device, rt_base_t pin, r
             break;
         }
         
+        if(rt1052_pin_map[pin].gpio != GPIO5)
+        {
+            IOMUXC_SetPinConfig(0, 0, 0, 0, 0x401F8200U + pin*4, config_value); 
+        }
+        else
+        {
+            IOMUXC_SetPinConfig(0, 0, 0, 0, 0x400A8018U + (pin-125)*4, config_value); 
+        }
+        
         irq_num = rt1052_get_irqnum(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin); 
         
         NVIC_SetPriority(irq_num, NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 5, 0));
@@ -675,7 +683,7 @@ int rt_hw_pin_init(void)
     rt1052_pin_ops.pin_read        = rt1052_pin_read; 
     rt1052_pin_ops.pin_write       = rt1052_pin_write; 
     rt1052_pin_ops.pin_attach_irq  = rt1052_pin_attach_irq; 
-    rt1052_pin_ops.pin_detach_irq = rt1052_pin_detach_irq;
+    rt1052_pin_ops.pin_detach_irq  = rt1052_pin_detach_irq;
     rt1052_pin_ops.pin_irq_enable  = rt1052_pin_irq_enable; 
     
     ret = rt_device_pin_register("pin", &rt1052_pin_ops, RT_NULL);


### PR DESCRIPTION
1. 当首先配置PIN为普通输入输出后, 再修改成中断, 不会出现无法触发中断的问题.