### PR TITLE
Add list iterators over list elements

### DIFF
--- a/include/rtservice.h
+++ b/include/rtservice.h
@@ -141,7 +141,7 @@ rt_inline unsigned int rt_list_len(const rt_list_t *l)
     rt_container_of(node, type, member)
 
 /**
- * rt_list_for_each	-	iterate over a list
+ * rt_list_for_each - iterate over a list
  * @pos:	the rt_list_t * to use as a loop cursor.
  * @head:	the head for your list.
  */
@@ -273,12 +273,12 @@ rt_inline int rt_slist_isempty(rt_slist_t *l)
     rt_container_of(node, type, member)
 
 /**
- * rt_slist_for_each  -   iterate over a single list
+ * rt_slist_for_each - iterate over a single list
  * @pos:    the rt_slist_t * to use as a loop cursor.
  * @head:   the head for your single list.
  */
 #define rt_slist_for_each(pos, head) \
-    for (pos = (head)->next; &pos->next != (head); pos = pos->next)
+    for (pos = (head)->next; pos != RT_NULL; pos = pos->next)
 
 /**
  * rt_slist_for_each_entry  -   iterate over single list of given type

--- a/include/rtservice.h
+++ b/include/rtservice.h
@@ -141,6 +141,24 @@ rt_inline unsigned int rt_list_len(const rt_list_t *l)
     rt_container_of(node, type, member)
 
 /**
+ * rt_list_for_each	-	iterate over a list
+ * @pos:	the rt_list_t * to use as a loop cursor.
+ * @head:	the head for your list.
+ */
+#define rt_list_for_each(pos, head) \
+    for (pos = (head)->next; pos != (head); pos = pos->next)
+
+/**
+ * rt_list_for_each_safe - iterate over a list safe against removal of list entry
+ * @pos:	the rt_list_t * to use as a loop cursor.
+ * @n:		another rt_list_t * to use as temporary storage
+ * @head:	the head for your list.
+ */
+#define rt_list_for_each_safe(pos, n, head) \
+	for (pos = (head)->next, n = pos->next; pos != (head); \
+		pos = n, n = pos->next)
+
+/**
  * rt_list_for_each_entry  -   iterate over list of given type
  * @pos:    the type * to use as a loop cursor.
  * @head:   the head for your list.
@@ -253,6 +271,14 @@ rt_inline int rt_slist_isempty(rt_slist_t *l)
  */
 #define rt_slist_entry(node, type, member) \
     rt_container_of(node, type, member)
+
+/**
+ * rt_slist_for_each  -   iterate over a single list
+ * @pos:    the rt_slist_t * to use as a loop cursor.
+ * @head:   the head for your single list.
+ */
+#define rt_slist_for_each(pos, head) \
+    for (pos = (head)->next; &pos->next != (head); pos = pos->next)
 
 /**
  * rt_slist_for_each_entry  -   iterate over single list of given type


### PR DESCRIPTION
Some non-gnu toolchains don't support gnu C extended keyword "typeof", like MDK (if no "gnu" option) and IAR, in this case we can provide list element manipulation macro functions to iterate over the list.