### PR TITLE
[BSP][STM32F4xx-HAL] Fix template file for building under mdk5.

### DIFF
--- a/bsp/stm32f4xx-HAL/template.uvprojx
+++ b/bsp/stm32f4xx-HAL/template.uvprojx
@@ -187,7 +187,7 @@
             <hadIRAM2>1</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
-            <useUlib>0</useUlib>
+            <useUlib>1</useUlib>
             <EndSel>0</EndSel>
             <uLtcg>0</uLtcg>
             <nSecure>0</nSecure>
@@ -323,7 +323,7 @@
             <wLevel>0</wLevel>
             <uThumb>0</uThumb>
             <uSurpInc>0</uSurpInc>
-            <uC99>0</uC99>
+            <uC99>1</uC99>
             <uGnu>0</uGnu>
             <useXO>0</useXO>
             <v6Lang>0</v6Lang>


### PR DESCRIPTION
STM32F4XX需要开启MicroLib和c99才能正常在keil5中编译。