### PR TITLE
add more assert for object check

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -62,6 +62,7 @@ rt_object_t rt_object_allocate(enum rt_object_class_type type,
                                const char               *name);
 void rt_object_delete(rt_object_t object);
 rt_bool_t rt_object_is_systemobject(rt_object_t object);
+rt_uint8_t rt_object_get_type(rt_object_t object);
 rt_object_t rt_object_find(const char *name, rt_uint8_t type);
 
 #ifdef RT_USING_HOOK

--- a/src/device.c
+++ b/src/device.c
@@ -94,6 +94,8 @@ RTM_EXPORT(rt_device_register);
 rt_err_t rt_device_unregister(rt_device_t dev)
 {
     RT_ASSERT(dev != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&dev->parent) == RT_Object_Class_Device);
+    RT_ASSERT(rt_object_is_systemobject(&dev->parent));
 
     rt_object_detach(&(dev->parent));
 
@@ -191,15 +193,18 @@ RTM_EXPORT(rt_device_create);
 /**
  * This function destroy the specific device object.
  *
- * @param device, the specific device object.
+ * @param dev, the specific device object.
  */
-void rt_device_destroy(rt_device_t device)
+void rt_device_destroy(rt_device_t dev)
 {
-    /* unregister device firstly */
-    rt_device_unregister(device);
+    RT_ASSERT(dev != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&dev->parent) == RT_Object_Class_Device);
+    RT_ASSERT(rt_object_is_systemobject(&dev->parent) == RT_FALSE);
+
+    rt_object_detach(&(dev->parent));
 
     /* release this device object */
-    rt_free(device);
+    rt_free(dev);
 }
 RTM_EXPORT(rt_device_destroy);
 #endif
@@ -251,6 +256,7 @@ rt_err_t rt_device_open(rt_device_t dev, rt_uint16_t oflag)
     rt_err_t result = RT_EOK;
 
     RT_ASSERT(dev != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&dev->parent) == RT_Object_Class_Device);
 
     /* if device is not initialized, initialize it. */
     if (!(dev->flag & RT_DEVICE_FLAG_ACTIVATED))
@@ -315,6 +321,7 @@ rt_err_t rt_device_close(rt_device_t dev)
     rt_err_t result = RT_EOK;
 
     RT_ASSERT(dev != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&dev->parent) == RT_Object_Class_Device);
 
     if (dev->ref_count == 0)
         return -RT_ERROR;
@@ -356,6 +363,7 @@ rt_size_t rt_device_read(rt_device_t dev,
                          rt_size_t   size)
 {
     RT_ASSERT(dev != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&dev->parent) == RT_Object_Class_Device);
 
     if (dev->ref_count == 0)
     {
@@ -394,6 +402,7 @@ rt_size_t rt_device_write(rt_device_t dev,
                           rt_size_t   size)
 {
     RT_ASSERT(dev != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&dev->parent) == RT_Object_Class_Device);
 
     if (dev->ref_count == 0)
     {
@@ -426,6 +435,7 @@ RTM_EXPORT(rt_device_write);
 rt_err_t rt_device_control(rt_device_t dev, int cmd, void *arg)
 {
     RT_ASSERT(dev != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&dev->parent) == RT_Object_Class_Device);
 
     /* call device write interface */
     if (device_control != RT_NULL)
@@ -451,6 +461,7 @@ rt_device_set_rx_indicate(rt_device_t dev,
                           rt_err_t (*rx_ind)(rt_device_t dev, rt_size_t size))
 {
     RT_ASSERT(dev != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&dev->parent) == RT_Object_Class_Device);
 
     dev->rx_indicate = rx_ind;
 
@@ -472,6 +483,7 @@ rt_device_set_tx_complete(rt_device_t dev,
                           rt_err_t (*tx_done)(rt_device_t dev, void *buffer))
 {
     RT_ASSERT(dev != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&dev->parent) == RT_Object_Class_Device);
 
     dev->tx_complete = tx_done;
 

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -242,7 +242,10 @@ RTM_EXPORT(rt_sem_init);
  */
 rt_err_t rt_sem_detach(rt_sem_t sem)
 {
+    /* parameter check */
     RT_ASSERT(sem != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&sem->parent.parent) == RT_Object_Class_Semaphore);
+    RT_ASSERT(rt_object_is_systemobject(&sem->parent.parent));
 
     /* wakeup all suspend threads */
     rt_ipc_list_resume_all(&(sem->parent.suspend_thread));
@@ -303,7 +306,10 @@ rt_err_t rt_sem_delete(rt_sem_t sem)
 {
     RT_DEBUG_NOT_IN_INTERRUPT;
 
+    /* parameter check */
     RT_ASSERT(sem != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&sem->parent.parent) == RT_Object_Class_Semaphore);
+    RT_ASSERT(rt_object_is_systemobject(&sem->parent.parent) == RT_FALSE);
 
     /* wakeup all suspend threads */
     rt_ipc_list_resume_all(&(sem->parent.suspend_thread));
@@ -330,7 +336,9 @@ rt_err_t rt_sem_take(rt_sem_t sem, rt_int32_t time)
     register rt_base_t temp;
     struct rt_thread *thread;
 
+    /* parameter check */
     RT_ASSERT(sem != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&sem->parent.parent) == RT_Object_Class_Semaphore);
 
     RT_OBJECT_HOOK_CALL(rt_object_trytake_hook, (&(sem->parent.parent)));
 
@@ -437,6 +445,10 @@ rt_err_t rt_sem_release(rt_sem_t sem)
     register rt_base_t temp;
     register rt_bool_t need_schedule;
 
+    /* parameter check */
+    RT_ASSERT(sem != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&sem->parent.parent) == RT_Object_Class_Semaphore);
+
     RT_OBJECT_HOOK_CALL(rt_object_put_hook, (&(sem->parent.parent)));
 
     need_schedule = RT_FALSE;
@@ -481,7 +493,10 @@ RTM_EXPORT(rt_sem_release);
 rt_err_t rt_sem_control(rt_sem_t sem, int cmd, void *arg)
 {
     rt_ubase_t level;
+
+    /* parameter check */
     RT_ASSERT(sem != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&sem->parent.parent) == RT_Object_Class_Semaphore);
 
     if (cmd == RT_IPC_CMD_RESET)
     {
@@ -524,6 +539,7 @@ RTM_EXPORT(rt_sem_control);
  */
 rt_err_t rt_mutex_init(rt_mutex_t mutex, const char *name, rt_uint8_t flag)
 {
+    /* parameter check */
     RT_ASSERT(mutex != RT_NULL);
 
     /* init object */
@@ -555,7 +571,10 @@ RTM_EXPORT(rt_mutex_init);
  */
 rt_err_t rt_mutex_detach(rt_mutex_t mutex)
 {
+    /* parameter check */
     RT_ASSERT(mutex != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mutex->parent.parent) == RT_Object_Class_Mutex);
+    RT_ASSERT(rt_object_is_systemobject(&mutex->parent.parent));
 
     /* wakeup all suspend threads */
     rt_ipc_list_resume_all(&(mutex->parent.suspend_thread));
@@ -617,7 +636,10 @@ rt_err_t rt_mutex_delete(rt_mutex_t mutex)
 {
     RT_DEBUG_NOT_IN_INTERRUPT;
 
+    /* parameter check */
     RT_ASSERT(mutex != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mutex->parent.parent) == RT_Object_Class_Mutex);
+    RT_ASSERT(rt_object_is_systemobject(&mutex->parent.parent) == RT_FALSE);
 
     /* wakeup all suspend threads */
     rt_ipc_list_resume_all(&(mutex->parent.suspend_thread));
@@ -647,7 +669,9 @@ rt_err_t rt_mutex_take(rt_mutex_t mutex, rt_int32_t time)
     /* this function must not be used in interrupt even if time = 0 */
     RT_DEBUG_IN_THREAD_CONTEXT;
 
+    /* parameter check */
     RT_ASSERT(mutex != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mutex->parent.parent) == RT_Object_Class_Mutex);
 
     /* get current thread */
     thread = rt_thread_self();
@@ -779,6 +803,10 @@ rt_err_t rt_mutex_release(rt_mutex_t mutex)
     struct rt_thread *thread;
     rt_bool_t need_schedule;
 
+    /* parameter check */
+    RT_ASSERT(mutex != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mutex->parent.parent) == RT_Object_Class_Mutex);
+
     need_schedule = RT_FALSE;
 
     /* only thread could release mutex because we need test the ownership */
@@ -874,6 +902,10 @@ RTM_EXPORT(rt_mutex_release);
  */
 rt_err_t rt_mutex_control(rt_mutex_t mutex, int cmd, void *arg)
 {
+    /* parameter check */
+    RT_ASSERT(mutex != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mutex->parent.parent) == RT_Object_Class_Mutex);
+
     return -RT_ERROR;
 }
 RTM_EXPORT(rt_mutex_control);
@@ -892,6 +924,7 @@ RTM_EXPORT(rt_mutex_control);
  */
 rt_err_t rt_event_init(rt_event_t event, const char *name, rt_uint8_t flag)
 {
+    /* parameter check */
     RT_ASSERT(event != RT_NULL);
 
     /* init object */
@@ -921,6 +954,8 @@ rt_err_t rt_event_detach(rt_event_t event)
 {
     /* parameter check */
     RT_ASSERT(event != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&event->parent.parent) == RT_Object_Class_Event);
+    RT_ASSERT(rt_object_is_systemobject(&event->parent.parent));
 
     /* resume all suspended thread */
     rt_ipc_list_resume_all(&(event->parent.suspend_thread));
@@ -976,6 +1011,8 @@ rt_err_t rt_event_delete(rt_event_t event)
 {
     /* parameter check */
     RT_ASSERT(event != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&event->parent.parent) == RT_Object_Class_Event);
+    RT_ASSERT(rt_object_is_systemobject(&event->parent.parent) == RT_FALSE);
 
     RT_DEBUG_NOT_IN_INTERRUPT;
 
@@ -1009,6 +1046,8 @@ rt_err_t rt_event_send(rt_event_t event, rt_uint32_t set)
 
     /* parameter check */
     RT_ASSERT(event != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&event->parent.parent) == RT_Object_Class_Event);
+
     if (set == 0)
         return -RT_ERROR;
 
@@ -1109,6 +1148,8 @@ rt_err_t rt_event_recv(rt_event_t   event,
 
     /* parameter check */
     RT_ASSERT(event != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&event->parent.parent) == RT_Object_Class_Event);
+
     if (set == 0)
         return -RT_ERROR;
 
@@ -1218,8 +1259,11 @@ RTM_EXPORT(rt_event_recv);
 rt_err_t rt_event_control(rt_event_t event, int cmd, void *arg)
 {
     rt_ubase_t level;
-    RT_ASSERT(event != RT_NULL);
 
+    /* parameter check */
+    RT_ASSERT(event != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&event->parent.parent) == RT_Object_Class_Event);
+    
     if (cmd == RT_IPC_CMD_RESET)
     {
         /* disable interrupt */
@@ -1299,6 +1343,8 @@ rt_err_t rt_mb_detach(rt_mailbox_t mb)
 {
     /* parameter check */
     RT_ASSERT(mb != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mb->parent.parent) == RT_Object_Class_MailBox);
+    RT_ASSERT(rt_object_is_systemobject(&mb->parent.parent));
 
     /* resume all suspended thread */
     rt_ipc_list_resume_all(&(mb->parent.suspend_thread));
@@ -1373,6 +1419,8 @@ rt_err_t rt_mb_delete(rt_mailbox_t mb)
 
     /* parameter check */
     RT_ASSERT(mb != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mb->parent.parent) == RT_Object_Class_MailBox);
+    RT_ASSERT(rt_object_is_systemobject(&mb->parent.parent) == RT_FALSE);
 
     /* resume all suspended thread */
     rt_ipc_list_resume_all(&(mb->parent.suspend_thread));
@@ -1411,6 +1459,7 @@ rt_err_t rt_mb_send_wait(rt_mailbox_t mb,
 
     /* parameter check */
     RT_ASSERT(mb != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mb->parent.parent) == RT_Object_Class_MailBox);
 
     /* initialize delta tick */
     tick_delta = 0;
@@ -1556,6 +1605,7 @@ rt_err_t rt_mb_recv(rt_mailbox_t mb, rt_uint32_t *value, rt_int32_t timeout)
 
     /* parameter check */
     RT_ASSERT(mb != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mb->parent.parent) == RT_Object_Class_MailBox);
 
     /* initialize delta tick */
     tick_delta = 0;
@@ -1686,7 +1736,10 @@ RTM_EXPORT(rt_mb_recv);
 rt_err_t rt_mb_control(rt_mailbox_t mb, int cmd, void *arg)
 {
     rt_ubase_t level;
+
+    /* parameter check */
     RT_ASSERT(mb != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mb->parent.parent) == RT_Object_Class_MailBox);
 
     if (cmd == RT_IPC_CMD_RESET)
     {
@@ -1796,6 +1849,8 @@ rt_err_t rt_mq_detach(rt_mq_t mq)
 {
     /* parameter check */
     RT_ASSERT(mq != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mq->parent.parent) == RT_Object_Class_MessageQueue);
+    RT_ASSERT(rt_object_is_systemobject(&mq->parent.parent));
 
     /* resume all suspended thread */
     rt_ipc_list_resume_all(&mq->parent.suspend_thread);
@@ -1889,6 +1944,8 @@ rt_err_t rt_mq_delete(rt_mq_t mq)
 
     /* parameter check */
     RT_ASSERT(mq != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mq->parent.parent) == RT_Object_Class_MessageQueue);
+    RT_ASSERT(rt_object_is_systemobject(&mq->parent.parent) == RT_FALSE);
 
     /* resume all suspended thread */
     rt_ipc_list_resume_all(&(mq->parent.suspend_thread));
@@ -1919,7 +1976,9 @@ rt_err_t rt_mq_send(rt_mq_t mq, void *buffer, rt_size_t size)
     register rt_ubase_t temp;
     struct rt_mq_message *msg;
 
+    /* parameter check */
     RT_ASSERT(mq != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mq->parent.parent) == RT_Object_Class_MessageQueue);
     RT_ASSERT(buffer != RT_NULL);
     RT_ASSERT(size != 0);
 
@@ -2007,7 +2066,9 @@ rt_err_t rt_mq_urgent(rt_mq_t mq, void *buffer, rt_size_t size)
     register rt_ubase_t temp;
     struct rt_mq_message *msg;
 
+    /* parameter check */
     RT_ASSERT(mq != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mq->parent.parent) == RT_Object_Class_MessageQueue);
     RT_ASSERT(buffer != RT_NULL);
     RT_ASSERT(size != 0);
 
@@ -2095,7 +2156,9 @@ rt_err_t rt_mq_recv(rt_mq_t    mq,
     struct rt_mq_message *msg;
     rt_uint32_t tick_delta;
 
+    /* parameter check */
     RT_ASSERT(mq != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mq->parent.parent) == RT_Object_Class_MessageQueue);
     RT_ASSERT(buffer != RT_NULL);
     RT_ASSERT(size != 0);
 
@@ -2229,7 +2292,9 @@ rt_err_t rt_mq_control(rt_mq_t mq, int cmd, void *arg)
     rt_ubase_t level;
     struct rt_mq_message *msg;
 
+    /* parameter check */
     RT_ASSERT(mq != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mq->parent.parent) == RT_Object_Class_MessageQueue);
 
     if (cmd == RT_IPC_CMD_RESET)
     {

--- a/src/memheap.c
+++ b/src/memheap.c
@@ -134,6 +134,8 @@ RTM_EXPORT(rt_memheap_init);
 rt_err_t rt_memheap_detach(struct rt_memheap *heap)
 {
     RT_ASSERT(heap);
+    RT_ASSERT(rt_object_get_type(&heap->parent) == RT_Object_Class_MemHeap);
+    RT_ASSERT(rt_object_is_systemobject(&heap->parent));
 
     rt_object_detach(&(heap->lock.parent.parent));
     rt_object_detach(&(heap->parent));
@@ -150,6 +152,7 @@ void *rt_memheap_alloc(struct rt_memheap *heap, rt_uint32_t size)
     struct rt_memheap_item *header_ptr;
 
     RT_ASSERT(heap != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&heap->parent) == RT_Object_Class_MemHeap);
 
     /* align allocated size */
     size = RT_ALIGN(size, RT_ALIGN_SIZE);
@@ -294,6 +297,9 @@ void *rt_memheap_realloc(struct rt_memheap *heap, void *ptr, rt_size_t newsize)
     rt_size_t oldsize;
     struct rt_memheap_item *header_ptr;
     struct rt_memheap_item *new_ptr;
+
+    RT_ASSERT(heap);
+    RT_ASSERT(rt_object_get_type(&heap->parent) == RT_Object_Class_MemHeap);
 
     if (newsize == 0)
     {
@@ -524,6 +530,9 @@ void rt_memheap_free(void *ptr)
     /* get pool ptr */
     heap = header_ptr->pool_ptr;
 
+    RT_ASSERT(heap);
+    RT_ASSERT(rt_object_get_type(&heap->parent) == RT_Object_Class_MemHeap);
+
     /* lock memheap */
     result = rt_sem_take(&(heap->lock), RT_WAITING_FOREVER);
     if (result != RT_EOK)
@@ -630,6 +639,9 @@ void *rt_malloc(rt_size_t size)
         {
             object = rt_list_entry(node, struct rt_object, list);
             heap   = (struct rt_memheap *)object;
+
+            RT_ASSERT(heap);
+            RT_ASSERT(rt_object_get_type(&heap->parent) == RT_Object_Class_MemHeap);
 
             /* not allocate in the default system heap */
             if (heap == &_heap)

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -150,6 +150,8 @@ rt_err_t rt_mp_detach(struct rt_mempool *mp)
 
     /* parameter check */
     RT_ASSERT(mp != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mp->parent) == RT_Object_Class_MemPool);
+    RT_ASSERT(rt_object_is_systemobject(&mp->parent));
 
     /* wake up all suspended threads */
     while (!rt_list_isempty(&(mp->suspend_thread)))
@@ -266,6 +268,8 @@ rt_err_t rt_mp_delete(rt_mp_t mp)
 
     /* parameter check */
     RT_ASSERT(mp != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&mp->parent) == RT_Object_Class_MemPool);
+    RT_ASSERT(rt_object_is_systemobject(&mp->parent) == RT_FALSE);
 
     /* wake up all suspended threads */
     while (!rt_list_isempty(&(mp->suspend_thread)))

--- a/src/module.c
+++ b/src/module.c
@@ -1182,6 +1182,7 @@ rt_err_t rt_module_destroy(rt_module_t module)
     /* check parameter */
     RT_ASSERT(module != RT_NULL);
     RT_ASSERT(module->nref == 0);
+    RT_ASSERT(rt_object_get_type(&module->parent) == RT_Object_Class_Module);
 
     RT_DEBUG_LOG(RT_DEBUG_MODULE, ("rt_module_destroy: %8.*s\n",
                                    RT_NAME_MAX, module->parent.name));

--- a/src/object.c
+++ b/src/object.c
@@ -291,6 +291,9 @@ void rt_object_detach(rt_object_t object)
 
     RT_OBJECT_HOOK_CALL(rt_object_detach_hook, (object));
 
+    /* reset object type */
+    object->type = 0;
+
     /* lock interrupt */
     temp = rt_hw_interrupt_disable();
 
@@ -377,6 +380,9 @@ void rt_object_delete(rt_object_t object)
     RT_ASSERT(!(object->type & RT_Object_Class_Static));
 
     RT_OBJECT_HOOK_CALL(rt_object_detach_hook, (object));
+
+    /* reset object type */
+    object->type = 0;
 
     /* lock interrupt */
     temp = rt_hw_interrupt_disable();

--- a/src/object.c
+++ b/src/object.c
@@ -419,6 +419,22 @@ rt_bool_t rt_object_is_systemobject(rt_object_t object)
 }
 
 /**
+ * This function will return the type of object without
+ * RT_Object_Class_Static flag.
+ *
+ * @param object the specified object to be get type.
+ *
+ * @return the type of object.
+ */
+rt_uint8_t rt_object_get_type(rt_object_t object)
+{
+    /* object check */
+    RT_ASSERT(object != RT_NULL);
+
+    return object->type & ~RT_Object_Class_Static;
+}
+
+/**
  * This function will find specified name object from object
  * container.
  *

--- a/src/thread.c
+++ b/src/thread.c
@@ -275,6 +275,7 @@ rt_err_t rt_thread_startup(rt_thread_t thread)
     /* thread check */
     RT_ASSERT(thread != RT_NULL);
     RT_ASSERT((thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_INIT);
+    RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);
 
     /* set current priority to init priority */
     thread->current_priority = thread->init_priority;
@@ -318,6 +319,8 @@ rt_err_t rt_thread_detach(rt_thread_t thread)
 
     /* thread check */
     RT_ASSERT(thread != RT_NULL);
+    RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);
+    RT_ASSERT(rt_object_is_systemobject((rt_object_t)thread));
 
     if ((thread->stat & RT_THREAD_STAT_MASK) != RT_THREAD_INIT)
     {
@@ -416,6 +419,8 @@ rt_err_t rt_thread_delete(rt_thread_t thread)
 
     /* thread check */
     RT_ASSERT(thread != RT_NULL);
+    RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);
+    RT_ASSERT(rt_object_is_systemobject((rt_object_t)thread) == RT_FALSE);
 
     if ((thread->stat & RT_THREAD_STAT_MASK) != RT_THREAD_INIT)
     {
@@ -504,6 +509,7 @@ rt_err_t rt_thread_sleep(rt_tick_t tick)
     /* set to current thread */
     thread = rt_current_thread;
     RT_ASSERT(thread != RT_NULL);
+    RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);
 
     /* suspend thread */
     rt_thread_suspend(thread);
@@ -572,6 +578,7 @@ rt_err_t rt_thread_control(rt_thread_t thread, int cmd, void *arg)
 
     /* thread check */
     RT_ASSERT(thread != RT_NULL);
+    RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);
 
     switch (cmd)
     {
@@ -650,6 +657,7 @@ rt_err_t rt_thread_suspend(rt_thread_t thread)
 
     /* thread check */
     RT_ASSERT(thread != RT_NULL);
+    RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);
 
     RT_DEBUG_LOG(RT_DEBUG_THREAD, ("thread suspend:  %s\n", thread->name));
 
@@ -692,6 +700,7 @@ rt_err_t rt_thread_resume(rt_thread_t thread)
 
     /* thread check */
     RT_ASSERT(thread != RT_NULL);
+    RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);
 
     RT_DEBUG_LOG(RT_DEBUG_THREAD, ("thread resume:  %s\n", thread->name));
 
@@ -737,6 +746,7 @@ void rt_thread_timeout(void *parameter)
     /* thread check */
     RT_ASSERT(thread != RT_NULL);
     RT_ASSERT((thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND);
+    RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);
 
     /* set error number */
     thread->error = -RT_ETIMEOUT;

--- a/src/timer.c
+++ b/src/timer.c
@@ -207,6 +207,8 @@ rt_err_t rt_timer_detach(rt_timer_t timer)
 
     /* timer check */
     RT_ASSERT(timer != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&timer->parent) == RT_Object_Class_Timer);
+    RT_ASSERT(rt_object_is_systemobject(&timer->parent));
 
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
@@ -268,6 +270,8 @@ rt_err_t rt_timer_delete(rt_timer_t timer)
 
     /* timer check */
     RT_ASSERT(timer != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&timer->parent) == RT_Object_Class_Timer);
+    RT_ASSERT(rt_object_is_systemobject(&timer->parent) == RT_FALSE);
 
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
@@ -302,6 +306,7 @@ rt_err_t rt_timer_start(rt_timer_t timer)
 
     /* timer check */
     RT_ASSERT(timer != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&timer->parent) == RT_Object_Class_Timer);
 
     /* stop timer firstly */
     level = rt_hw_interrupt_disable();
@@ -422,6 +427,8 @@ rt_err_t rt_timer_stop(rt_timer_t timer)
 
     /* timer check */
     RT_ASSERT(timer != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&timer->parent) == RT_Object_Class_Timer);
+
     if (!(timer->parent.flag & RT_TIMER_FLAG_ACTIVATED))
         return -RT_ERROR;
 
@@ -455,6 +462,7 @@ rt_err_t rt_timer_control(rt_timer_t timer, int cmd, void *arg)
 {
     /* timer check */
     RT_ASSERT(timer != RT_NULL);
+    RT_ASSERT(rt_object_get_type(&timer->parent) == RT_Object_Class_Timer);
 
     switch (cmd)
     {


### PR DESCRIPTION
尝试修复 https://github.com/RT-Thread/rt-thread/issues/1550 这个问题。
我的修复思路是： 
     在从object里移除的时候， 把object的list的prev和next成员设置为空指针。然后在使用delete/detach/release/take等等API的，对prev和next做空指针检查。
