### PR TITLE
修复TM4C129开发板系统无法启动问题

### DIFF
--- a/bsp/tm4c129x-dk/README.md
+++ b/bsp/tm4c129x-dk/README.md
@@ -32,6 +32,7 @@ TM4C129X-DK本身提供了一个烧录接口，是Stellaris ICDI，keil本身不
 http://www.ti.com.cn/tool/cn/stellaris_icdi_drivers
 
 供电方式：使用ICDI接口即可供电
+串口：ICDI也可用作串口，使用uart0
 
 ### 3.1 运行结果
 

--- a/src/components.c
+++ b/src/components.c
@@ -237,6 +237,7 @@ int rtthread_startup(void)
     /* timer system initialization */
     rt_system_timer_init();
 
+	rt_system_heap_init((void*)0x20004000,(void*)0x2000F000);
     /* scheduler system initialization */
     rt_system_scheduler_init();
 


### PR DESCRIPTION
因未进行heap初始化，无法启动系统