### PR TITLE
Fix rtdbg

### DIFF
--- a/bsp/allwinner_tina/drivers/drv_gpio.c
+++ b/bsp/allwinner_tina/drivers/drv_gpio.c
@@ -28,7 +28,7 @@
 #include "interrupt.h"
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME  "[GPIO]"
+#define DBG_SECTION_NAME  "GPIO"
 #define DBG_LEVEL         DBG_WARNING
 #define DBG_COLOR
 #include <rtdbg.h>

--- a/bsp/allwinner_tina/drivers/drv_sdio.c
+++ b/bsp/allwinner_tina/drivers/drv_sdio.c
@@ -33,7 +33,7 @@
 #include "drv_clock.h"
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME  "[MMC]"
+#define DBG_SECTION_NAME  "MMC"
 // #define DBG_LEVEL DBG_LOG    
 // #define DBG_LEVEL DBG_INFO   
 #define DBG_LEVEL DBG_WARNING

--- a/bsp/allwinner_tina/drivers/spi/drv_spi.c
+++ b/bsp/allwinner_tina/drivers/spi/drv_spi.c
@@ -34,7 +34,7 @@
 #define SPI_BUS_MAX_CLK    (30 * 1000 * 1000)
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME  "[SPI]"
+#define DBG_SECTION_NAME  "SPI"
 #define DBG_LEVEL         DBG_WARNING
 #define DBG_COLOR
 #include <rtdbg.h>

--- a/bsp/allwinner_tina/drivers/spi/drv_spi_flash.c
+++ b/bsp/allwinner_tina/drivers/spi/drv_spi_flash.c
@@ -27,7 +27,7 @@
 #include <rtdevice.h>
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME  "[FLASH]"
+#define DBG_SECTION_NAME  "FLASH"
 #define DBG_LEVEL         DBG_LOG
 #define DBG_COLOR
 #include <rtdbg.h>

--- a/bsp/imxrt1052-evk/drivers/drv_eth.c
+++ b/bsp/imxrt1052-evk/drivers/drv_eth.c
@@ -42,7 +42,7 @@
 //#define ETH_TX_DUMP
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME    "[ETH]"
+#define DBG_SECTION_NAME    "ETH"
 #define DBG_COLOR
 #define DBG_LEVEL           DBG_INFO
 #include <rtdbg.h>

--- a/bsp/imxrt1052-evk/drivers/drv_eth_fire.c
+++ b/bsp/imxrt1052-evk/drivers/drv_eth_fire.c
@@ -42,7 +42,7 @@
 //#define ETH_TX_DUMP
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME    "[ETH]"
+#define DBG_SECTION_NAME    "ETH"
 #define DBG_COLOR
 #define DBG_LEVEL           DBG_LOG
 #include <rtdbg.h>

--- a/bsp/imxrt1052-evk/drivers/fsl_phy_fire.c
+++ b/bsp/imxrt1052-evk/drivers/fsl_phy_fire.c
@@ -26,7 +26,7 @@
 #include <rtthread.h>
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME    "[PHY]"
+#define DBG_SECTION_NAME    "PHY"
 #define DBG_COLOR
 #define DBG_LEVEL           DBG_LOG
 #include <rtdbg.h>

--- a/bsp/qemu-vexpress-a9/drivers/audio/drv_pl041.c
+++ b/bsp/qemu-vexpress-a9/drivers/audio/drv_pl041.c
@@ -29,7 +29,7 @@
 #include "realview.h"
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME  "[PL041]"
+#define DBG_SECTION_NAME  "PL041"
 // #define DBG_LEVEL         DBG_LOG
 // #define DBG_LEVEL         DBG_INFO
 #define DBG_LEVEL         DBG_WARNING

--- a/bsp/x1000/drivers/mmc/drv_mmc.c
+++ b/bsp/x1000/drivers/mmc/drv_mmc.c
@@ -34,7 +34,7 @@
 #define PIO_THRESHOLD       64  /* use pio mode if data length < PIO_THRESHOLD */
 
 #define DEBUG_ENABLE
-#define DEBUG_SECTION_NAME  "[SDIO]"
+#define DEBUG_SECTION_NAME  "SDIO"
 #define DEBUG_LEVEL         DBG_INFO
 // #define DEBUG_LEVEL         DBG_LOG
 #define DEBUG_COLOR

--- a/components/dfs/include/dfs_private.h
+++ b/components/dfs/include/dfs_private.h
@@ -4,7 +4,7 @@
 #include <dfs.h>
 
 // #define DBG_ENABLE
-#define DBG_SECTION_NAME	"[ DFS]"
+#define DBG_SECTION_NAME	"DFS"
 #define DBG_COLOR
 #define DBG_LEVEL			DBG_LOG
 #include <rtdbg.h>

--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -43,7 +43,7 @@
 
 // #define DEBUG_ENABLE
 #define DEBUG_LEVEL         DBG_LOG
-#define DBG_SECTION_NAME    "[UART]"
+#define DBG_SECTION_NAME    "UART"
 #define DEBUG_COLOR
 #include <rtdbg.h>
 

--- a/components/lwp/lwp.c
+++ b/components/lwp/lwp.c
@@ -32,7 +32,7 @@
 #include "lwp.h"
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME    "[LWP]"
+#define DBG_SECTION_NAME    "LWP"
 #define DBG_COLOR
 #define DBG_LEVEL           DBG_WARNING
 #include <rtdbg.h>

--- a/components/lwp/lwp_mem.c
+++ b/components/lwp/lwp_mem.c
@@ -26,7 +26,7 @@
 #include <lwp.h>
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME    "[LWPMEM]"
+#define DBG_SECTION_NAME    "LWPMEM"
 #define DBG_COLOR
 #define DBG_LEVEL           DBG_WARNING
 #include <rtdbg.h>

--- a/components/lwp/lwp_syscall.c
+++ b/components/lwp/lwp_syscall.c
@@ -27,7 +27,7 @@
 #include <lwp_syscall.h>
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME    "[LWP_CALL]"
+#define DBG_SECTION_NAME    "LWP_CALL"
 #define DBG_COLOR
 #define DBG_LEVEL           DBG_WARNING
 #include <rtdbg.h>

--- a/include/rtdbg.h
+++ b/include/rtdbg.h
@@ -131,17 +131,21 @@
         rt_kprintf("\n");                                   \
     }
 
+#define dbg_raw(...)         rt_kprintf(__VA_ARGS__);
+
 #else
 #define dbg_log(level, fmt, ...)
 #define dbg_here
 #define dbg_enter
 #define dbg_exit
 #define dbg_log_line(level, ...)
+#define dbg_raw(...)
 #endif
 
 #define LOG_D(...)           dbg_log_line(DBG_LOG    , __VA_ARGS__)
 #define LOG_I(...)           dbg_log_line(DBG_INFO   , __VA_ARGS__)
 #define LOG_W(...)           dbg_log_line(DBG_WARNING, __VA_ARGS__)
 #define LOG_E(...)           dbg_log_line(DBG_ERROR  , __VA_ARGS__)
+#define LOG_RAW(...)         dbg_raw(__VA_ARGS__)
 
 #endif /* RT_DBG_H__ */

--- a/include/rtdbg.h
+++ b/include/rtdbg.h
@@ -32,7 +32,7 @@
  * In your C/C++ file, enable/disable DEBUG_ENABLE macro, and then include this
  * header file.
  *
- * #define DBG_SECTION_NAME    "[ MOD]"
+ * #define DBG_SECTION_NAME    "MOD"
  * #define DBG_ENABLE          // enable debug macro
  * #define DBG_LEVEL           DBG_INFO
  * #include <rtdbg.h>          // must after of DEBUG_ENABLE or some other options
@@ -81,10 +81,14 @@
  * WHITE    37
  */
 #ifdef DBG_COLOR
-#define _DBG_COLOR(n)       rt_kprintf("\033["#n"m")
+#define _DBG_COLOR(n)        rt_kprintf("\033["#n"m")
+#define _DBG_LOG_HDR(lvl_name, color_n)                    \
+    rt_kprintf("\033["#color_n"m["lvl_name"/"DBG_SECTION_NAME"] ")
 #else
 #define _DBG_COLOR(n)
-#endif
+#define _DBG_LOG_HDR(lvl_name, color_n)                    \
+    rt_kprintf("["lvl_name"/"DBG_SECTION_NAME"] ")
+#endif /* DBG_COLOR */
 
 /*
  * static debug routine
@@ -94,12 +98,13 @@
     {                                                       \
         switch(level)                                       \
         {                                                   \
-            case DBG_ERROR:   _DBG_COLOR(31); break;        \
-            case DBG_WARNING: _DBG_COLOR(33); break;        \
-            case DBG_INFO:    _DBG_COLOR(32); break;        \
+            case DBG_ERROR:   _DBG_LOG_HDR("E", 31); break; \
+            case DBG_WARNING: _DBG_LOG_HDR("W", 33); break; \
+            case DBG_INFO:    _DBG_LOG_HDR("I", 32); break; \
+            case DBG_LOG:     _DBG_LOG_HDR("D", 0); break;  \
             default: break;                                 \
         }                                                   \
-        rt_kprintf(DBG_SECTION_NAME fmt, ##__VA_ARGS__);    \
+        rt_kprintf(fmt, ##__VA_ARGS__);                     \
         _DBG_COLOR(0);                                      \
     }
 

--- a/src/signal.c
+++ b/src/signal.c
@@ -35,7 +35,7 @@
 #endif
 
 // #define DBG_ENABLE
-#define DBG_SECTION_NAME    "[SIGN]"
+#define DBG_SECTION_NAME    "SIGN"
 #define DBG_COLOR
 #define DBG_LEVEL           DBG_LOG
 #include <rtdbg.h>


### PR DESCRIPTION
- 1、增加 `dbg_raw` 及 `LOG_RAW` API，便于使用日志接口执行类似 hexdump 的操作
- 2、完善日志头的格式，便于在不开启彩色日志的情况，也能够很容易的区分日志的类型。

改动前

```
[AT] AT version:1.2.0.0(Jul  1 2016 20:04:45)
[AT] SDK version:1.5.4.1(39cb9a32)
[AT] Ai-Thinker Technology Co. Ltd.
[AT] Dec  2 2016 14:21:16
[AT] ESP8266 WIFI is connected.
[AT] AT network initialize success!
```

改动后

```
[D/AT] AT version:1.2.0.0(Jul  1 2016 20:04:45)
[D/AT] SDK version:1.5.4.1(39cb9a32)
[D/AT] Ai-Thinker Technology Co. Ltd.
[D/AT] Dec  2 2016 14:21:16
[I/AT] ESP8266 WIFI is connected.
[I/AT] AT network initialize success!
```