### PR TITLE
[dfs] Fix dfs_file_ioctl return check on fcntl.

### DIFF
--- a/components/dfs/src/dfs_posix.c
+++ b/components/dfs/src/dfs_posix.c
@@ -449,7 +449,7 @@ int fcntl(int fildes, int cmd, ...)
     }
     else ret = -EBADF;
 
-    if (ret != 0)
+    if (ret < 0)
     {
         rt_set_errno(ret);
         ret = -1;


### PR DESCRIPTION
参考 http://pubs.opengroup.org/onlinepubs/7908799/xsh/fcntl.html

避免 F_GETFL 无法获取