### PR TITLE
[libc] dependence update: 

### DIFF
--- a/components/libc/compilers/armlibc/stubs.c
+++ b/components/libc/compilers/armlibc/stubs.c
@@ -189,7 +189,7 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
 
     if ((fh == STDOUT) || (fh == STDERR))
     {
-#ifndef RT_USING_CONSOLE
+#if !defined(RT_USING_CONSOLE) || !defined(RT_USING_DEVICE)
         return 0;
 #else
 #ifdef RT_USING_POSIX


### PR DESCRIPTION
rt_device_write()/rt_console_get_device() need RT_USING_CONSOLE and RT_USING_DEVICE

如果只打开RT_USING_CONSOLE，不打开RT_USING_DEVICE就会编译报错。