### PR TITLE
[device][serial] call rx_indicate function only if the rx_length is n…

### DIFF
--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -1180,7 +1180,10 @@ void rt_hw_serial_isr(struct rt_serial_device *serial, int event)
                     (serial->config.bufsz - (rx_fifo->get_index - rx_fifo->put_index));
                 rt_hw_interrupt_enable(level);
 
-                serial->parent.rx_indicate(&serial->parent, rx_length);
+                if (rx_length)
+                {
+                    serial->parent.rx_indicate(&serial->parent, rx_length);
+                }
             }
             break;
         }


### PR DESCRIPTION
…ot equal 0

在使用软件方式模拟中断去实现类似segger jlink rtt输入的时候，有可能出现调用了
`rt_hw_serial_isr(&serial, RT_SERIAL_EVENT_RX_IND);` 但是没有数据的情况，所以在serial.c里加入了判断。