### PR TITLE
remove “for loop initial declarations are only allowed in C99 or C11 mode” compile errors in linux system.

### DIFF
--- a/bsp/stm32f429-armfly/drivers/drv_ft5x06.c
+++ b/bsp/stm32f429-armfly/drivers/drv_ft5x06.c
@@ -123,7 +123,6 @@ static int _ft5x06_read(unsigned char cmd,
 #ifdef RT_USING_FINSH
 static int search_ft5x06(void)
 {
-    int i;
     struct rt_i2c_msg msgs[2];
     uint8_t cmd = 0xA3;
     uint8_t buf = 0;
@@ -136,7 +135,7 @@ static int search_ft5x06(void)
     msgs[1].buf   = &buf;
     msgs[1].len   = 1;
 
-    for (i = 0; i <= 0x7f; i++)
+    for (int i = 0; i <= 0x7f; i++)
     {
         int len;
         msgs[0].addr  = i;

--- a/bsp/stm32f429-armfly/drivers/drv_ft5x06.c
+++ b/bsp/stm32f429-armfly/drivers/drv_ft5x06.c
@@ -123,6 +123,7 @@ static int _ft5x06_read(unsigned char cmd,
 #ifdef RT_USING_FINSH
 static int search_ft5x06(void)
 {
+    int i;
     struct rt_i2c_msg msgs[2];
     uint8_t cmd = 0xA3;
     uint8_t buf = 0;
@@ -135,7 +136,7 @@ static int search_ft5x06(void)
     msgs[1].buf   = &buf;
     msgs[1].len   = 1;
 
-    for (int i = 0; i <= 0x7f; i++)
+    for (i = 0; i <= 0x7f; i++)
     {
         int len;
         msgs[0].addr  = i;

--- a/bsp/stm32f429-armfly/rtconfig.py
+++ b/bsp/stm32f429-armfly/rtconfig.py
@@ -52,10 +52,10 @@ if PLATFORM == 'gcc':
     LPATH = ''
 
     if BUILD == 'debug':
-        CFLAGS += ' -O0 -gdwarf-2'
+        CFLAGS += ' -O0 -gdwarf-2 -std=c99'
         AFLAGS += ' -gdwarf-2'
     else:
-        CFLAGS += ' -O2'
+        CFLAGS += ' -O2 -std=c99'
 
     POST_ACTION = OBJCPY + ' -O binary $TARGET rtthread.bin\n' + SIZE + ' $TARGET \n'
 


### PR DESCRIPTION
remove “for loop initial declarations are only allowed in C99 or C11 mode” compile errors in linux system. please ignore the changes of drv_ft5x06.c file and just focus on the rtconfig.py file.