### PR TITLE
add scons --dist-strip support

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -115,7 +115,7 @@ class Win32Spawn:
 # generate cconfig.h file
 def GenCconfigFile(env, BuildOptions):
     import rtconfig
-    
+
     if rtconfig.PLATFORM == 'gcc':
         contents = ''
         if not os.path.isfile('cconfig.h'):
@@ -147,21 +147,16 @@ def PrepareBuilding(env, root_directory, has_libcpu=False, remove_components = [
     global Rtt_Root
 
     # ===== Add option to SCons =====
-    AddOption('--copy',
-                      dest = 'copy',
-                      action = 'store_true',
-                      default = False,
-                      help = 'copy rt-thread directory to local.')
-    AddOption('--copy-header',
-                      dest = 'copy-header',
-                      action = 'store_true',
-                      default = False,
-                      help = 'copy header of rt-thread directory to local.')
     AddOption('--dist',
                       dest = 'make-dist',
                       action = 'store_true',
                       default = False,
                       help = 'make distribution')
+    AddOption('--dist-strip',
+                      dest = 'make-dist-strip',
+                      action = 'store_true',
+                      default = False,
+                      help = 'make distribution and strip useless files')
     AddOption('--cscope',
                       dest = 'cscope',
                       action = 'store_true',
@@ -713,7 +708,7 @@ def DoBuilding(target, objects):
         program = Env.Program(target, objects)
 
     EndBuilding(target, program)
-        
+
 def GenTargetProject(program = None):
 
     if GetOption('target') == 'mdk':
@@ -789,17 +784,12 @@ def EndBuilding(target, program = None):
         GenTargetProject(program)
 
     BSP_ROOT = Dir('#').abspath
-    if GetOption('copy') and program != None:
-        from mkdist import MakeCopy
-        MakeCopy(program, BSP_ROOT, Rtt_Root, Env)
-        need_exit = True
-    if GetOption('copy-header') and program != None:
-        from mkdist import MakeCopyHeader
-        MakeCopyHeader(program, BSP_ROOT, Rtt_Root, Env)
-        need_exit = True
     if GetOption('make-dist') and program != None:
         from mkdist import MkDist
         MkDist(program, BSP_ROOT, Rtt_Root, Env)
+    if GetOption('make-dist-strip') and program != None:
+        from mkdist import MkDist_Strip
+        MkDist_Strip(program, BSP_ROOT, Rtt_Root, Env)
         need_exit = True
     if GetOption('cscope'):
         from cscope import CscopeDatabase

--- a/tools/mkdist.py
+++ b/tools/mkdist.py
@@ -234,8 +234,8 @@ def MkDist_Strip(program, BSP_ROOT, RTT_ROOT, Env):
     do_copy_file(os.path.join(RTT_ROOT, 'README.md'), os.path.join(target_path, 'README.md'))
     do_copy_file(os.path.join(RTT_ROOT, 'README_zh.md'), os.path.join(target_path, 'README_zh.md'))
 
-    print('=> %s' % os.path.join('components', 'libc', 'components'))
-    do_copy_folder(os.path.join(RTT_ROOT, 'rcomponents', 'libc', 'compilers'), os.path.join(target_path, 'components', 'libc', 'compilers'))
+    print('=> %s' % os.path.join('components', 'libc', 'compilers'))
+    do_copy_folder(os.path.join(RTT_ROOT, 'components', 'libc', 'compilers'), os.path.join(target_path, 'components', 'libc', 'compilers'))
 
     # copy all libcpu/ARCH directory
     print('=> libcpu')

--- a/tools/mkdist.py
+++ b/tools/mkdist.py
@@ -142,10 +142,10 @@ def bs_update_ide_project(bsp_root, rtt_root):
         if child.returncode == 0:
             print('update %s project' % item)
 
-def zip_dist(bsp_root, dist_dir, dist_name):
+def zip_dist(dist_dir, dist_name):
     import zipfile
 
-    zip_filename = os.path.join(bsp_root, 'dist', dist_name)
+    zip_filename = os.path.join(dist_dir)
     zip = zipfile.ZipFile(zip_filename + '.zip', 'w')
     pre_len = len(os.path.dirname(dist_dir))
 
@@ -163,7 +163,7 @@ def MkDist_Strip(program, BSP_ROOT, RTT_ROOT, Env):
     print('make distribution and strip useless files....')
 
     dist_name = os.path.basename(BSP_ROOT)
-    dist_dir  = os.path.join(BSP_ROOT, 'dist', dist_name)
+    dist_dir  = os.path.join(BSP_ROOT, 'dist-strip', dist_name)
     target_path = os.path.join(dist_dir, 'rt-thread')
 
     print('=> %s' % os.path.basename(BSP_ROOT))
@@ -254,7 +254,7 @@ def MkDist_Strip(program, BSP_ROOT, RTT_ROOT, Env):
     bs_update_ide_project(dist_dir, target_path)
 
     # make zip package
-    zip_dist(BSP_ROOT, dist_dir, dist_name)
+    zip_dist(dist_dir, dist_name)
 
     print('done!')
 
@@ -310,7 +310,7 @@ def MkDist(program, BSP_ROOT, RTT_ROOT, Env):
     bs_update_ide_project(dist_dir, target_path)
 
     # make zip package
-    zip_dist(BSP_ROOT, dist_dir, dist_name)
+    zip_dist(dist_dir, dist_name)
 
     print('done!')
 

--- a/tools/mkdist.py
+++ b/tools/mkdist.py
@@ -178,6 +178,8 @@ def MkDist_Strip(program, BSP_ROOT, RTT_ROOT, Env):
     target_list = []
     libcpu_dir = os.path.join(RTT_ROOT, 'libcpu').lower()
     libc_dir = os.path.join(RTT_ROOT, 'components', 'libc', 'compilers').lower()
+    sal_dir = os.path.join(RTT_ROOT, 'components', 'net', 'sal_socket').lower()
+    sources_include_sal = False
     for src in source_list:
         if src.lower().startswith(BSP_ROOT.lower()):
             continue
@@ -186,6 +188,9 @@ def MkDist_Strip(program, BSP_ROOT, RTT_ROOT, Env):
         if src.lower().startswith(libcpu_dir):
             continue
         if src.lower().startswith(libc_dir):
+            continue
+        if src.lower().startswith(sal_dir):
+            sources_include_sal = True
             continue
 
         if src.lower().startswith(RTT_ROOT.lower()):
@@ -237,11 +242,16 @@ def MkDist_Strip(program, BSP_ROOT, RTT_ROOT, Env):
     print('=> %s' % os.path.join('components', 'libc', 'compilers'))
     do_copy_folder(os.path.join(RTT_ROOT, 'components', 'libc', 'compilers'), os.path.join(target_path, 'components', 'libc', 'compilers'))
 
+    if sources_include_sal:
+        print('=> %s' % os.path.join('components', 'net', 'sal_socket'))
+        do_copy_folder(os.path.join(RTT_ROOT, 'components', 'net', 'sal_socket'), os.path.join(target_path, 'components', 'net', 'sal_socket'))
+
     # copy all libcpu/ARCH directory
-    print('=> libcpu')
     import rtconfig
+    print('=> %s' % (os.path.join('libcpu', rtconfig.ARCH, rtconfig.CPU)))
     do_copy_folder(os.path.join(RTT_ROOT, 'libcpu', rtconfig.ARCH, rtconfig.CPU), os.path.join(target_path, 'libcpu', rtconfig.ARCH, rtconfig.CPU))
     if os.path.exists(os.path.join(RTT_ROOT, 'libcpu', rtconfig.ARCH, 'common')):
+        print('=> %s' % (os.path.join('libcpu', rtconfig.ARCH, 'common')))
         do_copy_folder(os.path.join(RTT_ROOT, 'libcpu', rtconfig.ARCH, 'common'), os.path.join(target_path, 'libcpu', rtconfig.ARCH, 'common'))
     do_copy_file(os.path.join(RTT_ROOT, 'libcpu', 'Kconfig'), os.path.join(target_path, 'libcpu', 'Kconfig'))
     do_copy_file(os.path.join(RTT_ROOT, 'libcpu', 'SConscript'), os.path.join(target_path, 'libcpu', 'SConscript'))


### PR DESCRIPTION
使用scons --dist-strip ，而不是scons --dist --strip，因为没法找到合适的办法添加二级参数，可以在help里面显示正确的信息。

scons --dist-strip的工作是：
- 复制BSP目录下的所有文件
- 复制libcpu/ARCH目录下当前BSP可能需要的文件
- 复制compontents/libc/compilers下所有的文件。
- 复制当前程序所有用到RT-Thread目录下的源码（*.c *.h）
- 复制所有源码的相关目录下的SConscript文件
- 复制所有Kconfig文件
- 更新BSP目录下的Sconstruct文件，
- 更新BSP目录下的可能存在的Kconfig文件
- 更新BSP目录下的所有的工程文件（目前支持mdk4/mdk5/iar/vs/vs2012/cdk）
- 打包到dist目录