### PR TITLE
修复tools/utils.py 数组越界问题 ，在Linux环境下会遇到无后缀的文件。

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -114,7 +114,14 @@ def walk_children(child):
 
     # print child
     full_path = child.rfile().abspath
-    file_type  = full_path.rsplit('.',1)[1]
+    file_type_list  = full_path.rsplit('.',1)
+    if(len(file_type_list) >= 2):
+        file_type=file_type_list[1]
+    else:
+        print("Info : something below seems to be a regular file without suffix,and won't be added:")
+        print(full_path)
+        file_type="Something without suffix"
+
     #print file_type
     if file_type in source_ext:
         if full_path not in source_list:


### PR DESCRIPTION
修复tools/utils.py 数组越界问题  ，在Linux环境下会遇到无后缀的文件。参见
#1566 
在修复之前，Linux 下使用`scons --target=xxx -s`会遇到如下问题：
```
IndexError: list index out of range:
  File "/home/tender/workplace/git/rt-thread/bsp/qemu-vexpress-a9/SConstruct", line 30:
    DoBuilding(TARGET, objs)
  File "/home/tender/workplace/git/rt-thread/tools/building.py", line 715:
    EndBuilding(target, program)
  File "/home/tender/workplace/git/rt-thread/tools/building.py", line 789:
    GenTargetProject(program)
  File "/home/tender/workplace/git/rt-thread/tools/building.py", line 768:
    GenerateVSCode(Env)
  File "/home/tender/workplace/git/rt-thread/tools/vsc.py", line 74:
    GenerateCFiles(env)
  File "/home/tender/workplace/git/rt-thread/tools/vsc.py", line 42:
    info = utils.ProjectInfo(env)
  File "/home/tender/workplace/git/rt-thread/tools/utils.py", line 206:
    HEADERS = TargetGetList(env, ['h'])
  File "/home/tender/workplace/git/rt-thread/tools/utils.py", line 163:
    walk_children(item)
  File "/home/tender/workplace/git/rt-thread/tools/utils.py", line 126:
    walk_children(item)
  File "/home/tender/workplace/git/rt-thread/tools/utils.py", line 126:
    walk_children(item)
  File "/home/tender/workplace/git/rt-thread/tools/utils.py", line 117:
    file_type  = full_path.rsplit('.',1)[1]
```
经调试，发现访问了如下文件（没有后缀导致数组越界）：
```
/usr/bin/arm-none-eabi-gcc
/usr/bin/arm-none-eabi-g++
/usr/bin/arm-none-eabi-objcopy
/usr/bin/arm-none-eabi-size

```
故做此修复，经验证修复后在Linux下可正常运行`scons --target=xxx -s`





Signed-off-by: Jia Qingtong <wanywhn@qq.com>