### PR TITLE
[rtdbg] Optimize footprint for rtdbg log.

### DIFF
--- a/include/rtdbg.h
+++ b/include/rtdbg.h
@@ -54,10 +54,10 @@
 #include <rtconfig.h>
 
 /* DEBUG level */
-#define DBG_LOG             0
-#define DBG_INFO            1
-#define DBG_WARNING         2
-#define DBG_ERROR           3
+#define DBG_ERROR           0
+#define DBG_WARNING         1
+#define DBG_INFO            2
+#define DBG_LOG             3
 
 #ifndef DBG_SECTION_NAME
 #define DBG_SECTION_NAME    "DBG"
@@ -98,7 +98,7 @@
  * static debug routine
  */
 #define dbg_log(level, fmt, ...)                            \
-    if ((level) >= DBG_LEVEL)                               \
+    if ((level) <= DBG_LEVEL)                               \
     {                                                       \
         switch(level)                                       \
         {                                                   \
@@ -113,13 +113,13 @@
     }
 
 #define dbg_here                                            \
-    if ((DBG_LEVEL) >= DBG_LOG){                            \
+    if ((DBG_LEVEL) <= DBG_LOG){                            \
         rt_kprintf(DBG_SECTION_NAME " Here %s:%d\n",        \
             __FUNCTION__, __LINE__);                        \
     }
 
 #define dbg_enter                                           \
-    if ((DBG_LEVEL) >= DBG_LOG){                            \
+    if ((DBG_LEVEL) <= DBG_LOG){                            \
         _DBG_COLOR(32);                                     \
         rt_kprintf(DBG_SECTION_NAME " Enter %s\n",          \
             __FUNCTION__);                                  \
@@ -127,7 +127,7 @@
     }
 
 #define dbg_exit                                            \
-    if ((DBG_LEVEL) >= DBG_LOG){                            \
+    if ((DBG_LEVEL) <= DBG_LOG){                            \
         _DBG_COLOR(32);                                     \
         rt_kprintf(DBG_SECTION_NAME " Exit  %s:%d\n",       \
             __FUNCTION__);                                  \
@@ -155,25 +155,25 @@
 #define dbg_raw(...)
 #endif /* DBG_ENABLE */
 
-#if (DBG_LEVEL <= DBG_LOG)
+#if (DBG_LEVEL >= DBG_LOG)
 #define LOG_D(fmt, ...)      dbg_log_line("D", 0, fmt, ##__VA_ARGS__)
 #else
 #define LOG_D(...)
 #endif
 
-#if (DBG_LEVEL <= DBG_INFO)
+#if (DBG_LEVEL >= DBG_INFO)
 #define LOG_I(fmt, ...)      dbg_log_line("I", 32, fmt, ##__VA_ARGS__)
 #else
 #define LOG_I(...)
 #endif
 
-#if (DBG_LEVEL <= DBG_WARNING)
+#if (DBG_LEVEL >= DBG_WARNING)
 #define LOG_W(fmt, ...)      dbg_log_line("W", 33, fmt, ##__VA_ARGS__)
 #else
 #define LOG_W(...)
 #endif
 
-#if (DBG_LEVEL <= DBG_ERROR)
+#if (DBG_LEVEL >= DBG_ERROR)
 #define LOG_E(fmt, ...)      dbg_log_line("E", 31, fmt, ##__VA_ARGS__)
 #else
 #define LOG_E(...)

--- a/include/rtdbg.h
+++ b/include/rtdbg.h
@@ -84,10 +84,14 @@
 #define _DBG_COLOR(n)        rt_kprintf("\033["#n"m")
 #define _DBG_LOG_HDR(lvl_name, color_n)                    \
     rt_kprintf("\033["#color_n"m["lvl_name"/"DBG_SECTION_NAME"] ")
+#define _DBG_LOG_X_END                                     \
+    rt_kprintf("\033[0m\n")
 #else
 #define _DBG_COLOR(n)
 #define _DBG_LOG_HDR(lvl_name, color_n)                    \
     rt_kprintf("["lvl_name"/"DBG_SECTION_NAME"] ")
+#define _DBG_LOG_X_END                                     \
+    rt_kprintf("\n")
 #endif /* DBG_COLOR */
 
 /*
@@ -130,11 +134,15 @@
         _DBG_COLOR(0);                                      \
     }
 
-#define dbg_log_line(level, ...)                            \
-    dbg_log(level, __VA_ARGS__);                            \
-    if ((level) >= DBG_LEVEL) {                             \
-        rt_kprintf("\n");                                   \
-    }
+
+#define dbg_log_line(lvl, color_n, fmt, ...)                \
+    do                                                      \
+    {                                                       \
+        _DBG_LOG_HDR(lvl, color_n);                         \
+        rt_kprintf(fmt, ##__VA_ARGS__);                     \
+        _DBG_LOG_X_END;                                     \
+    }                                                       \
+    while (0)
 
 #define dbg_raw(...)         rt_kprintf(__VA_ARGS__);
 
@@ -143,14 +151,34 @@
 #define dbg_here
 #define dbg_enter
 #define dbg_exit
-#define dbg_log_line(level, ...)
+#define dbg_log_line(lvl, color_n, fmt, ...)
 #define dbg_raw(...)
+#endif /* DBG_ENABLE */
+
+#if (DBG_LEVEL <= DBG_LOG)
+#define LOG_D(fmt, ...)      dbg_log_line("D", 0, fmt, ##__VA_ARGS__)
+#else
+#define LOG_D(...)
 #endif
 
-#define LOG_D(...)           dbg_log_line(DBG_LOG    , __VA_ARGS__)
-#define LOG_I(...)           dbg_log_line(DBG_INFO   , __VA_ARGS__)
-#define LOG_W(...)           dbg_log_line(DBG_WARNING, __VA_ARGS__)
-#define LOG_E(...)           dbg_log_line(DBG_ERROR  , __VA_ARGS__)
+#if (DBG_LEVEL <= DBG_INFO)
+#define LOG_I(fmt, ...)      dbg_log_line("I", 32, fmt, ##__VA_ARGS__)
+#else
+#define LOG_I(...)
+#endif
+
+#if (DBG_LEVEL <= DBG_WARNING)
+#define LOG_W(fmt, ...)      dbg_log_line("W", 33, fmt, ##__VA_ARGS__)
+#else
+#define LOG_W(...)
+#endif
+
+#if (DBG_LEVEL <= DBG_ERROR)
+#define LOG_E(fmt, ...)      dbg_log_line("E", 31, fmt, ##__VA_ARGS__)
+#else
+#define LOG_E(...)
+#endif
+
 #define LOG_RAW(...)         dbg_raw(__VA_ARGS__)
 
 #endif /* RT_DBG_H__ */


### PR DESCRIPTION
- 重定义 dbg_log_line 宏，不再使用 dbg_log ，降低 LOG_X 宏展开时的代码体积
- 增加 LOG_X 宏 API 的日志级别检测功能，低于设定级别日志不仅不输出，同时也会不再展开。进一步降低资源占用