### PR TITLE
rt_serial_t没有定义成指针类型

### DIFF
--- a/components/drivers/include/drivers/serial.h
+++ b/components/drivers/include/drivers/serial.h
@@ -159,7 +159,7 @@ struct rt_serial_device
     void *serial_rx;
     void *serial_tx;
 };
-typedef struct rt_serial_device rt_serial_t;
+typedef struct rt_serial_device *rt_serial_t;
 
 /**
  * uart operators


### PR DESCRIPTION
typedef struct rt_serial_device *rt_serial_t;