### PR TITLE
修正打开"Support C++ features"后gcc编译失败问题

### DIFF
--- a/components/cplusplus/crt_init.c
+++ b/components/cplusplus/crt_init.c
@@ -36,11 +36,11 @@ void $Sub$$__cpp_initialize__aeabi_(void)
 }
 #elif defined(__GNUC__) && !defined(__CS_SOURCERYGXX_MAJ__)
 /* The _init()/_fini() routines has been defined in codesourcery g++ lite */
-void _init()
+RT_WEAK void _init()
 {
 }
 
-void _fini()
+RT_WEAK void _fini()
 {
 }
 


### PR DESCRIPTION
打开"Support C++ features"后gcc将编译失败,提示_init和_fini重复定义.暂时加入RT_WEAK避开此问题.