### PR TITLE
修正drivers下一处bug,并修正armclang编译时该目录下的错误或警告

### DIFF
--- a/components/drivers/cputime/cputime.c
+++ b/components/drivers/cputime/cputime.c
@@ -68,7 +68,7 @@ uint32_t clock_cpu_microsecond(uint32_t cpu_tick)
 {
     float unit = clock_cpu_getres();
 
-    return (cpu_tick * unit) / 1000;
+    return (uint32_t)((cpu_tick * unit) / 1000);
 }
 
 /**
@@ -83,7 +83,7 @@ uint32_t clock_cpu_millisecond(uint32_t cpu_tick)
 {
     float unit = clock_cpu_getres();
 
-    return (cpu_tick * unit) / (1000 * 1000);
+    return (uint32_t)((cpu_tick * unit) / (1000 * 1000));
 }
 
 /**

--- a/components/drivers/usb/usbdevice/class/cdc_vcom.c
+++ b/components/drivers/usb/usbdevice/class/cdc_vcom.c
@@ -849,7 +849,7 @@ static void vcom_tx_thread_entry(void* parameter)
         {
             continue;
         }
-        if(!res & CDC_TX_HAS_DATE)
+        if(!(res & CDC_TX_HAS_DATE))
         {
             continue;
         }

--- a/components/drivers/usb/usbhost/core/hub.c
+++ b/components/drivers/usb/usbhost/core/hub.c
@@ -502,11 +502,11 @@ static rt_err_t rt_usbh_hub_enable(void *arg)
 {
     int i = 0;
     rt_err_t ret = RT_EOK;
-    uep_desc_t ep_desc;
+    uep_desc_t ep_desc = RT_NULL;
     uhub_t hub;
     struct uinstance* device;
     struct uhintf* intf = (struct uhintf*)arg;
-    upipe_t pipe_in;
+    upipe_t pipe_in = RT_NULL;
     int timeout = 300;
     /* paremeter check */
     RT_ASSERT(intf != RT_NULL);


### PR DESCRIPTION
armclang支持PR拆分出来的改动: 修正drivers下,armclang编译时的警告或错误
注:vcom_tx_thread_entry下, if(!res & CDC_TX_HAS_DATE)应为bug.