### PR TITLE
dfs_uffs_getdents函数声明问题修正

### DIFF
--- a/components/dfs/filesystems/uffs/dfs_uffs.c
+++ b/components/dfs/filesystems/uffs/dfs_uffs.c
@@ -481,7 +481,7 @@ static int dfs_uffs_seek(struct dfs_fd* file,
 static int dfs_uffs_getdents(
     struct dfs_fd* file,
     struct dirent* dirp,
-    rt_uint32_t count)
+    uint32_t count)
 {
     rt_uint32_t index;
     char * file_path;


### PR DESCRIPTION
修正参数类型不匹配问题. uint32_t为unsigned int, 而rt_uint32_t为unsigned long
注: armclang编译器报错