### PR TITLE
修正armlibc下两处错误

### DIFF
--- a/components/libc/compilers/armlibc/mem_std.c
+++ b/components/libc/compilers/armlibc/mem_std.c
@@ -19,7 +19,7 @@
 /* avoid the heap and heap-using library functions supplied by arm */
 #pragma import(__use_no_heap)
 
-void *malloc(int n)
+void *malloc(rt_size_t n)
 {
     return rt_malloc(n);
 }

--- a/components/libc/compilers/armlibc/stubs.c
+++ b/components/libc/compilers/armlibc/stubs.c
@@ -249,7 +249,7 @@ int _sys_tmpnam(char *name, int fileno, unsigned maxlength)
 char *_sys_command_string(char *cmd, int len)
 {
     /* no support */
-    return cmd;
+    return RT_NULL;
 }
 
 /* This function writes a character to the console. */


### PR DESCRIPTION
1. 修正_sys_command_string返回值错误, no support时cmd为随机数据,可能导致c库初始化时在此函数返回处死循环或跑飞 2. malloc的参数类型应为rt_size_t(无符号), 否则armclang报错