### PR TITLE
[bsp] stm32f10x correct fifo1 alloc error

### DIFF
--- a/bsp/stm32f10x/drivers/bxcan.c
+++ b/bsp/stm32f10x/drivers/bxcan.c
@@ -512,12 +512,14 @@ static rt_err_t bxcancalcbaseoff(struct stm_bxcan *pbxcan, rt_int32_t hdr,
     rt_uint32_t fifo1start, fifo1end;
     rt_uint32_t ptr;
     fifo0start = 0;
-    fifo0end = pbxcan->filtermap[0].id32mask_cnt
+    fifo0end = fifo0start 
+               + pbxcan->filtermap[0].id32mask_cnt
                + pbxcan->filtermap[0].id32bit_cnt
                + pbxcan->filtermap[0].id16mask_cnt
                + pbxcan->filtermap[0].id16bit_cnt ;
     fifo1start = pbxcan->fifo1filteroff * 4;
-    fifo1end = pbxcan->filtermap[1].id32mask_cnt
+    fifo1end = fifo1start 
+               + pbxcan->filtermap[1].id32mask_cnt
                + pbxcan->filtermap[1].id32bit_cnt
                + pbxcan->filtermap[1].id16mask_cnt
                + pbxcan->filtermap[1].id16bit_cnt ;
@@ -525,17 +527,18 @@ static rt_err_t bxcancalcbaseoff(struct stm_bxcan *pbxcan, rt_int32_t hdr,
     {
         *pbase = 0;
         ptr = 0;
+	hdr -= fifo0start; 
     }
     else if (hdr >= fifo1start && hdr < fifo1end)
     {
         *pbase = pbxcan->fifo1filteroff;
         ptr = 1;
+	hdr -= fifo1start; 
     }
     else
     {
         return RT_ERROR;
     }
-    ptr = 0;
     if (hdr > pbxcan->filtermap[ptr].id32mask_cnt)
     {
         hdr -= pbxcan->filtermap[ptr].id32mask_cnt;

--- a/bsp/stm32f10x/drivers/bxcan.c
+++ b/bsp/stm32f10x/drivers/bxcan.c
@@ -527,13 +527,13 @@ static rt_err_t bxcancalcbaseoff(struct stm_bxcan *pbxcan, rt_int32_t hdr,
     {
         *pbase = 0;
         ptr = 0;
-	hdr -= fifo0start; 
+        hdr -= fifo0start; 
     }
     else if (hdr >= fifo1start && hdr < fifo1end)
     {
         *pbase = pbxcan->fifo1filteroff;
         ptr = 1;
-	hdr -= fifo1start; 
+        hdr -= fifo1start; 
     }
     else
     {


### PR DESCRIPTION
correct error when alloc filter to fifo1