### PR TITLE
修正_sys_command_string返回值

### DIFF
--- a/components/libc/compilers/armlibc/stubs.c
+++ b/components/libc/compilers/armlibc/stubs.c
@@ -249,7 +249,7 @@ int _sys_tmpnam(char *name, int fileno, unsigned maxlength)
 char *_sys_command_string(char *cmd, int len)
 {
     /* no support */
-    return cmd;
+    return RT_NULL;
 }
 
 /* This function writes a character to the console. */


### PR DESCRIPTION
_sys_command_string返回值错误,no support时cmd为随机数据,可能导致c库初始化时在此函数返回处死循环或跑飞.