### PR TITLE
Update libc.c

### DIFF
--- a/components/libc/compilers/newlib/libc.c
+++ b/components/libc/compilers/newlib/libc.c
@@ -39,7 +39,7 @@ int	_EXFUN(putenv,(char *__string));
 
 int libc_system_init(void)
 {
-#if defined(RT_USING_DFS) & defined(RT_USING_DFS_DEVFS)
+#if defined(RT_USING_DFS) & defined(RT_USING_DFS_DEVFS) & defined(RT_USING_CONSOLE)
     rt_device_t dev_console;
 
     dev_console = rt_console_get_device();


### PR DESCRIPTION
修复没有使用RT_USING_CONSOLE时，libc.c编译报错