### PR TITLE
[kernel] Remove unnecessary assertions

### DIFF
--- a/src/memheap.c
+++ b/src/memheap.c
@@ -124,8 +124,6 @@ RTM_EXPORT(rt_memheap_init);
 rt_err_t rt_memheap_detach(struct rt_memheap *heap)
 {
     RT_ASSERT(heap);
-    RT_ASSERT(rt_object_get_type(&heap->parent) == RT_Object_Class_MemHeap);
-    RT_ASSERT(rt_object_is_systemobject(&heap->parent));
 
     rt_object_detach(&(heap->lock.parent.parent));
     rt_object_detach(&(heap->parent));
@@ -142,7 +140,6 @@ void *rt_memheap_alloc(struct rt_memheap *heap, rt_uint32_t size)
     struct rt_memheap_item *header_ptr;
 
     RT_ASSERT(heap != RT_NULL);
-    RT_ASSERT(rt_object_get_type(&heap->parent) == RT_Object_Class_MemHeap);
 
     /* align allocated size */
     size = RT_ALIGN(size, RT_ALIGN_SIZE);
@@ -289,7 +286,6 @@ void *rt_memheap_realloc(struct rt_memheap *heap, void *ptr, rt_size_t newsize)
     struct rt_memheap_item *new_ptr;
 
     RT_ASSERT(heap);
-    RT_ASSERT(rt_object_get_type(&heap->parent) == RT_Object_Class_MemHeap);
 
     if (newsize == 0)
     {
@@ -521,7 +517,6 @@ void rt_memheap_free(void *ptr)
     heap = header_ptr->pool_ptr;
 
     RT_ASSERT(heap);
-    RT_ASSERT(rt_object_get_type(&heap->parent) == RT_Object_Class_MemHeap);
 
     /* lock memheap */
     result = rt_sem_take(&(heap->lock), RT_WAITING_FOREVER);
@@ -631,7 +626,6 @@ void *rt_malloc(rt_size_t size)
             heap   = (struct rt_memheap *)object;
 
             RT_ASSERT(heap);
-            RT_ASSERT(rt_object_get_type(&heap->parent) == RT_Object_Class_MemHeap);
 
             /* not allocate in the default system heap */
             if (heap == &_heap)


### PR DESCRIPTION
移除非必需的断言，rt_memheadp_alloc 不要求一定是是object的