### PR TITLE
修正fputc函数并移除__MICROLIB限定. 否则finsh功能不正常.

### DIFF
--- a/components/libc/compilers/armlibc/stubs.c
+++ b/components/libc/compilers/armlibc/stubs.c
@@ -304,14 +304,11 @@ int system(const char *string)
 }
 #endif
 
-#ifdef __MICROLIB
 #include <stdio.h>
 
 int fputc(int c, FILE *f) 
 {
-    char ch = c;
-
-    rt_kprintf(&ch);
+    rt_kprintf((char*)&c);
     return 1;
 }
 
@@ -326,4 +323,3 @@ int fgetc(FILE *f)
 
     return -1;
 }
-#endif


### PR DESCRIPTION
1. 修正fputc函数bug.
   arm c库汇编中使用ldrb r0, xxx传入参数c,因此第2~4字节为0. 直接转为字符串类型传入rt_kprintf即可.原实现,将因可能未找到'\0'结束符而当机.
2. 移除__MICROLIB限定.只要调用printf等函数,必须重新实现这两个函数. 否则需要实现半主机(semihost)功能.