### PR TITLE
Fix fpu

### DIFF
--- a/components/libc/compilers/armlibc/stubs.c
+++ b/components/libc/compilers/armlibc/stubs.c
@@ -315,7 +315,7 @@ int fputc(int c, FILE *f)
 {
     char ch[2] = {0};
 
-    ch[1] = c;
+    ch[0] = c;
     rt_kprintf(&ch[0]);
     return 1;
 }

--- a/libcpu/arm/cortex-m4/context_rvds.S
+++ b/libcpu/arm/cortex-m4/context_rvds.S
@@ -1,12 +1,8 @@
 ;/*
-; * File      : context_rvds.S
-; * This file is part of RT-Thread RTOS
-; * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
-; *
-; * The license and distribution terms for this file may be
-; * found in the file LICENSE in this distribution or at
-; * http://www.rt-thread.org/license/LICENSE
-; *
+;* Copyright (c) 2006-2018, RT-Thread Development Team
+;*
+;* SPDX-License-Identifier: Apache-2.0
+;*
 ; * Change Logs:
 ; * Date           Author       Notes
 ; * 2009-01-17     Bernard      first version.

--- a/libcpu/arm/cortex-m4/cpuport.c
+++ b/libcpu/arm/cortex-m4/cpuport.c
@@ -1,11 +1,7 @@
 /*
- * File      : cpuport.c
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- * The license and distribution terms for this file may be
- * found in the file LICENSE in this distribution or at
- * http://www.rt-thread.org/license/LICENSE
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes
@@ -23,7 +19,7 @@
 #include <rtthread.h>
 
 #if               /* ARMCC */ (  (defined ( __CC_ARM ) && defined ( __TARGET_FPU_VFP ))    \
-                  /* Clang */ || (defined ( __CLANG_ARM ) && defined ( __TARGET_FPU_VFP )) \
+                  /* Clang */ || (defined ( __CLANG_ARM ) && defined ( __VFP_FP__ ) && !defined(__SOFTFP__)) \
                   /* IAR */   || (defined ( __ICCARM__ ) && defined ( __ARMVFP__ ))        \
                   /* GNU */   || (defined ( __GNUC__ ) && defined ( __VFP_FP__ ) && !defined(__SOFTFP__)) )
 #define USE_FPU   1

--- a/libcpu/arm/cortex-m7/cpuport.c
+++ b/libcpu/arm/cortex-m7/cpuport.c
@@ -1,11 +1,7 @@
 /*
- * File      : cpuport.c
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- * The license and distribution terms for this file may be
- * found in the file LICENSE in this distribution or at
- * http://www.rt-thread.org/license/LICENSE
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes
@@ -23,7 +19,7 @@
 #include <rtthread.h>
 
 #if               /* ARMCC */ (  (defined ( __CC_ARM ) && defined ( __TARGET_FPU_VFP ))    \
-                  /* Clang */ || (defined ( __CLANG_ARM ) && defined ( __TARGET_FPU_VFP )) \
+                  /* Clang */ || (defined ( __CLANG_ARM ) && defined ( __VFP_FP__ ) && !defined(__SOFTFP__)) \
                   /* IAR */   || (defined ( __ICCARM__ ) && defined ( __ARMVFP__ ))        \
                   /* GNU */   || (defined ( __GNUC__ ) && defined ( __VFP_FP__ ) && !defined(__SOFTFP__)) )
 #define USE_FPU   1

--- a/src/clock.c
+++ b/src/clock.c
@@ -3,11 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- */
-
-/*
- * File      : clock.c
- *
  * Change Logs:
  * Date           Author       Notes
  * 2006-03-12     Bernard      first version

--- a/src/components.c
+++ b/src/components.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : init.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/device.c
+++ b/src/device.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : device.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/idle.c
+++ b/src/idle.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : idle.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : ipc.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/irq.c
+++ b/src/irq.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : irq.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : kservice.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/mem.c
+++ b/src/mem.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : mem.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : mempool.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/object.c
+++ b/src/object.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : object.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : scheduler.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/signal.c
+++ b/src/signal.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : signal.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/thread.c
+++ b/src/thread.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : thread.c
  *
  * Change Logs:
  * Date           Author       Notes

--- a/src/timer.c
+++ b/src/timer.c
@@ -2,10 +2,6 @@
  * Copyright (c) 2006-2018, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
- */
-
-/*
- * File      : timer.c
  *
  * Change Logs:
  * Date           Author       Notes


### PR DESCRIPTION
1. Fix the fputc issue when enable microlib for Keil/MDK.
2. Adjust the copyright information in the Kernel
3. Fix the FPU definition in M4/M7 for ARM Clang.
