### PR TITLE
Fix stm32f4xx-HAL I2C_BITOPS error

### DIFF
--- a/bsp/stm32f4xx-HAL/drivers/SConscript
+++ b/bsp/stm32f4xx-HAL/drivers/SConscript
@@ -34,7 +34,7 @@ if GetDepend(['RT_USING_RTC']):
 if GetDepend(['RT_USING_USB_HOST']):
     src += ['drv_usbh.c']
 
-if GetDepend(['RT_USING_I2C']):
+if GetDepend(['RT_USING_I2C_BITOPS']):
     src += ['drv_i2c.c']
 
 if GetDepend(['RT_USING_CAN']):


### PR DESCRIPTION
在 bs\stm32f4xx-HAL 下如果 menuconfig 选中：

    RT-Thread Components  --->
        Device Drivers  --->
            [*] Using I2C device drivers
            []   Use GPIO to simulate I2C

也就是使用 I2C 却不打开 GPIO 模拟 I2C，编译就会报错。
因为 drivers/drv_i2c.c 其实是用的软件模拟 I2C，必须同时选中 I2C 和 GPIO模拟 才行。

将宏定义从 RT_USING_I2C 改为 RT_USING_I2C_BITOPS 就可以避免这个问题。
