### PR TITLE
avoid to conflicting types for 'uint32_t' error.

### DIFF
--- a/libcpu/ia32/__udivsi3.c
+++ b/libcpu/ia32/__udivsi3.c
@@ -12,10 +12,7 @@
  * 2006-10-09     Bernard      the first version for i386
  */
 
-#include <rtthread.h>
-
-typedef rt_uint32_t uint32_t;
-typedef rt_int32_t int32_t;
+#include <stdint.h>
 
 uint32_t __udivsi3(uint32_t num, uint32_t den)
 {

--- a/libcpu/ia32/__umodsi3.c
+++ b/libcpu/ia32/__umodsi3.c
@@ -12,10 +12,7 @@
  * 2006-10-09     Bernard      the first version for i386
  */
 
-#include <rtthread.h>
-
-typedef rt_uint32_t uint32_t;
-typedef rt_int32_t int32_t;
+#include <stdint.h>
 
 uint32_t __umodsi3(uint32_t num, uint32_t den)
 {


### PR DESCRIPTION
already uint32_t is defined at components/libc/compilers/minilibc/stdint.h.

there is two ways to solve, using <stdint.h>/uint32_t pair or
<rtthread.h>/rt_uint32_t pair.

I choose former because this code belongs to C compiler, not RT-Thread system.