### PR TITLE
change hello.mo building process, compile and link separately

### DIFF
--- a/bsp/x86/Makefile
+++ b/bsp/x86/Makefile
@@ -7,7 +7,7 @@ all: rtthread rtsym exe dll floppy.img
 	@sudo mount -t vfat floppy.img tmp -o loop
 	@sudo cp -fv rtthread.elf tmp/boot/oskernel
 	@sudo rm tmp/bin/* -fr
-	@sudo cp out/* tmp/bin/ -fv
+	@sudo cp out/*.mo tmp/bin/ -fv
 	@sudo umount tmp
 
 rtthread:
@@ -23,7 +23,8 @@ out:
 	mkdir -p out
 
 dll: obj out
-	$(CC) -shared -s -fPIC -e main -Isrc src/hello.c -o out/hello.mo
+	$(CC) -c -fPIC -Isrc src/hello.c -o out/hello.o
+	$(CC) -s -Wl,-shared,-melf_i386,--entry=main -o out/hello.mo out/hello.o
 
 disasm: obj out
 	$(CC) -shared -S -fPIC -Isrc src/hello.c -o obj/hello.s

--- a/bsp/x86/applications/application.c
+++ b/bsp/x86/applications/application.c
@@ -48,7 +48,7 @@ void components_init(void)
 #endif
 
 #ifdef RT_USING_MODULE
-	rt_system_module_init();
+	rt_system_dlmodule_init();
 #endif
 #endif
 }

--- a/bsp/x86/drivers/board.c
+++ b/bsp/x86/drivers/board.c
@@ -71,12 +71,4 @@ void reboot(void)
 }
 FINSH_FUNCTION_EXPORT(reboot, reboot PC)
 #endif
-#ifdef RT_USING_DFS
-#include <time.h>
-time_t time(time_t* tm)
-{
-	(void)tm;
-	return 0;
-}
-#endif
 /*@}*/

--- a/components/libc/libdl/arch/x86.c
+++ b/components/libc/libdl/arch/x86.c
@@ -11,7 +11,7 @@
 #include "../dlmodule.h"
 #include "../dlelf.h"
 
-#ifdef __x86__
+#ifdef __i386__
 
 #define R_X86_64_GLOB_DAT	6	/* Create GOT entry */
 #define R_X86_64_JUMP_SLOT	7	/* Create PLT entry */


### PR DESCRIPTION
There is no problem to create hello.mo with default compiler on
Debian-9.5/amd64.

But building hello.mo with i386-elf-gcc (5.5.0) cross compiler on
OpenBSD-6.3/amd64, undefined reference to 'rt_kprintf' error occurs.

To avoid this error, "compile and link" process needs to be divided to
simply "compile" and "link".

On Debian-9.5, both previous and current method produces same hello.mo.

We have to improve disk image creation (Linux dependent),
this is a future homework.