### PR TITLE
sal框架，使用at设备，UDP通讯数据无法获得

### DIFF
--- a/components/net/at/at_socket/at_socket.c
+++ b/components/net/at/at_socket/at_socket.c
@@ -791,6 +791,8 @@ int at_sendto(int socket, const void *data, size_t size, int flags, const struct
                 goto __exit;
             }
             sock->state = AT_SOCKET_CONNECT;
+            at_dev_ops->at_set_event_cb(AT_SOCKET_EVT_RECV, at_recv_notice_cb);
+            at_dev_ops->at_set_event_cb(AT_SOCKET_EVT_CLOSED, at_closed_notice_cb);
         }
 
         if ((len = at_dev_ops->at_send(sock->socket, (char *) data, size, sock->type)) < 0)

--- a/components/net/at/at_socket/at_socket.c
+++ b/components/net/at/at_socket/at_socket.c
@@ -791,6 +791,7 @@ int at_sendto(int socket, const void *data, size_t size, int flags, const struct
                 goto __exit;
             }
             sock->state = AT_SOCKET_CONNECT;
+            /* set AT socket receive data callback function */
             at_dev_ops->at_set_event_cb(AT_SOCKET_EVT_RECV, at_recv_notice_cb);
             at_dev_ops->at_set_event_cb(AT_SOCKET_EVT_CLOSED, at_closed_notice_cb);
         }


### PR DESCRIPTION
使用ec20做coap的时候发现的，rtthread的sal层框架，在使用at指令集设备时UDP通讯的时候，数据接受不上来，debug下来发现UDP不用调用connect方法，所以接受的回调函数没有和事件绑定，回调函数设置后就没问题了。
在at_socket.c的at_sendto函数中udp分支下添加
/* set AT socket receive data callback function */
at_dev_ops->at_set_event_cb(AT_SOCKET_EVT_RECV, at_recv_notice_cb);
at_dev_ops->at_set_event_cb(AT_SOCKET_EVT_CLOSED, at_closed_notice_cb);