### PR TITLE
Fix at

### DIFF
--- a/components/net/at/Kconfig
+++ b/components/net/at/Kconfig
@@ -76,7 +76,13 @@ if RT_USING_AT
             default n
          
     endif
-    
+
+    config AT_SW_VERSION_NUM
+        int
+        default 0x10100
+        help
+            sfotware module version number
+
 endif
 
 endmenu

--- a/components/net/at/Kconfig
+++ b/components/net/at/Kconfig
@@ -79,7 +79,7 @@ if RT_USING_AT
 
     config AT_SW_VERSION_NUM
         int
-        default 0x10100
+        default 0x10200
         help
             sfotware module version number
 

--- a/components/net/at/at_socket/at_socket.c
+++ b/components/net/at/at_socket/at_socket.c
@@ -1,21 +1,7 @@
 /*
- * File      : at_socket.c
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes

--- a/components/net/at/at_socket/at_socket.c
+++ b/components/net/at/at_socket/at_socket.c
@@ -34,10 +34,8 @@
 #include <dfs_poll.h>
 #endif
 
-#ifdef DBG_SECTION_NAME
-#undef DBG_SECTION_NAME
-#define DBG_SECTION_NAME     "AT_SOC"
-#endif
+#define LOG_TAG              "at.skt"
+#include <at_log.h>
 
 #define HTONS_PORT(x) ((((x) & 0x00ffUL) << 8) | (((x) & 0xff00UL) >> 8))
 #define NIPQUAD(addr) \

--- a/components/net/at/at_socket/at_socket.h
+++ b/components/net/at/at_socket/at_socket.h
@@ -1,21 +1,7 @@
 /*
- * File      : at_socket.h
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes

--- a/components/net/at/include/at.h
+++ b/components/net/at/include/at.h
@@ -33,7 +33,6 @@ extern "C" {
 #endif
 
 #define AT_SW_VERSION                  "1.1.0"
-#define AT_SW_VERSION_NUM              0x10100
 
 #define DBG_ENABLE
 #define DBG_SECTION_NAME               "AT"

--- a/components/net/at/include/at.h
+++ b/components/net/at/include/at.h
@@ -1,21 +1,7 @@
 /*
- * File      : at.h
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes

--- a/components/net/at/include/at.h
+++ b/components/net/at/include/at.h
@@ -32,28 +32,13 @@
 extern "C" {
 #endif
 
-#define AT_SW_VERSION                  "1.1.0"
-
-#define DBG_ENABLE
-#define DBG_SECTION_NAME               "AT"
-#ifdef AT_DEBUG
-#define DBG_LEVEL                      DBG_LOG
-#else
-#define DBG_LEVEL                      DBG_INFO
-#endif /* AT_DEBUG */
-#define DBG_COLOR
-#include <rtdbg.h>
+#define AT_SW_VERSION                  "1.2.0"
 
 #define AT_CMD_NAME_LEN                16
 #define AT_END_MARK_LEN                4
 
 #ifndef AT_CMD_MAX_LEN
 #define AT_CMD_MAX_LEN                 128
-#endif
-
-/* client receive idle timeout, client will wait this timeout when send data, unit: ms */
-#ifndef AT_CLIENT_RECV_IDEL
-#define AT_CLIENT_RECV_IDEL            50
 #endif
 
 /* the server AT commands new line sign */

--- a/components/net/at/include/at_log.h
+++ b/components/net/at/include/at_log.h
@@ -1,0 +1,44 @@
+/*
+ * File      : at_log.h
+ * This file is part of RT-Thread RTOS
+ * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2018-10-12     armink       first version
+ */
+
+/*
+ * NOTE: DO NOT include this file on the header file.
+ */
+
+#define DBG_ENABLE
+#define DBG_COLOR
+
+#ifndef LOG_TAG
+#define DBG_SECTION_NAME               "at"
+#else
+#define DBG_SECTION_NAME               LOG_TAG
+#endif /* LOG_TAG */
+
+#ifdef AT_DEBUG
+#define DBG_LEVEL                      DBG_LOG
+#else
+#define DBG_LEVEL                      DBG_INFO
+#endif /* AT_DEBUG */
+
+#include <rtdbg.h>

--- a/components/net/at/include/at_log.h
+++ b/components/net/at/include/at_log.h
@@ -1,21 +1,7 @@
 /*
- * File      : at_log.h
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes

--- a/components/net/at/src/at_base_cmd.c
+++ b/components/net/at/src/at_base_cmd.c
@@ -29,6 +29,8 @@
 
 #include <rtdevice.h>
 
+#ifdef AT_USING_SERVER
+
 #define AT_ECHO_MODE_CLOSE             0
 #define AT_ECHO_MODE_OPEN              1
 
@@ -129,3 +131,5 @@ static at_result_t at_uart_setup(const char *args)
 }
 
 AT_CMD_EXPORT("AT+UART", "=<baudrate>,<databits>,<stopbits>,<parity>,<flow_control>", RT_NULL, at_uart_query, at_uart_setup, RT_NULL);
+
+#endif /* AT_USING_SERVER */

--- a/components/net/at/src/at_base_cmd.c
+++ b/components/net/at/src/at_base_cmd.c
@@ -1,21 +1,7 @@
 /*
- * File      : at_base_cmd.c
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes

--- a/components/net/at/src/at_cli.c
+++ b/components/net/at/src/at_cli.c
@@ -1,21 +1,7 @@
 /*
- * File      : at_cli.c
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes

--- a/components/net/at/src/at_client.c
+++ b/components/net/at/src/at_client.c
@@ -1,21 +1,7 @@
 /*
- * File      : at_client.c
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes

--- a/components/net/at/src/at_client.c
+++ b/components/net/at/src/at_client.c
@@ -29,6 +29,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define LOG_TAG              "at.clnt"
+#include <at_log.h>
+
+#ifdef AT_USING_CLIENT
+
 #define AT_RESP_END_OK                 "OK"
 #define AT_RESP_END_ERROR              "ERROR"
 #define AT_RESP_END_FAIL               "FAIL"
@@ -924,3 +929,4 @@ __exit:
 
     return result;
 }
+#endif /* AT_USING_CLIENT */

--- a/components/net/at/src/at_server.c
+++ b/components/net/at/src/at_server.c
@@ -1,21 +1,7 @@
 /*
- * File      : at_server.c
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes

--- a/components/net/at/src/at_server.c
+++ b/components/net/at/src/at_server.c
@@ -30,6 +30,11 @@
 
 #include <rthw.h>
 
+#define LOG_TAG              "at.svr"
+#include <at_log.h>
+
+#ifdef AT_USING_SERVER
+
 #define AT_CMD_CHAR_0                  '0'
 #define AT_CMD_CHAR_9                  '9'
 #define AT_CMD_QUESTION_MARK           '?'
@@ -565,3 +570,5 @@ RT_WEAK void at_port_factory_reset(void)
 {
     LOG_E("The factory reset for AT server is not implement.");
 }
+
+#endif /* AT_USING_SERVER */

--- a/components/net/at/src/at_utils.c
+++ b/components/net/at/src/at_utils.c
@@ -1,21 +1,7 @@
 /*
- * File      : at_utils.c
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2006 - 2018, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes


### PR DESCRIPTION
- 在 Kconfig 增加 at 组件版本定义，便于其他组件去做版本依赖检查
- 将 at.h 中 rtdbg 日志移动至 at_log.h 中，避免 at 的日志 api 污染用户的使用环境