### PR TITLE
[kernel][mem] Improve some ISR check range.

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -261,10 +261,10 @@ void *rt_malloc(rt_size_t size)
     rt_size_t ptr, ptr2;
     struct heap_mem *mem, *mem2;
 
-    RT_DEBUG_NOT_IN_INTERRUPT;
-
     if (size == 0)
         return RT_NULL;
+
+    RT_DEBUG_NOT_IN_INTERRUPT;
 
     if (size != RT_ALIGN(size, RT_ALIGN_SIZE))
         RT_DEBUG_LOG(RT_DEBUG_MEM, ("malloc size %d, but align to %d\n",
@@ -513,8 +513,6 @@ void *rt_calloc(rt_size_t count, rt_size_t size)
 {
     void *p;
 
-    RT_DEBUG_NOT_IN_INTERRUPT;
-
     /* allocate 'count' objects of size 'size' */
     p = rt_malloc(count * size);
 
@@ -536,10 +534,11 @@ void rt_free(void *rmem)
 {
     struct heap_mem *mem;
 
-    RT_DEBUG_NOT_IN_INTERRUPT;
-
     if (rmem == RT_NULL)
         return;
+
+    RT_DEBUG_NOT_IN_INTERRUPT;
+
     RT_ASSERT((((rt_uint32_t)rmem) & (RT_ALIGN_SIZE - 1)) == 0);
     RT_ASSERT((rt_uint8_t *)rmem >= (rt_uint8_t *)heap_ptr &&
               (rt_uint8_t *)rmem < (rt_uint8_t *)heap_end);


### PR DESCRIPTION
减低了 malloc/free 中的 ISR 检查范围，使得其内部一些 ISR 无关代码也可以在 ISR 中执行。

该 pr 可以解决，在 GCC 环境下，中断中无法使用 `loacltime_r` 的问题。