### PR TITLE
解决usb相关问题

### DIFF
--- a/components/drivers/include/drivers/usb_common.h
+++ b/components/drivers/include/drivers/usb_common.h
@@ -216,6 +216,19 @@ extern "C" {
 #define HID_REPORT_ID_GENERAL           5
 #define HID_REPORT_ID_MOUSE             6
 
+/*
+ * Time of usb timeout
+ */
+#ifndef USB_TIMEOUT_BASIC
+#define USB_TIMEOUT_BASIC               (RT_TICK_PER_SECOND)        /* 1s */
+#endif
+#ifndef USB_TIMEOUT_LONG
+#define USB_TIMEOUT_LONG                (RT_TICK_PER_SECOND * 5)    /* 5s */
+#endif
+#ifndf USB_DEBOUNCE_TIME
+#define USB_DEBOUNCE_TIME               (RT_TICK_PER_SECOND / 5)    /* 0.2s */
+#endif
+
 #define uswap_32(x) \
     ((((x) & 0xff000000) >> 24) | \
      (((x) & 0x00ff0000) >>  8) | \

--- a/components/drivers/include/drivers/usb_device.h
+++ b/components/drivers/include/drivers/usb_device.h
@@ -17,6 +17,10 @@
 #include <rtthread.h>
 #include "drivers/usb_common.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Vendor ID */
 #ifdef USB_VENDOR_ID
 #define _VENDOR_ID                  USB_VENDOR_ID
@@ -453,4 +457,9 @@ rt_inline void usbd_os_proerty_descriptor_send(ufunction_t func, ureq_t setup, u
     }
     rt_usbd_ep0_write(func->device, data, setup->wLength);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif

--- a/components/drivers/usb/usbhost/class/adk.c
+++ b/components/drivers/usb/usbhost/class/adk.c
@@ -55,7 +55,7 @@ static rt_err_t rt_usbh_adk_get_protocol(struct uintf* intf, rt_uint16_t *protoc
 {
     struct urequest setup;
     uinst_t device;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
 
         /* parameter check */
     RT_ASSERT(intf != RT_NULL);
@@ -89,7 +89,7 @@ static rt_err_t rt_usbh_adk_send_string(struct uintf* intf, rt_uint16_t index,
 {
     struct urequest setup;
     uinst_t device;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
 
         /* parameter check */
     RT_ASSERT(intf != RT_NULL);
@@ -122,7 +122,7 @@ static rt_err_t rt_usbh_adk_start(struct uintf* intf)
 {
     struct urequest setup;
     uinst_t device;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
 
         /* parameter check */
     RT_ASSERT(intf != RT_NULL);

--- a/components/drivers/usb/usbhost/class/hid.c
+++ b/components/drivers/usb/usbhost/class/hid.c
@@ -30,7 +30,7 @@ rt_err_t rt_usbh_hid_set_idle(struct uintf* intf, int duration, int report_id)
 {
     struct urequest setup;
     struct uinstance* device;    
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
         
     /* parameter check */
     RT_ASSERT(intf != RT_NULL);
@@ -64,7 +64,7 @@ rt_err_t rt_usbh_hid_get_report(struct uintf* intf, rt_uint8_t type,
 {
     struct urequest setup;
     struct uinstance* device;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
         
     /* parameter check */
     RT_ASSERT(intf != RT_NULL);
@@ -97,7 +97,7 @@ rt_err_t rt_usbh_hid_set_report(struct uintf* intf, rt_uint8_t *buffer, rt_size_
 {
     struct urequest setup;
     struct uinstance* device;        
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
         
     /* parameter check */
     RT_ASSERT(intf != RT_NULL);
@@ -129,7 +129,7 @@ rt_err_t rt_usbh_hid_set_protocal(struct uintf* intf, int protocol)
 {
     struct urequest setup;
     struct uinstance* device;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
         
     /* parameter check */
     RT_ASSERT(intf != RT_NULL);
@@ -164,7 +164,7 @@ rt_err_t rt_usbh_hid_get_report_descriptor(struct uintf* intf,
 {
     struct urequest setup;
     struct uinstance* device;    
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
         
     /* parameter check */
     RT_ASSERT(intf != RT_NULL);
@@ -214,7 +214,7 @@ static void rt_usbh_hid_callback(void* context)
 {
     upipe_t pipe; 
     struct uhid* hid;
-    int timeout = 300;
+    int timeout = USB_TIMEOUT_LONG;
 
     /* parameter check */
     RT_ASSERT(context != RT_NULL);
@@ -269,7 +269,7 @@ static rt_err_t rt_usbh_hid_enable(void* arg)
     uprotocal_t protocal;    
     struct uhid* hid;
     struct uintf* intf = (struct uintf*)arg;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
     upipe_t pipe;
     
     /* parameter check */

--- a/components/drivers/usb/usbhost/class/mass.c
+++ b/components/drivers/usb/usbhost/class/mass.c
@@ -190,7 +190,7 @@ rt_err_t rt_usbh_storage_get_max_lun(struct uhintf* intf, rt_uint8_t* max_lun)
 {
     struct uinstance* device;    
     struct urequest setup;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
 
     if(intf == RT_NULL)
     {
@@ -240,7 +240,7 @@ rt_err_t rt_usbh_storage_reset(struct uhintf* intf)
 {
     struct urequest setup;
     struct uinstance* device;    
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
 
     /* parameter check */
     if(intf == RT_NULL)
@@ -377,7 +377,7 @@ rt_err_t rt_usbh_storage_write10(struct uhintf* intf, rt_uint8_t *buffer,
 rt_err_t rt_usbh_storage_request_sense(struct uhintf* intf, rt_uint8_t* buffer)
 {
     struct ustorage_cbw cmd;
-    int timeout = 200;
+    int timeout = USB_TIMEOUT_LONG;
 
     /* parameter check */
     if(intf == RT_NULL)
@@ -413,7 +413,7 @@ rt_err_t rt_usbh_storage_request_sense(struct uhintf* intf, rt_uint8_t* buffer)
 rt_err_t rt_usbh_storage_test_unit_ready(struct uhintf* intf)
 {
     struct ustorage_cbw cmd;
-    int timeout = 200;
+    int timeout = USB_TIMEOUT_LONG;
 
     /* parameter check */
     if(intf == RT_NULL)
@@ -449,7 +449,7 @@ rt_err_t rt_usbh_storage_test_unit_ready(struct uhintf* intf)
 rt_err_t rt_usbh_storage_inquiry(struct uhintf* intf, rt_uint8_t* buffer)
 {
     struct ustorage_cbw cmd;
-    int timeout = 200;
+    int timeout = USB_TIMEOUT_LONG;
     
     /* parameter check */
     if(intf == RT_NULL)
@@ -486,7 +486,7 @@ rt_err_t rt_usbh_storage_inquiry(struct uhintf* intf, rt_uint8_t* buffer)
 rt_err_t rt_usbh_storage_get_capacity(struct uhintf* intf, rt_uint8_t* buffer)
 {
     struct ustorage_cbw cmd;
-    int timeout = 200;
+    int timeout = USB_TIMEOUT_LONG;
 
     /* parameter check */
     if(intf == RT_NULL)

--- a/components/drivers/usb/usbhost/class/udisk.c
+++ b/components/drivers/usb/usbhost/class/udisk.c
@@ -70,13 +70,13 @@ static rt_size_t rt_udisk_read(rt_device_t dev, rt_off_t pos, void* buffer,
     rt_err_t ret;
     struct uhintf* intf;
     struct ustor_data* data;
-    int timeout = 500;
+    int timeout = USB_TIMEOUT_LONG;
 
     /* check parameter */
     RT_ASSERT(dev != RT_NULL);
     RT_ASSERT(buffer != RT_NULL);
 
-    if(size > 4096) timeout = 800;
+    if(size > 4096) timeout *= 2;
 
     data = (struct ustor_data*)dev->user_data;
     intf = data->intf;
@@ -108,13 +108,13 @@ static rt_size_t rt_udisk_write (rt_device_t dev, rt_off_t pos, const void* buff
     rt_err_t ret;
     struct uhintf* intf;
     struct ustor_data* data;
-    int timeout = 500;
+    int timeout = USB_TIMEOUT_LONG;
 
     /* check parameter */
     RT_ASSERT(dev != RT_NULL);
     RT_ASSERT(buffer != RT_NULL);
 
-    if(size * SECTOR_SIZE > 4096) timeout = 800;
+    if(size * SECTOR_SIZE > 4096) timeout *= 2;
 
     data = (struct ustor_data*)dev->user_data;
     intf = data->intf;
@@ -293,7 +293,7 @@ rt_err_t rt_udisk_run(struct uhintf* intf)
     RT_DEBUG_LOG(RT_DEBUG_USB, ("read partition table\n"));
 
     /* get the partition table */
-    ret = rt_usbh_storage_read10(intf, sector, 0, 1, 500);
+    ret = rt_usbh_storage_read10(intf, sector, 0, 1, USB_TIMEOUT_LONG);
     if(ret != RT_EOK)
     {
         rt_kprintf("read parition table error\n");

--- a/components/drivers/usb/usbhost/core/core.c
+++ b/components/drivers/usb/usbhost/core/core.c
@@ -260,18 +260,20 @@ rt_err_t rt_usbh_detach_instance(uinst_t device)
     }
     
     /* free configration descriptor */
-    for(i=0; i<device->cfg_desc->bNumInterfaces; i++)
-    {
-        if(device->intf[i] == RT_NULL) continue;
-        if(device->intf[i]->drv == RT_NULL) continue;
+    if (device->cfg_desc) {
+        for (i = 0; i < device->cfg_desc->bNumInterfaces; i++)
+        {
+            if (device->intf[i] == RT_NULL) continue;
+            if (device->intf[i]->drv == RT_NULL) continue;
 
-        RT_ASSERT(device->intf[i]->device == device);
+            RT_ASSERT(device->intf[i]->device == device);
 
-        RT_DEBUG_LOG(RT_DEBUG_USB, ("free interface instance %d\n", i));
-        rt_usbh_class_driver_disable(device->intf[i]->drv, (void*)device->intf[i]);
-        rt_free(device->intf[i]);
+            RT_DEBUG_LOG(RT_DEBUG_USB, ("free interface instance %d\n", i));
+            rt_usbh_class_driver_disable(device->intf[i]->drv, (void*)device->intf[i]);
+            rt_free(device->intf[i]);
+        }
+        rt_free(device->cfg_desc);
     }
-    if(device->cfg_desc) rt_free(device->cfg_desc);
     
     rt_usb_hcd_free_pipe(device->hcd,device->pipe_ep0_out);
     rt_usb_hcd_free_pipe(device->hcd,device->pipe_ep0_in);
@@ -301,7 +303,7 @@ rt_err_t rt_usbh_get_descriptor(uinst_t device, rt_uint8_t type, void* buffer,
     int nbytes)
 {
     struct urequest setup;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
     
     RT_ASSERT(device != RT_NULL);
 
@@ -335,7 +337,7 @@ rt_err_t rt_usbh_get_descriptor(uinst_t device, rt_uint8_t type, void* buffer,
 rt_err_t rt_usbh_set_address(uinst_t device)
 {
     struct urequest setup;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
     
     RT_ASSERT(device != RT_NULL);
 
@@ -371,7 +373,7 @@ rt_err_t rt_usbh_set_address(uinst_t device)
 rt_err_t rt_usbh_set_configure(uinst_t device, int config)
 {
     struct urequest setup;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
 
     /* check parameter */
     RT_ASSERT(device != RT_NULL);
@@ -405,7 +407,7 @@ rt_err_t rt_usbh_set_configure(uinst_t device, int config)
 rt_err_t rt_usbh_set_interface(uinst_t device, int intf)
 {
     struct urequest setup;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
 
     /* check parameter */
     RT_ASSERT(device != RT_NULL);
@@ -436,7 +438,7 @@ rt_err_t rt_usbh_set_interface(uinst_t device, int intf)
 rt_err_t rt_usbh_clear_feature(uinst_t device, int endpoint, int feature)
 {
     struct urequest setup;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
 
     /* check parameter */
     RT_ASSERT(device != RT_NULL);

--- a/components/drivers/usb/usbhost/core/hub.c
+++ b/components/drivers/usb/usbhost/core/hub.c
@@ -118,7 +118,7 @@ void rt_usbh_root_hub_disconnect_handler(struct uhcd *hcd, rt_uint8_t port)
 rt_err_t rt_usbh_hub_get_descriptor(struct uinstance* device, rt_uint8_t *buffer, rt_size_t nbytes)
 {
     struct urequest setup;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
         
     /* parameter check */
     RT_ASSERT(device != RT_NULL);
@@ -151,7 +151,7 @@ rt_err_t rt_usbh_hub_get_descriptor(struct uinstance* device, rt_uint8_t *buffer
 rt_err_t rt_usbh_hub_get_status(struct uinstance* device, rt_uint32_t* buffer)
 {
     struct urequest setup;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
     
     /* parameter check */
     RT_ASSERT(device != RT_NULL);
@@ -184,7 +184,7 @@ rt_err_t rt_usbh_hub_get_status(struct uinstance* device, rt_uint32_t* buffer)
 rt_err_t rt_usbh_hub_get_port_status(uhub_t hub, rt_uint16_t port, rt_uint32_t* buffer)
 {
     struct urequest setup;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
     
     /* parameter check */
     RT_ASSERT(hub != RT_NULL);
@@ -226,7 +226,7 @@ rt_err_t rt_usbh_hub_get_port_status(uhub_t hub, rt_uint16_t port, rt_uint32_t* 
 rt_err_t rt_usbh_hub_clear_port_feature(uhub_t hub, rt_uint16_t port, rt_uint16_t feature)
 {
     struct urequest setup;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
         
     /* parameter check */
     RT_ASSERT(hub != RT_NULL);
@@ -267,7 +267,7 @@ rt_err_t rt_usbh_hub_set_port_feature(uhub_t hub, rt_uint16_t port,
     rt_uint16_t feature)
 {
     struct urequest setup;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
         
     /* parameter check */
     RT_ASSERT(hub != RT_NULL);
@@ -345,6 +345,9 @@ rt_err_t rt_usbh_hub_port_debounce(uhub_t hub, rt_uint16_t port)
     int i = 0, times = 20;
     rt_uint32_t pstatus;
     rt_bool_t connect = RT_TRUE;
+    int delayticks = USB_DEBOUNCE_TIME / times;
+    if (delayticks < 1)
+        delayticks = 1;
 
     /* parameter check */
     RT_ASSERT(hub != RT_NULL);
@@ -360,7 +363,7 @@ rt_err_t rt_usbh_hub_port_debounce(uhub_t hub, rt_uint16_t port)
             break;
         }
         
-        rt_thread_delay(1);
+        rt_thread_delay(delayticks);
     }        
 
     if(connect) return RT_EOK;
@@ -428,6 +431,7 @@ static rt_err_t rt_usbh_hub_port_change(uhub_t hub)
             device->speed = (pstatus & PORT_LSDA) ? 1 : 0;
             device->parent_hub = hub;    
             device->hcd = hub->hcd;
+            device->port = i + 1;
             hub->child[i] = device;
 
             /* reset usb roothub port */
@@ -452,7 +456,7 @@ static void rt_usbh_hub_irq(void* context)
 {
     upipe_t pipe;
     uhub_t hub;
-    int timeout = 100;
+    int timeout = USB_TIMEOUT_BASIC;
     
     RT_ASSERT(context != RT_NULL);
     
@@ -493,7 +497,7 @@ static rt_err_t rt_usbh_hub_enable(void *arg)
     struct uinstance* device;
     struct uhintf* intf = (struct uhintf*)arg;
     upipe_t pipe_in = RT_NULL;
-    int timeout = 300;
+    int timeout = USB_TIMEOUT_LONG;
     /* paremeter check */
     RT_ASSERT(intf != RT_NULL);
     


### PR DESCRIPTION
1) usb驱动中时间未与RT_TICK_PER_SECOND关联问题,RT_TICK_PER_SECOND变化时,这些时间将发生变化
解决: 增加USB_TIMEOUT_BASIC/USB_TIMEOUT_LONG/USB_DEBOUNCE_TIME
    注: 这些时间经过15个以上品牌usb测试(am335x平台,RT_TICK_PER_SECOND=500).
2) 修正rt_usbh_detach_instance函数使用device->cfg_desc前未判断是否有效. 可导致abort
3) rt_usbh_hub_port_change增加device->port初始化,否则struct uhcd_ops相关函数无法直接得到端口号