### PR TITLE
 Add RT_VCOM_TX_TIMEOUT and some configure to Kconfig

### DIFF
--- a/components/drivers/Kconfig
+++ b/components/drivers/Kconfig
@@ -392,6 +392,23 @@ menu "Using USB"
                         bool "Enable to use device as winusb device"
                         default n
                 endif
+                if RT_USB_DEVICE_CDC
+                    config RT_VCOM_TASK_STK_SIZE
+                        int "virtual com thread stack size"
+                        default 512
+                    config RT_VCOM_TX_USE_DMA
+                        bool "Enable to use dma for vcom tx"
+                        default n
+                    config RT_VCOM_SERNO
+                        string "serial number of virtual com"
+                        default "32021919830108"
+                    config RT_VCOM_SER_LEN
+                        int "serial number length of virtual com"
+                        default 14
+                    config RT_VCOM_TX_TIMEOUT
+                        int "tx timeout(ticks) of virtual com"
+                        default 1000
+                endif
                 if RT_USB_DEVICE_WINUSB
                     config RT_WINUSB_GUID
                     string "Guid for winusb"

--- a/components/drivers/include/drivers/usb_common.h
+++ b/components/drivers/include/drivers/usb_common.h
@@ -225,7 +225,7 @@ extern "C" {
 #ifndef USB_TIMEOUT_LONG
 #define USB_TIMEOUT_LONG                (RT_TICK_PER_SECOND * 5)    /* 5s */
 #endif
-#ifndf USB_DEBOUNCE_TIME
+#ifndef USB_DEBOUNCE_TIME
 #define USB_DEBOUNCE_TIME               (RT_TICK_PER_SECOND / 5)    /* 0.2s */
 #endif
 

--- a/components/drivers/usb/usbdevice/class/cdc_vcom.c
+++ b/components/drivers/usb/usbdevice/class/cdc_vcom.c
@@ -22,7 +22,12 @@
 
 #ifdef RT_USB_DEVICE_CDC
 
-#define TX_TIMEOUT              1000
+#ifdef RT_VCOM_TX_TIMEOUT
+#define VCOM_TX_TIMEOUT      RT_VCOM_TX_TIMEOUT
+#else /*!RT_VCOM_TX_TIMEOUT*/
+#define VCOM_TX_TIMEOUT      1000
+#endif /*RT_VCOM_TX_TIMEOUT*/
+
 #define CDC_RX_BUFSIZE          128
 #define CDC_MAX_PACKET_SIZE     64
 #define VCOM_DEVICE             "vcom"
@@ -880,7 +885,7 @@ static void vcom_tx_thread_entry(void* parameter)
 
             rt_usbd_io_request(func->device, data->ep_in, &data->ep_in->request);
 
-            if (rt_completion_wait(&data->wait, TX_TIMEOUT) != RT_EOK)
+            if (rt_completion_wait(&data->wait, VCOM_TX_TIMEOUT) != RT_EOK)
             {
                 RT_DEBUG_LOG(RT_DEBUG_USB, ("vcom tx timeout\n"));
             }


### PR DESCRIPTION
1. Add 'RT_VCOM_TX_TIMEOUT' to configure TX_TIMEOUT whick may block vcom tx thread for a long time if TX_TIMEOUT is too large(like 1000).
2. Add 'RT_VCOM_TASK_STK_SIZE', 'RT_VCOM_TX_USE_DMA', 'RT_VCOM_SERNO', 'RT_VCOM_SER_LEN', 'RT_VCOM_TX_TIMEOUT' to Kconfig.
3. Fix a typo in usb_common.h.


