### PR TITLE
修复IAR dlib的时间映射，从rtt历史版本找到iar支持64bit时间的起始版本

### DIFF
--- a/components/libc/compilers/dlib/time.c
+++ b/components/libc/compilers/dlib/time.c
@@ -41,10 +41,15 @@ int gettimeofday(struct timeval *tp, void *ignore)
  *
  */
 #pragma module_name = "?time"
-#if _DLIB_TIME_ALLOW_64
-__time64_t __time64(__time64_t *t)
+#if _DLIB_TIME_USES_64
+time_t __time64(time_t *t)
 #else
-__time32_t __time32(__time32_t *t)
+/* for IAR 6.2 later Compiler */
+#if defined (__IAR_SYSTEMS_ICC__) &&  (__VER__) >= 6020000
+time_t __time32(time_t *t)
+#else
+time_t time(time_t *t)
+#endif
 #endif
 {
   time_t time_now = 0;


### PR DESCRIPTION
修复IAR dlib的时间映射，从rtt历史版本找到iar支持64bit时间的起始版本