### PR TITLE
Add ulog compatible with rtdbg.

### DIFF
--- a/components/utilities/ulog/syslog/syslog.c
+++ b/components/utilities/ulog/syslog/syslog.c
@@ -95,7 +95,7 @@ void vsyslog(int priority, const char *format, va_list args)
         priority |= local_facility;
     }
 
-    ulog_voutput(priority, local_ident, format, args);
+    ulog_voutput(priority, local_ident, RT_TRUE, format, args);
 }
 
 /**
@@ -169,7 +169,7 @@ static const char *get_month_str(uint8_t month)
     }
 }
 
-RT_WEAK rt_size_t syslog_formater(char *log_buf, int level, const char *tag, const char *format, va_list args)
+RT_WEAK rt_size_t syslog_formater(char *log_buf, int level, const char *tag, rt_bool_t newline, const char *format, va_list args)
 {
     extern size_t ulog_strcpy(size_t cur_len, char *dst, const char *src);
 
@@ -252,7 +252,10 @@ RT_WEAK rt_size_t syslog_formater(char *log_buf, int level, const char *tag, con
     }
 
     /* package newline sign */
-    log_len += ulog_strcpy(log_len, log_buf + log_len, ULOG_NEWLINE_SIGN);
+    if (newline)
+    {
+        log_len += ulog_strcpy(log_len, log_buf + log_len, ULOG_NEWLINE_SIGN);
+    }
 
     return log_len;
 }

--- a/components/utilities/ulog/ulog.h
+++ b/components/utilities/ulog/ulog.h
@@ -84,8 +84,8 @@ void ulog_hexdump(const char *name, rt_size_t width, rt_uint8_t *buf, rt_size_t 
 /*
  * Another log output API. This API is difficult to use than LOG_X API.
  */
-void ulog_voutput(rt_uint32_t level, const char *tag, const char *format, va_list args);
-void ulog_output(rt_uint32_t level, const char *tag, const char *format, ...);
+void ulog_voutput(rt_uint32_t level, const char *tag, rt_bool_t newline, const char *format, va_list args);
+void ulog_output(rt_uint32_t level, const char *tag, rt_bool_t newline, const char *format, ...);
 void ulog_raw(const char *format, ...);
 
 #ifdef __cplusplus

--- a/components/utilities/ulog/ulog_def.h
+++ b/components/utilities/ulog/ulog_def.h
@@ -40,10 +40,16 @@ extern "C" {
 #undef DBG_WARNING
 #undef DBG_INFO
 #undef DBG_LOG
+#undef dbg_log
 #define DBG_ERROR                      LOG_LVL_ERROR
 #define DBG_WARNING                    LOG_LVL_WARNING
 #define DBG_INFO                       LOG_LVL_INFO
 #define DBG_LOG                        LOG_LVL_DBG
+#define dbg_log(level, ...)                                \
+    if ((level) <= DBG_LEVEL)                              \
+    {                                                      \
+        ulog_output(level, LOG_TAG, RT_FALSE, __VA_ARGS__);\
+    }
 
 #if !defined(LOG_TAG)
     /* compatible for rtdbg */
@@ -64,25 +70,25 @@ extern "C" {
 #endif /* !defined(LOG_LVL) */
 
 #if (LOG_LVL >= LOG_LVL_DBG) && (ULOG_OUTPUT_LVL >= LOG_LVL_DBG)
-    #define ulog_d(TAG, ...)           ulog_output(LOG_LVL_DBG, TAG, __VA_ARGS__)
+    #define ulog_d(TAG, ...)           ulog_output(LOG_LVL_DBG, TAG, RT_TRUE, __VA_ARGS__)
 #else
     #define ulog_d(TAG, ...)
 #endif /* (LOG_LVL >= LOG_LVL_DBG) && (ULOG_OUTPUT_LVL >= LOG_LVL_DBG) */
 
 #if (LOG_LVL >= LOG_LVL_INFO) && (ULOG_OUTPUT_LVL >= LOG_LVL_INFO)
-    #define ulog_i(TAG, ...)           ulog_output(LOG_LVL_INFO, TAG, __VA_ARGS__)
+    #define ulog_i(TAG, ...)           ulog_output(LOG_LVL_INFO, TAG, RT_TRUE, __VA_ARGS__)
 #else
     #define ulog_i(TAG, ...)
 #endif /* (LOG_LVL >= LOG_LVL_INFO) && (ULOG_OUTPUT_LVL >= LOG_LVL_INFO) */
 
 #if (LOG_LVL >= LOG_LVL_WARNING) && (ULOG_OUTPUT_LVL >= LOG_LVL_WARNING)
-    #define ulog_w(TAG, ...)           ulog_output(LOG_LVL_WARNING, TAG, __VA_ARGS__)
+    #define ulog_w(TAG, ...)           ulog_output(LOG_LVL_WARNING, TAG, RT_TRUE, __VA_ARGS__)
 #else
     #define ulog_w(TAG, ...)
 #endif /* (LOG_LVL >= LOG_LVL_WARNING) && (ULOG_OUTPUT_LVL >= LOG_LVL_WARNING) */
 
 #if (LOG_LVL >= LOG_LVL_ERROR) && (ULOG_OUTPUT_LVL >= LOG_LVL_ERROR)
-    #define ulog_e(TAG, ...)           ulog_output(LOG_LVL_ERROR, TAG, __VA_ARGS__)
+    #define ulog_e(TAG, ...)           ulog_output(LOG_LVL_ERROR, TAG, RT_TRUE, __VA_ARGS__)
 #else
     #define ulog_e(TAG, ...)
 #endif /* (LOG_LVL >= LOG_LVL_ERROR) && (ULOG_OUTPUT_LVL >= LOG_LVL_ERROR) */
@@ -92,7 +98,7 @@ extern "C" {
     #define ULOG_ASSERT(EXPR)                                                 \
     if (!(EXPR))                                                              \
     {                                                                         \
-        ulog_output(LOG_LVL_ASSERT, LOG_TAG, "(%s) has assert failed at %s:%ld.", #EXPR, __FUNCTION__, __LINE__); \
+        ulog_output(LOG_LVL_ASSERT, LOG_TAG, RT_TRUE, "(%s) has assert failed at %s:%ld.", #EXPR, __FUNCTION__, __LINE__); \
         ulog_flush();                                                         \
         while (1);                                                            \
     }

--- a/include/rtdbg.h
+++ b/include/rtdbg.h
@@ -23,10 +23,7 @@
  * #define DBG_LEVEL           DBG_INFO
  * #include <rtdbg.h>          // must after of DEBUG_ENABLE or some other options
  *
- * Then in your C/C++ file, you can use dbg_log macro to print out logs:
- * dbg_log(DBG_INFO, "this is a log!\n");
- *
- * Or if you want to using the simple API, you can
+ * Then in your C/C++ file, you can use LOG_X macro to print out logs:
  * LOG_D("this is a debug log!");
  * LOG_E("this is a error log!");
  *
@@ -38,6 +35,11 @@
 #define RT_DBG_H__
 
 #include <rtconfig.h>
+
+#if defined(RT_USING_ULOG) && defined(DBG_ENABLE)
+/* using ulog compatible with rtdbg  */
+#include <ulog.h>
+#else
 
 /* DEBUG level */
 #define DBG_ERROR           0
@@ -82,6 +84,8 @@
 
 /*
  * static debug routine
+ * NOTE: This is a NOT RECOMMENDED API. Please using LOG_X API.
+ *       It will be DISCARDED later. Because it will take up more resources.
  */
 #define dbg_log(level, fmt, ...)                            \
     if ((level) <= DBG_LEVEL)                               \
@@ -166,5 +170,7 @@
 #endif
 
 #define LOG_RAW(...)         dbg_raw(__VA_ARGS__)
+
+#endif /* defined(RT_USING_ULOG) && define(DBG_ENABLE) */
 
 #endif /* RT_DBG_H__ */


### PR DESCRIPTION
增强了 ulog 对于 rtdbg 的兼容性。当 ulog 启用后，rtdbg 会依赖于 ulog 完成日志的输出转换。

应用层无需做任何修改，即可调用 rtdbg 的 API 来使用 ulog 。