### PR TITLE
增加一些general device commands

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -825,6 +825,10 @@ enum rt_device_class_type
 #define RT_DEVICE_CTRL_RESUME           0x01            /**< resume device */
 #define RT_DEVICE_CTRL_SUSPEND          0x02            /**< suspend device */
 #define RT_DEVICE_CTRL_CONFIG           0x03            /**< configure device */
+#define RT_DEVICE_CTRL_CONFIG_SET       0x03            /**< configure device, same as above */
+#define RT_DEVICE_CTRL_CONFIG_GET       0x04            /**< device configure get*/
+#define RT_DEVICE_CRTL_TIMEOUT          0x05            /**< timeout ctrl */
+#define RT_DEVICE_CTRL_INTERVAL         0x06            /**< timeout interval ctrl */
 
 #define RT_DEVICE_CTRL_SET_INT          0x10            /**< set interrupt */
 #define RT_DEVICE_CTRL_CLR_INT          0x11            /**< clear interrupt */


### PR DESCRIPTION
增加一些general device commands，用于编写设备驱动时使用。
RT_DEVICE_CTRL_CONFIG_SET         // 用于设备参数配置
RT_DEVICE_CTRL_CONFIG_GET        // 用于设备参数获取      
RT_DEVICE_CRTL_TIMEOUT             // 对于阻塞的驱动，rt_device_read的超时时间配置        
RT_DEVICE_CTRL_INTERVAL            // 对于阻塞的字符设备驱动，rt_devcie_read的超时字符间隔        