### PR TITLE
Fix ulog

### DIFF
--- a/components/utilities/Kconfig
+++ b/components/utilities/Kconfig
@@ -225,7 +225,7 @@ config RT_USING_ULOG
             
         config ULOG_SW_VERSION_NUM
             hex
-            default 0x00100
+            default 0x00101
             help
                 sfotware module version number
     endif

--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -625,17 +625,17 @@ void ulog_raw(const char *format, ...)
 /**
  * dump the hex format data to log
  *
- * @param name name for hex object, it will show on log header
+ * @param tag name for hex object, it will show on log header
  * @param width hex number for every line, such as: 16, 32
  * @param buf hex buffer
  * @param size buffer size
  */
-void ulog_hexdump(const char *name, rt_size_t width, rt_uint8_t *buf, rt_size_t size)
+void ulog_hexdump(const char *tag, rt_size_t width, rt_uint8_t *buf, rt_size_t size)
 {
 #define __is_print(ch)       ((unsigned int)((ch) - ' ') < 127u - ' ')
 
     rt_size_t i, j;
-    rt_size_t log_len = 0, name_len = rt_strlen(name);
+    rt_size_t log_len = 0, name_len = rt_strlen(tag);
     char *log_buf = NULL, dump_string[8];
     int fmt_result;
 
@@ -644,7 +644,7 @@ void ulog_hexdump(const char *name, rt_size_t width, rt_uint8_t *buf, rt_size_t 
 #ifdef ULOG_USING_FILTER
     /* level filter */
 #ifndef ULOG_USING_SYSLOG
-    if (LOG_LVL_DBG > ulog.filter.level)
+    if (LOG_LVL_DBG > ulog.filter.level || LOG_LVL_DBG > ulog_tag_lvl_filter_get(tag))
     {
         return;
     }
@@ -654,6 +654,11 @@ void ulog_hexdump(const char *name, rt_size_t width, rt_uint8_t *buf, rt_size_t 
         return;
     }
 #endif /* ULOG_USING_SYSLOG */
+    else if (!rt_strstr(tag, ulog.filter.tag))
+    {
+        /* tag filter */
+        return;
+    }
 #endif /* ULOG_USING_FILTER */
 
     /* get log buffer */
@@ -668,7 +673,7 @@ void ulog_hexdump(const char *name, rt_size_t width, rt_uint8_t *buf, rt_size_t 
         if (i == 0)
         {
             log_len += ulog_strcpy(log_len, log_buf + log_len, "D/HEX ");
-            log_len += ulog_strcpy(log_len, log_buf + log_len, name);
+            log_len += ulog_strcpy(log_len, log_buf + log_len, tag);
             log_len += ulog_strcpy(log_len, log_buf + log_len, ": ");
         }
         else

--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -21,7 +21,7 @@
 #endif
 
 #ifdef ULOG_TIME_USING_TIMESTAMP
-#include <time.h>
+#include <sys/time.h>
 #endif
 
 #ifdef ULOG_USING_ASYNC_OUTPUT

--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -1044,6 +1044,56 @@ static void ulog_kw(uint8_t argc, char **argv)
     }
 }
 MSH_CMD_EXPORT(ulog_kw, Set ulog global filter keyword);
+
+static void ulog_filter(uint8_t argc, char **argv)
+{
+#ifndef ULOG_USING_SYSLOG
+    const char *lvl_name[] = { "Assert ", "Error  ", "Error  ", "Error  ", "Warning", "Info   ", "Info   ", "Debug  " };
+#endif
+    const char *tag = ulog_global_filter_tag_get(), *kw = ulog_global_filter_kw_get();
+    rt_slist_t *node;
+    ulog_tag_lvl_filter_t tag_lvl = NULL;
+
+    rt_kprintf("--------------------------------------\n");
+    rt_kprintf("ulog global filter:\n");
+
+#ifndef ULOG_USING_SYSLOG
+    rt_kprintf("level   : %s\n", lvl_name[ulog_global_filter_lvl_get()]);
+#else
+    rt_kprintf("level   : %d\n", ulog_global_filter_lvl_get());
+#endif
+
+    rt_kprintf("tag     : %s\n", rt_strlen(tag) == 0 ? "NULL" : tag);
+    rt_kprintf("keyword : %s\n", rt_strlen(kw) == 0 ? "NULL" : kw);
+
+    rt_kprintf("--------------------------------------\n");
+    rt_kprintf("ulog tag's level filter:\n");
+    if (rt_slist_isempty(ulog_tag_lvl_list_get()))
+    {
+        rt_kprintf("settings not found\n");
+    }
+    else
+    {
+        /* lock output */
+        output_lock();
+        /* find the tag in list */
+        for (node = rt_slist_first(ulog_tag_lvl_list_get()); node; node = rt_slist_next(node))
+        {
+            tag_lvl = rt_slist_entry(node, struct ulog_tag_lvl_filter, list);
+            rt_kprintf("%-*.s: ", ULOG_FILTER_TAG_MAX_LEN, tag_lvl->tag);
+
+#ifndef ULOG_USING_SYSLOG
+            rt_kprintf("%s\n", lvl_name[tag_lvl->level]);
+#else
+            rt_kprintf("%d\n", tag_lvl->level);
+#endif
+
+        }
+        /* unlock output */
+        output_unlock();
+    }
+}
+MSH_CMD_EXPORT(ulog_filter, Show ulog filter settings);
 #endif /* defined(RT_USING_FINSH) && defined(FINSH_USING_MSH) */
 #endif /* ULOG_USING_FILTER */
 

--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -790,6 +790,7 @@ int ulog_tag_lvl_filter_set(const char *tag, rt_uint32_t level)
         {
             /* remove current tag's level filter when input level is the lowest level */
             rt_slist_remove(&ulog.filter.tag_lvl_list, &tag_lvl->list);
+            rt_free(tag_lvl);
         }
         else
         {

--- a/components/utilities/ulog/ulog.h
+++ b/components/utilities/ulog/ulog.h
@@ -58,9 +58,13 @@ rt_err_t ulog_backend_unregister(ulog_backend_t backend);
  */
 int ulog_tag_lvl_filter_set(const char *tag, rt_uint32_t level);
 rt_uint32_t ulog_tag_lvl_filter_get(const char *tag);
+rt_slist_t *ulog_tag_lvl_list_get(void);
 void ulog_global_filter_lvl_set(rt_uint32_t level);
+rt_uint32_t ulog_global_filter_lvl_get(void);
 void ulog_global_filter_tag_set(const char *tag);
+const char *ulog_global_filter_tag_get(void);
 void ulog_global_filter_kw_set(const char *keyword);
+const char *ulog_global_filter_kw_get(void);
 #endif /* ULOG_USING_FILTER */
 
 /*

--- a/components/utilities/ulog/ulog.h
+++ b/components/utilities/ulog/ulog.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define ULOG_VERSION_STR               "0.1.0"
+#define ULOG_VERSION_STR               "0.1.1"
 
 /*
  * ulog init and deint

--- a/components/utilities/ulog/ulog.h
+++ b/components/utilities/ulog/ulog.h
@@ -83,7 +83,7 @@ void ulog_async_waiting_log(rt_int32_t time);
 /*
  * dump the hex format data to log
  */
-void ulog_hexdump(const char *name, rt_size_t width, rt_uint8_t *buf, rt_size_t size);
+void ulog_hexdump(const char *tag, rt_size_t width, rt_uint8_t *buf, rt_size_t size);
 
 /*
  * Another log output API. This API is more difficult to use than LOG_X API.

--- a/components/utilities/ulog/ulog_def.h
+++ b/components/utilities/ulog/ulog_def.h
@@ -165,6 +165,15 @@ extern "C" {
 
 #define ULOG_FRAME_MAGIC               0x10
 
+/* tag's level filter */
+struct ulog_tag_lvl_filter
+{
+    char tag[ULOG_FILTER_TAG_MAX_LEN + 1];
+    rt_uint32_t level;
+    rt_slist_t list;
+};
+typedef struct ulog_tag_lvl_filter *ulog_tag_lvl_filter_t;
+
 struct ulog_frame
 {
     /* magic word is 0x10 ('lo') */


### PR DESCRIPTION
- 增加 过滤器信息获取接口
- 增加 查看当前过滤器配置的命令
- 增加 标签过滤功能到 hexdump 
- fixed #1950 