### PR TITLE
add include path to bsp/x86/applications/SConscript

### DIFF
--- a/bsp/x86/applications/SConscript
+++ b/bsp/x86/applications/SConscript
@@ -6,6 +6,8 @@ cwd     = os.path.join(str(Dir('#')), 'applications')
 src	= Glob('*.c')
 CPPPATH = [cwd, str(Dir('#'))]
 
+CPPPATH += [cwd + '/../../../components/drivers/include']
+
 group = DefineGroup('Applications', src, depend = [''], CPPPATH = CPPPATH)
 
 Return('group')


### PR DESCRIPTION
avoid  'rtdevice.h' not found error when including 
rt-thread/components/dfs/include/dfs_fs.h and rt-thread/components/dfs/include/dfs.h.
