### PR TITLE
pin接口数据类型整理相关

### DIFF
--- a/bsp/gd32303e-eval/drivers/drv_gpio.c
+++ b/bsp/gd32303e-eval/drivers/drv_gpio.c
@@ -248,10 +248,10 @@ const struct pin_index *get_pin(rt_uint8_t pin)
     return index;
 };
 
-void gd32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void gd32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
-    rt_uint32_t pin_mode;
+    uint32_t pin_mode;
     index = get_pin(pin);
     if (index == RT_NULL)
     {
@@ -291,7 +291,7 @@ void gd32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     gpio_init(index->gpio_periph, pin_mode, GPIO_OSPEED_50MHZ, index->pin);
 }
 
-void gd32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void gd32_pin_write(rt_device_t dev, int32_t pin, int32_t value)
 {
     const struct pin_index *index;
 
@@ -304,7 +304,7 @@ void gd32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     gpio_bit_write(index->gpio_periph, index->pin, (bit_status)value);
 }
 
-int gd32_pin_read(rt_device_t dev, rt_base_t pin)
+int32_t gd32_pin_read(rt_device_t dev, int32_t pin)
 {
     int value;
     const struct pin_index *index;
@@ -323,9 +323,9 @@ int gd32_pin_read(rt_device_t dev, rt_base_t pin)
 }
 
 
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    rt_uint8_t i;
+    int32_t i;
     for (i = 0; i < 32; i++)
     {
         if ((0x01 << i) == bit)
@@ -335,7 +335,7 @@ rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
     }
     return -1;
 }
-rt_inline const struct pin_irq_map *get_pin_irq_map(rt_uint32_t pinbit)
+rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
 {
     rt_int32_t mapindex = bit2bitno(pinbit);
     if (mapindex < 0 || mapindex >= ITEM_NUM(pin_irq_map))
@@ -344,12 +344,12 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(rt_uint32_t pinbit)
     }
     return &pin_irq_map[mapindex];
 };
-rt_err_t gd32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
+rt_err_t gd32_pin_attach_irq(struct rt_device *device, int32_t pin,
                               rt_uint32_t mode, void (*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t hdr_index = -1;
+    int32_t hdr_index = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -384,11 +384,11 @@ rt_err_t gd32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
 
     return RT_EOK;
 }
-rt_err_t gd32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t gd32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t hdr_index = -1;
+    int32_t hdr_index = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -415,12 +415,12 @@ rt_err_t gd32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
 
     return RT_EOK;
 }
-rt_err_t gd32_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+rt_err_t gd32_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     const struct pin_index *index;
     const struct pin_irq_map *irqmap;
     rt_base_t level;
-    rt_int32_t hdr_index = -1;
+    int32_t hdr_index = -1;
     exti_trig_type_enum trigger_mode;
 
     index = get_pin(pin);
@@ -509,7 +509,7 @@ int rt_hw_pin_init(void)
 }
 INIT_BOARD_EXPORT(rt_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     if (pin_irq_hdr_tab[irqno].hdr)
     {

--- a/bsp/stm32f107/drivers/gpio.c
+++ b/bsp/stm32f107/drivers/gpio.c
@@ -23,7 +23,7 @@
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
+    int32_t index;
     uint32_t rcc;
     GPIO_TypeDef *gpio;
     uint32_t pin;
@@ -469,7 +469,7 @@ const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, int32_t value)
 {
     const struct pin_index *index;
 
@@ -489,9 +489,9 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     }
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+int32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value;
+    int32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -514,7 +514,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef  GPIO_InitStructure;
@@ -556,9 +556,9 @@ void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     GPIO_Init(index->gpio, &GPIO_InitStructure);
 }
 
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    int i;
+    int32_t i;
     for(i = 0; i < 32; i++)
     {
         if((0x01 << i) == bit)
@@ -577,8 +577,7 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
     }
     return &pin_irq_map[mapindex];
 };
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                  rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -618,7 +617,7 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
  
     return RT_EOK;
 }
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -744,14 +743,14 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int stm32_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }
 INIT_BOARD_EXPORT(stm32_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     EXTI_ClearITPendingBit(pin_irq_map[irqno].irqbit);
     if(pin_irq_hdr_tab[irqno].hdr)

--- a/bsp/stm32f107/drivers/gpio.h
+++ b/bsp/stm32f107/drivers/gpio.h
@@ -21,6 +21,6 @@ struct stm32_hw_pin_userdata
 
 extern struct stm32_hw_pin_userdata stm32_pins[];
 
-int stm32_hw_pin_init(void);
+int32_t stm32_hw_pin_init(void);
 
 #endif

--- a/bsp/stm32f10x-HAL/drivers/drv_gpio.c
+++ b/bsp/stm32f10x-HAL/drivers/drv_gpio.c
@@ -617,7 +617,7 @@ static rt_uint16_t get_pin(uint8_t pin)
     return gpio_pin;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, int32_t value)
 {
     rt_uint16_t gpio_pin;
     gpio_pin = get_pin(pin);
@@ -628,7 +628,7 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     HAL_GPIO_WritePin(get_st_gpio(gpio_pin), get_st_pin(gpio_pin), (GPIO_PinState)value);
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+int32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
     rt_uint16_t gpio_pin;
     gpio_pin = get_pin(pin);
@@ -639,7 +639,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return HAL_GPIO_ReadPin(get_st_gpio(gpio_pin), get_st_pin(gpio_pin));
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     rt_uint16_t gpio_pin;
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -690,8 +690,7 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(rt_uint16_t gpio_pin)
     return &pin_irq_map[mapindex];
 };
 
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                              rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     rt_uint16_t gpio_pin;
     rt_base_t level;
@@ -728,7 +727,7 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     rt_uint16_t gpio_pin;
     rt_base_t level;
@@ -835,7 +834,7 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int rt_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }

--- a/bsp/stm32f10x/drivers/gpio.c
+++ b/bsp/stm32f10x/drivers/gpio.c
@@ -24,7 +24,7 @@
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
+    int32_t index;
     uint32_t rcc;
     GPIO_TypeDef *gpio;
     uint32_t pin;
@@ -470,7 +470,7 @@ const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, int32_t value)
 {
     const struct pin_index *index;
 
@@ -490,9 +490,9 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     }
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+int32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value;
+    int32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -515,7 +515,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef  GPIO_InitStructure;
@@ -562,9 +562,9 @@ void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     GPIO_Init(index->gpio, &GPIO_InitStructure);
 }
 
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    int i;
+    int32_t i;
     for(i = 0; i < 32; i++)
     {
         if((0x01 << i) == bit)
@@ -583,8 +583,7 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
     }
     return &pin_irq_map[mapindex];
 };
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                  rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -624,7 +623,7 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
  
     return RT_EOK;
 }
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -750,14 +749,14 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int stm32_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }
 INIT_BOARD_EXPORT(stm32_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     EXTI_ClearITPendingBit(pin_irq_map[irqno].irqbit);
     if(pin_irq_hdr_tab[irqno].hdr)

--- a/bsp/stm32f10x/drivers/gpio.h
+++ b/bsp/stm32f10x/drivers/gpio.h
@@ -21,6 +21,6 @@ struct stm32_hw_pin_userdata
 
 extern struct stm32_hw_pin_userdata stm32_pins[];
 
-int stm32_hw_pin_init(void);
+int32_t stm32_hw_pin_init(void);
 
 #endif

--- a/bsp/stm32f40x/drivers/gpio.c
+++ b/bsp/stm32f40x/drivers/gpio.c
@@ -24,7 +24,7 @@
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
+    int32_t index;
     uint32_t rcc;
     GPIO_TypeDef *gpio;
     uint32_t pin;
@@ -34,13 +34,13 @@ struct pin_index
 struct pin_irq
 {
     /* EXTI port source gpiox, such as EXTI_PortSourceGPIOA */
-    rt_uint8_t port_source;
+    uint8_t port_source;
     /* EXTI pin sources, such as EXTI_PinSource0 */
-    rt_uint8_t pin_source;
+    uint8_t pin_source;
     /* NVIC IRQ EXTI channel, such as EXTI0_IRQn */
     enum IRQn irq_exti_channel;
     /* EXTI line, such as EXTI_Line0 */
-    rt_uint32_t exti_line;
+    uint32_t exti_line;
 };
 
 static const struct pin_index pins[] =
@@ -455,7 +455,7 @@ const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, int32_t value)
 {
     const struct pin_index *index;
 
@@ -475,9 +475,9 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     }
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+int32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value;
+    int32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -500,7 +500,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef  GPIO_InitStructure;
@@ -557,9 +557,9 @@ void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     GPIO_Init(index->gpio, &GPIO_InitStructure);
 }
 
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    int i;
+    int32_t i;
     for (i = 0; i < 32; i++)
     {
         if ((1UL << i) == bit)
@@ -570,7 +570,7 @@ rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
     return -1;
 }
 
-rt_inline rt_int32_t bitno2bit(rt_uint32_t bitno)
+rt_inline int32_t bitno2bit(uint32_t bitno)
 {
     if (bitno <= 32)
     {
@@ -620,13 +620,12 @@ static const struct pin_irq *get_pin_irq(uint16_t pin)
     return &irq;
 };
 
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                  rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
 
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     index = get_pin(pin);
     if (index == RT_NULL)
     {
@@ -663,11 +662,11 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -695,12 +694,12 @@ rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
     return RT_EOK;
 }
 
-rt_err_t stm32_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+rt_err_t stm32_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     const struct pin_index *index;
     const struct pin_irq *irq;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     NVIC_InitTypeDef NVIC_InitStructure;
     EXTI_InitTypeDef EXTI_InitStructure;
 
@@ -789,7 +788,7 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int stm32_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     /* enable SYSCFG clock for EXTI */
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
@@ -799,7 +798,7 @@ int stm32_hw_pin_init(void)
 }
 INIT_BOARD_EXPORT(stm32_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     EXTI_ClearITPendingBit(bitno2bit(irqno));
     if (pin_irq_hdr_tab[irqno].hdr)

--- a/bsp/stm32f40x/drivers/gpio.h
+++ b/bsp/stm32f40x/drivers/gpio.h
@@ -10,6 +10,6 @@
 #ifndef GPIO_H__
 #define GPIO_H__
 
-int stm32_hw_pin_init(void);
+int32_t stm32_hw_pin_init(void);
 
 #endif

--- a/bsp/stm32f429-apollo/drivers/drv_gpio.c
+++ b/bsp/stm32f429-apollo/drivers/drv_gpio.c
@@ -97,7 +97,7 @@ static void GPIOC_CLK_ENABLE(void)
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
+    int32_t index;
     void (*rcc)(void);
     GPIO_TypeDef *gpio;
     uint32_t pin;
@@ -1549,7 +1549,7 @@ const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, int32_t value)
 {
     const struct pin_index *index;
 
@@ -1562,9 +1562,9 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     HAL_GPIO_WritePin(index->gpio, index->pin, (GPIO_PinState)value);
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+int32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value;
+    int32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -1580,7 +1580,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -1633,9 +1633,9 @@ void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
 
     HAL_GPIO_Init(index->gpio, &GPIO_InitStruct);
 }
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    int i;
+    int32_t i;
     for (i = 0; i < 32; i++)
     {
         if ((0x01 << i) == bit)
@@ -1654,8 +1654,7 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
     }
     return &pin_irq_map[mapindex];
 };
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                              rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void(*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -1694,7 +1693,7 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
 
     return RT_EOK;
 }
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -1804,14 +1803,14 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int rt_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }
 INIT_BOARD_EXPORT(rt_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     if (pin_irq_hdr_tab[irqno].hdr)
     {

--- a/bsp/stm32f4xx-HAL/drivers/drv_gpio.c
+++ b/bsp/stm32f4xx-HAL/drivers/drv_gpio.c
@@ -1586,7 +1586,7 @@ static rt_uint16_t get_pin(uint8_t pin)
     return gpio_pin;
 };
 
-static void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void stm32_pin_write(rt_device_t dev, int32_t pin, int32_t value)
 {
     rt_uint16_t gpio_pin;
     gpio_pin = get_pin(pin);
@@ -1597,7 +1597,7 @@ static void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     HAL_GPIO_WritePin(get_st_gpio(gpio_pin), get_st_pin(gpio_pin), (GPIO_PinState)value);
 }
 
-static int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+static int32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
     rt_uint16_t gpio_pin;
     gpio_pin = get_pin(pin);
@@ -1608,7 +1608,7 @@ static int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return HAL_GPIO_ReadPin(get_st_gpio(gpio_pin), get_st_pin(gpio_pin));
 }
 
-static void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     rt_uint16_t gpio_pin;
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -1659,8 +1659,7 @@ static const struct pin_irq_map *get_pin_irq_map(rt_uint16_t gpio_pin)
     return &pin_irq_map[mapindex];
 };
 
-static rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                              rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void(*hdr)(void *args), void *args)
 {
     rt_uint16_t gpio_pin;
     rt_base_t level;
@@ -1697,7 +1696,7 @@ static rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-static rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     rt_uint16_t gpio_pin;
     rt_base_t level;
@@ -1804,7 +1803,7 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int rt_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }
@@ -1812,7 +1811,7 @@ INIT_BOARD_EXPORT(rt_hw_pin_init);
 
 static void pin_irq_hdr(uint16_t GPIO_Pin)
 {
-    int irqno = 0;
+    int32_t irqno = 0;
     for(irqno = 0; irqno < 16; irqno ++)
     {
         if((0x01 << irqno) == GPIO_Pin)

--- a/bsp/stm32l072/app/application.c
+++ b/bsp/stm32l072/app/application.c
@@ -19,6 +19,7 @@
 #include <rtdevice.h>
 #include "board.h"
 #include <rtthread.h>
+#include <finsh.h>
 
 static void rt_init_thread_entry(void* parameter)
 {

--- a/bsp/stm32l072/board/board.h
+++ b/bsp/stm32l072/board/board.h
@@ -46,9 +46,9 @@ void rt_hw_msd_init(void);
 #define UFQFPN32
 
 #ifdef RT_USING_PIN
-extern inline void stm32_pin_write_early(rt_base_t pin, rt_base_t value);
-extern inline int stm32_pin_read_early(rt_base_t pin);
-extern void stm32_pin_mode_early(rt_base_t pin, rt_base_t mode);
+extern void stm32_pin_write_early(int32_t pin, rt_base_t value);
+extern int32_t stm32_pin_read_early(int32_t pin);
+extern void stm32_pin_mode_early(int32_t pin, uint32_t mode);
 #endif /*RT_USING_PIN*/
 
 #define RT_USING_UART1

--- a/bsp/stm32l072/board/gpio.c
+++ b/bsp/stm32l072/board/gpio.c
@@ -31,8 +31,8 @@
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
-    unsigned int clk;
+    int32_t index;
+    uint32_t clk;
     GPIO_TypeDef *gpio;
     uint32_t pin;
 };
@@ -95,7 +95,7 @@ const struct pin_index *get_pin(uint8_t pin)
 
     return index;
 };
-inline void stm32_pin_write_early(rt_base_t pin, rt_base_t value)
+void stm32_pin_write_early(int32_t pin, rt_base_t value)
 {
     const struct pin_index *index;
 
@@ -106,13 +106,13 @@ inline void stm32_pin_write_early(rt_base_t pin, rt_base_t value)
     }
     HAL_GPIO_WritePin(index->gpio, index->pin, value);
 }
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, int32_t value)
 {
     stm32_pin_write_early(pin, value);
 }
-inline int stm32_pin_read_early(rt_base_t pin)
+int32_t stm32_pin_read_early(int32_t pin)
 {
-    int value;
+    int32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -125,11 +125,11 @@ inline int stm32_pin_read_early(rt_base_t pin)
     value = HAL_GPIO_ReadPin(index->gpio, index->pin);
     return value;
 }
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+int32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
     return stm32_pin_read_early(pin);
 }
-void stm32_pin_mode_early(rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode_early(int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef  GPIO_InitStructure;
@@ -175,7 +175,7 @@ void stm32_pin_mode_early(rt_base_t pin, rt_base_t mode)
     }
     HAL_GPIO_Init(index->gpio, &GPIO_InitStructure);
 }
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     stm32_pin_mode_early(pin, mode);
 }
@@ -187,7 +187,7 @@ const static struct rt_pin_ops _stm32_pin_ops =
 };
 int stm32_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;

--- a/bsp/stm32l476-nucleo/drivers/drv_gpio.c
+++ b/bsp/stm32l476-nucleo/drivers/drv_gpio.c
@@ -80,7 +80,7 @@ static void GPIOH_CLK_ENABLE(void)
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
+    int32_t index;
     void (*rcc)(void);
     GPIO_TypeDef *gpio;
     uint32_t pin;
@@ -525,7 +525,7 @@ const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, int32_t value)
 {
     const struct pin_index *index;
 
@@ -538,9 +538,9 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     HAL_GPIO_WritePin(index->gpio, index->pin, (GPIO_PinState)value);
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+int32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value;
+    int32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -556,7 +556,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -610,9 +610,9 @@ void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     HAL_GPIO_Init(index->gpio, &GPIO_InitStruct);
 }
 
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    int i;
+    int32_t i;
     for (i = 0; i < 32; i++)
     {
         if ((0x01 << i) == bit)
@@ -633,8 +633,7 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
     return &pin_irq_map[mapindex];
 };
 
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                              rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void(*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -674,7 +673,7 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -786,14 +785,14 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int bsp_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }
 INIT_BOARD_EXPORT(bsp_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     if (pin_irq_hdr_tab[irqno].hdr)
     {

--- a/components/drivers/include/drivers/pin.h
+++ b/components/drivers/include/drivers/pin.h
@@ -48,43 +48,41 @@ struct rt_device_pin
 
 struct rt_device_pin_mode
 {
-    rt_uint16_t pin;
-    rt_uint16_t mode;
+    uint16_t pin;
+    uint16_t mode;
 };
 struct rt_device_pin_status
 {
-    rt_uint16_t pin;
-    rt_uint16_t status;
+    uint16_t pin;
+    uint16_t status;
 };
 struct rt_pin_irq_hdr
 {
-    rt_int16_t        pin;
-    rt_uint16_t       mode;
+    int16_t pin;
+    uint16_t mode;
     void (*hdr)(void *args);
-    void             *args;
+    void *args;
 };
 struct rt_pin_ops
 {
-    void (*pin_mode)(struct rt_device *device, rt_base_t pin, rt_base_t mode);
-    void (*pin_write)(struct rt_device *device, rt_base_t pin, rt_base_t value);
-    int (*pin_read)(struct rt_device *device, rt_base_t pin);
+    void (*pin_mode)(struct rt_device *device, int32_t pin, uint32_t mode);
+    void (*pin_write)(struct rt_device *device, int32_t pin, int32_t value);
+    int32_t (*pin_read)(struct rt_device *device, int32_t pin);
 
     /* TODO: add GPIO interrupt */
-    rt_err_t (*pin_attach_irq)(struct rt_device *device, rt_int32_t pin,
-                      rt_uint32_t mode, void (*hdr)(void *args), void *args);
-    rt_err_t (*pin_detach_irq)(struct rt_device *device, rt_int32_t pin);
-    rt_err_t (*pin_irq_enable)(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled);
+    rt_err_t (*pin_attach_irq)(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args);
+    rt_err_t (*pin_detach_irq)(struct rt_device *device, int32_t pin);
+    rt_err_t (*pin_irq_enable)(struct rt_device *device, int32_t pin, uint32_t enabled);
 };
 
-int rt_device_pin_register(const char *name, const struct rt_pin_ops *ops, void *user_data);
+int32_t rt_device_pin_register(const char *name, const struct rt_pin_ops *ops, void *user_data);
 
-void rt_pin_mode(rt_base_t pin, rt_base_t mode);
-void rt_pin_write(rt_base_t pin, rt_base_t value);
-int  rt_pin_read(rt_base_t pin);
-rt_err_t rt_pin_attach_irq(rt_int32_t pin, rt_uint32_t mode,
-                             void (*hdr)(void *args), void  *args);
-rt_err_t rt_pin_detach_irq(rt_int32_t pin);
-rt_err_t rt_pin_irq_enable(rt_base_t pin, rt_uint32_t enabled);
+void rt_pin_mode(int32_t pin, uint32_t mode);
+void rt_pin_write(int32_t pin, int32_t value);
+int32_t rt_pin_read(int32_t pin);
+rt_err_t rt_pin_attach_irq(int32_t pin, uint32_t mode, void (*hdr)(void *args), void  *args);
+rt_err_t rt_pin_detach_irq(int32_t pin);
+rt_err_t rt_pin_irq_enable(int32_t pin, uint32_t enabled);
 
 #ifdef __cplusplus
 }

--- a/components/drivers/misc/pin.c
+++ b/components/drivers/misc/pin.c
@@ -74,7 +74,7 @@ const static struct rt_device_ops pin_ops =
 };
 #endif
 
-int rt_device_pin_register(const char *name, const struct rt_pin_ops *ops, void *user_data)
+int32_t rt_device_pin_register(const char *name, const struct rt_pin_ops *ops, void *user_data)
 {
     _hw_pin.parent.type         = RT_Device_Class_Miscellaneous;
     _hw_pin.parent.rx_indicate  = RT_NULL;
@@ -120,7 +120,7 @@ rt_err_t rt_pin_detach_irq(rt_int32_t pin)
     return RT_ENOSYS;
 }
 
-rt_err_t rt_pin_irq_enable(rt_base_t pin, rt_uint32_t enabled)
+rt_err_t rt_pin_irq_enable(int32_t pin, uint32_t enabled)
 {
     RT_ASSERT(_hw_pin.ops != RT_NULL);
     if(_hw_pin.ops->pin_irq_enable)
@@ -131,21 +131,21 @@ rt_err_t rt_pin_irq_enable(rt_base_t pin, rt_uint32_t enabled)
 }
 
 /* RT-Thread Hardware PIN APIs */
-void rt_pin_mode(rt_base_t pin, rt_base_t mode)
+void rt_pin_mode(int32_t pin, uint32_t mode)
 {
     RT_ASSERT(_hw_pin.ops != RT_NULL);
     _hw_pin.ops->pin_mode(&_hw_pin.parent, pin, mode);
 }
 FINSH_FUNCTION_EXPORT_ALIAS(rt_pin_mode, pinMode, set hardware pin mode);
 
-void rt_pin_write(rt_base_t pin, rt_base_t value)
+void rt_pin_write(int32_t pin, rt_base_t value)
 {
     RT_ASSERT(_hw_pin.ops != RT_NULL);
     _hw_pin.ops->pin_write(&_hw_pin.parent, pin, value);
 }
 FINSH_FUNCTION_EXPORT_ALIAS(rt_pin_write, pinWrite, write value to hardware pin);
 
-int  rt_pin_read(rt_base_t pin)
+int32_t rt_pin_read(int32_t pin)
 {
     RT_ASSERT(_hw_pin.ops != RT_NULL);
     return _hw_pin.ops->pin_read(&_hw_pin.parent, pin);

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -32,6 +32,7 @@
 
 /* include rtconfig header to import configuration */
 #include <rtconfig.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
当前pin接口数据类型比较乱,此处使用C标准数据类型整理了下. 注意: pin为管脚索引号,用32位数据表示即可.至于是32位(32位cpu)一组还是64位一组(64位cpu),在bsp中处理即可.