### PR TITLE
pin接口数据类型整理相关

### DIFF
--- a/bsp/allwinner_tina/drivers/drv_gpio.c
+++ b/bsp/allwinner_tina/drivers/drv_gpio.c
@@ -44,9 +44,9 @@
 *********************************************************/
 int gpio_set_func(enum gpio_port port, enum gpio_pin pin, rt_uint8_t func)
 {
-    rt_uint32_t addr;
-    rt_uint32_t offset;
-    rt_uint32_t data;
+    uint32_t addr;
+    uint32_t offset;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_A <= port) && (port < GPIO_PORT_NUM));
     RT_ASSERT((GPIO_PIN_0 <= pin) && (pin < GPIO_PIN_NUM));
@@ -65,15 +65,15 @@ int gpio_set_func(enum gpio_port port, enum gpio_pin pin, rt_uint8_t func)
     data |= func << offset;
     writel(data, addr);
 
-    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((uint32_t *)addr));
     return RT_EOK;
 }
 
 int gpio_set_value(enum gpio_port port, enum gpio_pin pin, rt_uint8_t value)
 {
-    rt_uint32_t addr;
-    rt_uint32_t offset;
-    rt_uint32_t data;
+    uint32_t addr;
+    uint32_t offset;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_A <= port) && (port < GPIO_PORT_NUM));
     RT_ASSERT((GPIO_PIN_0 <= pin) && (pin < GPIO_PIN_NUM));
@@ -92,15 +92,15 @@ int gpio_set_value(enum gpio_port port, enum gpio_pin pin, rt_uint8_t value)
     data |= value << offset;
     writel(data, addr);
 
-    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((uint32_t *)addr));
     return RT_EOK;
 }
 
 int gpio_get_value(enum gpio_port port, enum gpio_pin pin)
 {
-    rt_uint32_t addr;
-    rt_uint32_t offset;
-    rt_uint32_t data;
+    uint32_t addr;
+    uint32_t offset;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_A <= port) && (port < GPIO_PORT_NUM));
     RT_ASSERT((GPIO_PIN_0 <= pin) && (pin < GPIO_PIN_NUM));
@@ -110,15 +110,15 @@ int gpio_get_value(enum gpio_port port, enum gpio_pin pin)
 
     data = readl(addr);
 
-    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((uint32_t *)addr));
     return (data >> offset) & 0x01;
 }
 
 int gpio_set_pull_mode(enum gpio_port port,  enum gpio_pin pin, enum gpio_pull pull)
 {
-    rt_uint32_t addr;
-    rt_uint32_t offset;
-    rt_uint32_t data;
+    uint32_t addr;
+    uint32_t offset;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_A <= port) && (port < GPIO_PORT_NUM));
     RT_ASSERT((GPIO_PIN_0 <= pin) && (pin < GPIO_PIN_NUM));
@@ -138,15 +138,15 @@ int gpio_set_pull_mode(enum gpio_port port,  enum gpio_pin pin, enum gpio_pull p
     data |= pull << offset;
     writel(data, addr);
 
-    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((uint32_t *)addr));
     return RT_EOK;
 }
 
 int gpio_set_drive_level(enum gpio_port port, enum gpio_pin pin, enum gpio_drv_level level)
 {
-    volatile rt_uint32_t addr;
-    rt_uint32_t offset;
-    rt_uint32_t data;
+    volatile uint32_t addr;
+    uint32_t offset;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_A <= port) && (port < GPIO_PORT_NUM));
     RT_ASSERT((GPIO_PIN_0 <= pin) && (pin < GPIO_PIN_NUM));
@@ -166,15 +166,15 @@ int gpio_set_drive_level(enum gpio_port port, enum gpio_pin pin, enum gpio_drv_l
     data |= level << offset;
     writel(data, addr);
 
-    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((uint32_t *)addr));
     return RT_EOK;
 }
 
 void gpio_direction_input(enum gpio_port port,  enum gpio_pin pin)
 {
-    volatile rt_uint32_t addr;
-    rt_uint32_t offset;
-    rt_uint32_t data;
+    volatile uint32_t addr;
+    uint32_t offset;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_A <= port) && (port < GPIO_PORT_NUM));
     RT_ASSERT((GPIO_PIN_0 <= pin) && (pin < GPIO_PIN_NUM));
@@ -187,14 +187,14 @@ void gpio_direction_input(enum gpio_port port,  enum gpio_pin pin)
     data |= IO_INPUT << offset;
     writel(data, addr);
 
-    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((uint32_t *)addr));
 }
 
 void gpio_direction_output(enum gpio_port port, enum gpio_pin pin, int value)
 {
-    volatile rt_uint32_t addr;
-    rt_uint32_t offset;
-    rt_uint32_t data;
+    volatile uint32_t addr;
+    uint32_t offset;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_A <= port) && (port < GPIO_PORT_NUM));
     RT_ASSERT((GPIO_PIN_0 <= pin) && (pin < GPIO_PIN_NUM));
@@ -208,15 +208,15 @@ void gpio_direction_output(enum gpio_port port, enum gpio_pin pin, int value)
     data |= IO_OUTPUT << offset;
     writel(data, addr);
 
-    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((uint32_t *)addr));
 }
 /*********************************************************
 **   IRQ
 *********************************************************/
 static void gpio_ack_irq(enum gpio_port port,  enum gpio_pin pin)
 {
-    rt_uint32_t addr;
-    rt_uint32_t data;
+    uint32_t addr;
+    uint32_t data;
 
     addr = GPIOn_INT_STA_ADDR(port);
     data = readl(addr);
@@ -226,8 +226,8 @@ static void gpio_ack_irq(enum gpio_port port,  enum gpio_pin pin)
 
 void gpio_select_irq_clock(enum gpio_port port, enum gpio_irq_clock clock)
 {
-    rt_uint32_t addr;
-    rt_uint32_t data;
+    uint32_t addr;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_C < port) && (port < GPIO_PORT_NUM));
 
@@ -237,13 +237,13 @@ void gpio_select_irq_clock(enum gpio_port port, enum gpio_irq_clock clock)
     data &= ~0x01;
     data |= clock;
     writel(data, addr);
-    LOG_D("[line]:%d addr:%08x data:%08x", __LINE__, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d addr:%08x data:%08x", __LINE__, addr, *((uint32_t *)addr));
 }
 
 void gpio_set_debounce(enum gpio_port port, enum gpio_direction_type prescaler)
 {
-    rt_uint32_t addr;
-    rt_uint32_t data;
+    uint32_t addr;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_C < port) && (port < GPIO_PORT_NUM));
 
@@ -253,14 +253,14 @@ void gpio_set_debounce(enum gpio_port port, enum gpio_direction_type prescaler)
     data &= ~(0x07 << 4);
     data |= prescaler << 4;
     writel(data, addr);
-    LOG_D("[line]:%d addr:%08x data:%08x", __LINE__, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d addr:%08x data:%08x", __LINE__, addr, *((uint32_t *)addr));
 }
 
 void gpio_irq_enable(enum gpio_port port,  enum gpio_pin pin)
 {
-    rt_uint32_t addr;
-    rt_uint32_t offset;
-    rt_uint32_t data;
+    uint32_t addr;
+    uint32_t offset;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_C < port) && (port < GPIO_PORT_NUM));
     RT_ASSERT((GPIO_PIN_0 <= pin) && (pin < GPIO_PIN_NUM));
@@ -272,14 +272,14 @@ void gpio_irq_enable(enum gpio_port port,  enum gpio_pin pin)
     data |= 0x1 << offset;
     writel(data, addr);
     gpio_select_irq_clock(port, GPIO_IRQ_HOSC_24MHZ);
-    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((uint32_t *)addr));
 }
 
 void gpio_irq_disable(enum gpio_port port,  enum gpio_pin pin)
 {
-    rt_uint32_t addr;
-    rt_uint32_t offset;
-    rt_uint32_t data;
+    uint32_t addr;
+    uint32_t offset;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_C < port) && (port < GPIO_PORT_NUM));
     RT_ASSERT((GPIO_PIN_0 <= pin) && (pin < GPIO_PIN_NUM));
@@ -292,14 +292,14 @@ void gpio_irq_disable(enum gpio_port port,  enum gpio_pin pin)
     data &= ~(0x1 << offset);
 
     writel(data, addr);
-    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((uint32_t *)addr));
 }
 
 void gpio_set_irq_type(enum gpio_port port,  enum gpio_pin pin, enum gpio_irq_type irq_type)
 {
-    rt_uint32_t addr;
-    rt_uint32_t offset;
-    rt_uint32_t data;
+    uint32_t addr;
+    uint32_t offset;
+    uint32_t data;
 
     RT_ASSERT((GPIO_PORT_C < port) && (port < GPIO_PORT_NUM));
     RT_ASSERT((GPIO_PIN_0 <= pin) && (pin < GPIO_PIN_NUM));
@@ -312,7 +312,7 @@ void gpio_set_irq_type(enum gpio_port port,  enum gpio_pin pin, enum gpio_irq_ty
     data |= irq_type << offset;
     writel(data, addr);
 
-    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((rt_uint32_t *)addr));
+    LOG_D("[line]:%d offset:%d addr:%08x data:%08x", __LINE__, offset, addr, *((uint32_t *)addr));
 }
 
 static struct gpio_irq_def _g_gpio_irq_tbl[GPIO_PORT_NUM];
@@ -337,9 +337,9 @@ void gpio_clear_irq_callback(enum gpio_port port, enum gpio_pin pin)
 static void gpio_irq_handler(int irq, void *param)
 {
     struct gpio_irq_def *irq_def = (struct gpio_irq_def *)param;
-    rt_uint32_t pend, enable;
+    uint32_t pend, enable;
     int port, pin;
-    rt_uint32_t addr;
+    uint32_t addr;
 
     pin = 0;
     port = irq - PIOD_INTERRUPT;
@@ -448,7 +448,7 @@ static struct _pin_index pin_index[] =
     {66, GPIO_PORT_A, GPIO_PIN_0, PIN_MAGIC},
 };
 
-static void pin_mode(struct rt_device *dev, rt_base_t pin, rt_base_t mode)
+static void pin_mode(struct rt_device *dev, int32_t pin, uint32_t mode)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {
@@ -459,7 +459,7 @@ static void pin_mode(struct rt_device *dev, rt_base_t pin, rt_base_t mode)
     gpio_set_func(pin_index[pin].pin_port, pin_index[pin].pin, mode);
 }
 
-static void pin_write(struct rt_device *dev, rt_base_t pin, rt_base_t value)
+static void pin_write(struct rt_device *dev, int32_t pin, uint32_t value)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {
@@ -470,7 +470,7 @@ static void pin_write(struct rt_device *dev, rt_base_t pin, rt_base_t value)
     gpio_set_value(pin_index[pin].pin_port, pin_index[pin].pin, value);
 }
 
-static int pin_read(struct rt_device *device, rt_base_t pin)
+static uint32_t pin_read(struct rt_device *device, int32_t pin)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {
@@ -481,7 +481,7 @@ static int pin_read(struct rt_device *device, rt_base_t pin)
     return gpio_get_value(pin_index[pin].pin_port, pin_index[pin].pin);
 }
 
-static rt_err_t pin_attach_irq(struct rt_device *device, rt_int32_t pin, rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {
@@ -493,7 +493,7 @@ static rt_err_t pin_attach_irq(struct rt_device *device, rt_int32_t pin, rt_uint
     gpio_set_irq_type(pin_index[pin].pin_port, pin_index[pin].pin, mode);
     return RT_EOK;
 }
-static rt_err_t pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {
@@ -506,7 +506,7 @@ static rt_err_t pin_detach_irq(struct rt_device *device, rt_int32_t pin)
     return RT_EOK;
 }
 
-rt_err_t pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+rt_err_t pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {

--- a/bsp/apollo2/board/gpio.c
+++ b/bsp/apollo2/board/gpio.c
@@ -32,7 +32,7 @@
 #define APLLO2_PIN_NUMBERS    64 //[34, 64]
 struct rt_pin_irq_hdr am_pin_irq_hdr_tab[64];
 
-void am_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void am_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     if (mode == PIN_MODE_OUTPUT)
     {
@@ -61,7 +61,7 @@ void am_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     }
 }
 
-void am_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void am_pin_write(rt_device_t dev, int32_t pin, uint32_t value)
 {
     if (value == PIN_LOW)
     {
@@ -73,9 +73,9 @@ void am_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     }    
 }
 
-int am_pin_read(rt_device_t dev, rt_base_t pin)
+uint32_t am_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value = PIN_LOW;
+    uint32_t value = PIN_LOW;
 
     if (am_hal_gpio_pin_config_read(pin) == AM_HAL_GPIO_OUTPUT)
     {
@@ -103,11 +103,10 @@ int am_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-rt_err_t am_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t am_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     irqindex = pin;
 
@@ -135,10 +134,10 @@ rt_err_t am_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-rt_err_t am_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t am_pin_dettach_irq(struct rt_device *device, int32_t pin)
 {
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     irqindex = pin;
 
@@ -157,10 +156,10 @@ rt_err_t am_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
     return RT_EOK;
 }
 
-rt_err_t am_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+rt_err_t am_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     irqindex = pin;
 

--- a/bsp/beaglebone/drivers/gpio.c
+++ b/bsp/beaglebone/drivers/gpio.c
@@ -19,7 +19,7 @@
 
 #ifdef RT_USING_PIN
 
-#define reg(base)         *(int*)(base)
+#define reg(base)         *(uint32_t*)(base)
 
 #define GPIO_PIN_LOW              (0x0)
 #define GPIO_PIN_HIGH             (0x1)
@@ -37,7 +37,7 @@ static rt_base_t GPIO_BASE[] =
     AM33XX_GPIO_3_REGS
 };
 
-static void am33xx_pin_mode(struct rt_device *device, rt_base_t pin, rt_base_t mode)
+static void am33xx_pin_mode(struct rt_device *device, int32_t pin, uint32_t mode)
 {
     RT_ASSERT(pin >= 0 && pin < 128);
     RT_ASSERT(mode != PIN_MODE_INPUT_PULLUP); /* Mode not supported */
@@ -54,11 +54,11 @@ static void am33xx_pin_mode(struct rt_device *device, rt_base_t pin, rt_base_t m
     }
 }
 
-static void am33xx_pin_write(struct rt_device *device, rt_base_t pin, rt_base_t value)
+static void am33xx_pin_write(struct rt_device *device, int32_t pin, uint32_t value)
 {
     RT_ASSERT(pin >= 0 && pin < 128);
-    rt_base_t gpiox     = pin >> 5;
-    rt_base_t pinNumber = pin & 0x1F;
+    uint32_t gpiox     = pin >> 5;
+    uint32_t  pinNumber = pin & 0x1F;
 
     if(GPIO_PIN_HIGH == value)
     {
@@ -70,11 +70,11 @@ static void am33xx_pin_write(struct rt_device *device, rt_base_t pin, rt_base_t 
     }
 }
 
-static int am33xx_pin_read(struct rt_device *device, rt_base_t pin)
+static uint32_t am33xx_pin_read(struct rt_device *device, int32_t pin)
 {
     RT_ASSERT(pin >= 0 && pin < 128);
-    rt_base_t gpiox     = pin >> 5;
-    rt_base_t pinNumber = pin & 0x1F;
+    uint32_t  gpiox     = pin >> 5;
+    uint32_t  pinNumber = pin & 0x1F;
 
     return reg(GPIO_BASE[gpiox] + GPIO_DATAIN) & (1 << pinNumber) ? 1 : 0;
 }

--- a/bsp/gd32303e-eval/drivers/drv_gpio.c
+++ b/bsp/gd32303e-eval/drivers/drv_gpio.c
@@ -248,10 +248,10 @@ const struct pin_index *get_pin(rt_uint8_t pin)
     return index;
 };
 
-void gd32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void gd32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
-    rt_uint32_t pin_mode;
+    uint32_t pin_mode;
     index = get_pin(pin);
     if (index == RT_NULL)
     {
@@ -291,7 +291,7 @@ void gd32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     gpio_init(index->gpio_periph, pin_mode, GPIO_OSPEED_50MHZ, index->pin);
 }
 
-void gd32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void gd32_pin_write(rt_device_t dev, int32_t pin, uint32_t value)
 {
     const struct pin_index *index;
 
@@ -304,9 +304,9 @@ void gd32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     gpio_bit_write(index->gpio_periph, index->pin, (bit_status)value);
 }
 
-int gd32_pin_read(rt_device_t dev, rt_base_t pin)
+uint32_t gd32_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value;
+    uint32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -323,9 +323,9 @@ int gd32_pin_read(rt_device_t dev, rt_base_t pin)
 }
 
 
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    rt_uint8_t i;
+    int32_t i;
     for (i = 0; i < 32; i++)
     {
         if ((0x01 << i) == bit)
@@ -335,7 +335,7 @@ rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
     }
     return -1;
 }
-rt_inline const struct pin_irq_map *get_pin_irq_map(rt_uint32_t pinbit)
+rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
 {
     rt_int32_t mapindex = bit2bitno(pinbit);
     if (mapindex < 0 || mapindex >= ITEM_NUM(pin_irq_map))
@@ -344,12 +344,11 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(rt_uint32_t pinbit)
     }
     return &pin_irq_map[mapindex];
 };
-rt_err_t gd32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                              rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t gd32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t hdr_index = -1;
+    int32_t hdr_index = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -384,11 +383,11 @@ rt_err_t gd32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
 
     return RT_EOK;
 }
-rt_err_t gd32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t gd32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t hdr_index = -1;
+    int32_t hdr_index = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -415,12 +414,12 @@ rt_err_t gd32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
 
     return RT_EOK;
 }
-rt_err_t gd32_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+rt_err_t gd32_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     const struct pin_index *index;
     const struct pin_irq_map *irqmap;
     rt_base_t level;
-    rt_int32_t hdr_index = -1;
+    int32_t hdr_index = -1;
     exti_trig_type_enum trigger_mode;
 
     index = get_pin(pin);
@@ -509,7 +508,7 @@ int rt_hw_pin_init(void)
 }
 INIT_BOARD_EXPORT(rt_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     if (pin_irq_hdr_tab[irqno].hdr)
     {

--- a/bsp/imxrt/Libraries/imxrt1050/drivers/drv_pin.c
+++ b/bsp/imxrt/Libraries/imxrt1050/drivers/drv_pin.c
@@ -24,7 +24,7 @@ struct rt1052_pin
 {
     rt_uint16_t   pin; 
     GPIO_Type    *gpio; 
-    rt_uint32_t   gpio_pin; 
+    uint32_t   gpio_pin; 
 }; 
 
 struct rt1052_irq
@@ -218,7 +218,7 @@ static struct rt1052_irq rt1052_irq_map[] =
     {PIN_IRQ_DISABLE, {PIN_IRQ_PIN_NONE, PIN_IRQ_MODE_RISING, RT_NULL, RT_NULL} }
 }; 
 
-void gpio_isr(GPIO_Type* base, rt_uint32_t gpio_pin)
+void gpio_isr(GPIO_Type* base, uint32_t gpio_pin)
 {
     if((GPIO_PortGetInterruptFlags(base) & (1 << gpio_pin)) != 0)
     {
@@ -233,7 +233,7 @@ void gpio_isr(GPIO_Type* base, rt_uint32_t gpio_pin)
 
 void GPIO1_Combined_0_15_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
+    uint8_t gpio_pin; 
     
     rt_interrupt_enter();
 
@@ -247,7 +247,7 @@ void GPIO1_Combined_0_15_IRQHandler(void)
 
 void GPIO1_Combined_16_31_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
+    uint8_t gpio_pin; 
     
     rt_interrupt_enter();
 
@@ -261,7 +261,7 @@ void GPIO1_Combined_16_31_IRQHandler(void)
 
 void GPIO2_Combined_0_15_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
+    uint8_t gpio_pin; 
     
     rt_interrupt_enter();
 
@@ -275,7 +275,7 @@ void GPIO2_Combined_0_15_IRQHandler(void)
 
 void GPIO2_Combined_16_31_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
+    uint8_t gpio_pin; 
     
     rt_interrupt_enter();
 
@@ -289,7 +289,7 @@ void GPIO2_Combined_16_31_IRQHandler(void)
 
 void GPIO3_Combined_0_15_IRQHandler(void) 
 {
-    rt_uint8_t gpio_pin; 
+    uint8_t gpio_pin; 
     
     rt_interrupt_enter();
 
@@ -303,7 +303,7 @@ void GPIO3_Combined_0_15_IRQHandler(void)
 
 void GPIO3_Combined_16_31_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
+    uint8_t gpio_pin; 
     
     rt_interrupt_enter();
 
@@ -317,7 +317,7 @@ void GPIO3_Combined_16_31_IRQHandler(void)
 
 void GPIO4_Combined_0_15_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
+    uint8_t gpio_pin; 
     
     rt_interrupt_enter();
 
@@ -330,7 +330,7 @@ void GPIO4_Combined_0_15_IRQHandler(void)
 }
 void GPIO4_Combined_16_31_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
+    uint8_t gpio_pin; 
     
     rt_interrupt_enter();
 
@@ -344,7 +344,7 @@ void GPIO4_Combined_16_31_IRQHandler(void)
 
 void GPIO5_Combined_0_15_IRQHandler(void)
 { 
-    rt_uint8_t gpio_pin; 
+    uint8_t gpio_pin; 
     
     rt_interrupt_enter();
 
@@ -356,7 +356,7 @@ void GPIO5_Combined_0_15_IRQHandler(void)
     rt_interrupt_leave();
 }
 
-static IRQn_Type rt1052_get_irqnum(GPIO_Type *gpio, rt_uint32_t gpio_pin)
+static IRQn_Type rt1052_get_irqnum(GPIO_Type *gpio, uint32_t gpio_pin)
 {
     IRQn_Type irq_num = NotAvail_IRQn;  /* Invalid interrupt number */
     
@@ -419,10 +419,10 @@ static IRQn_Type rt1052_get_irqnum(GPIO_Type *gpio, rt_uint32_t gpio_pin)
     return irq_num; 
 }
 
-static void rt1052_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void rt1052_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     gpio_pin_config_t gpio; 
-    rt_uint32_t config_value = 0; 
+    uint32_t config_value = 0; 
     
     if((pin > __ARRAY_LEN(rt1052_pin_map)) || (pin == 0))
     {
@@ -493,18 +493,17 @@ static void rt1052_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     GPIO_PinInit(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin, &gpio); 
 }
 
-static int rt1052_pin_read(rt_device_t dev, rt_base_t pin)
+static uint32_t rt1052_pin_read(rt_device_t dev, int32_t pin)
 {
     return GPIO_PinReadPadStatus(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin); 
 }
 
-static void rt1052_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void rt1052_pin_write(rt_device_t dev, int32_t pin, uint32_t value)
 {
     GPIO_PinWrite(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin, value);
 }
 
-static rt_err_t rt1052_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-    rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t rt1052_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     struct rt1052_pin* pin_map = RT_NULL; 
     struct rt1052_irq* irq_map = RT_NULL; 
@@ -530,7 +529,7 @@ static rt_err_t rt1052_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-static rt_err_t rt1052_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t rt1052_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     struct rt1052_pin* pin_map = RT_NULL; 
     struct rt1052_irq* irq_map = RT_NULL; 
@@ -556,11 +555,11 @@ static rt_err_t rt1052_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
     return RT_EOK;
 }
 
-static rt_err_t rt1052_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+static rt_err_t rt1052_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     gpio_pin_config_t gpio; 
     IRQn_Type irq_num;
-    rt_uint32_t config_value = 0x1b0a0; 
+    uint32_t config_value = 0x1b0a0; 
     
     struct rt1052_pin* pin_map = RT_NULL; 
     struct rt1052_irq* irq_map = RT_NULL; 

--- a/bsp/imxrt1052-evk/drivers/drv_pin.c
+++ b/bsp/imxrt1052-evk/drivers/drv_pin.c
@@ -28,7 +28,7 @@ struct rt1052_pin
 {
     rt_uint16_t   pin; 
     GPIO_Type    *gpio; 
-    rt_uint32_t   gpio_pin; 
+    uint32_t   gpio_pin; 
 }; 
 
 struct rt1052_irq
@@ -222,7 +222,7 @@ static struct rt1052_irq rt1052_irq_map[] =
     {PIN_IRQ_DISABLE, {PIN_IRQ_PIN_NONE, PIN_IRQ_MODE_RISING, RT_NULL, RT_NULL} }
 }; 
 
-void gpio_isr(GPIO_Type* base, rt_uint32_t gpio_pin)
+void gpio_isr(GPIO_Type* base, uint32_t gpio_pin)
 {
     if((GPIO_PortGetInterruptFlags(base) & (1 << gpio_pin)) != 0)
     {
@@ -360,7 +360,7 @@ void GPIO5_Combined_0_15_IRQHandler(void)
     rt_interrupt_leave();
 }
 
-static IRQn_Type rt1052_get_irqnum(GPIO_Type *gpio, rt_uint32_t gpio_pin)
+static IRQn_Type rt1052_get_irqnum(GPIO_Type *gpio, uint32_t gpio_pin)
 {
     IRQn_Type irq_num = -100;  /* Invalid interrupt number */
     
@@ -423,10 +423,10 @@ static IRQn_Type rt1052_get_irqnum(GPIO_Type *gpio, rt_uint32_t gpio_pin)
     return irq_num; 
 }
 
-static void rt1052_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void rt1052_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     gpio_pin_config_t gpio; 
-    rt_uint32_t config_value = 0; 
+    uint32_t config_value = 0; 
     
     if((pin > __ARRAY_LEN(rt1052_pin_map)) || (pin == 0))
     {
@@ -497,18 +497,17 @@ static void rt1052_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     GPIO_PinInit(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin, &gpio); 
 }
 
-static int rt1052_pin_read(rt_device_t dev, rt_base_t pin)
+static uint32_t rt1052_pin_read(rt_device_t dev, int32_t pin)
 {
     return GPIO_PinReadPadStatus(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin); 
 }
 
-static void rt1052_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void rt1052_pin_write(rt_device_t dev, int32_t pin, uint32_t value)
 {
     GPIO_PinWrite(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin, value);
 }
 
-static rt_err_t rt1052_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-    rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t rt1052_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     struct rt1052_pin* pin_map = RT_NULL; 
     struct rt1052_irq* irq_map = RT_NULL; 
@@ -534,7 +533,7 @@ static rt_err_t rt1052_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-static rt_err_t rt1052_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t rt1052_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     struct rt1052_pin* pin_map = RT_NULL; 
     struct rt1052_irq* irq_map = RT_NULL; 
@@ -560,11 +559,11 @@ static rt_err_t rt1052_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
     return RT_EOK;
 }
 
-static rt_err_t rt1052_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+static rt_err_t rt1052_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     gpio_pin_config_t gpio; 
     IRQn_Type irq_num;
-    rt_uint32_t config_value = 0x1b0a0; 
+    uint32_t config_value = 0x1b0a0; 
     
     struct rt1052_pin* pin_map = RT_NULL; 
     struct rt1052_irq* irq_map = RT_NULL; 

--- a/bsp/ls1cdev/drivers/drv_gpio.c
+++ b/bsp/ls1cdev/drivers/drv_gpio.c
@@ -31,9 +31,9 @@
 
 #ifdef RT_USING_PIN
 
-void ls1c_pin_mode(struct rt_device *device, rt_base_t pin, rt_base_t mode)
+void ls1c_pin_mode(struct rt_device *device, int32_t pin, uint32_t mode)
 {
-    unsigned int gpio = pin;
+    uint32_t gpio = pin;
 
     if (PIN_MODE_OUTPUT == mode)
     {
@@ -48,9 +48,9 @@ void ls1c_pin_mode(struct rt_device *device, rt_base_t pin, rt_base_t mode)
 }
 
 
-void ls1c_pin_write(struct rt_device *device, rt_base_t pin, rt_base_t value)
+void ls1c_pin_write(struct rt_device *device, int32_t pin, uint32_t value)
 {
-    unsigned int gpio = pin;
+    uint32_t gpio = pin;
 
     if (PIN_LOW == value)
     {
@@ -65,10 +65,10 @@ void ls1c_pin_write(struct rt_device *device, rt_base_t pin, rt_base_t value)
 }
 
 
-int ls1c_pin_read(struct rt_device *device, rt_base_t pin)
+uint32_t ls1c_pin_read(struct rt_device *device, int32_t pin)
 {
-    unsigned int gpio = pin;
-    int value = PIN_LOW;
+    uint32_t gpio = pin;
+    uint32_t value = PIN_LOW;
 
     if (0 == gpio_get(gpio))
     {
@@ -82,10 +82,9 @@ int ls1c_pin_read(struct rt_device *device, rt_base_t pin)
     return value;
 }
 
-rt_err_t ls1c_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                             rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t ls1c_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
-    unsigned int gpio = pin;
+    uint32_t gpio = pin;
     char irq_name[10];
 
     gpio_set_irq_type(gpio, mode);
@@ -95,14 +94,14 @@ rt_err_t ls1c_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-rt_err_t ls1c_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t ls1c_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     return RT_EOK;
 }
 
-rt_err_t ls1c_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+rt_err_t ls1c_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
-    unsigned int gpio = pin;
+    uint32_t gpio = pin;
 
     if (enabled)
         rt_hw_interrupt_umask(LS1C_GPIO_TO_IRQ(gpio));

--- a/bsp/stm32f107/drivers/gpio.c
+++ b/bsp/stm32f107/drivers/gpio.c
@@ -23,7 +23,7 @@
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
+    int32_t index;
     uint32_t rcc;
     GPIO_TypeDef *gpio;
     uint32_t pin;
@@ -469,7 +469,7 @@ const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, uint32_t value)
 {
     const struct pin_index *index;
 
@@ -489,9 +489,9 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     }
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+uint32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value;
+    uint32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -514,7 +514,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef  GPIO_InitStructure;
@@ -556,9 +556,9 @@ void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     GPIO_Init(index->gpio, &GPIO_InitStructure);
 }
 
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    int i;
+    int32_t i;
     for(i = 0; i < 32; i++)
     {
         if((0x01 << i) == bit)
@@ -577,12 +577,11 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
     }
     return &pin_irq_map[mapindex];
 };
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                  rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -618,11 +617,11 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
  
     return RT_EOK;
 }
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -649,13 +648,12 @@ rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
  
     return RT_EOK;
 }
-rt_err_t stm32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                                                  rt_uint32_t enabled)
+rt_err_t stm32_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     const struct pin_index *index;
     const struct pin_irq_map *irqmap;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     GPIO_InitTypeDef  GPIO_InitStructure;
     NVIC_InitTypeDef  NVIC_InitStructure;
     EXTI_InitTypeDef EXTI_InitStructure;
@@ -744,14 +742,14 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int stm32_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }
 INIT_BOARD_EXPORT(stm32_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     EXTI_ClearITPendingBit(pin_irq_map[irqno].irqbit);
     if(pin_irq_hdr_tab[irqno].hdr)

--- a/bsp/stm32f107/drivers/gpio.h
+++ b/bsp/stm32f107/drivers/gpio.h
@@ -21,6 +21,6 @@ struct stm32_hw_pin_userdata
 
 extern struct stm32_hw_pin_userdata stm32_pins[];
 
-int stm32_hw_pin_init(void);
+int32_t stm32_hw_pin_init(void);
 
 #endif

--- a/bsp/stm32f10x-HAL/drivers/drv_gpio.c
+++ b/bsp/stm32f10x-HAL/drivers/drv_gpio.c
@@ -607,9 +607,9 @@ struct rt_pin_irq_hdr pin_irq_hdr_tab[] =
 };
 
 #define ITEM_NUM(items) sizeof(items) / sizeof(items[0])
-static rt_uint16_t get_pin(uint8_t pin)
+static uint16_t get_pin(uint8_t pin)
 {
-    rt_uint16_t gpio_pin = __STM32_PIN_DEFAULT;
+    uint16_t gpio_pin = __STM32_PIN_DEFAULT;
     if (pin < ITEM_NUM(pins))
     {
         gpio_pin = pins[pin];
@@ -617,9 +617,9 @@ static rt_uint16_t get_pin(uint8_t pin)
     return gpio_pin;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, uint32_t value)
 {
-    rt_uint16_t gpio_pin;
+    uint16_t gpio_pin;
     gpio_pin = get_pin(pin);
     if (get_st_gpio(gpio_pin) == RT_NULL)
     {
@@ -628,9 +628,9 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     HAL_GPIO_WritePin(get_st_gpio(gpio_pin), get_st_pin(gpio_pin), (GPIO_PinState)value);
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+uint32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    rt_uint16_t gpio_pin;
+    uint16_t gpio_pin;
     gpio_pin = get_pin(pin);
     if (get_st_gpio(gpio_pin) == RT_NULL)
     {
@@ -639,7 +639,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return HAL_GPIO_ReadPin(get_st_gpio(gpio_pin), get_st_pin(gpio_pin));
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     rt_uint16_t gpio_pin;
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -680,9 +680,9 @@ void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     HAL_GPIO_Init(get_st_gpio(gpio_pin), &GPIO_InitStruct);
 }
 
-rt_inline const struct pin_irq_map *get_pin_irq_map(rt_uint16_t gpio_pin)
+rt_inline const struct pin_irq_map *get_pin_irq_map(uint16_t gpio_pin)
 {
-    rt_int32_t mapindex = gpio_pin & 0x00FF;
+    int32_t mapindex = gpio_pin & 0x00FF;
     if (mapindex < 0 || mapindex >= ITEM_NUM(pin_irq_map))
     {
         return RT_NULL;
@@ -690,12 +690,11 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(rt_uint16_t gpio_pin)
     return &pin_irq_map[mapindex];
 };
 
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                              rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
-    rt_uint16_t gpio_pin;
+    uint16_t gpio_pin;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     gpio_pin = get_pin(pin);
     if (get_st_gpio(gpio_pin) == RT_NULL)
     {
@@ -728,11 +727,11 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
-    rt_uint16_t gpio_pin;
+    uint16_t gpio_pin;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     gpio_pin = get_pin(pin);
     if (get_st_gpio(gpio_pin) == RT_NULL)
     {
@@ -757,13 +756,12 @@ rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
     return RT_EOK;
 }
 
-rt_err_t stm32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                              rt_uint32_t enabled)
+rt_err_t stm32_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
-    rt_uint16_t gpio_pin;
+    uint16_t gpio_pin;
     const struct pin_irq_map *irqmap;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     GPIO_InitTypeDef GPIO_InitStruct;
     gpio_pin = get_pin(pin);
     if (get_st_gpio(gpio_pin) == RT_NULL)
@@ -835,7 +833,7 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int rt_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }

--- a/bsp/stm32f10x/drivers/gpio.c
+++ b/bsp/stm32f10x/drivers/gpio.c
@@ -24,7 +24,7 @@
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
+    int32_t index;
     uint32_t rcc;
     GPIO_TypeDef *gpio;
     uint32_t pin;
@@ -408,9 +408,9 @@ static const struct pin_index pins[] =
 
 struct pin_irq_map
 {
-    rt_uint16_t            pinbit;
-    rt_uint32_t            irqbit;
-    enum IRQn              irqno;
+    uint16_t        bit;
+    uint32_t        irqbit;
+    enum IRQn       irqno;
 };
 static const  struct pin_irq_map pin_irq_map[] =
 {
@@ -470,7 +470,7 @@ const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, uint32_t value)
 {
     const struct pin_index *index;
 
@@ -490,9 +490,9 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     }
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+uint32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value;
+    uint32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -515,7 +515,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef  GPIO_InitStructure;
@@ -562,9 +562,9 @@ void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     GPIO_Init(index->gpio, &GPIO_InitStructure);
 }
 
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    int i;
+    int32_t i;
     for(i = 0; i < 32; i++)
     {
         if((0x01 << i) == bit)
@@ -576,19 +576,18 @@ rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
 }
 rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
 {
-    rt_int32_t mapindex = bit2bitno(pinbit);
+    int32_t mapindex = bit2bitno(pinbit);
     if(mapindex < 0 || mapindex >= ITEM_NUM(pin_irq_map))
     {
         return RT_NULL;
     }
     return &pin_irq_map[mapindex];
 };
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                  rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -624,11 +623,11 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
  
     return RT_EOK;
 }
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -655,13 +654,12 @@ rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
  
     return RT_EOK;
 }
-rt_err_t stm32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                                                  rt_uint32_t enabled)
+rt_err_t stm32_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     const struct pin_index *index;
     const struct pin_irq_map *irqmap;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     GPIO_InitTypeDef  GPIO_InitStructure;
     NVIC_InitTypeDef  NVIC_InitStructure;
     EXTI_InitTypeDef EXTI_InitStructure;
@@ -750,14 +748,14 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int stm32_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }
 INIT_BOARD_EXPORT(stm32_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     EXTI_ClearITPendingBit(pin_irq_map[irqno].irqbit);
     if(pin_irq_hdr_tab[irqno].hdr)

--- a/bsp/stm32f10x/drivers/gpio.h
+++ b/bsp/stm32f10x/drivers/gpio.h
@@ -21,6 +21,6 @@ struct stm32_hw_pin_userdata
 
 extern struct stm32_hw_pin_userdata stm32_pins[];
 
-int stm32_hw_pin_init(void);
+int32_t stm32_hw_pin_init(void);
 
 #endif

--- a/bsp/stm32f40x/drivers/gpio.c
+++ b/bsp/stm32f40x/drivers/gpio.c
@@ -24,7 +24,7 @@
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
+    int32_t index;
     uint32_t rcc;
     GPIO_TypeDef *gpio;
     uint32_t pin;
@@ -34,13 +34,13 @@ struct pin_index
 struct pin_irq
 {
     /* EXTI port source gpiox, such as EXTI_PortSourceGPIOA */
-    rt_uint8_t port_source;
+    uint8_t port_source;
     /* EXTI pin sources, such as EXTI_PinSource0 */
-    rt_uint8_t pin_source;
+    uint8_t pin_source;
     /* NVIC IRQ EXTI channel, such as EXTI0_IRQn */
     enum IRQn irq_exti_channel;
     /* EXTI line, such as EXTI_Line0 */
-    rt_uint32_t exti_line;
+    uint32_t exti_line;
 };
 
 static const struct pin_index pins[] =
@@ -455,7 +455,7 @@ const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, uint32_t value)
 {
     const struct pin_index *index;
 
@@ -475,9 +475,9 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     }
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+uint32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value;
+    uint32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -500,7 +500,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef  GPIO_InitStructure;
@@ -557,9 +557,9 @@ void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     GPIO_Init(index->gpio, &GPIO_InitStructure);
 }
 
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    int i;
+    int32_t i;
     for (i = 0; i < 32; i++)
     {
         if ((1UL << i) == bit)
@@ -570,7 +570,7 @@ rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
     return -1;
 }
 
-rt_inline rt_int32_t bitno2bit(rt_uint32_t bitno)
+rt_inline int32_t bitno2bit(uint32_t bitno)
 {
     if (bitno <= 32)
     {
@@ -620,13 +620,12 @@ static const struct pin_irq *get_pin_irq(uint16_t pin)
     return &irq;
 };
 
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                  rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
 
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     index = get_pin(pin);
     if (index == RT_NULL)
     {
@@ -663,11 +662,11 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -695,12 +694,12 @@ rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
     return RT_EOK;
 }
 
-rt_err_t stm32_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+rt_err_t stm32_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     const struct pin_index *index;
     const struct pin_irq *irq;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     NVIC_InitTypeDef NVIC_InitStructure;
     EXTI_InitTypeDef EXTI_InitStructure;
 
@@ -789,7 +788,7 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int stm32_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     /* enable SYSCFG clock for EXTI */
     RCC_APB2PeriphClockCmd(RCC_APB2Periph_SYSCFG, ENABLE);
@@ -799,7 +798,7 @@ int stm32_hw_pin_init(void)
 }
 INIT_BOARD_EXPORT(stm32_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     EXTI_ClearITPendingBit(bitno2bit(irqno));
     if (pin_irq_hdr_tab[irqno].hdr)

--- a/bsp/stm32f40x/drivers/gpio.h
+++ b/bsp/stm32f40x/drivers/gpio.h
@@ -10,6 +10,6 @@
 #ifndef GPIO_H__
 #define GPIO_H__
 
-int stm32_hw_pin_init(void);
+int32_t stm32_hw_pin_init(void);
 
 #endif

--- a/bsp/stm32f429-apollo/drivers/drv_gpio.c
+++ b/bsp/stm32f429-apollo/drivers/drv_gpio.c
@@ -97,7 +97,7 @@ static void GPIOC_CLK_ENABLE(void)
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
+    int32_t index;
     void (*rcc)(void);
     GPIO_TypeDef *gpio;
     uint32_t pin;
@@ -1488,7 +1488,7 @@ static const struct pin_index pins[] =
 
 struct pin_irq_map
 {
-    rt_uint16_t pinbit;
+    uint16_t pinbit;
     IRQn_Type irqno;
 };
 static const struct pin_irq_map pin_irq_map[] =
@@ -1549,7 +1549,7 @@ const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, int32_t value)
 {
     const struct pin_index *index;
 
@@ -1562,9 +1562,9 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     HAL_GPIO_WritePin(index->gpio, index->pin, (GPIO_PinState)value);
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+uint32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value;
+    int32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -1580,7 +1580,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -1633,9 +1633,9 @@ void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
 
     HAL_GPIO_Init(index->gpio, &GPIO_InitStruct);
 }
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    int i;
+    int32_t i;
     for (i = 0; i < 32; i++)
     {
         if ((0x01 << i) == bit)
@@ -1647,19 +1647,18 @@ rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
 }
 rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
 {
-    rt_int32_t mapindex = bit2bitno(pinbit);
+    int32_t mapindex = bit2bitno(pinbit);
     if (mapindex < 0 || mapindex >= ITEM_NUM(pin_irq_map))
     {
         return RT_NULL;
     }
     return &pin_irq_map[mapindex];
 };
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                              rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void(*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -1694,11 +1693,11 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
 
     return RT_EOK;
 }
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -1725,13 +1724,12 @@ rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
 
     return RT_EOK;
 }
-rt_err_t stm32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                              rt_uint32_t enabled)
+rt_err_t stm32_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     const struct pin_index *index;
     const struct pin_irq_map *irqmap;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     GPIO_InitTypeDef GPIO_InitStruct;
 
     index = get_pin(pin);
@@ -1804,14 +1802,14 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int rt_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }
 INIT_BOARD_EXPORT(rt_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     if (pin_irq_hdr_tab[irqno].hdr)
     {

--- a/bsp/stm32f429-apollo/drivers/drv_nand.c
+++ b/bsp/stm32f429-apollo/drivers/drv_nand.c
@@ -30,7 +30,6 @@
 
 
 static struct stm32f4_nand _device;
-static rt_bool_t read_status(rt_uint8_t cmd);
 
 NAND_HandleTypeDef NAND_Handler;    //NAND FLASH¾ä±ú
 
@@ -189,7 +188,7 @@ void HAL_NAND_MspInit(NAND_HandleTypeDef *hnand)
 //·µ»ØÖµ:NAND×´Ì¬Öµ
 //bit0:0,³É¹¦;1,´íÎó(±à³Ì/²Á³ý/READ)
 //bit6:0,Busy;1,Ready
-static rt_bool_t read_status(rt_uint8_t cmd)
+RT_WEAK rt_bool_t read_status(rt_uint8_t cmd)
 {
     volatile rt_uint8_t value=0; 
     SET_NAND_CMD(NAND_READSTA);//·¢ËÍ¶Á×´Ì¬ÃüÁî

--- a/bsp/stm32f429-apollo/drivers/drv_sdio_sd.c
+++ b/bsp/stm32f429-apollo/drivers/drv_sdio_sd.c
@@ -36,7 +36,6 @@ rt_uint8_t SD_Init(void)
 //hsd:SD¿¨¾ä±ú
 void HAL_SD_MspInit(SD_HandleTypeDef *hsd)
 {
-    DMA_HandleTypeDef TxDMAHandler,RxDMAHandler;
     GPIO_InitTypeDef GPIO_Initure;
     
     __HAL_RCC_SDIO_CLK_ENABLE();    //Ê¹ÄÜSDIOÊ±ÖÓ

--- a/bsp/stm32f429-apollo/drivers/drv_spi.c
+++ b/bsp/stm32f429-apollo/drivers/drv_spi.c
@@ -617,7 +617,9 @@ rt_err_t stm32_spi_bus_register(SPI_TypeDef * SPI,
                             //struct stm32_spi_bus * stm32_spi,
                             const char * spi_bus_name)
 {
+#ifdef SPI_USE_DMA
     struct stm32f4_spi * p_spi_bus;
+#endif
     struct rt_spi_bus *  spi_bus;
     
     RT_ASSERT(SPI != RT_NULL);

--- a/bsp/stm32f4xx-HAL/drivers/drv_gpio.c
+++ b/bsp/stm32f4xx-HAL/drivers/drv_gpio.c
@@ -26,7 +26,7 @@
 #define J   (10U << 8)
 #define K   (11U << 8)
 
-static GPIO_TypeDef * get_st_gpio(rt_uint16_t gpio_pin)
+static GPIO_TypeDef * get_st_gpio(uint16_t gpio_pin)
 {
     switch(gpio_pin & 0xFF00)
     {
@@ -81,7 +81,7 @@ static GPIO_TypeDef * get_st_gpio(rt_uint16_t gpio_pin)
 
 #define get_st_pin(gpio_pin) (0x01 << (gpio_pin&0xFF))
 
-static void drv_clock_enable(rt_uint16_t gpio_pin)
+static void drv_clock_enable(uint16_t gpio_pin)
 {
     switch(gpio_pin & 0xFF00)
     {
@@ -146,7 +146,7 @@ static void drv_clock_enable(rt_uint16_t gpio_pin)
 }
 
 /* STM32 GPIO driver */
-static const rt_uint16_t pins[] =
+static const uint16_t pins[] =
 {
 #if (STM32F4xx_PIN_NUMBERS == 36)
     __STM32_PIN_DEFAULT,
@@ -1531,7 +1531,7 @@ static const rt_uint16_t pins[] =
 
 struct pin_irq_map
 {
-    rt_uint16_t pinbit;
+    uint16_t pinbit;
     IRQn_Type irqno;
 };
 
@@ -1576,9 +1576,9 @@ struct rt_pin_irq_hdr pin_irq_hdr_tab[] =
 };
 
 #define ITEM_NUM(items) sizeof(items) / sizeof(items[0])
-static rt_uint16_t get_pin(uint8_t pin)
+static uint16_t get_pin(uint8_t pin)
 {
-    rt_uint16_t gpio_pin = __STM32_PIN_DEFAULT;
+    uint16_t gpio_pin = __STM32_PIN_DEFAULT;
     if (pin < ITEM_NUM(pins))
     {
         gpio_pin = pins[pin];
@@ -1586,9 +1586,9 @@ static rt_uint16_t get_pin(uint8_t pin)
     return gpio_pin;
 };
 
-static void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void stm32_pin_write(rt_device_t dev, int32_t pin, uint32_t value)
 {
-    rt_uint16_t gpio_pin;
+    uint16_t gpio_pin;
     gpio_pin = get_pin(pin);
     if (get_st_gpio(gpio_pin) == RT_NULL)
     {
@@ -1597,9 +1597,9 @@ static void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     HAL_GPIO_WritePin(get_st_gpio(gpio_pin), get_st_pin(gpio_pin), (GPIO_PinState)value);
 }
 
-static int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+static uint32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    rt_uint16_t gpio_pin;
+    uint16_t gpio_pin;
     gpio_pin = get_pin(pin);
     if (get_st_gpio(gpio_pin) == RT_NULL)
     {
@@ -1608,9 +1608,9 @@ static int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return HAL_GPIO_ReadPin(get_st_gpio(gpio_pin), get_st_pin(gpio_pin));
 }
 
-static void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
-    rt_uint16_t gpio_pin;
+    uint16_t gpio_pin;
     GPIO_InitTypeDef GPIO_InitStruct;
     gpio_pin = get_pin(pin);
     if (get_st_gpio(gpio_pin) == RT_NULL)
@@ -1649,9 +1649,9 @@ static void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     HAL_GPIO_Init(get_st_gpio(gpio_pin), &GPIO_InitStruct);
 }
 
-static const struct pin_irq_map *get_pin_irq_map(rt_uint16_t gpio_pin)
+static const struct pin_irq_map *get_pin_irq_map(uint16_t gpio_pin)
 {
-    rt_int32_t mapindex = gpio_pin & 0xFF;
+    int32_t mapindex = gpio_pin & 0xFF;
     if (mapindex < 0 || mapindex >= ITEM_NUM(pin_irq_map))
     {
         return RT_NULL;
@@ -1659,12 +1659,11 @@ static const struct pin_irq_map *get_pin_irq_map(rt_uint16_t gpio_pin)
     return &pin_irq_map[mapindex];
 };
 
-static rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                              rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void(*hdr)(void *args), void *args)
 {
-    rt_uint16_t gpio_pin;
+    uint16_t gpio_pin;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     gpio_pin = get_pin(pin);
     if (get_st_gpio(gpio_pin) == RT_NULL)
     {
@@ -1697,11 +1696,11 @@ static rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-static rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
-    rt_uint16_t gpio_pin;
+    uint16_t gpio_pin;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     gpio_pin = get_pin(pin);
     if (get_st_gpio(gpio_pin) == RT_NULL)
     {
@@ -1726,13 +1725,12 @@ static rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
     return RT_EOK;
 }
 
-static rt_err_t stm32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                              rt_uint32_t enabled)
+static rt_err_t stm32_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
-    rt_uint16_t gpio_pin;
+    uint16_t gpio_pin;
     const struct pin_irq_map *irqmap;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     GPIO_InitTypeDef GPIO_InitStruct;
     gpio_pin = get_pin(pin);
     if (get_st_gpio(gpio_pin) == RT_NULL)
@@ -1804,7 +1802,7 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int rt_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }
@@ -1812,7 +1810,7 @@ INIT_BOARD_EXPORT(rt_hw_pin_init);
 
 static void pin_irq_hdr(uint16_t GPIO_Pin)
 {
-    int irqno = 0;
+    int32_t irqno = 0;
     for(irqno = 0; irqno < 16; irqno ++)
     {
         if((0x01 << irqno) == GPIO_Pin)

--- a/bsp/stm32l072/app/application.c
+++ b/bsp/stm32l072/app/application.c
@@ -19,6 +19,7 @@
 #include <rtdevice.h>
 #include "board.h"
 #include <rtthread.h>
+#include <finsh.h>
 
 static void rt_init_thread_entry(void* parameter)
 {

--- a/bsp/stm32l072/board/board.h
+++ b/bsp/stm32l072/board/board.h
@@ -46,9 +46,9 @@ void rt_hw_msd_init(void);
 #define UFQFPN32
 
 #ifdef RT_USING_PIN
-extern inline void stm32_pin_write_early(rt_base_t pin, rt_base_t value);
-extern inline int stm32_pin_read_early(rt_base_t pin);
-extern void stm32_pin_mode_early(rt_base_t pin, rt_base_t mode);
+extern void stm32_pin_write_early(int32_t pin, uint32_t value);
+extern uint32_t stm32_pin_read_early(int32_t pin);
+extern void stm32_pin_mode_early(int32_t pin, uint32_t mode);
 #endif /*RT_USING_PIN*/
 
 #define RT_USING_UART1

--- a/bsp/stm32l072/board/gpio.c
+++ b/bsp/stm32l072/board/gpio.c
@@ -31,8 +31,8 @@
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
-    unsigned int clk;
+    int32_t index;
+    uint32_t clk;
     GPIO_TypeDef *gpio;
     uint32_t pin;
 };
@@ -95,7 +95,7 @@ const struct pin_index *get_pin(uint8_t pin)
 
     return index;
 };
-inline void stm32_pin_write_early(rt_base_t pin, rt_base_t value)
+void stm32_pin_write_early(int32_t pin, uint32_t value)
 {
     const struct pin_index *index;
 
@@ -106,13 +106,13 @@ inline void stm32_pin_write_early(rt_base_t pin, rt_base_t value)
     }
     HAL_GPIO_WritePin(index->gpio, index->pin, value);
 }
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, uint32_t value)
 {
     stm32_pin_write_early(pin, value);
 }
-inline int stm32_pin_read_early(rt_base_t pin)
+uint32_t stm32_pin_read_early(int32_t pin)
 {
-    int value;
+    uint32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -125,11 +125,11 @@ inline int stm32_pin_read_early(rt_base_t pin)
     value = HAL_GPIO_ReadPin(index->gpio, index->pin);
     return value;
 }
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+uint32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
     return stm32_pin_read_early(pin);
 }
-void stm32_pin_mode_early(rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode_early(int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef  GPIO_InitStructure;
@@ -175,7 +175,7 @@ void stm32_pin_mode_early(rt_base_t pin, rt_base_t mode)
     }
     HAL_GPIO_Init(index->gpio, &GPIO_InitStructure);
 }
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     stm32_pin_mode_early(pin, mode);
 }
@@ -187,7 +187,7 @@ const static struct rt_pin_ops _stm32_pin_ops =
 };
 int stm32_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;

--- a/bsp/stm32l476-nucleo/drivers/drv_gpio.c
+++ b/bsp/stm32l476-nucleo/drivers/drv_gpio.c
@@ -80,7 +80,7 @@ static void GPIOH_CLK_ENABLE(void)
 /* STM32 GPIO driver */
 struct pin_index
 {
-    int index;
+    int32_t index;
     void (*rcc)(void);
     GPIO_TypeDef *gpio;
     uint32_t pin;
@@ -525,7 +525,7 @@ const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+void stm32_pin_write(rt_device_t dev, int32_t pin, uint32_t value)
 {
     const struct pin_index *index;
 
@@ -538,9 +538,9 @@ void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     HAL_GPIO_WritePin(index->gpio, index->pin, (GPIO_PinState)value);
 }
 
-int stm32_pin_read(rt_device_t dev, rt_base_t pin)
+uint32_t stm32_pin_read(rt_device_t dev, int32_t pin)
 {
-    int value;
+    uint32_t value;
     const struct pin_index *index;
 
     value = PIN_LOW;
@@ -556,7 +556,7 @@ int stm32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+void stm32_pin_mode(rt_device_t dev, int32_t pin, uint32_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -610,9 +610,9 @@ void stm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     HAL_GPIO_Init(index->gpio, &GPIO_InitStruct);
 }
 
-rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
+rt_inline int32_t bit2bitno(uint32_t bit)
 {
-    int i;
+    int32_t i;
     for (i = 0; i < 32; i++)
     {
         if ((0x01 << i) == bit)
@@ -625,7 +625,7 @@ rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
 
 rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
 {
-    rt_int32_t mapindex = bit2bitno(pinbit);
+    int32_t mapindex = bit2bitno(pinbit);
     if (mapindex < 0 || mapindex >= ITEM_NUM(pin_irq_map))
     {
         return RT_NULL;
@@ -633,12 +633,11 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
     return &pin_irq_map[mapindex];
 };
 
-rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                              rt_uint32_t mode, void (*hdr)(void *args), void *args)
+rt_err_t stm32_pin_attach_irq(struct rt_device *device, int32_t pin, uint32_t mode, void(*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -674,11 +673,11 @@ rt_err_t stm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+rt_err_t stm32_pin_detach_irq(struct rt_device *device, int32_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
 
     index = get_pin(pin);
     if (index == RT_NULL)
@@ -706,13 +705,12 @@ rt_err_t stm32_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
     return RT_EOK;
 }
 
-rt_err_t stm32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                              rt_uint32_t enabled)
+rt_err_t stm32_pin_irq_enable(struct rt_device *device, int32_t pin, uint32_t enabled)
 {
     const struct pin_index *index;
     const struct pin_irq_map *irqmap;
     rt_base_t level;
-    rt_int32_t irqindex = -1;
+    int32_t irqindex = -1;
     GPIO_InitTypeDef GPIO_InitStruct;
 
     index = get_pin(pin);
@@ -786,14 +784,14 @@ const static struct rt_pin_ops _stm32_pin_ops =
 
 int bsp_hw_pin_init(void)
 {
-    int result;
+    int32_t result;
 
     result = rt_device_pin_register("pin", &_stm32_pin_ops, RT_NULL);
     return result;
 }
 INIT_BOARD_EXPORT(bsp_hw_pin_init);
 
-rt_inline void pin_irq_hdr(int irqno)
+rt_inline void pin_irq_hdr(int32_t irqno)
 {
     if (pin_irq_hdr_tab[irqno].hdr)
     {

--- a/components/drivers/include/drivers/pin.h
+++ b/components/drivers/include/drivers/pin.h
@@ -48,43 +48,41 @@ struct rt_device_pin
 
 struct rt_device_pin_mode
 {
-    rt_uint16_t pin;
-    rt_uint16_t mode;
+    uint16_t pin;
+    uint16_t mode;
 };
 struct rt_device_pin_status
 {
-    rt_uint16_t pin;
-    rt_uint16_t status;
+    uint16_t pin;
+    uint16_t status;
 };
 struct rt_pin_irq_hdr
 {
-    rt_int16_t        pin;
-    rt_uint16_t       mode;
+    int16_t pin;
+    uint16_t mode;
     void (*hdr)(void *args);
-    void             *args;
+    void *args;
 };
 struct rt_pin_ops
 {
-    void (*pin_mode)(struct rt_device *device, rt_base_t pin, rt_base_t mode);
-    void (*pin_write)(struct rt_device *device, rt_base_t pin, rt_base_t value);
-    int (*pin_read)(struct rt_device *device, rt_base_t pin);
+    void (*pin_mode)(struct rt_device *device, int32_t pin, uint32_t mode);
+    void (*pin_write)(struct rt_device *device, int32_t pin, uint32_t value);
+    uint32_t (*pin_read)(struct rt_device *device, int32_t pin);
 
     /* TODO: add GPIO interrupt */
-    rt_err_t (*pin_attach_irq)(struct rt_device *device, rt_int32_t pin,
-                      rt_uint32_t mode, void (*hdr)(void *args), void *args);
-    rt_err_t (*pin_detach_irq)(struct rt_device *device, rt_int32_t pin);
-    rt_err_t (*pin_irq_enable)(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled);
+    rt_err_t (*pin_attach_irq)(struct rt_device *device, int32_t pin, uint32_t mode, void (*hdr)(void *args), void *args);
+    rt_err_t (*pin_detach_irq)(struct rt_device *device, int32_t pin);
+    rt_err_t (*pin_irq_enable)(struct rt_device *device, int32_t pin, uint32_t enabled);
 };
 
-int rt_device_pin_register(const char *name, const struct rt_pin_ops *ops, void *user_data);
+int32_t rt_device_pin_register(const char *name, const struct rt_pin_ops *ops, void *user_data);
 
-void rt_pin_mode(rt_base_t pin, rt_base_t mode);
-void rt_pin_write(rt_base_t pin, rt_base_t value);
-int  rt_pin_read(rt_base_t pin);
-rt_err_t rt_pin_attach_irq(rt_int32_t pin, rt_uint32_t mode,
-                             void (*hdr)(void *args), void  *args);
-rt_err_t rt_pin_detach_irq(rt_int32_t pin);
-rt_err_t rt_pin_irq_enable(rt_base_t pin, rt_uint32_t enabled);
+void rt_pin_mode(int32_t pin, uint32_t mode);
+void rt_pin_write(int32_t pin, uint32_t value);
+uint32_t rt_pin_read(int32_t pin);
+rt_err_t rt_pin_attach_irq(int32_t pin, uint32_t mode, void (*hdr)(void *args), void  *args);
+rt_err_t rt_pin_detach_irq(int32_t pin);
+rt_err_t rt_pin_irq_enable(int32_t pin, uint32_t enabled);
 
 #ifdef __cplusplus
 }

--- a/components/drivers/misc/pin.c
+++ b/components/drivers/misc/pin.c
@@ -74,7 +74,7 @@ const static struct rt_device_ops pin_ops =
 };
 #endif
 
-int rt_device_pin_register(const char *name, const struct rt_pin_ops *ops, void *user_data)
+int32_t rt_device_pin_register(const char *name, const struct rt_pin_ops *ops, void *user_data)
 {
     _hw_pin.parent.type         = RT_Device_Class_Miscellaneous;
     _hw_pin.parent.rx_indicate  = RT_NULL;
@@ -100,8 +100,7 @@ int rt_device_pin_register(const char *name, const struct rt_pin_ops *ops, void 
     return 0;
 }
 
-rt_err_t rt_pin_attach_irq(rt_int32_t pin, rt_uint32_t mode,
-                             void (*hdr)(void *args), void  *args)
+rt_err_t rt_pin_attach_irq(int32_t pin, uint32_t mode, void (*hdr)(void *args), void  *args)
 {
     RT_ASSERT(_hw_pin.ops != RT_NULL);
     if(_hw_pin.ops->pin_attach_irq)
@@ -110,7 +109,7 @@ rt_err_t rt_pin_attach_irq(rt_int32_t pin, rt_uint32_t mode,
     }
     return RT_ENOSYS;
 }
-rt_err_t rt_pin_detach_irq(rt_int32_t pin)
+rt_err_t rt_pin_detach_irq(int32_t pin)
 {
     RT_ASSERT(_hw_pin.ops != RT_NULL);
     if(_hw_pin.ops->pin_detach_irq)
@@ -120,7 +119,7 @@ rt_err_t rt_pin_detach_irq(rt_int32_t pin)
     return RT_ENOSYS;
 }
 
-rt_err_t rt_pin_irq_enable(rt_base_t pin, rt_uint32_t enabled)
+rt_err_t rt_pin_irq_enable(int32_t pin, uint32_t enabled)
 {
     RT_ASSERT(_hw_pin.ops != RT_NULL);
     if(_hw_pin.ops->pin_irq_enable)
@@ -131,21 +130,21 @@ rt_err_t rt_pin_irq_enable(rt_base_t pin, rt_uint32_t enabled)
 }
 
 /* RT-Thread Hardware PIN APIs */
-void rt_pin_mode(rt_base_t pin, rt_base_t mode)
+void rt_pin_mode(int32_t pin, uint32_t mode)
 {
     RT_ASSERT(_hw_pin.ops != RT_NULL);
     _hw_pin.ops->pin_mode(&_hw_pin.parent, pin, mode);
 }
 FINSH_FUNCTION_EXPORT_ALIAS(rt_pin_mode, pinMode, set hardware pin mode);
 
-void rt_pin_write(rt_base_t pin, rt_base_t value)
+void rt_pin_write(int32_t pin, uint32_t value)
 {
     RT_ASSERT(_hw_pin.ops != RT_NULL);
     _hw_pin.ops->pin_write(&_hw_pin.parent, pin, value);
 }
 FINSH_FUNCTION_EXPORT_ALIAS(rt_pin_write, pinWrite, write value to hardware pin);
 
-int  rt_pin_read(rt_base_t pin)
+uint32_t rt_pin_read(int32_t pin)
 {
     RT_ASSERT(_hw_pin.ops != RT_NULL);
     return _hw_pin.ops->pin_read(&_hw_pin.parent, pin);

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -33,6 +33,7 @@
 
 /* include rtconfig header to import configuration */
 #include <rtconfig.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
当前pin接口数据类型比较乱,此处使用C标准数据类型整理了下. 注意: pin为管脚索引号,用32位数据表示即可.至于是32位(32位cpu)一组还是64位一组(64位cpu),在bsp中处理即可.