### PR TITLE
[DeviceDriver] update RT_USING_DEVICE_OPS.

### DIFF
--- a/components/drivers/audio/audio_pipe.c
+++ b/components/drivers/audio/audio_pipe.c
@@ -188,7 +188,7 @@ static rt_err_t rt_pipe_control(rt_device_t dev, int cmd, void *args)
 }
 
 #ifdef RT_USING_DEVICE_OPS
-const static struct rt_device_ops audio_pipe_ops
+const static struct rt_device_ops audio_pipe_ops =
 {
     RT_NULL,
     RT_NULL,

--- a/components/drivers/misc/rt_drv_pwm.c
+++ b/components/drivers/misc/rt_drv_pwm.c
@@ -88,21 +88,36 @@ static rt_size_t _pwm_write(rt_device_t dev, rt_off_t pos, const void *buffer, r
     return size;
 }
 
+#ifdef RT_USING_DEVICE_OPS
+static const struct rt_device_ops pwm_device_ops =
+{
+    RT_NULL,
+    RT_NULL,
+    RT_NULL,
+    _pwm_read,
+    _pwm_write,
+    _pwm_control
+};
+#endif /* RT_USING_DEVICE_OPS */
+
 rt_err_t rt_device_pwm_register(struct rt_device_pwm *device, const char *name, const struct rt_pwm_ops *ops, const void *user_data)
 {
     rt_err_t result = RT_EOK;
 
     memset(device, 0, sizeof(struct rt_device_pwm));
 
+#ifdef RT_USING_DEVICE_OPS
+    device->parent.ops = &pwm_device_ops;
+#else
+    device->parent.init = RT_NULL;
+    device->parent.open = RT_NULL;
+    device->parent.close = RT_NULL;
+    device->parent.read  = _pwm_read;
+    device->parent.write = _pwm_write;
+    device->parent.control = _pwm_control;
+#endif /* RT_USING_DEVICE_OPS */
+
     device->parent.type         = RT_Device_Class_Miscellaneous;
-
-    device->parent.init         = RT_NULL;
-    device->parent.open         = RT_NULL;
-    device->parent.close        = RT_NULL;
-    device->parent.read         = _pwm_read;
-    device->parent.write        = _pwm_write;
-    device->parent.control      = _pwm_control;
-
     device->ops                 = ops;
     device->parent.user_data    = (void *)user_data;
 


### PR DESCRIPTION
1. fixed audio_pipe.c compile error.
2. update pwm driver: support RT_USING_DEVICE_OPS.