### PR TITLE
Add RTT version number on Kconfig file.

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -316,4 +316,10 @@ menu "Kernel Device Object"
 
 endmenu
 
+config RT_VER_NUM
+    hex
+    default 0x40000
+    help
+        RT-Thread version number
+
 endmenu


### PR DESCRIPTION
The external package can use this number on Kconfig version choice, when need version depend. 

For example: 
```
        prompt "Version"
        default PKG_USING_AT_DEVICE_LATEST_VERSION
        help
            Select the at_device version

        if AT_SW_VERSION_NUM >= 0x10200
            config PKG_USING_AT_DEVICE_V140
                bool "v1.4.0"
        endif 
           
        if AT_SW_VERSION_NUM = 0x10100
            config PKG_USING_AT_DEVICE_V130
                bool "v1.3.0"
        endif

        # AT command component version from v1.0.0 to v1.1.0 or at version not definition
        if (AT_SW_VERSION_NUM >= 0x10000 && AT_SW_VERSION_NUM < 0x10100) || (!AT_SW_VERSION_NUM)
            config PKG_USING_AT_DEVICE_V120
                bool "v1.2.0"
        endif

        config PKG_USING_AT_DEVICE_LATEST_VERSION
            bool "latest"

    endchoice

    config PKG_AT_DEVICE_VER
        string
        default "latest"    if PKG_USING_AT_DEVICE_LATEST_VERSION
        default "v1.4.0"    if PKG_USING_AT_DEVICE_V140
        default "v1.3.0"    if PKG_USING_AT_DEVICE_V130
        default "v1.2.0"    if PKG_USING_AT_DEVICE_V120
```