### PR TITLE
[STM32F4xx-HAL] Fix link error when enable cmbacktrace package.

### DIFF
--- a/bsp/stm32f4xx-HAL/stm32_rom.ld
+++ b/bsp/stm32f4xx-HAL/stm32_rom.ld
@@ -80,6 +80,7 @@ SECTIONS
 
     .stack : 
     {
+        _sstack = .;
         . = . + _system_stack_size;
         . = ALIGN(4);
         _estack = .;


### PR DESCRIPTION
链接文件中缺少相应的标签，导致链接失败。