### PR TITLE
rt_hw_interrupt_install函数name参数增加const限定

### DIFF
--- a/bsp/allwinner_tina/libcpu/interrupt.c
+++ b/bsp/allwinner_tina/libcpu/interrupt.c
@@ -132,7 +132,7 @@ void rt_hw_interrupt_umask(int vector)
  * @return old handler
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
     rt_uint32_t pend_addr, en_addr, data;

--- a/bsp/allwinner_tina/libcpu/interrupt.h
+++ b/bsp/allwinner_tina/libcpu/interrupt.h
@@ -102,6 +102,6 @@ typedef struct tina_intc *tina_intc_t;
 void rt_hw_interrupt_init(void);
 void rt_hw_interrupt_mask(int vector);
 void rt_hw_interrupt_umask(int vector);
-rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler, void *param, char *name);
+rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler, void *param, const char *name);
 
 #endif /* __INTERRUPT_H__ */

--- a/bsp/asm9260t/platform/interrupt.c
+++ b/bsp/asm9260t/platform/interrupt.c
@@ -151,7 +151,7 @@ void rt_hw_interrupt_umask(int irq)
  * @return old handler
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/bsp/at91sam9260/platform/interrupt.c
+++ b/bsp/at91sam9260/platform/interrupt.c
@@ -319,7 +319,7 @@ void rt_hw_interrupt_umask(int irq)
  * @return old handler
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler, 
-                                    void *param, char *name)
+                                    void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/bsp/dm365/platform/interrupt.c
+++ b/bsp/dm365/platform/interrupt.c
@@ -253,7 +253,7 @@ void rt_hw_interrupt_umask(int irq)
  */
 
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-									void *param, char *name)
+									void *param, const char *name)
 {
 	rt_isr_handler_t old_handler = RT_NULL;
 

--- a/bsp/fh8620/drivers/interrupt.c
+++ b/bsp/fh8620/drivers/interrupt.c
@@ -169,7 +169,7 @@ void rt_hw_interrupt_umask(int irq)
  * @return old handler
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler, 
-                                    void *param, char *name)
+                                    void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/bsp/fh8620/drivers/interrupt.h
+++ b/bsp/fh8620/drivers/interrupt.h
@@ -35,6 +35,6 @@ void rt_hw_interrupt_init(void);
 void rt_hw_interrupt_mask(int irq);
 void rt_hw_interrupt_umask(int irq);
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-		void *param, char *name);
+		void *param, const char *name);
 
 #endif /* INTERRUPT_H_ */

--- a/bsp/gkipc/armv6/interrupt.c
+++ b/bsp/gkipc/armv6/interrupt.c
@@ -97,7 +97,7 @@ void rt_hw_interrupt_umask(int irq)
  * @return old handler
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-                                    void *param, char *name)
+                                    void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/bsp/hifive1/drivers/interrupt.c
+++ b/bsp/hifive1/drivers/interrupt.c
@@ -110,7 +110,7 @@ void rt_hw_interrupt_ack(rt_uint32_t fiq_irq, rt_uint32_t id)
  * @return old handler
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/bsp/hifive1/drivers/interrupt.h
+++ b/bsp/hifive1/drivers/interrupt.h
@@ -32,6 +32,6 @@ void rt_hw_interrupt_init(void);
 rt_uint32_t rt_hw_interrupt_get_active(rt_uint32_t fiq_irq);
 void rt_hw_interrupt_ack(rt_uint32_t fiq_irq, rt_uint32_t id);
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name);
+        void *param, const char *name);
         
 #endif

--- a/bsp/imx6sx/cortex-a9/cpu/interrupt.c
+++ b/bsp/imx6sx/cortex-a9/cpu/interrupt.c
@@ -110,7 +110,7 @@ void rt_hw_interrupt_umask(int vector)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/bsp/qemu-vexpress-a9/cpu/interrupt.c
+++ b/bsp/qemu-vexpress-a9/cpu/interrupt.c
@@ -93,7 +93,7 @@ void rt_hw_interrupt_umask(int vector)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/bsp/qemu-vexpress-gemini/cpu/interrupt.c
+++ b/bsp/qemu-vexpress-gemini/cpu/interrupt.c
@@ -108,7 +108,7 @@ void rt_hw_interrupt_umask(int vector)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/bsp/raspi2/cpu/interrupt.c
+++ b/bsp/raspi2/cpu/interrupt.c
@@ -114,7 +114,7 @@ void rt_hw_interrupt_umask(int vector)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/include/rthw.h
+++ b/include/rthw.h
@@ -92,7 +92,7 @@ void rt_hw_interrupt_umask(int vector);
 rt_isr_handler_t rt_hw_interrupt_install(int              vector,
                                          rt_isr_handler_t handler,
                                          void            *param,
-                                         char            *name);
+                                         const char      *name);
 
 #ifdef RT_USING_SMP
 rt_base_t rt_hw_local_irq_disable();

--- a/libcpu/arm/AT91SAM7X/interrupt.c
+++ b/libcpu/arm/AT91SAM7X/interrupt.c
@@ -91,7 +91,7 @@ void rt_hw_interrupt_umask(int vector)
  * @return the old handler
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler, 
-									void *param, char *name)
+									void *param, const char *name)
 {
 	rt_isr_handler_t old_handler = RT_NULL;
 	if(vector >= 0 && vector < MAX_HANDLERS)

--- a/libcpu/arm/am335x/interrupt.c
+++ b/libcpu/arm/am335x/interrupt.c
@@ -158,7 +158,7 @@ void rt_hw_interrupt_ack(int fiq_irq)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/arm/cortex-a/interrupt.c
+++ b/libcpu/arm/cortex-a/interrupt.c
@@ -110,7 +110,7 @@ void rt_hw_interrupt_umask(int vector)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/arm/cortex-r4/interrupt.c
+++ b/libcpu/arm/cortex-r4/interrupt.c
@@ -86,7 +86,7 @@ void rt_hw_interrupt_umask(int vector)
  * @return the old handler
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-									void *param, char *name)
+									void *param, const char *name)
 {
 	rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/arm/lpc214x/cpuport.c
+++ b/libcpu/arm/lpc214x/cpuport.c
@@ -137,7 +137,7 @@ void rt_hw_interrupt_umask(int vector)
  * @return old handler
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-                                         void *param, char *name)
+                                         void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/arm/lpc24xx/interrupt.c
+++ b/libcpu/arm/lpc24xx/interrupt.c
@@ -83,7 +83,7 @@ void rt_hw_interrupt_umask(int vector)
  * @return the old handler
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler, 
-									void *param, char *name)
+									void *param, const char *name)
 {
 	rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/arm/realview-a8-vmm/interrupt.c
+++ b/libcpu/arm/realview-a8-vmm/interrupt.c
@@ -103,7 +103,7 @@ void rt_hw_interrupt_umask(int vector)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/arm/s3c24x0/interrupt.c
+++ b/libcpu/arm/s3c24x0/interrupt.c
@@ -104,7 +104,7 @@ void rt_hw_interrupt_umask(int vector)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-                                        void *param, char *name)
+                                        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/arm/sep4020/interrupt.c
+++ b/libcpu/arm/sep4020/interrupt.c
@@ -107,7 +107,7 @@ void rt_hw_interrupt_umask(int vector)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-                                        void *param, char *name)
+                                        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/arm/zynq7000/interrupt.c
+++ b/libcpu/arm/zynq7000/interrupt.c
@@ -112,7 +112,7 @@ void rt_hw_interrupt_umask(int vector)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/ia32/interrupt.c
+++ b/libcpu/ia32/interrupt.c
@@ -131,7 +131,7 @@ void rt_hw_interrupt_mask(int vector)
 rt_isr_handler_t rt_hw_interrupt_install(int              vector,
                                          rt_isr_handler_t handler,
                                          void            *param,
-                                         char            *name)
+                                         const char      *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/mips/loongson_1b/interrupt.c
+++ b/libcpu/mips/loongson_1b/interrupt.c
@@ -96,7 +96,7 @@ void rt_hw_interrupt_umask(int vector)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-                                         void *param, char *name)
+                                         void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/mips/loongson_1c/interrupt.c
+++ b/libcpu/mips/loongson_1c/interrupt.c
@@ -112,7 +112,7 @@ void rt_hw_interrupt_umask(int vector)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-                                         void *param, char *name)
+                                         void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/mips/x1000/interrupt.c
+++ b/libcpu/mips/x1000/interrupt.c
@@ -80,7 +80,7 @@ void rt_hw_interrupt_umask(int vector)
 }
 
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/mips/xburst/interrupt.c
+++ b/libcpu/mips/xburst/interrupt.c
@@ -95,7 +95,7 @@ void rt_hw_interrupt_umask(int vector)
  * @return old handler
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-        void *param, char *name)
+        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 

--- a/libcpu/ppc/ppc405/interrupt.c
+++ b/libcpu/ppc/ppc405/interrupt.c
@@ -79,7 +79,7 @@ void uic_interrupt(rt_uint32_t uic_base, int vec_base)
 }
 
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t new_handler, 
-    void* param, char* name)
+    void* param, const char* name)
 {
     int	intVal;
     rt_isr_handler_t old_handler;

--- a/libcpu/unicore32/sep6200/interrupt.c
+++ b/libcpu/unicore32/sep6200/interrupt.c
@@ -199,7 +199,7 @@ void rt_hw_interrupt_umask(int irq)
  * @param old_handler the old interrupt service routine
  */
 rt_isr_handler_t rt_hw_interrupt_install(int vector, rt_isr_handler_t handler,
-                                        void *param, char *name)
+                                        void *param, const char *name)
 {
     rt_isr_handler_t old_handler = RT_NULL;
 


### PR DESCRIPTION
目前改函数name参数有的有const限定,有的没有.当用常量字符串直接传给name时,如果name没有const限定,那么gcc可正常通过, armclang则报错. 此处统一加上const限定.