### PR TITLE
【bsp/stm32f10x】 复位后串口打印第一个字节丢失的问题 | The loss of the first byte of serial port pr…

### DIFF
--- a/bsp/stm32f10x/drivers/usart.c
+++ b/bsp/stm32f10x/drivers/usart.c
@@ -100,6 +100,8 @@ static rt_err_t stm32_configure(struct rt_serial_device *serial, struct serial_c
 
     /* Enable USART */
     USART_Cmd(uart->uart_device, ENABLE);
+    
+    USART_ClearFlag(uart->uart_device,USART_FLAG_TC);
 
     return RT_EOK;
 }


### PR DESCRIPTION
…inting after reset.