### PR TITLE
[bsp/stm32f7-disco] 修复串口驱动编译报错

### DIFF
--- a/bsp/stm32f7-disco/drivers/drv_usart.c
+++ b/bsp/stm32f7-disco/drivers/drv_usart.c
@@ -106,8 +106,9 @@ static int drv_putc(struct rt_serial_device *serial, char c)
     struct drv_uart *uart;
     RT_ASSERT(serial != RT_NULL);
     uart = (struct drv_uart *)serial->parent.user_data;
-    __HAL_UART_CLEAR_FLAG(&(uart->UartHandle), UART_FLAG_TC);
+    __HAL_UART_CLEAR_IT(&(uart->UartHandle), UART_CLEAR_TCF);
     uart->UartHandle.Instance->TDR = c;
+    while (__HAL_UART_GET_FLAG(&(uart->UartHandle), UART_FLAG_TC) == RESET);
     return 1;
 }
 


### PR DESCRIPTION
__HAL_UART_CLEAR_FLAG在stm32f7xx_hal_uart.h中不存在，编译会报错