### PR TITLE
修复I2C和RTC中的粗心BUG

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
@@ -134,7 +134,7 @@ static rt_err_t rt_rtc_control(rt_device_t dev, int cmd, void *args)
     {
     case RT_DEVICE_CTRL_RTC_GET_TIME:
         *(rt_uint32_t *)args = get_rtc_timestamp();
-        LOG_D("RTC: get rtc_time %x\n", *(rt_uint32_t *)args());
+        LOG_D("RTC: get rtc_time %x\n", *(rt_uint32_t *)args);
         break;
 
     case RT_DEVICE_CTRL_RTC_SET_TIME:

--- a/bsp/stm32/libraries/HAL_Drivers/drv_soft_i2c.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_soft_i2c.c
@@ -32,7 +32,7 @@ static const struct stm32_soft_i2c_config soft_i2c_config[] =
     I2C2_BUS_CONFIG,
 #endif
 #ifdef BSP_USING_I2C3
-    I2C2_BUS_CONFIG,
+    I2C3_BUS_CONFIG,
 #endif
 };
 


### PR DESCRIPTION
I2C.c文件中I2C2_BUS_CONFIG改为I2C3_BUS_CONFIG。RTC驱动137行多了()