### PR TITLE
fix some bug when stack grows upward

### DIFF
--- a/components/finsh/cmd.c
+++ b/components/finsh/cmd.c
@@ -116,7 +116,7 @@ static long _list_thread(struct rt_list_node *list)
         else if (stat == RT_THREAD_CLOSE)   rt_kprintf(" close  ");
 
 #if defined(ARCH_CPU_STACK_GROWS_UPWARD)
-        ptr = (rt_uint8_t *)thread->stack_addr + thread->stack_size;
+        ptr = (rt_uint8_t *)thread->stack_addr + thread->stack_size - 1;
         while (*ptr == '#')ptr --;
 
         rt_kprintf(" 0x%08x 0x%08x    %02d%%   0x%08x %03d\n",

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -84,15 +84,12 @@ static void _rt_scheduler_stack_check(struct rt_thread *thread)
 
 #if defined(ARCH_CPU_STACK_GROWS_UPWARD)
 	if (*((rt_uint8_t *)((rt_ubase_t)thread->stack_addr + thread->stack_size - 1)) != '#' ||
-        (rt_ubase_t)thread->sp <= (rt_ubase_t)thread->stack_addr ||
-        (rt_ubase_t)thread->sp >
-        (rt_ubase_t)thread->stack_addr + (rt_ubase_t)thread->stack_size)
 #else
     if (*((rt_uint8_t *)thread->stack_addr) != '#' ||
+#endif
         (rt_ubase_t)thread->sp <= (rt_ubase_t)thread->stack_addr ||
         (rt_ubase_t)thread->sp >
         (rt_ubase_t)thread->stack_addr + (rt_ubase_t)thread->stack_size)
-#endif
     {
         rt_ubase_t level;
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -82,10 +82,17 @@ static void _rt_scheduler_stack_check(struct rt_thread *thread)
 {
     RT_ASSERT(thread != RT_NULL);
 
+#if defined(ARCH_CPU_STACK_GROWS_UPWARD)
+	if (*((rt_uint8_t *)((rt_ubase_t)thread->stack_addr + thread->stack_size - 1)) != '#' ||
+        (rt_ubase_t)thread->sp <= (rt_ubase_t)thread->stack_addr ||
+        (rt_ubase_t)thread->sp >
+        (rt_ubase_t)thread->stack_addr + (rt_ubase_t)thread->stack_size)
+#else
     if (*((rt_uint8_t *)thread->stack_addr) != '#' ||
         (rt_ubase_t)thread->sp <= (rt_ubase_t)thread->stack_addr ||
         (rt_ubase_t)thread->sp >
         (rt_ubase_t)thread->stack_addr + (rt_ubase_t)thread->stack_size)
+#endif
     {
         rt_ubase_t level;
 


### PR DESCRIPTION
对栈顶的位置应该是原程序中ptr = (rt_uint8_t *)thread->stack_addr + thread->stack_size的值- 1，如果不减实际上已经溢出到别的内存区域了