### PR TITLE
fix zynq7000 bsp's bug which is in the zynq7000.ld

### DIFF
--- a/bsp/zynq7000/drivers/board.h
+++ b/bsp/zynq7000/drivers/board.h
@@ -24,7 +24,7 @@
 #include <zynq7000.h>
 
 /* Freq of all peripherals */
-#define APU_FREQ     666666667
+#define APU_FREQ     766666667
 #define DDR_FREQ     533333313
 #define DCI_FREQ     10159000
 #define QSPI_FREQ    200000000
@@ -34,7 +34,7 @@
 #define USB0_FREQ    60000000
 #define USB1_FREQ    60000000
 #define SDIO_FREQ    50000000
-#define UART_FREQ    50000000
+#define UART_FREQ    100000000
 #define SPI_FREQ     166666666
 #define I2C_FREQ     25000000
 #define WDT_FREQ     133333333

--- a/bsp/zynq7000/drivers/uart.c
+++ b/bsp/zynq7000/drivers/uart.c
@@ -118,14 +118,14 @@ static rt_err_t uart_configure(struct rt_serial_device *serial, struct serial_co
         /* enable the coresponding AMBA Peripheral Clock */
         __REG32(Zynq7000_SLCR_BASE+Zynq7000_SLCR_APER_CLK_CTRL) |= 1 << 20;
         /* enable uart clock. Divider 0x14 gives 50MHZ ref clock on IO PLL input. */
-        __REG32(Zynq7000_SLCR_BASE+Zynq7000_SLCR_UART_CLK_CTRL) |= (0x14 << 8) | 0x01;
+        __REG32(Zynq7000_SLCR_BASE+Zynq7000_SLCR_UART_CLK_CTRL) |= (0xa << 8) | 0x01;
         /* deassert the AMBA clock and software reset */
         __REG32(Zynq7000_SLCR_BASE+Zynq7000_SLCR_UART_RST_CTRL) &= ~((0x01 << 2)|(0x01 << 0));
     }
     else if (uart == (void*)Zynq7000_UART1_BASE)
     {
         __REG32(Zynq7000_SLCR_BASE+Zynq7000_SLCR_APER_CLK_CTRL) |= 1 << 21;
-        __REG32(Zynq7000_SLCR_BASE+Zynq7000_SLCR_UART_CLK_CTRL) |= (0x14 << 8) | 0x02;
+        __REG32(Zynq7000_SLCR_BASE+Zynq7000_SLCR_UART_CLK_CTRL) |= (0xa << 8) | 0x02;
         __REG32(Zynq7000_SLCR_BASE+Zynq7000_SLCR_UART_RST_CTRL) &= ~((0x01 << 3)|(0x01 << 1));
     }
     else

--- a/bsp/zynq7000/drivers/uart_hw.h
+++ b/bsp/zynq7000/drivers/uart_hw.h
@@ -153,7 +153,7 @@ typedef struct
 
 /*Baudrates assuming input clock speed is 3125000L */
 /*Baud_rate_gen_reg0*/
-#define UART_BAUDGEN_115200       62 /*Baud Rate Clock Divisor*/
+#define UART_BAUDGEN_115200       124 /*Baud Rate Clock Divisor*/
 
 /*Register Baud_rate_divider_reg0 Details*/
 #define UART_BAUDDIV_115200       6  /*Baud Rate Clock Divisor*/

--- a/bsp/zynq7000/rtconfig.h
+++ b/bsp/zynq7000/rtconfig.h
@@ -83,7 +83,7 @@
 // <integer name="RT_CONSOLEBUF_SIZE" description="The buffer size for console output" default="128" />
 #define RT_CONSOLEBUF_SIZE	128
 // <string name="RT_CONSOLE_DEVICE_NAME" description="The device name for console" default="uart" />
-#define RT_CONSOLE_DEVICE_NAME	"uart0"
+#define RT_CONSOLE_DEVICE_NAME	"uart1"
 // </section>
 
 // <bool name="RT_USING_COMPONENTS_INIT" description="Using RT-Thread components initialization" default="true" />

--- a/bsp/zynq7000/rtconfig.py
+++ b/bsp/zynq7000/rtconfig.py
@@ -10,7 +10,7 @@ if os.getenv('RTT_CC'):
 
 # only support GNU GCC compiler
 PLATFORM 	= 'gcc'
-EXEC_PATH 	= '/opt/arm-none-eabi-gcc'
+EXEC_PATH 	= '/home/work/arm-2011.09/bin'
 
 if os.getenv('RTT_EXEC_PATH'):
     EXEC_PATH = os.getenv('RTT_EXEC_PATH')

--- a/bsp/zynq7000/zynq7000.ld
+++ b/bsp/zynq7000/zynq7000.ld
@@ -92,7 +92,7 @@ SECTIONS
     __data_end = .;
 
     . = ALIGN(4);
-    __bss_start = 0;
+    __bss_start = __data_end;
     .bss       :
     {
     *(.bss)


### PR DESCRIPTION
When I  use rt-thread on the AX7021 development board, it could not start normally. I found that there was something wrong with the zynq7000.ld link file，"bss_start" value was wrong.