### PR TITLE
[components][USB][Device][Core]fix the device_qualifier error respond on fullspeed

### DIFF
--- a/components/drivers/usb/usbdevice/core/core.c
+++ b/components/drivers/usb/usbdevice/core/core.c
@@ -194,7 +194,18 @@ static rt_err_t _get_descriptor(struct udevice* device, ureq_t setup)
             _get_string_descriptor(device, setup);
             break;
         case USB_DESC_TYPE_DEVICEQUALIFIER:
-            _get_qualifier_descriptor(device, setup);
+            /* If a full-speed only device (with a device descriptor version number equal to 0200H) receives a
+            GetDescriptor() request for a device_qualifier, it must respond with a request error. The host must not make
+            a request for an other_speed_configuration descriptor unless it first successfully retrieves the
+            device_qualifier descriptor. */
+            if(device->dcd->device_is_hs)
+            {
+                _get_qualifier_descriptor(device, setup);
+            }
+            else
+            {
+                rt_usbd_ep0_set_stall(device);
+            }
             break;
         case USB_DESC_TYPE_OTHERSPEED:
             _get_config_descriptor(device, setup);


### PR DESCRIPTION
根据 usb2.0白皮书第292页所述，当只支持Fullspeed的设备收到主机的 get device_qualifier 时应返回错误的请求。原文如下

> If a full-speed only device (with a device descriptor version number equal to 0200H) receives a
> GetDescriptor()
> request for a device_qualifier, it must respond with a request error. The host must not make
> a request for an other_speed_configuration descriptor unless it first successfully retrieves the
> device_qualifier descriptor.