### PR TITLE
[tools] menuconfig.py silent 模式的时候，不检查 .config 文件时间戳变化，直接更新 rtconfig.h

### DIFF
--- a/tools/menuconfig.py
+++ b/tools/menuconfig.py
@@ -264,18 +264,7 @@ def pyconfig_silent(RTT_ROOT):
 
     fn = '.config'
 
-    if os.path.isfile(fn):
-        mtime = os.path.getmtime(fn)
-    else:
-        mtime = -1
-
     pymenuconfig.main(['--kconfig', 'Kconfig', '--config', '.config', '--silent', 'True'])
 
-    if os.path.isfile(fn):
-        mtime2 = os.path.getmtime(fn)
-    else:
-        mtime2 = -1
-
-    # make rtconfig.h
-    if mtime != mtime2:
-        mk_rtconfig(fn)
+    # silent mode, force to make rtconfig.h
+    mk_rtconfig(fn)


### PR DESCRIPTION
这么修改，是因为虽然 .config 没有变化，但与 rtconfig.h 的配置已经不一致。

Signed-off-by: MurphyZhao <d2014zjt@163.com>