### PR TITLE
[components][ulog] fix ulog_console_backend_init auto init level

### DIFF
--- a/components/utilities/ulog/backend/console_be.c
+++ b/components/utilities/ulog/backend/console_be.c
@@ -45,12 +45,13 @@ void ulog_console_backend_output(struct ulog_backend *backend, rt_uint32_t level
 
 int ulog_console_backend_init(void)
 {
+    ulog_init();
     console.output = ulog_console_backend_output;
 
     ulog_backend_register(&console, "console", RT_TRUE);
 
     return 0;
 }
-INIT_COMPONENT_EXPORT(ulog_console_backend_init);
+INIT_PREV_EXPORT(ulog_console_backend_init);
 
 #endif /* ULOG_BACKEND_USING_CONSOLE */


### PR DESCRIPTION

### Summary of this Pull Request (PR) 拉取/合并请求的简述  

修改 `ulog_console_backend_init` 函数的自动初始化级别，使用与 `ulog_init` 同级别的 `INIT_PREV_EXPORT` 而非 `INIT_COMPONENT_EXPORT`。

这样做的目的是为了组件初始化中的其他模块可以使用 ulog 输出日志。

### Intent for your PR 拉取/合并请求的目的  

Choose one (Mandatory): 必须选择一项  

- [ ] This PR is for a code-review and is intended to get feedback 本拉取/合并请求是一个草稿版本  
- [x] This PR is mature, and ready to be integrated into the repo 本拉取/合并请求是一个成熟版本  

### Reviewers (Mandatory): 代码审阅者（必须指定）

@BernardXiong @armink 

### Code Quality： 代码质量  

As part of this pull request, I've considered the following:  
我在这个拉取/合并请求中已经考虑了：

- [x] Already check the difference between PR and old code 已经仔细查看过代码改动的对比
- [x] Style guide is adhered to, including spacing, naming and other style 代码风格正确，包括缩进空格，命名及其他风格
- [x] All redundant code is removed and cleaned up 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码
- [x] All modifications are justified and not affect other components or BSP 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP
- [x] I've commented appropriately where code is tricky 对难懂代码均提供对应的注释
- [x] Code in this PR is of high quality 本拉取/合并请求代码是高质量的

### Testing：代码测试

I've tested the code using the following test programs (provide list here):  
我已经在如下场合跑过对应的测试：  

- [x] stm32.stm32f429-atk-apollo
- [x] qemu
