### PR TITLE
修复一些关于CAN驱动以及链表处理的问题

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f4.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f4.c
@@ -227,7 +227,8 @@ int stm32_flash_write(rt_uint32_t addr, const rt_uint8_t *buf, size_t size)
 
     __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR);
 
-    for (size_t i = 0; i < size; i++, addr++, buf++)
+    size_t i = 0;
+    for (i = 0; i < size; i++, addr++, buf++)
     {
         /* write data to flash */
         if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_BYTE, addr, (rt_uint64_t)(*buf)) == HAL_OK)

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
@@ -553,8 +553,8 @@ int rt_hw_usart_init(void)
     struct serial_configure config = RT_SERIAL_CONFIG_DEFAULT;
     
     rt_err_t result = 0;
-    
-    for (int i = 0; i < obj_num; i++)
+    int i = 0;
+    for (i = 0; i < obj_num; i++)
     {
         uart_obj[i].config = &uart_config[i];
         uart_obj[i].serial.ops    = &stm32_uart_ops;

--- a/bsp/stm32f4xx-HAL/drivers/drv_can.c
+++ b/bsp/stm32f4xx-HAL/drivers/drv_can.c
@@ -362,12 +362,16 @@ void CAN2_SCE_IRQHandler(void)
  */
 void HAL_CAN_ErrorCallback(CAN_HandleTypeDef *hcan)
 {
-    /* TODO Error Callback */
-    /* Prevent unused argument(s) compilation warning */
-    UNUSED(hcan);
-    /* NOTE : This function Should not be modified, when the callback is needed,
-       the HAL_CAN_ErrorCallback could be implemented in the user file
-    */
+    __HAL_CAN_ENABLE_IT(hcan, CAN_IT_EWG |
+                               CAN_IT_EPV |
+                               CAN_IT_BOF |
+                               CAN_IT_LEC |
+                               CAN_IT_ERR |
+                               CAN_IT_FMP0|
+                               CAN_IT_FOV0|
+                               CAN_IT_FMP1|
+                               CAN_IT_FOV1|
+                               CAN_IT_TME);
 }
 
 /**

--- a/components/drivers/can/can.c
+++ b/components/drivers/can/can.c
@@ -405,6 +405,7 @@ static rt_err_t rt_can_close(struct rt_device *dev)
 
         rt_free(rx_fifo);
         dev->open_flag &= ~RT_DEVICE_FLAG_INT_RX;
+        can->can_rx = RT_NULL;
         /* configure low level device */
         can->ops->control(can, RT_DEVICE_CTRL_CLR_INT, (void *)RT_DEVICE_FLAG_INT_RX);
     }
@@ -418,6 +419,7 @@ static rt_err_t rt_can_close(struct rt_device *dev)
 
         rt_free(tx_fifo);
         dev->open_flag &= ~RT_DEVICE_FLAG_INT_TX;
+        can->can_tx = RT_NULL;
         /* configure low level device */
         can->ops->control(can, RT_DEVICE_CTRL_CLR_INT, (void *)RT_DEVICE_FLAG_INT_TX);
     }

--- a/include/rtservice.h
+++ b/include/rtservice.h
@@ -151,9 +151,9 @@ rt_inline unsigned int rt_list_len(const rt_list_t *l)
  * @member: the name of the list_struct within the struct.
  */
 #define rt_list_for_each_entry(pos, head, member) \
-    for (pos = rt_list_entry((head)->next, typeof(*pos), member); \
+    for (pos = rt_list_entry((head)->next, __typeof__(*pos), member); \
          &pos->member != (head); \
-         pos = rt_list_entry(pos->member.next, typeof(*pos), member))
+         pos = rt_list_entry(pos->member.next, __typeof__(*pos), member))
 
 /**
  * rt_list_for_each_entry_safe - iterate over list of given type safe against removal of list entry
@@ -163,10 +163,10 @@ rt_inline unsigned int rt_list_len(const rt_list_t *l)
  * @member: the name of the list_struct within the struct.
  */
 #define rt_list_for_each_entry_safe(pos, n, head, member) \
-    for (pos = rt_list_entry((head)->next, typeof(*pos), member), \
-         n = rt_list_entry(pos->member.next, typeof(*pos), member); \
+    for (pos = rt_list_entry((head)->next, __typeof__(*pos), member), \
+         n = rt_list_entry(pos->member.next, __typeof__(*pos), member); \
          &pos->member != (head); \
-         pos = n, n = rt_list_entry(n->member.next, typeof(*n), member))
+         pos = n, n = rt_list_entry(n->member.next, __typeof__(*n), member))
 
 /**
  * rt_list_first_entry - get the first element from a list
@@ -280,9 +280,9 @@ rt_inline int rt_slist_isempty(rt_slist_t *l)
  * @member: the name of the list_struct within the struct.
  */
 #define rt_slist_for_each_entry(pos, head, member) \
-    for (pos = rt_slist_entry((head)->next, typeof(*pos), member); \
+    for (pos = rt_slist_entry((head)->next, __typeof__(*pos), member); \
          &pos->member != (RT_NULL); \
-         pos = rt_slist_entry(pos->member.next, typeof(*pos), member))
+         pos = rt_slist_entry(pos->member.next, __typeof__(*pos), member))
 
 /**
  * rt_slist_first_entry - get the first element from a slist


### PR DESCRIPTION
### Summary of this Pull Request (PR) 拉取/合并请求的简述  

**Add description here.** **请在这里加入描述**

1. 修改系统中关于链表操作的实现，具体得将typeof关键字修改为__typeof__,以使其同时支持C90和C99编译器。
2. 修改STM32新架构里部分驱动的代码实现，以使其兼容标准C90的语法。
3. 修改系统CAN驱动框架中关闭设备时对于接收和发送handler的处理，如果此处不恢复为空，在下次打开设备后，驱动将无法正常工作。
4. 修改STM32F4xx_hal中CAN驱动，使其在发生OV等异常中断后，继续使能其他正常中断。

### Intent for your PR 拉取/合并请求的目的  

Choose one (Mandatory): 必须选择一项  

- [ ] This PR is for a code-review and is intended to get feedback 本拉取/合并请求是一个草稿版本  
- [x] This PR is mature, and ready to be integrated into the repo 本拉取/合并请求是一个成熟版本  

### Reviewers (Mandatory): 代码审阅者（必须指定）

@BernardXiong
@armink 

### Code Quality： 代码质量  

As part of this pull request, I've considered the following:  
我在这个拉取/合并请求中已经考虑了：

- [x] Already check the difference between PR and old code 已经仔细查看过代码改动的对比
- [x] Style guide is adhered to, including spacing, naming and other style 代码风格正确，包括缩进空格，命名及其他风格
- [x] All redundant code is removed and cleaned up 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码
- [x] All modifications are justified and not affect other components or BSP 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP
- [x] I've commented appropriately where code is tricky 对难懂代码均提供对应的注释
- [x] Code in this PR is of high quality 本拉取/合并请求代码是高质量的

### Testing：代码测试

I've tested the code using the following test programs (provide list here):  
我已经在如下场合跑过对应的测试：  

- [x] STM32F412芯片对链表操作的验证
- [x] STM32F412芯片下，对中断方式操作的CAN驱动的功能验证（重开设备后，正常接收发送中断，以及异常OV中断后，接收发送中断的验证）
- [x] C90，C99编译标准下功能的验证
- [x] Keil和gcc编译测试通过
