### PR TITLE
[bsp][qemu-vexpress-a9][rtconfig.py] 增加对浮点输出的支持

### DIFF
--- a/bsp/qemu-vexpress-a9/rtconfig.py
+++ b/bsp/qemu-vexpress-a9/rtconfig.py
@@ -34,7 +34,7 @@ if PLATFORM == 'gcc':
     CFLAGS = DEVICE + ' -Wall'
     AFLAGS = ' -c' + DEVICE + ' -x assembler-with-cpp -D__ASSEMBLY__ -I.'
     LINK_SCRIPT = 'link.lds'
-    LFLAGS = DEVICE + ' -nostartfiles -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,system_vectors'+\
+    LFLAGS = DEVICE + ' -nostartfiles -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,system_vectors, -specs=nano.specs -u _printf_float'+\
                       ' -T %s' % LINK_SCRIPT
 
     CPATH = ''


### PR DESCRIPTION

### Summary of this Pull Request (PR) 拉取/合并请求的简述  

QEMU BSP 通过增加 `-specs=nano.specs -u _printf_float` 链接选项增加对浮点数输出的支持。

### Intent for your PR 拉取/合并请求的目的  

Choose one (Mandatory): 必须选择一项  

- [ ] This PR is for a code-review and is intended to get feedback 本拉取/合并请求是一个草稿版本  
- [x] This PR is mature, and ready to be integrated into the repo 本拉取/合并请求是一个成熟版本  

### Reviewers (Mandatory): 代码审阅者（必须指定）

@BernardXiong @armink 

### Code Quality： 代码质量  

As part of this pull request, I've considered the following:  
我在这个拉取/合并请求中已经考虑了：

- [x] Already check the difference between PR and old code 已经仔细查看过代码改动的对比
- [x] Style guide is adhered to, including spacing, naming and other style 代码风格正确，包括缩进空格，命名及其他风格
- [x] All redundant code is removed and cleaned up 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码
- [x] All modifications are justified and not affect other components or BSP 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP
- [x] I've commented appropriately where code is tricky 对难懂代码均提供对应的注释
- [x] Code in this PR is of high quality 本拉取/合并请求代码是高质量的

### Testing：代码测试

I've tested the code using the following test programs (provide list here):  
我已经在如下场合跑过对应的测试：  

- [x] qemu-vexpress-a9
