### PR TITLE
update dfs.c  dfs_file.c  dfs_file.h

### DIFF
--- a/components/dfs/include/dfs_file.h
+++ b/components/dfs/include/dfs_file.h
@@ -44,6 +44,7 @@ struct dfs_fd
     char *path;                  /* Name (below mount point) */
     int ref_count;               /* Descriptor reference count */
 
+    struct dfs_filesystem *fs;
     const struct dfs_file_ops *fops;
 
     uint32_t flags;              /* Descriptor flags */

--- a/components/dfs/src/dfs.c
+++ b/components/dfs/src/dfs.c
@@ -320,7 +320,7 @@ int fd_is_open(const char *pathname)
             fd = fdt->fds[index];
             if (fd == NULL || fd->fops == NULL || fd->path == NULL) continue;
 
-            if (fd->fops == fs->ops->fops && strcmp(fd->path, mountpath) == 0)
+            if (fd->fs == fs && strcmp(fd->path, mountpath) == 0)
             {
                 /* found file in file descriptor table */
                 rt_free(fullpath);

--- a/components/dfs/src/dfs_file.c
+++ b/components/dfs/src/dfs_file.c
@@ -66,7 +66,8 @@ int dfs_file_open(struct dfs_fd *fd, const char *path, int flags)
     }
 
     LOG_D("open in filesystem:%s", fs->ops->name);
-    fd->fops  = fs->ops->fops; /* set file ops */
+    fd->fs    = fs;             /* set file system */
+    fd->fops  = fs->ops->fops;  /* set file ops */
 
     /* initialize the fd item */
     fd->type  = FT_REGULAR;


### PR DESCRIPTION
Signed-off-by: yangfasheng <yangfasheng@rt-thread.com>

### Summary of this Pull Request (PR) 拉取/合并请求的简述  

修复文件系统挂载多个设备，并同时在不同设备上同样的相对路径下打开相同文件名的文件时其中一个打开失败的BUG。

### Intent for your PR 拉取/合并请求的目的  

Choose one (Mandatory): 必须选择一项  

- [ ] This PR is for a code-review and is intended to get feedback 本拉取/合并请求是一个草稿版本  
- [x] This PR is mature, and ready to be integrated into the repo 本拉取/合并请求是一个成熟版本  

### Reviewers (Mandatory): 代码审阅者（必须指定）

@BernardXiong 

### Code Quality： 代码质量  

As part of this pull request, I've considered the following:  
我在这个拉取/合并请求中已经考虑了：

- [x] Already check the difference between PR and old code 已经仔细查看过代码改动的对比
- [x] Style guide is adhered to, including spacing, naming and other style 代码风格正确，包括缩进空格，命名及其他风格
- [x] All redundant code is removed and cleaned up 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码
- [ ] All modifications are justified and not affect other components or BSP 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP
- [ ] I've commented appropriately where code is tricky 对难懂代码均提供对应的注释
- [x] Code in this PR is of high quality 本拉取/合并请求代码是高质量的

### Testing：代码测试

I've tested the code using the following test programs (provide list here):  
我已经在如下场合跑过对应的测试：  

- [ ] 在文件系统中挂在两个设备，比如 flash 设备挂在到 "/" 目录，SD 卡设备挂载到 "/mnt/sd0" 目录，然后同时打开两个文件，如 "/test/test.txt" 和 "/mnt/sd0/test/test.txt" ，两个文件都打开成功
