### PR TITLE
Fix bug: when set the tag level in LOG_LVL_DBG, tag will be remove.

### DIFF
--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -784,9 +784,9 @@ int ulog_tag_lvl_filter_set(const char *tag, rt_uint32_t level)
     /* find OK */
     if (tag_lvl)
     {
-        if (level == LOG_FILTER_LVL_ALL)
+        if (level > LOG_FILTER_LVL_ALL)
         {
-            /* remove current tag's level filter when input level is the lowest level */
+            /* remove current tag's level filter when input level is lower than the lowest level */
             rt_slist_remove(ulog_tag_lvl_list_get(), &tag_lvl->list);
             rt_free(tag_lvl);
         }


### PR DESCRIPTION
Fix bug: when set the tag level in LOG_LVL_DBG, tag will be remove.

## 拉取/合并请求描述：(PR description)
在设置tag level为LOG_LVL_DBG时，tag被删除了。将"level == LOG_FILTER_LVL_ALL"改成"level > LOG_FILTER_LVL_ALL"，避免等于LOG_FILTER_LVL_ALL(等于LOG_LVL_DBG)时tag被删除。

已在"stm32f429-apollo"BSP上测试.

以下的内容请在提交PR后，一项项进行check，没问题后逐条在页面上打钩。
The following contents should be checked item by item after submitted PR, and ticked on the browser one by one after no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
