### PR TITLE
[Kernel] Enable RUNNING status in thread.

### DIFF
--- a/components/finsh/cmd.c
+++ b/components/finsh/cmd.c
@@ -214,6 +214,7 @@ long list_thread(void)
                     else if (stat == RT_THREAD_SUSPEND) rt_kprintf(" suspend");
                     else if (stat == RT_THREAD_INIT)    rt_kprintf(" init   ");
                     else if (stat == RT_THREAD_CLOSE)   rt_kprintf(" close  ");
+                    else if (stat == RT_THREAD_RUNNING) rt_kprintf(" running");
 
 #if defined(ARCH_CPU_STACK_GROWS_UPWARD)
                     ptr = (rt_uint8_t *)thread->stack_addr + thread->stack_size - 1;

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -265,6 +265,7 @@ void rt_system_scheduler_start(void)
 #endif /*RT_USING_SMP*/
 
     rt_schedule_remove_thread(to_thread);
+    to_thread->stat = RT_THREAD_RUNNING;
 
     /* switch to new thread */
 #ifdef RT_USING_SMP
@@ -311,7 +312,7 @@ void rt_schedule(void)
     int cpu_id;
 
     /* disable interrupt */
-    level = rt_hw_interrupt_disable();
+    level  = rt_hw_interrupt_disable();
 
     cpu_id = rt_hw_cpu_id();
     pcpu   = rt_cpu_index(cpu_id);
@@ -330,7 +331,7 @@ void rt_schedule(void)
         {
             to_thread = _get_highest_priority_thread(&highest_ready_priority);
             current_thread->oncpu = RT_CPU_DETACHED;
-            if ((current_thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_READY)
+            if ((current_thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_RUNNING)
             {
                 if (current_thread->current_priority < highest_ready_priority)
                 {
@@ -350,6 +351,7 @@ void rt_schedule(void)
                 RT_OBJECT_HOOK_CALL(rt_scheduler_hook, (current_thread, to_thread));
 
                 rt_schedule_remove_thread(to_thread);
+                to_thread->stat = RT_THREAD_RUNNING;
 
                 /* switch to new thread */
                 RT_DEBUG_LOG(RT_DEBUG_SCHEDULER,
@@ -414,7 +416,7 @@ void rt_schedule(void)
 
             to_thread = _get_highest_priority_thread(&highest_ready_priority);
 
-            if ((rt_current_thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_READY)
+            if ((rt_current_thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_RUNNING)
             {
                 if (rt_current_thread->current_priority < highest_ready_priority)
                 {
@@ -441,6 +443,7 @@ void rt_schedule(void)
                 }
 
                 rt_schedule_remove_thread(to_thread);
+                to_thread->stat = RT_THREAD_RUNNING;
 
                 /* switch to new thread */
                 RT_DEBUG_LOG(RT_DEBUG_SCHEDULER,
@@ -482,6 +485,7 @@ void rt_schedule(void)
             else
             {
                 rt_schedule_remove_thread(rt_current_thread);
+                rt_current_thread->stat = RT_THREAD_RUNNING;
             }
         }
     }
@@ -531,7 +535,7 @@ void rt_scheduler_do_irq_switch(void *context)
         {
             to_thread = _get_highest_priority_thread(&highest_ready_priority);
             current_thread->oncpu = RT_CPU_DETACHED;
-            if ((current_thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_READY)
+            if ((current_thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_RUNNING)
             {
                 if (current_thread->current_priority < highest_ready_priority)
                 {
@@ -552,6 +556,7 @@ void rt_scheduler_do_irq_switch(void *context)
                 RT_OBJECT_HOOK_CALL(rt_scheduler_hook, (current_thread, to_thread));
 
                 rt_schedule_remove_thread(to_thread);
+                to_thread->stat = RT_THREAD_RUNNING;
 
 #ifdef RT_USING_OVERFLOW_CHECK
                 _rt_scheduler_stack_check(to_thread);

--- a/src/timer.c
+++ b/src/timer.c
@@ -399,7 +399,7 @@ rt_err_t rt_timer_start(rt_timer_t timer)
     if (timer->parent.flag & RT_TIMER_FLAG_SOFT_TIMER)
     {
         /* check whether timer thread is ready */
-        if ((timer_thread.stat & RT_THREAD_STAT_MASK) != RT_THREAD_READY)
+        if ((timer_thread.stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND)
         {
             /* resume timer thread to check soft timer */
             rt_thread_resume(&timer_thread);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

在RT-Thread 4.0中，当任务获得CPU进行执行时，已经从READY队列中脱离，并进行运行（如果是多核情况，分别放到不同的核心上进行执行），所以这个时候RUNNING状态已经和原来的READY状态完全独立出来了。所以把RUNNING状态定义成非READY状态，并在shell中也给出相应的状态信息出来。

已经在下述BSP中测试验证：

* K210

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
