### PR TITLE
[lwp] Fix compiling warning in lwP.

### DIFF
--- a/components/lwp/lwp_syscall.h
+++ b/components/lwp/lwp_syscall.h
@@ -30,14 +30,19 @@ typedef uint32_t id_t;          /* may contain pid, uid or gid */
 #define	PRIO_PGRP	    1
 #define	PRIO_USER	    2
 
+#ifndef TIMEVAL_TO_TIMESPEC
 #define TIMEVAL_TO_TIMESPEC(tv, ts) {                   \
     (ts)->tv_sec = (tv)->tv_sec;                        \
     (ts)->tv_nsec = (tv)->tv_usec * 1000;               \
 }
+#endif
+
+#ifndef TIMESPEC_TO_TIMEVAL
 #define TIMESPEC_TO_TIMEVAL(tv, ts) {                   \
     (tv)->tv_sec = (ts)->tv_sec;                        \
     (tv)->tv_usec = (ts)->tv_nsec / 1000;               \
 }
+#endif
 
 void sys_exit(int value);
 ssize_t sys_read(int fd, void *buf, size_t nbyte);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

修正lwP编译时和libc的宏定义冲突。目前在qemu-vexpress-a9上进行测试。

以下的内容请在提交PR后，一项项进行check，没问题后逐条在页面上打钩。
The following contents should be checked item by item after submitted PR, and ticked on the browser one by one after no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
