### PR TITLE
[DFS][romfs] fix the mkrom issue when file/dir size zero

### DIFF
--- a/components/dfs/filesystems/romfs/dfs_romfs.h
+++ b/components/dfs/filesystems/romfs/dfs_romfs.h
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2006-2018, RT-Thread Development Team
+ * Copyright (c) 2006-2019, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes
+ * 2019/01/13     Bernard      code cleanup
  */
 
 #ifndef __DFS_ROMFS_H__
@@ -17,11 +18,11 @@
 
 struct romfs_dirent
 {
-    rt_uint32_t		 type;	/* dirent type */
+    rt_uint32_t	     type;  /* dirent type */
 
-    const char		 *name;	/* dirent name */
-    const rt_uint8_t *data;	/* file date ptr */
-    rt_size_t		 size;	/* file size */
+    const char       *name; /* dirent name */
+    const rt_uint8_t *data; /* file date ptr */
+    rt_size_t        size;  /* file size */
 };
 
 int dfs_romfs_init(void);

--- a/components/dfs/filesystems/romfs/dfs_romfs.h
+++ b/components/dfs/filesystems/romfs/dfs_romfs.h
@@ -17,11 +17,11 @@
 
 struct romfs_dirent
 {
-	rt_uint32_t		 type;	/* dirent type */
+    rt_uint32_t		 type;	/* dirent type */
 
-	const char		 *name;	/* dirent name */
-	const rt_uint8_t *data;	/* file date ptr */
-	rt_size_t		 size;	/* file size */
+    const char		 *name;	/* dirent name */
+    const rt_uint8_t *data;	/* file date ptr */
+    rt_size_t		 size;	/* file size */
 };
 
 int dfs_romfs_init(void);

--- a/components/dfs/filesystems/romfs/dfs_romfs.h
+++ b/components/dfs/filesystems/romfs/dfs_romfs.h
@@ -18,7 +18,7 @@
 
 struct romfs_dirent
 {
-    rt_uint32_t	     type;  /* dirent type */
+    rt_uint32_t      type;  /* dirent type */
 
     const char       *name; /* dirent name */
     const rt_uint8_t *data; /* file date ptr */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

修正mkromfs.py脚本的问题，并移到tools目录中。这个问题主要是当要生成romfs的C代码时，如果遇到空目录或空文件时，生成了空的结构体，导致编译出错。已经在qemu-vexpress-a9上测试通过，但生成bin文件的方式未验证，还需要进行验证。

以下的内容请在提交PR后，一项项进行check，没问题后逐条在页面上打钩。
The following contents should be checked item by item after submitted PR, and ticked on the browser one by one after no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
