### PR TITLE
修复CAN驱动部分问题

### DIFF
--- a/bsp/stm32f4xx-HAL/drivers/drv_can.c
+++ b/bsp/stm32f4xx-HAL/drivers/drv_can.c
@@ -362,12 +362,16 @@ void CAN2_SCE_IRQHandler(void)
  */
 void HAL_CAN_ErrorCallback(CAN_HandleTypeDef *hcan)
 {
-    /* TODO Error Callback */
-    /* Prevent unused argument(s) compilation warning */
-    UNUSED(hcan);
-    /* NOTE : This function Should not be modified, when the callback is needed,
-       the HAL_CAN_ErrorCallback could be implemented in the user file
-    */
+    __HAL_CAN_ENABLE_IT(hcan, CAN_IT_EWG |
+                               CAN_IT_EPV |
+                               CAN_IT_BOF |
+                               CAN_IT_LEC |
+                               CAN_IT_ERR |
+                               CAN_IT_FMP0|
+                               CAN_IT_FOV0|
+                               CAN_IT_FMP1|
+                               CAN_IT_FOV1|
+                               CAN_IT_TME);
 }
 
 /**

--- a/components/drivers/can/can.c
+++ b/components/drivers/can/can.c
@@ -405,6 +405,7 @@ static rt_err_t rt_can_close(struct rt_device *dev)
 
         rt_free(rx_fifo);
         dev->open_flag &= ~RT_DEVICE_FLAG_INT_RX;
+        can->can_rx = RT_NULL;
         /* configure low level device */
         can->ops->control(can, RT_DEVICE_CTRL_CLR_INT, (void *)RT_DEVICE_FLAG_INT_RX);
     }
@@ -418,6 +419,7 @@ static rt_err_t rt_can_close(struct rt_device *dev)
 
         rt_free(tx_fifo);
         dev->open_flag &= ~RT_DEVICE_FLAG_INT_TX;
+        can->can_tx = RT_NULL;
         /* configure low level device */
         can->ops->control(can, RT_DEVICE_CTRL_CLR_INT, (void *)RT_DEVICE_FLAG_INT_TX);
     }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
由于#2164 PR有部分争议，但关于CAN驱动的修改是完备的，故先行提交。
特别地：

1. 修改系统CAN驱动框架中关闭设备时对于接收和发送handler的处理，如果此处不恢复为空，在下次打开设备后，驱动将无法正常工作。
2. 修改STM32F4xx_hal中CAN驱动，使其在发生OV等异常中断后，能够继续使能其他正常中断。

]

以下的内容请在提交PR后，一项项进行check，没问题后逐条在页面上打钩。
The following contents should be checked item by item after submitted PR, and ticked on the browser one by one after no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
