### PR TITLE
Update serial.c

### DIFF
--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -566,13 +566,11 @@ static rt_err_t rt_serial_open(struct rt_device *dev, rt_uint16_t oflag)
 
     LOG_D("open serial device: 0x%08x with open flag: 0x%04x",
         dev, oflag);
-#ifdef RT_SERIAL_USING_DMA
     /* check device flag with the open flag */
     if ((oflag & RT_DEVICE_FLAG_DMA_RX) && !(dev->flag & RT_DEVICE_FLAG_DMA_RX))
         return -RT_EIO;
     if ((oflag & RT_DEVICE_FLAG_DMA_TX) && !(dev->flag & RT_DEVICE_FLAG_DMA_TX))
         return -RT_EIO;
-#endif /* RT_SERIAL_USING_DMA */
     if ((oflag & RT_DEVICE_FLAG_INT_RX) && !(dev->flag & RT_DEVICE_FLAG_INT_RX))
         return -RT_EIO;
     if ((oflag & RT_DEVICE_FLAG_INT_TX) && !(dev->flag & RT_DEVICE_FLAG_INT_TX))


### PR DESCRIPTION
"remove  #ifdef RT_SERIAL_USING_DMA in rt_serial_open， always check device open dma flag"

## 拉取/合并请求描述：(PR description)

[
    针对at client发送请求at_server响应超时的问题：
    测试条件：
        1. 串口未支持DMA驱动，同时关闭了宏 RT_SERIAL_USING_DMA
        2. 使用at_client_sample.c 测试程序

    测试步骤：
        1. at_client_init uart3    打开串口
        2. at_client_test          发送ATE0 指令， 超时等待at server响应

    测试结果：
        执行 at_client_init uart3  显示打开串口成功   [I/at.clnt] AT client(V1.2.0) on device uart3 initialize success.
        执行 at_client_test        显示超时


    问题发现：
        1. 通过追踪代码，调试等，发现在函数 at_client_init中打开串口的机制是：优选DMA方式打开，如果DMA方式打开失败，使用终端接受的方式打开
            at_client_init
                ->open_result = rt_device_open(client->device, RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_DMA_RX);   [优选DMA]
                    如果上述打开失败执行：->open_result = rt_device_open(client->device, RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_INT_RX); [使用INT方式]

        2. 因为我当前是关闭了RT_SERIAL_USING_DMA宏，且串口暂驱动未支持DMA，理论上，优选DMA方式打开肯定是要失败的，但是实际上使用DMA方式打开串口竟然成功了，
           那么，at server再怎么给at client发送数据，at client也是收不到的，因此显示超时

  问题解决：注释掉serial.c中RT_SERIAL_USING_DMA 

  当前已经在在efm32开发板上验证了
]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
