### PR TITLE
fix Kconfig syntax error

### DIFF
--- a/bsp/allwinner_tina/Kconfig
+++ b/bsp/allwinner_tina/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
@@ -13,7 +13,7 @@ config $RTT_DIR
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/amebaz/Kconfig
+++ b/bsp/amebaz/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
@@ -13,12 +13,12 @@ config $RTT_DIR
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"
     
-config $ENV_DIR
+config ENV_DIR
     string
     option env="ENV_ROOT"
     default "/"

--- a/bsp/asm9260t/Kconfig
+++ b/bsp/asm9260t/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/at91sam9260/Kconfig
+++ b/bsp/at91sam9260/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/beaglebone/Kconfig
+++ b/bsp/beaglebone/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
@@ -13,12 +13,12 @@ config $RTT_DIR
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example: default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"
     
-config $ENV_DIR
+config ENV_DIR
     string
     option env="ENV_ROOT"
     default "/"

--- a/bsp/ck802/Kconfig
+++ b/bsp/ck802/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
@@ -13,7 +13,7 @@ config $RTT_DIR
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/dm365/Kconfig
+++ b/bsp/dm365/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/gd32303e-eval/Kconfig
+++ b/bsp/gd32303e-eval/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/gd32450z-eval/Kconfig
+++ b/bsp/gd32450z-eval/Kconfig
@@ -8,7 +8,7 @@ config BSP_DIR
 config RTT_DIR
     string
     option env="RTT_ROOT"
-    default: "../.."
+    default "../.."
     
 # you can change the RTT_ROOT default: "rt-thread"
 # example : default "F:/git_repositories/rt-thread"

--- a/bsp/gd32450z-eval/Kconfig
+++ b/bsp/gd32450z-eval/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default: "../.."
@@ -13,7 +13,7 @@ config $RTT_DIR
 # you can change the RTT_ROOT default: "rt-thread"
 # example : default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/gkipc/Kconfig
+++ b/bsp/gkipc/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/hifive1/Kconfig
+++ b/bsp/hifive1/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/imx6sx/cortex-a9/Kconfig
+++ b/bsp/imx6sx/cortex-a9/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
@@ -13,12 +13,12 @@ config $RTT_DIR
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example: default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"
     
-config $ENV_DIR
+config ENV_DIR
     string
     option env="ENV_ROOT"
     default "/"

--- a/bsp/imx6ul/Kconfig
+++ b/bsp/imx6ul/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/imxrt/imxrt1050-ArchMix/Kconfig
+++ b/bsp/imxrt/imxrt1050-ArchMix/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/imxrt/imxrt1050-evk/Kconfig
+++ b/bsp/imxrt/imxrt1050-evk/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/imxrt1052-evk/Kconfig
+++ b/bsp/imxrt1052-evk/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/k210/Kconfig
+++ b/bsp/k210/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Project Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/lpc408x/Kconfig
+++ b/bsp/lpc408x/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Project Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/lpc54114-lite/Kconfig
+++ b/bsp/lpc54114-lite/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/lpc54608-LPCXpresso/Kconfig
+++ b/bsp/lpc54608-LPCXpresso/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
@@ -13,7 +13,7 @@ config $RTT_DIR
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/ls1cdev/Kconfig
+++ b/bsp/ls1cdev/Kconfig
@@ -1,17 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
     
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/nuvoton_m05x/Kconfig
+++ b/bsp/nuvoton_m05x/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/nuvoton_m487/Kconfig
+++ b/bsp/nuvoton_m487/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
@@ -13,7 +13,7 @@ config $RTT_DIR
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/qemu-vexpress-a9/Kconfig
+++ b/bsp/qemu-vexpress-a9/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Project Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/qemu-vexpress-gemini/Kconfig
+++ b/bsp/qemu-vexpress-gemini/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Project Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/raspi2/Kconfig
+++ b/bsp/raspi2/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Project Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/rv32m1_vega/ri5cy/Kconfig
+++ b/bsp/rv32m1_vega/ri5cy/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Project Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/simulator/Kconfig
+++ b/bsp/simulator/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/libraries/templates/stm32f0xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f0xx/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/libraries/templates/stm32f10x/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f10x/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/libraries/templates/stm32f4xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f4xx/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/libraries/templates/stm32f7xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f7xx/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/libraries/templates/stm32l4xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32l4xx/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f091-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f091-st-nucleo/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f103-atk-nano/Kconfig
+++ b/bsp/stm32/stm32f103-atk-nano/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f103-fire-arbitrary/Kconfig
+++ b/bsp/stm32/stm32f103-fire-arbitrary/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f407-atk-explorer/Kconfig
+++ b/bsp/stm32/stm32f407-atk-explorer/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f407-st-discovery/Kconfig
+++ b/bsp/stm32/stm32f407-st-discovery/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f411-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f411-st-nucleo/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f429-armfly-v6/Kconfig
+++ b/bsp/stm32/stm32f429-armfly-v6/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f429-atk-apollo/Kconfig
+++ b/bsp/stm32/stm32f429-atk-apollo/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f429-fire-challenger/Kconfig
+++ b/bsp/stm32/stm32f429-fire-challenger/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f446-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f446-st-nucleo/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f767-atk-apollo/Kconfig
+++ b/bsp/stm32/stm32f767-atk-apollo/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f767-fire-challenger/Kconfig
+++ b/bsp/stm32/stm32f767-fire-challenger/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32l475-atk-pandora/Kconfig
+++ b/bsp/stm32/stm32l475-atk-pandora/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32f107/Kconfig
+++ b/bsp/stm32f107/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
@@ -13,12 +13,12 @@ config $RTT_DIR
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example: default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"
     
-config $ENV_DIR
+config ENV_DIR
     string
     option env="ENV_ROOT"
     default "/"

--- a/bsp/stm32f10x-HAL/Kconfig
+++ b/bsp/stm32f10x-HAL/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32f10x/Kconfig
+++ b/bsp/stm32f10x/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Project Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32f20x/Kconfig
+++ b/bsp/stm32f20x/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Project Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32f40x/Kconfig
+++ b/bsp/stm32f40x/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Project Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32f411-nucleo/Kconfig
+++ b/bsp/stm32f411-nucleo/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32f429-apollo/Kconfig
+++ b/bsp/stm32f429-apollo/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32f429-armfly/Kconfig
+++ b/bsp/stm32f429-armfly/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32f429-disco/Kconfig
+++ b/bsp/stm32f429-disco/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
@@ -13,7 +13,7 @@ config $RTT_DIR
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32f4xx-HAL/Kconfig
+++ b/bsp/stm32f4xx-HAL/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32f7-disco/Kconfig
+++ b/bsp/stm32f7-disco/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default: "../.."
@@ -13,7 +13,7 @@ config $RTT_DIR
 # you can change the RTT_ROOT default: "../.."
 # example : default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32f7-disco/Kconfig
+++ b/bsp/stm32f7-disco/Kconfig
@@ -8,7 +8,7 @@ config BSP_DIR
 config RTT_DIR
     string
     option env="RTT_ROOT"
-    default: "../.."
+    default "../.."
     
 # you can change the RTT_ROOT default: "../.."
 # example : default "F:/git_repositories/rt-thread"

--- a/bsp/stm32h743-nucleo/Kconfig
+++ b/bsp/stm32h743-nucleo/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32l476-nucleo/Kconfig
+++ b/bsp/stm32l476-nucleo/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default: "../.."
@@ -13,7 +13,7 @@ config $RTT_DIR
 # you can change the RTT_ROOT default: "rt-thread"
 # example : default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32l476-nucleo/Kconfig
+++ b/bsp/stm32l476-nucleo/Kconfig
@@ -8,7 +8,7 @@ config BSP_DIR
 config RTT_DIR
     string
     option env="RTT_ROOT"
-    default: "../.."
+    default "../.."
 
 # you can change the RTT_ROOT default: "rt-thread"
 # example : default "F:/git_repositories/rt-thread"

--- a/bsp/swm320-lq100/Kconfig
+++ b/bsp/swm320-lq100/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/tm4c129x/Kconfig
+++ b/bsp/tm4c129x/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/tms320f28379d/Kconfig
+++ b/bsp/tms320f28379d/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
@@ -13,7 +13,7 @@ config $RTT_DIR
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/x1000/Kconfig
+++ b/bsp/x1000/Kconfig
@@ -1,11 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../.."
@@ -13,7 +13,7 @@ config $RTT_DIR
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

BSP 根目录的 Kconfig 文件存在语法错误，config 选项前面多了 "$"符号，导致 menuconfig 的时候提示警告信息，如下图所示：

![image](https://user-images.githubusercontent.com/29756486/51290040-8b113a00-1a3d-11e9-931a-512e50405f9f.png)

修改的文件已经一个个 check 过了。

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
