### PR TITLE
[bsp][stm32/libraries] 移除 flash 驱动中 flash write 函数对 size 对齐的限制

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f0.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f0.c
@@ -84,12 +84,6 @@ int stm32_flash_write(rt_uint32_t addr, const rt_uint8_t *buf, size_t size)
         return -RT_EINVAL;
     }
 
-    if (size % 4 != 0)
-    {
-        LOG_E("write size must be 4-byte alignment");
-        return -RT_EINVAL;
-    }
-
     if ((end_addr) > STM32_FLASH_END_ADDRESS)
     {
         LOG_E("write outrange flash size! addr is (0x%p)", (void *)(addr + size));

--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f1.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f1.c
@@ -84,12 +84,6 @@ int stm32_flash_write(rt_uint32_t addr, const rt_uint8_t *buf, size_t size)
         return -RT_EINVAL;
     }
 
-    if (size % 4 != 0)
-    {
-        LOG_E("write size must be 4-byte alignment");
-        return -RT_EINVAL;
-    }
-
     if ((end_addr) > STM32_FLASH_END_ADDRESS)
     {
         LOG_E("write outrange flash size! addr is (0x%p)", (void *)(addr + size));

--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_l4.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_l4.c
@@ -140,12 +140,6 @@ int stm32_flash_write(rt_uint32_t addr, const uint8_t *buf, size_t size)
         return -RT_EINVAL;
     }
 
-    if(size % 8 != 0)
-    {
-        LOG_E("write size must be 8-byte alignment");
-        return -RT_EINVAL;
-    }
-
     HAL_FLASH_Unlock();
 
     __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | FLASH_FLAG_PGSERR);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[bsp][stm32/libraries] 修复 drv_flash_l4.c 驱动中无法写入非8字节对齐的数据的限制，因为 L4 芯片要求 doubleworld 写入，在要求了写入地址是 8 字节对齐后，写入的数据会默认 8 字节对齐。

所有修改已经在 `stm32.stm32l475-atk-pandora` bsp 上得到验证。

同样，在 f0 和 f1 中也移除了 size 对齐限制的相关代码。

以下的内容请在提交PR后，一项项进行check，没问题后逐条在页面上打钩。
The following contents should be checked item by item after submitted PR, and ticked on the browser one by one after no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
