### PR TITLE
[lwIP] the errno definition of rt_libc.h is used by default.

### DIFF
--- a/components/net/lwip-2.0.2/src/arch/include/arch/cc.h
+++ b/components/net/lwip-2.0.2/src/arch/include/arch/cc.h
@@ -45,22 +45,6 @@
 #define S32_F "ld"
 #define X32_F "lx"
 
-#ifdef RT_USING_LIBC
-#if defined(__CC_ARM) || defined(__CLANG_ARM) || defined(__IAR_SYSTEMS_ICC__)
-#include <sys/errno.h>
-#else
-#include <errno.h>
-/* some errno not defined in newlib */
-#define ENSRNOTFOUND 163  /* Domain name not found */
-/* WARNING: ESHUTDOWN also not defined in newlib. We chose
-			180 here because the number "108" which is used
-			in arch.h has been assigned to another error code. */
-#define ESHUTDOWN 180
-#endif /* __CC_ARM/__IAR_SYSTEMS_ICC__ */
-#else
-#define LWIP_PROVIDE_ERRNO
-#endif
-
 #if defined(RT_USING_LIBC) || defined(RT_USING_MINILIBC)
 #include <sys/time.h>
 #define LWIP_TIMEVAL_PRIVATE	   0


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
解决 lwip 2.02 在未使能 LIBC 的情况下，errno 错误号重复定义的问题；
已在stm32f407-atk-explorer 上编译测试；
]

以下的内容请在提交PR后，一项项进行check，没问题后逐条在页面上打钩。
The following contents should be checked item by item after submitted PR, and ticked on the browser one by one after no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
