### PR TITLE
Fix libc posix

### DIFF
--- a/components/libc/aio/posix_aio.c
+++ b/components/libc/aio/posix_aio.c
@@ -170,7 +170,7 @@ static void aio_read_work(struct rt_work* work, void* work_data)
     if (len <= 0)
         cb->aio_result = errno;
     else 
-        cb->aio_result = 0;
+        cb->aio_result = len;
     rt_hw_interrupt_enable(level);
 
     return ;
@@ -321,6 +321,7 @@ static void aio_write_work(struct rt_work* work, void* work_data)
 
     return;
 }
+
 /**
  * The aio_write() function shall write aiocbp->aio_nbytes to the file associated 
  * with aiocbp->aio_fildes from the buffer pointed to by aiocbp->aio_buf. The 

--- a/components/libc/mmap/posix_mmap.c
+++ b/components/libc/mmap/posix_mmap.c
@@ -35,7 +35,7 @@ void *mmap(void *addr, size_t length, int prot, int flags,
         cur = lseek(fd, 0, SEEK_SET);
 
         lseek(fd, offset, SEEK_SET);
-        read_bytes = read(fd, addr, length);
+        read_bytes = read(fd, mem, length);
         if (read_bytes != length)
         {
             if (addr == RT_NULL)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

修正POSIX AIO中的aio_read_work返回值问题，应该返回读取到的长度；修正mmap中，当addr=0时，会造成0地址数据污染的问题；

以下的内容请在提交PR后，一项项进行check，没问题后逐条在页面上打钩。
The following contents should be checked item by item after submitted PR, and ticked on the browser one by one after no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
