### PR TITLE
实现_sys_flen()函数并解决了unistd.h和dirent.h不能同时包含的问题。

### DIFF
--- a/components/libc/compilers/armlibc/stubs.c
+++ b/components/libc/compilers/armlibc/stubs.c
@@ -265,7 +265,17 @@ void _sys_exit(int return_code)
  */
 long _sys_flen(FILEHANDLE fh)
 {
+    struct stat stat;
+    
+    if (fh < STDERR)
+        return -1;
+
+#ifndef RT_USING_DFS
     return -1;
+#else
+    fstat(fh, &stat);
+    return stat.st_size;
+#endif
 }
 
 int _sys_istty(FILEHANDLE fh)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
在这个PR中实现了_sys_flen()函数并解决了unistd.h和dirent.h不能同时包含的问题。

 `_sys_flen()`函数的文档[请看这里](http://www.keil.com/support/man/docs/armlib/armlib_chr1359122859809.htm)，在KEIL中，若要使用标准库中的`fseek()`函数需要实现`_sys_flen()`。本[实现](https://github.com/gztss/rt-thread/blob/7b5723f84d9b913b3fa892197dc68efcb1085fc8/components/libc/compilers/armlibc/stubs.c#L266)使用POSIX库中的`stat()`函数来获取文件尺寸。

这些改动已经在STM32L4 IOT Board开发板上测试过。
]

以下的内容请在提交PR后，一项项进行check，没问题后逐条在页面上打钩。
The following contents should be checked item by item after submitted PR, and ticked on the browser one by one after no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
