### PR TITLE
[Kernel] Fix rt_schedule_insert_thread issue

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -351,7 +351,7 @@ void rt_schedule(void)
                 RT_OBJECT_HOOK_CALL(rt_scheduler_hook, (current_thread, to_thread));
 
                 rt_schedule_remove_thread(to_thread);
-                to_thread->stat = RT_THREAD_RUNNING;
+                to_thread->stat = RT_THREAD_RUNNING | (to_thread->stat & ~RT_THREAD_STAT_MASK);
 
                 /* switch to new thread */
                 RT_DEBUG_LOG(RT_DEBUG_SCHEDULER,
@@ -412,6 +412,7 @@ void rt_schedule(void)
 
         if (rt_thread_ready_priority_group != 0)
         {
+            /* need_insert_from_thread: need to insert from_thread to ready queue */
             int need_insert_from_thread = 0;
 
             to_thread = _get_highest_priority_thread(&highest_ready_priority);
@@ -443,7 +444,7 @@ void rt_schedule(void)
                 }
 
                 rt_schedule_remove_thread(to_thread);
-                to_thread->stat = RT_THREAD_RUNNING;
+                to_thread->stat = RT_THREAD_RUNNING | (to_thread->stat & ~RT_THREAD_STAT_MASK);
 
                 /* switch to new thread */
                 RT_DEBUG_LOG(RT_DEBUG_SCHEDULER,
@@ -485,7 +486,7 @@ void rt_schedule(void)
             else
             {
                 rt_schedule_remove_thread(rt_current_thread);
-                rt_current_thread->stat = RT_THREAD_RUNNING;
+                rt_current_thread->stat = RT_THREAD_RUNNING | (rt_current_thread->stat & ~RT_THREAD_STAT_MASK);
             }
         }
     }
@@ -556,7 +557,7 @@ void rt_scheduler_do_irq_switch(void *context)
                 RT_OBJECT_HOOK_CALL(rt_scheduler_hook, (current_thread, to_thread));
 
                 rt_schedule_remove_thread(to_thread);
-                to_thread->stat = RT_THREAD_RUNNING;
+                to_thread->stat = RT_THREAD_RUNNING | (to_thread->stat & ~RT_THREAD_STAT_MASK);
 
 #ifdef RT_USING_OVERFLOW_CHECK
                 _rt_scheduler_stack_check(to_thread);
@@ -595,13 +596,15 @@ void rt_schedule_insert_thread(struct rt_thread *thread)
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
 
-    /* change stat */
-    thread->stat = RT_THREAD_READY | (thread->stat & ~RT_THREAD_STAT_MASK);
-
+    /* it should be RUNNING thread */
     if (thread->oncpu != RT_CPU_DETACHED)
     {
+        thread->stat = RT_THREAD_RUNNING | (thread->stat & ~RT_THREAD_STAT_MASK);
         goto __exit;
     }
+
+    /* READY thread, insert to ready queue */
+    thread->stat = RT_THREAD_READY | (thread->stat & ~RT_THREAD_STAT_MASK);
 
     cpu_id   = rt_hw_cpu_id();
     bind_cpu = thread->bind_cpu ;
@@ -655,14 +658,15 @@ void rt_schedule_insert_thread(struct rt_thread *thread)
     /* disable interrupt */
     temp = rt_hw_interrupt_disable();
 
-    /* change stat */
-    thread->stat = RT_THREAD_READY | (thread->stat & ~RT_THREAD_STAT_MASK);
-
+    /* it's current thread, it should be RUNNING thread */
     if (thread == rt_current_thread)
     {
+        thread->stat = RT_THREAD_RUNNING | (thread->stat & ~RT_THREAD_STAT_MASK);
         goto __exit;
     }
 
+    /* READY thread, insert to ready queue */
+    thread->stat = RT_THREAD_READY | (thread->stat & ~RT_THREAD_STAT_MASK);
     /* insert thread to ready list */
     rt_list_insert_before(&(rt_thread_priority_table[thread->current_priority]),
                           &(thread->tlist));


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

When suspend current thread and then enable interrupt, it's possible resume "the current thread" immediately and insert to ready queue. The rt_schedule_insert_thread should change  the status of "current thread" to RUNNING statue.

Test under IMXRT1050-EVK board with iPerf test.

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
