### PR TITLE
[component][utest] 增加 utest 日志输出级别配置

### DIFF
--- a/components/utilities/utest/utest.c
+++ b/components/utilities/utest/utest.c
@@ -8,9 +8,10 @@
  * 2018-11-19     MurphyZhao   the first version
  */
 
-#include "utest.h"
 #include <rtthread.h>
-#include <finsh.h>
+#include <string.h>
+#include "utest.h"
+#include <utest_log.h>
 
 #undef DBG_SECTION_NAME
 #undef DBG_LEVEL
@@ -31,6 +32,7 @@
 #error "RT_CONSOLEBUF_SIZE is less than 256!"
 #endif
 
+static rt_uint8_t utest_log_lv = UTEST_LOG_ALL;
 static utest_tc_export_t tc_table = RT_NULL;
 static rt_size_t tc_num;
 static struct utest local_utest = {UTEST_PASSED, 0, 0};
@@ -38,6 +40,14 @@ static struct utest local_utest = {UTEST_PASSED, 0, 0};
 #if defined(__ICCARM__) || defined(__ICCRX__)         /* for IAR compiler */
 #pragma section="UtestTcTab"
 #endif
+
+void utest_log_lv_set(rt_uint8_t lv)
+{
+    if (lv == UTEST_LOG_ALL || lv == UTEST_LOG_ASSERT)
+    {
+        utest_log_lv = lv;
+    }
+}
 
 int utest_init(void)
 {
@@ -200,7 +210,10 @@ void utest_assert(int value, const char *file, int line, const char *func, const
     }
     else
     {
-        LOG_D("[    OK    ] [ unit     ] (%s:%d) is passed", func, line);
+        if (utest_log_lv == UTEST_LOG_ALL)
+        {
+            LOG_D("[    OK    ] [ unit     ] (%s:%d) is passed", func, line);
+        }
         local_utest.error = UTEST_PASSED;
         local_utest.passed_num ++;
     }

--- a/components/utilities/utest/utest_log.h
+++ b/components/utilities/utest/utest_log.h
@@ -11,6 +11,8 @@
 #ifndef __UTEST_LOG_H__
 #define __UTEST_LOG_H__
 
+#include <rtthread.h>
+
 #define UTEST_DEBUG
 
 #undef DBG_SECTION_NAME
@@ -27,5 +29,10 @@
 #endif
 #define DBG_COLOR
 #include <rtdbg.h>
+
+#define UTEST_LOG_ALL    (1u)
+#define UTEST_LOG_ASSERT (2u)
+
+void utest_log_lv_set(rt_uint8_t lv);
 
 #endif /* __UTEST_LOG_H__ */


### PR DESCRIPTION
…g 输出

Signed-off-by: MurphyZhao <d2014zjt@163.com>

## 拉取/合并请求描述：(PR description)

增加 utest 日志输出级别配置，提供 ASSERT 和 ALL 两个级别，便于测试用例控制 log 输出。

**为什么只提供了两个级别？**

因为测试通过和测试失败的log是必须要输出的，能够控制的log就只有 assert 日志和 pass 日志，因此只提供了 ASSERT 级别的日志 和 ALL 全输出级别的日志。

设置了 ASSERT 级别的日志后，assert  的日志会输出，assert 通过的日志不会输出。

**测试：**

在 QEMU 和 F429 bsp 上测试通过。

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
