### PR TITLE
fix lwip2.1.0 port bug

### DIFF
--- a/components/net/lwip-2.1.0/src/arch/sys_arch.c
+++ b/components/net/lwip-2.1.0/src/arch/sys_arch.c
@@ -49,6 +49,8 @@
 #include "lwip/dhcp.h"
 #include "lwip/inet.h"
 
+#include "netif/etharp.h"
+
 #include <string.h>
 #include <stdio.h>
 
@@ -75,6 +77,10 @@ static err_t netif_device_init(struct netif *netif)
 
         /* copy device flags to netif flags */
         netif->flags = ethif->flags;
+        netif->mtu = ETHERNET_MTU;
+        
+        /* set output */
+        netif->output = etharp_output;
 
         return ERR_OK;
     }

--- a/components/net/lwip-2.1.0/src/netif/ethernetif.c
+++ b/components/net/lwip-2.1.0/src/netif/ethernetif.c
@@ -156,6 +156,9 @@ static err_t eth_netif_device_init(struct netif *netif)
         /* copy device flags to netif flags */
         netif->flags = (ethif->flags & 0xff);
         netif->mtu = ETHERNET_MTU;
+        
+        /* set output */
+        netif->output       = etharp_output;
 
 #if LWIP_IPV6
         netif->output_ip6 = ethip6_output;
@@ -239,6 +242,9 @@ rt_err_t eth_device_init_with_flag(struct eth_device *dev, char *name, rt_uint16
     /* maximum transfer unit */
     netif->mtu          = ETHERNET_MTU;
 
+    /* set linkoutput */
+    netif->linkoutput   = ethernetif_linkoutput;
+        
     /* get hardware MAC address */
     rt_device_control(&(dev->parent), NIOCTL_GADDR, netif->hwaddr);
 
@@ -262,10 +268,6 @@ rt_err_t eth_device_init_with_flag(struct eth_device *dev, char *name, rt_uint16
         IP4_ADDR(&netmask, 0, 0, 0, 0);
 #endif
         netifapi_netif_add(netif, &ipaddr, &netmask, &gw, dev, eth_netif_device_init, tcpip_input);
-
-        /* set output */
-        netif->output       = etharp_output;
-        netif->linkoutput   = ethernetif_linkoutput;
     }
 
     return RT_EOK;


### PR DESCRIPTION
fix lwip2.1.0 port bug

## 拉取/合并请求描述：(PR description)

[
fix lwip2.1.0 port bug
test: nuc977 with eth0 on chip.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
