### PR TITLE
[BSP] Fixed imxrt1050 gpio driver | 修复 imxrt1050 gpio 驱动

### DIFF
--- a/bsp/imxrt/Libraries/imxrt1050/drivers/drv_pin.c
+++ b/bsp/imxrt/Libraries/imxrt1050/drivers/drv_pin.c
@@ -8,41 +8,41 @@
  * 2018-03-13     Liuguang     the first version.
  * 2018-03-19     Liuguang     add GPIO interrupt mode support.
  */
-#include "drv_pin.h" 
+#include "drv_pin.h"
 
-#include "fsl_common.h" 
-#include "fsl_iomuxc.h" 
-#include "fsl_gpio.h" 
+#include "fsl_common.h"
+#include "fsl_iomuxc.h"
+#include "fsl_gpio.h"
 
 #ifdef RT_USING_PIN
 
 #if defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL
-    #error "Please don't define 'FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL'!"
+#error "Please don't define 'FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL'!"
 #endif
 
 struct rt1052_pin
 {
-    rt_uint16_t   pin; 
-    GPIO_Type    *gpio; 
-    rt_uint32_t   gpio_pin; 
-}; 
+    rt_uint16_t   pin;
+    GPIO_Type    *gpio;
+    rt_uint32_t   gpio_pin;
+};
 
 struct rt1052_irq
 {
-    rt_uint16_t           enable; 
-    struct rt_pin_irq_hdr irq_info; 
+    rt_uint16_t           enable;
+    struct rt_pin_irq_hdr irq_info;
 };
 
-#define __ARRAY_LEN(array) (sizeof(array)/sizeof(array[0])) 
-#define __RT1052_PIN_DEFAULT {0, 0, 0} 
-#define __RT1052_PIN(INDEX, PORT, PIN) {INDEX, PORT, PIN} 
+#define __ARRAY_LEN(array) (sizeof(array)/sizeof(array[0]))
+#define __RT1052_PIN_DEFAULT {0, 0, 0}
+#define __RT1052_PIN(INDEX, PORT, PIN) {INDEX, PORT, PIN}
 
-static struct rt_pin_ops rt1052_pin_ops; 
+static struct rt_pin_ops rt1052_pin_ops;
 
-static struct rt1052_pin rt1052_pin_map[] = 
+static struct rt1052_pin rt1052_pin_map[] =
 {
-    __RT1052_PIN_DEFAULT, 
-    
+    __RT1052_PIN_DEFAULT,
+
     /* GPIO4 */
     __RT1052_PIN( 1, GPIO4,  0),    /* GPIO_EMC_00 */
     __RT1052_PIN( 2, GPIO4,  1),    /* GPIO_EMC_01 */
@@ -76,7 +76,7 @@ static struct rt1052_pin rt1052_pin_map[] =
     __RT1052_PIN(30, GPIO4, 29),    /* GPIO_EMC_29 */
     __RT1052_PIN(31, GPIO4, 30),    /* GPIO_EMC_30 */
     __RT1052_PIN(32, GPIO4, 31),    /* GPIO_EMC_31 */
-    
+
     __RT1052_PIN(33, GPIO3, 18),    /* GPIO_EMC_32 */
     __RT1052_PIN(34, GPIO3, 19),    /* GPIO_EMC_33 */
     __RT1052_PIN(35, GPIO3, 20),    /* GPIO_EMC_34 */
@@ -86,10 +86,10 @@ static struct rt1052_pin rt1052_pin_map[] =
     __RT1052_PIN(39, GPIO3, 24),    /* GPIO_EMC_38 */
     __RT1052_PIN(40, GPIO3, 25),    /* GPIO_EMC_39 */
     __RT1052_PIN(41, GPIO3, 26),    /* GPIO_EMC_40 */
-    __RT1052_PIN(42, GPIO3, 27),    /* GPIO_EMC_41 */ 
-    
+    __RT1052_PIN(42, GPIO3, 27),    /* GPIO_EMC_41 */
+
     /* GPIO1 */
-    __RT1052_PIN(43, GPIO1,  0),    /* GPIO_AD_B0_00 */ 
+    __RT1052_PIN(43, GPIO1,  0),    /* GPIO_AD_B0_00 */
     __RT1052_PIN(44, GPIO1,  1),    /* GPIO_AD_B0_01 */
     __RT1052_PIN(45, GPIO1,  2),    /* GPIO_AD_B0_02 */
     __RT1052_PIN(46, GPIO1,  3),    /* GPIO_AD_B0_03 */
@@ -155,7 +155,7 @@ static struct rt1052_pin rt1052_pin_map[] =
     __RT1052_PIN(104, GPIO2, 29),    /* GPIO_B1_13 */
     __RT1052_PIN(105, GPIO2, 30),    /* GPIO_B1_14 */
     __RT1052_PIN(106, GPIO2, 31),    /* GPIO_B1_15 */
-    
+
     /* GPIO3 */
     __RT1052_PIN(107, GPIO3,  0),    /* GPIO_SD_B1_00 */
     __RT1052_PIN(108, GPIO3,  1),    /* GPIO_SD_B1_01 */
@@ -180,9 +180,9 @@ static struct rt1052_pin rt1052_pin_map[] =
     __RT1052_PIN(125, GPIO5,  0),    /* WAKEUP */
     __RT1052_PIN(126, GPIO5,  1),    /* PMIC_ON_REQ */
     __RT1052_PIN(127, GPIO5,  2)     /* PMIC_STBY_REQ */
-}; 
+};
 
-static struct rt1052_irq rt1052_irq_map[] = 
+static struct rt1052_irq rt1052_irq_map[] =
 {
     {PIN_IRQ_DISABLE, {PIN_IRQ_PIN_NONE, PIN_IRQ_MODE_RISING, RT_NULL, RT_NULL} },
     {PIN_IRQ_DISABLE, {PIN_IRQ_PIN_NONE, PIN_IRQ_MODE_RISING, RT_NULL, RT_NULL} },
@@ -216,11 +216,11 @@ static struct rt1052_irq rt1052_irq_map[] =
     {PIN_IRQ_DISABLE, {PIN_IRQ_PIN_NONE, PIN_IRQ_MODE_RISING, RT_NULL, RT_NULL} },
     {PIN_IRQ_DISABLE, {PIN_IRQ_PIN_NONE, PIN_IRQ_MODE_RISING, RT_NULL, RT_NULL} },
     {PIN_IRQ_DISABLE, {PIN_IRQ_PIN_NONE, PIN_IRQ_MODE_RISING, RT_NULL, RT_NULL} }
-}; 
+};
 
-void gpio_isr(GPIO_Type* base, rt_uint32_t gpio_pin)
+void gpio_isr(GPIO_Type *base, rt_uint32_t gpio_pin)
 {
-    if((GPIO_PortGetInterruptFlags(base) & (1 << gpio_pin)) != 0)
+    if ((GPIO_PortGetInterruptFlags(base) & (1 << gpio_pin)) != 0)
     {
         GPIO_PortClearInterruptFlags(base, (1 << gpio_pin));
 
@@ -233,124 +233,124 @@ void gpio_isr(GPIO_Type* base, rt_uint32_t gpio_pin)
 
 void GPIO1_Combined_0_15_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
-    
+    rt_uint8_t gpio_pin;
+
     rt_interrupt_enter();
 
-    for(gpio_pin = 0; gpio_pin <= 15; gpio_pin++)
+    for (gpio_pin = 0; gpio_pin <= 15; gpio_pin++)
     {
-        gpio_isr(GPIO1, gpio_pin); 
+        gpio_isr(GPIO1, gpio_pin);
     }
-    
+
     rt_interrupt_leave();
 }
 
 void GPIO1_Combined_16_31_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
-    
+    rt_uint8_t gpio_pin;
+
     rt_interrupt_enter();
 
-    for(gpio_pin = 16; gpio_pin <= 31; gpio_pin++)
+    for (gpio_pin = 16; gpio_pin <= 31; gpio_pin++)
     {
-        gpio_isr(GPIO1, gpio_pin); 
+        gpio_isr(GPIO1, gpio_pin);
     }
-    
+
     rt_interrupt_leave();
 }
 
 void GPIO2_Combined_0_15_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
-    
+    rt_uint8_t gpio_pin;
+
     rt_interrupt_enter();
 
-    for(gpio_pin = 0; gpio_pin <= 15; gpio_pin++)
+    for (gpio_pin = 0; gpio_pin <= 15; gpio_pin++)
     {
-        gpio_isr(GPIO2, gpio_pin); 
+        gpio_isr(GPIO2, gpio_pin);
     }
-    
+
     rt_interrupt_leave();
 }
 
 void GPIO2_Combined_16_31_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
-    
+    rt_uint8_t gpio_pin;
+
     rt_interrupt_enter();
 
-    for(gpio_pin = 16; gpio_pin <= 31; gpio_pin++)
+    for (gpio_pin = 16; gpio_pin <= 31; gpio_pin++)
     {
-        gpio_isr(GPIO2, gpio_pin); 
+        gpio_isr(GPIO2, gpio_pin);
     }
-    
+
     rt_interrupt_leave();
 }
 
-void GPIO3_Combined_0_15_IRQHandler(void) 
+void GPIO3_Combined_0_15_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
-    
+    rt_uint8_t gpio_pin;
+
     rt_interrupt_enter();
 
-    for(gpio_pin = 0; gpio_pin <= 15; gpio_pin++)
+    for (gpio_pin = 0; gpio_pin <= 15; gpio_pin++)
     {
-        gpio_isr(GPIO3, gpio_pin); 
+        gpio_isr(GPIO3, gpio_pin);
     }
-    
+
     rt_interrupt_leave();
 }
 
 void GPIO3_Combined_16_31_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
-    
+    rt_uint8_t gpio_pin;
+
     rt_interrupt_enter();
 
-    for(gpio_pin = 16; gpio_pin <= 31; gpio_pin++)
+    for (gpio_pin = 16; gpio_pin <= 31; gpio_pin++)
     {
-        gpio_isr(GPIO3, gpio_pin); 
+        gpio_isr(GPIO3, gpio_pin);
     }
-    
+
     rt_interrupt_leave();
 }
 
 void GPIO4_Combined_0_15_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
-    
+    rt_uint8_t gpio_pin;
+
     rt_interrupt_enter();
 
-    for(gpio_pin = 0; gpio_pin <= 15; gpio_pin++)
+    for (gpio_pin = 0; gpio_pin <= 15; gpio_pin++)
     {
-        gpio_isr(GPIO4, gpio_pin); 
+        gpio_isr(GPIO4, gpio_pin);
     }
-    
+
     rt_interrupt_leave();
 }
 void GPIO4_Combined_16_31_IRQHandler(void)
 {
-    rt_uint8_t gpio_pin; 
-    
+    rt_uint8_t gpio_pin;
+
     rt_interrupt_enter();
 
-    for(gpio_pin = 16; gpio_pin <= 31; gpio_pin++)
+    for (gpio_pin = 16; gpio_pin <= 31; gpio_pin++)
     {
-        gpio_isr(GPIO4, gpio_pin); 
+        gpio_isr(GPIO4, gpio_pin);
     }
-    
+
     rt_interrupt_leave();
 }
 
 void GPIO5_Combined_0_15_IRQHandler(void)
-{ 
-    rt_uint8_t gpio_pin; 
-    
+{
+    rt_uint8_t gpio_pin;
+
     rt_interrupt_enter();
 
-    for(gpio_pin = 0; gpio_pin <= 2; gpio_pin++)
+    for (gpio_pin = 0; gpio_pin <= 2; gpio_pin++)
     {
-        gpio_isr(GPIO5, gpio_pin); 
+        gpio_isr(GPIO5, gpio_pin);
     }
 
     rt_interrupt_leave();
@@ -359,143 +359,143 @@ void GPIO5_Combined_0_15_IRQHandler(void)
 static IRQn_Type rt1052_get_irqnum(GPIO_Type *gpio, rt_uint32_t gpio_pin)
 {
     IRQn_Type irq_num = NotAvail_IRQn;  /* Invalid interrupt number */
-    
-    if(gpio == GPIO1)
+
+    if (gpio == GPIO1)
     {
-        if(gpio_pin <= 15)
+        if (gpio_pin <= 15)
         {
-            irq_num = GPIO1_Combined_0_15_IRQn; 
+            irq_num = GPIO1_Combined_0_15_IRQn;
         }
         else
         {
-            irq_num = GPIO1_Combined_16_31_IRQn; 
+            irq_num = GPIO1_Combined_16_31_IRQn;
         }
     }
-    else if(gpio == GPIO2)
+    else if (gpio == GPIO2)
     {
-        if(gpio_pin <= 15)
+        if (gpio_pin <= 15)
         {
-            irq_num = GPIO2_Combined_0_15_IRQn; 
+            irq_num = GPIO2_Combined_0_15_IRQn;
         }
         else
         {
-            irq_num = GPIO2_Combined_16_31_IRQn; 
+            irq_num = GPIO2_Combined_16_31_IRQn;
         }
     }
-    else if(gpio == GPIO3)
+    else if (gpio == GPIO3)
     {
-        if(gpio_pin <= 15)
+        if (gpio_pin <= 15)
         {
-            irq_num = GPIO3_Combined_0_15_IRQn; 
+            irq_num = GPIO3_Combined_0_15_IRQn;
         }
         else
         {
-            irq_num = GPIO3_Combined_16_31_IRQn; 
+            irq_num = GPIO3_Combined_16_31_IRQn;
         }
     }
-    else if(gpio == GPIO4)
+    else if (gpio == GPIO4)
     {
-        if(gpio_pin <= 15)
+        if (gpio_pin <= 15)
         {
-            irq_num = GPIO4_Combined_0_15_IRQn; 
+            irq_num = GPIO4_Combined_0_15_IRQn;
         }
         else
         {
-            irq_num = GPIO4_Combined_16_31_IRQn; 
+            irq_num = GPIO4_Combined_16_31_IRQn;
         }
     }
-    else if(gpio == GPIO5)
+    else if (gpio == GPIO5)
     {
-        if(gpio_pin <= 15)
+        if (gpio_pin <= 15)
         {
-            irq_num = GPIO5_Combined_0_15_IRQn; 
+            irq_num = GPIO5_Combined_0_15_IRQn;
         }
         else
         {
-            irq_num = GPIO5_Combined_16_31_IRQn; 
+            irq_num = GPIO5_Combined_16_31_IRQn;
         }
     }
-    
-    return irq_num; 
+
+    return irq_num;
 }
 
 static void rt1052_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
 {
-    gpio_pin_config_t gpio; 
-    rt_uint32_t config_value = 0; 
-    
-    if((pin > __ARRAY_LEN(rt1052_pin_map)) || (pin == 0))
+    gpio_pin_config_t gpio;
+    rt_uint32_t config_value = 0;
+
+    if ((pin > __ARRAY_LEN(rt1052_pin_map)) || (pin == 0))
     {
-        return; 
+        return;
     }
-    
-    if(rt1052_pin_map[pin].gpio != GPIO5)
+
+    if (rt1052_pin_map[pin].gpio != GPIO5)
     {
-        CLOCK_EnableClock(kCLOCK_Iomuxc); 
-        IOMUXC_SetPinMux(0x401F8010U + pin*4, 0x5U, 0, 0, 0, 1); 
+        CLOCK_EnableClock(kCLOCK_Iomuxc);
+        IOMUXC_SetPinMux(0x401F8010U + pin * 4, 0x5U, 0, 0, 0, 1);
     }
     else
     {
-        CLOCK_EnableClock(kCLOCK_IomuxcSnvs); 
-        IOMUXC_SetPinMux(0x400A8000U + (pin-125)*4, 0x5U, 0, 0, 0, 1); 
-    }
-    
-    gpio.outputLogic = 0; 
-    gpio.interruptMode = kGPIO_NoIntmode; 
-    
-    switch(mode)
-    {
-        case PIN_MODE_OUTPUT:
-        {
-            config_value = 0x0030U;/* Drive Strength R0/6 */
-            gpio.direction = kGPIO_DigitalOutput;
-        }
-        break;
-
-        case PIN_MODE_INPUT:
-        {
-            config_value = 0x0830U;/* Open Drain Enable */
-            gpio.direction = kGPIO_DigitalInput;
-        }
-        break;
-
-        case PIN_MODE_INPUT_PULLDOWN:
-        {
-            config_value = 0x3030U;/* 100K Ohm Pull Down */
-            gpio.direction = kGPIO_DigitalInput;
-        }
-        break;
-
-        case PIN_MODE_INPUT_PULLUP:
-        {
-            config_value = 0xB030U;/* 100K Ohm Pull Up */
-            gpio.direction = kGPIO_DigitalInput;
-        }
-        break;
-
-        case PIN_MODE_OUTPUT_OD:
-        {
-            config_value = 0x0830U;/* Open Drain Enable */
-            gpio.direction = kGPIO_DigitalOutput;
-        }
-        break;
+        CLOCK_EnableClock(kCLOCK_IomuxcSnvs);
+        IOMUXC_SetPinMux(0x400A8000U + (pin - 125) * 4, 0x5U, 0, 0, 0, 1);
     }
 
-    if(rt1052_pin_map[pin].gpio != GPIO5)
+    gpio.outputLogic = 0;
+    gpio.interruptMode = kGPIO_NoIntmode;
+
+    switch (mode)
     {
-        IOMUXC_SetPinConfig(0, 0, 0, 0, 0x401F8200U + pin*4, config_value); 
+    case PIN_MODE_OUTPUT:
+    {
+        config_value = 0x0030U;/* Drive Strength R0/6 */
+        gpio.direction = kGPIO_DigitalOutput;
+    }
+    break;
+
+    case PIN_MODE_INPUT:
+    {
+        config_value = 0x0830U;/* Open Drain Enable */
+        gpio.direction = kGPIO_DigitalInput;
+    }
+    break;
+
+    case PIN_MODE_INPUT_PULLDOWN:
+    {
+        config_value = 0x3030U;/* 100K Ohm Pull Down */
+        gpio.direction = kGPIO_DigitalInput;
+    }
+    break;
+
+    case PIN_MODE_INPUT_PULLUP:
+    {
+        config_value = 0xB030U;/* 100K Ohm Pull Up */
+        gpio.direction = kGPIO_DigitalInput;
+    }
+    break;
+
+    case PIN_MODE_OUTPUT_OD:
+    {
+        config_value = 0x0830U;/* Open Drain Enable */
+        gpio.direction = kGPIO_DigitalOutput;
+    }
+    break;
+    }
+
+    if (rt1052_pin_map[pin].gpio != GPIO5)
+    {
+        IOMUXC_SetPinConfig(0, 0, 0, 0, 0x401F8200U + pin * 4, config_value);
     }
     else
     {
-        IOMUXC_SetPinConfig(0, 0, 0, 0, 0x400A8018U + (pin-125)*4, config_value); 
+        IOMUXC_SetPinConfig(0, 0, 0, 0, 0x400A8018U + (pin - 125) * 4, config_value);
     }
-    
-    GPIO_PinInit(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin, &gpio); 
+
+    GPIO_PinInit(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin, &gpio);
 }
 
 static int rt1052_pin_read(rt_device_t dev, rt_base_t pin)
 {
-    return GPIO_PinReadPadStatus(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin); 
+    return GPIO_PinReadPadStatus(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin);
 }
 
 static void rt1052_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
@@ -504,61 +504,61 @@ static void rt1052_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
 }
 
 static rt_err_t rt1052_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-    rt_uint32_t mode, void (*hdr)(void *args), void *args)
+                                      rt_uint32_t mode, void (*hdr)(void *args), void *args)
 {
-    struct rt1052_pin* pin_map = RT_NULL; 
-    struct rt1052_irq* irq_map = RT_NULL; 
-    
-    pin_map = &rt1052_pin_map[pin]; 
-    irq_map = &rt1052_irq_map[rt1052_pin_map[pin].gpio_pin]; 
-    
-    if(pin_map == RT_NULL || irq_map == RT_NULL) 
+    struct rt1052_pin *pin_map = RT_NULL;
+    struct rt1052_irq *irq_map = RT_NULL;
+
+    pin_map = &rt1052_pin_map[pin];
+    irq_map = &rt1052_irq_map[rt1052_pin_map[pin].gpio_pin];
+
+    if (pin_map == RT_NULL || irq_map == RT_NULL)
     {
-        return RT_ENOSYS; 
+        return RT_ENOSYS;
     }
-    
-    if(irq_map->enable == PIN_IRQ_ENABLE)
+
+    if (irq_map->enable == PIN_IRQ_ENABLE)
     {
-        return RT_EBUSY; 
+        return RT_EBUSY;
     }
-    
-    irq_map->irq_info.pin  = pin; 
-    irq_map->irq_info.hdr  = hdr; 
-    irq_map->irq_info.mode = mode; 
-    irq_map->irq_info.args = args; 
-    
+
+    irq_map->irq_info.pin  = pin;
+    irq_map->irq_info.hdr  = hdr;
+    irq_map->irq_info.mode = mode;
+    irq_map->irq_info.args = args;
+
     return RT_EOK;
 }
 
 static rt_err_t rt1052_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
 {
-    struct rt1052_pin* pin_map = RT_NULL; 
-    struct rt1052_irq* irq_map = RT_NULL; 
-    
-    pin_map = &rt1052_pin_map[pin]; 
-    irq_map = &rt1052_irq_map[rt1052_pin_map[pin].gpio_pin]; 
-    
-    if(pin_map == RT_NULL || irq_map == RT_NULL) 
+    struct rt1052_pin *pin_map = RT_NULL;
+    struct rt1052_irq *irq_map = RT_NULL;
+
+    pin_map = &rt1052_pin_map[pin];
+    irq_map = &rt1052_irq_map[rt1052_pin_map[pin].gpio_pin];
+
+    if (pin_map == RT_NULL || irq_map == RT_NULL)
     {
-        return RT_ENOSYS; 
+        return RT_ENOSYS;
     }
-    
-    if(irq_map->enable == PIN_IRQ_DISABLE)
+
+    if (irq_map->enable == PIN_IRQ_DISABLE)
     {
-        return RT_EOK; 
+        return RT_EOK;
     }
-    
-    irq_map->irq_info.pin  = PIN_IRQ_PIN_NONE; 
-    irq_map->irq_info.hdr  = RT_NULL; 
-    irq_map->irq_info.mode = PIN_IRQ_MODE_RISING; 
-    irq_map->irq_info.args = RT_NULL; 
-    
+
+    irq_map->irq_info.pin  = PIN_IRQ_PIN_NONE;
+    irq_map->irq_info.hdr  = RT_NULL;
+    irq_map->irq_info.mode = PIN_IRQ_MODE_RISING;
+    irq_map->irq_info.args = RT_NULL;
+
     return RT_EOK;
 }
 
 static rt_err_t rt1052_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
 {
-    gpio_pin_config_t gpio; 
+    gpio_pin_config_t gpio;
     IRQn_Type irq_num;
     rt_uint32_t config_value = 0;
     struct rt1052_pin *pin_map = RT_NULL;
@@ -569,24 +569,24 @@ static rt_err_t rt1052_pin_irq_enable(struct rt_device *device, rt_base_t pin, r
 
     if (pin_map == RT_NULL || irq_map == RT_NULL)
     {
-        return RT_ENOSYS; 
+        return RT_ENOSYS;
     }
-    
-    if(enabled == PIN_IRQ_ENABLE) 
+
+    if (enabled == PIN_IRQ_ENABLE)
     {
-        if(irq_map->enable == PIN_IRQ_ENABLE)
+        if (irq_map->enable == PIN_IRQ_ENABLE)
         {
-            return RT_EBUSY; 
+            return RT_EBUSY;
         }
-        
-        if(irq_map->irq_info.pin != pin)
+
+        if (irq_map->irq_info.pin != pin)
         {
-            return RT_EIO; 
+            return RT_EIO;
         }
-        
-        irq_map->enable = PIN_IRQ_ENABLE; 
-        
-        if(rt1052_pin_map[pin].gpio != GPIO5)
+
+        irq_map->enable = PIN_IRQ_ENABLE;
+
+        if (rt1052_pin_map[pin].gpio != GPIO5)
         {
             CLOCK_EnableClock(kCLOCK_Iomuxc);
             IOMUXC_SetPinMux(0x401F8010U + pin * 4, 0x5U, 0, 0, 0, 1);
@@ -596,100 +596,100 @@ static rt_err_t rt1052_pin_irq_enable(struct rt_device *device, rt_base_t pin, r
             CLOCK_EnableClock(kCLOCK_IomuxcSnvs);
             IOMUXC_SetPinMux(0x400A8000U + (pin - 125) * 4, 0x5U, 0, 0, 0, 1);
         }
-        
-        gpio.direction     = kGPIO_DigitalInput; 
-        gpio.outputLogic   = 0; 
-        
-        switch(irq_map->irq_info.mode)
+
+        gpio.direction     = kGPIO_DigitalInput;
+        gpio.outputLogic   = 0;
+
+        switch (irq_map->irq_info.mode)
         {
-            case PIN_IRQ_MODE_RISING:
-            {
-                config_value = 0x3030U;/* 100K Ohm Pull Down */
-                gpio.interruptMode = kGPIO_IntRisingEdge;
-            }
-            break;
-
-            case PIN_IRQ_MODE_FALLING:
-            {
-                config_value = 0xB030U;/* 100K Ohm Pull Up */
-                gpio.interruptMode = kGPIO_IntFallingEdge;
-            }
-            break;
-
-            case PIN_IRQ_MODE_RISING_FALLING:
-            {
-                config_value = 0x0830U;/* Open Drain Enable */
-                gpio.interruptMode = kGPIO_IntRisingOrFallingEdge;
-            }
-            break;
-
-            case PIN_IRQ_MODE_HIGH_LEVEL:
-            {
-                config_value = 0x3030U;/* 100K Ohm Pull Down */
-                gpio.interruptMode = kGPIO_IntHighLevel;
-            }
-            break;
-
-            case PIN_IRQ_MODE_LOW_LEVEL:
-            {
-                config_value = 0xB030U;/* 100K Ohm Pull Up */
-                gpio.interruptMode = kGPIO_IntLowLevel;
-            }
-            break;
+        case PIN_IRQ_MODE_RISING:
+        {
+            config_value = 0x3030U;/* 100K Ohm Pull Down */
+            gpio.interruptMode = kGPIO_IntRisingEdge;
         }
-        
-        if(rt1052_pin_map[pin].gpio != GPIO5)
+        break;
+
+        case PIN_IRQ_MODE_FALLING:
         {
-            IOMUXC_SetPinConfig(0, 0, 0, 0, 0x401F8200U + pin*4, config_value); 
+            config_value = 0xB030U;/* 100K Ohm Pull Up */
+            gpio.interruptMode = kGPIO_IntFallingEdge;
+        }
+        break;
+
+        case PIN_IRQ_MODE_RISING_FALLING:
+        {
+            config_value = 0x0830U;/* Open Drain Enable */
+            gpio.interruptMode = kGPIO_IntRisingOrFallingEdge;
+        }
+        break;
+
+        case PIN_IRQ_MODE_HIGH_LEVEL:
+        {
+            config_value = 0x3030U;/* 100K Ohm Pull Down */
+            gpio.interruptMode = kGPIO_IntHighLevel;
+        }
+        break;
+
+        case PIN_IRQ_MODE_LOW_LEVEL:
+        {
+            config_value = 0xB030U;/* 100K Ohm Pull Up */
+            gpio.interruptMode = kGPIO_IntLowLevel;
+        }
+        break;
+        }
+
+        if (rt1052_pin_map[pin].gpio != GPIO5)
+        {
+            IOMUXC_SetPinConfig(0, 0, 0, 0, 0x401F8200U + pin * 4, config_value);
         }
         else
         {
-            IOMUXC_SetPinConfig(0, 0, 0, 0, 0x400A8018U + (pin-125)*4, config_value); 
+            IOMUXC_SetPinConfig(0, 0, 0, 0, 0x400A8018U + (pin - 125) * 4, config_value);
         }
-        
-        irq_num = rt1052_get_irqnum(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin); 
-        
+
+        irq_num = rt1052_get_irqnum(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin);
+
         NVIC_SetPriority(irq_num, NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 5, 0));
         EnableIRQ(irq_num);
-        
-        GPIO_PinInit(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin, &gpio); 
-        GPIO_PortEnableInterrupts(rt1052_pin_map[pin].gpio, 1U << rt1052_pin_map[pin].gpio_pin); 
+
+        GPIO_PinInit(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin, &gpio);
+        GPIO_PortEnableInterrupts(rt1052_pin_map[pin].gpio, 1U << rt1052_pin_map[pin].gpio_pin);
     }
-    else if(enabled == PIN_IRQ_DISABLE)
+    else if (enabled == PIN_IRQ_DISABLE)
     {
-        if(irq_map->enable == PIN_IRQ_DISABLE)
+        if (irq_map->enable == PIN_IRQ_DISABLE)
         {
-            return RT_EOK; 
+            return RT_EOK;
         }
-        
+
         irq_map->enable = PIN_IRQ_DISABLE;
-        irq_num = rt1052_get_irqnum(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin); 
-        
+        irq_num = rt1052_get_irqnum(rt1052_pin_map[pin].gpio, rt1052_pin_map[pin].gpio_pin);
+
         NVIC_DisableIRQ(irq_num);
     }
     else
     {
-        return RT_EINVAL; 
+        return RT_EINVAL;
     }
-    
+
     return RT_EOK;
 }
 
 int rt_hw_pin_init(void)
 {
-    int ret = RT_EOK; 
-    
-    rt1052_pin_ops.pin_mode        = rt1052_pin_mode; 
-    rt1052_pin_ops.pin_read        = rt1052_pin_read; 
-    rt1052_pin_ops.pin_write       = rt1052_pin_write; 
-    rt1052_pin_ops.pin_attach_irq  = rt1052_pin_attach_irq; 
+    int ret = RT_EOK;
+
+    rt1052_pin_ops.pin_mode        = rt1052_pin_mode;
+    rt1052_pin_ops.pin_read        = rt1052_pin_read;
+    rt1052_pin_ops.pin_write       = rt1052_pin_write;
+    rt1052_pin_ops.pin_attach_irq  = rt1052_pin_attach_irq;
     rt1052_pin_ops.pin_detach_irq  = rt1052_pin_detach_irq;
-    rt1052_pin_ops.pin_irq_enable  = rt1052_pin_irq_enable; 
-    
+    rt1052_pin_ops.pin_irq_enable  = rt1052_pin_irq_enable;
+
     ret = rt_device_pin_register("pin", &rt1052_pin_ops, RT_NULL);
-    
+
     return ret;
 }
-INIT_BOARD_EXPORT(rt_hw_pin_init); 
+INIT_BOARD_EXPORT(rt_hw_pin_init);
 
 #endif /*RT_USING_PIN */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

 1. **修复 gpio 进入中断后，无法清除中断标志的问题**（见 bsp/imxrt/Libraries/imxrt1050/drivers/drv_pin.c 第225行）
 2. **修复 gpio 上下拉配置。**（见 bsp/imxrt/Libraries/imxrt1050/drivers/drv_pin.c 第450---478行, 第607---635行）
 3. **修复 gpio 配置为中断模式时，无法正确读取引脚状态的问题。**（ 见
 bsp/imxrt/Libraries/imxrt1050/drivers/drv_pin.c 第592行，第597行）

**测试情况说明：** 已经在自己画的 1052 板子上测试通过。

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
