### PR TITLE
[components/drivers & bsp/stm32]fix kconfig syntax error etc.

### DIFF
--- a/bsp/stm32/stm32f103-dofly-lyc8/Kconfig
+++ b/bsp/stm32/stm32f103-dofly-lyc8/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f103-hw100k-ibox/Kconfig
+++ b/bsp/stm32/stm32f103-hw100k-ibox/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f746-st-disco/Kconfig
+++ b/bsp/stm32/stm32f746-st-disco/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32f767-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f767-st-nucleo/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32g071-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32g071-st-nucleo/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/bsp/stm32/stm32l432-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32l432-st-nucleo/Kconfig
@@ -1,16 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config $BSP_DIR
+config BSP_DIR
     string
     option env="BSP_ROOT"
     default "."
 
-config $RTT_DIR
+config RTT_DIR
     string
     option env="RTT_ROOT"
     default "../../.."
 
-config $PKGS_DIR
+config PKGS_DIR
     string
     option env="PKGS_ROOT"
     default "packages"

--- a/components/drivers/Kconfig
+++ b/components/drivers/Kconfig
@@ -22,8 +22,8 @@ if RT_USING_SERIAL
         default y
 
     config RT_SERIAL_RB_BUFSZ
-    int "Set RX buffer size"
-    default 64
+        int "Set RX buffer size"
+        default 64
 
 endif
 
@@ -241,8 +241,8 @@ config RT_USING_AUDIO
 
 menu "Using WiFi"
     config RT_USING_WIFI
-    bool "Using Wi-Fi framework"
-    default n
+        bool "Using Wi-Fi framework"
+        default n
 
     if RT_USING_WIFI
         config RT_WLAN_DEVICE_STA_NAME

--- a/components/drivers/Kconfig
+++ b/components/drivers/Kconfig
@@ -20,7 +20,12 @@ if RT_USING_SERIAL
     config RT_SERIAL_USING_DMA
         bool "Enable serial DMA mode"
         default y
-endif    
+
+    config RT_SERIAL_RB_BUFSZ
+    int "Set RX buffer size"
+    default 64
+
+endif
 
 config RT_USING_CAN
     bool "Using CAN device drivers"
@@ -120,6 +125,7 @@ config RT_USING_PM
 
 config RT_USING_RTC
     bool "Using RTC device drivers"
+    select RT_USING_LIBC
     default n
 
     if RT_USING_RTC


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1. fix kconfig syntax error etc. some new stm32 BSP have this problem.

2. add RX buffer size config in kconfig file.

3. the RT_USING_LIBC option  is selected by default in RTC module.

* the above  has tested in qemu-vexpress-a9 BSP.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
