### PR TITLE
完善stm32_adc_init函数

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-12-05     zylx         first version
  * 2018-12-12     greedyhao    Porting for stm32f7xx
+ * 2019-02-01     yuneizhilin   fix the stm32_adc_init function initialization issue
  */
 
 #include <board.h>
@@ -206,29 +207,41 @@ static int stm32_adc_init(void)
 {
     int result = RT_EOK;
     /* save adc name */
-    char name_buf[6] = {0};
+    char name_buf[5] = {'a', 'd', 'c', '0', 0};
     int i = 0;
 
     for (i = 0; i < sizeof(adc_config) / sizeof(adc_config[0]); i++)
     {
         /* ADC init */
+        name_buf[3] = '0';
         stm32_adc_obj[i].ADC_Handler = adc_config[i];
+        if (stm32_adc_obj[i].ADC_Handler.Instance == ADC1)
+        {
+            name_buf[3] = '1';
+        }
+        if (stm32_adc_obj[i].ADC_Handler.Instance == ADC2)
+        {
+            name_buf[3] = '2';
+        }
+        if (stm32_adc_obj[i].ADC_Handler.Instance == ADC3)
+        {
+            name_buf[3] = '3';
+        }
         if (HAL_ADC_Init(&stm32_adc_obj[i].ADC_Handler) != HAL_OK)
         {
-            LOG_E("ADC%d init failed", i + 1);
+            LOG_E("%s init failed", name_buf);
             result = -RT_ERROR;
         }
         else
         {
-            rt_sprintf(name_buf, "adc%d", i + 1);
             /* register ADC device */
             if (rt_hw_adc_register(&stm32_adc_obj[i].stm32_adc_device, name_buf, &stm_adc_ops, &stm32_adc_obj[i].ADC_Handler) == RT_EOK)
             {
-                LOG_D("ADC%d init success", i + 1);
+                LOG_D("%s init success", name_buf);
             }
             else
             {
-                LOG_E("ADC%d register failed", i + 1);
+                LOG_E("%s register failed", name_buf);
                 result = -RT_ERROR;
             }
         }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
  解决了原函数在单独选择ADC2或ADC3的时候，注册到系统的名字仍是adc1的问题，通过判断当前选的ADC通道，给系统注册不同的名字，即单独选ADC2或ADC3时，注册到系统的名字是adc2或adc3。
在正点原子探索者开发板上进行了测试。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
