### PR TITLE
X1000: mtd_nor_partition.c: 修复编译过程中的警告/Fix compile-time warnings

### DIFF
--- a/bsp/x1000/drivers/sfc/mtd_nor_partition.c
+++ b/bsp/x1000/drivers/sfc/mtd_nor_partition.c
@@ -163,7 +163,7 @@ static rt_base_t mtd_part_mtd_read_id(struct rt_mtd_nor_device *dev)
     return rt_mtd_nor_read_id(mtd_nor);
 }
 
-static rt_size_t mtd_part_mtd_read(struct rt_mtd_nor_device *dev, rt_off_t offset, rt_uint8_t *buffer, rt_size_t length)
+static rt_size_t mtd_part_mtd_read(struct rt_mtd_nor_device *dev, rt_off_t offset, rt_uint8_t *buffer, rt_uint32_t length)
 {
     struct rt_mtd_nor_partition *mtd_part;
     struct rt_mtd_nor_device *mtd_nor;
@@ -197,7 +197,7 @@ static rt_size_t mtd_part_mtd_read(struct rt_mtd_nor_device *dev, rt_off_t offse
     return 0;
 }
 
-static rt_size_t mtd_part_mtd_write(struct rt_mtd_nor_device *dev, rt_off_t offset, const rt_uint8_t *buffer, rt_size_t length)
+static rt_size_t mtd_part_mtd_write(struct rt_mtd_nor_device *dev, rt_off_t offset, const rt_uint8_t *buffer, rt_uint32_t length)
 {
     struct rt_mtd_nor_partition *mtd_part;
     struct rt_mtd_nor_device *mtd_nor;


### PR DESCRIPTION
在第166行中,“rt_size_t length”应改为“rt_uint32_t length”。
在第200行中,“rt_size_t length”应改为“rt_uint32_t length”。

In line 166, "rt_size_t length" should be changed to "rt_uint32_t length".
In line 200, "rt_size_t length" should be changed to "rt_uint32_t length".

Signed-off-by: Zhou Yanjie <zhou_yan_jie@163.com>

## 拉取/合并请求描述：(PR description)

[
修复编译过程中的警告。
Fix compile-time warnings。

已在RatCharm板上进行过测试。
Has been tested on the RatCharm board.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
