### PR TITLE
[components][driver]修复使用spi驱动在sfud的qspi模式下的断言问题

### DIFF
--- a/components/drivers/spi/spi_flash_sfud.c
+++ b/components/drivers/spi/spi_flash_sfud.c
@@ -388,9 +388,10 @@ rt_spi_flash_device_t rt_sfud_flash_probe(const char *spi_flash_dev_name, const 
                 rt_qspi_configure(qspi_dev, &qspi_cfg);
                 if(qspi_dev->enter_qspi_mode != RT_NULL)
                     qspi_dev->enter_qspi_mode(qspi_dev);
+
+                /* set data lines width */
+                sfud_qspi_fast_read_enable(sfud_dev, qspi_dev->config.qspi_dl_width);
             }
-            /* set data lines width */
-            sfud_qspi_fast_read_enable(sfud_dev, qspi_dev->config.qspi_dl_width);
 #endif /* SFUD_USING_QSPI */
         }
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修复了使用 spi 驱动并打开 SFUD 的 QSPI 模式，调用 sfud_qspi_fast_read_enable 函数会导致断言的问题。
打开 debug 模式后编译通过，并在 stm32F429 上测试通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
