### PR TITLE
[Kernel] fix signal issue

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -234,7 +234,7 @@ void rt_schedule(void)
 
             if (rt_interrupt_nest == 0)
             {
-                extern void rt_thread_handle_sig(rt_bool_t clean_state);
+                extern void rt_thread_handle_sig(void);
 
                 rt_hw_context_switch((rt_uint32_t)&from_thread->sp,
                                      (rt_uint32_t)&to_thread->sp);
@@ -243,9 +243,10 @@ void rt_schedule(void)
                 rt_hw_interrupt_enable(level);
 
 #ifdef RT_USING_SIGNALS
-                /* check signal status */
-                rt_thread_handle_sig(RT_TRUE);
+                /* handle signal */
+                rt_thread_handle_sig();
 #endif
+                return ;
             }
             else
             {
@@ -253,21 +254,12 @@ void rt_schedule(void)
 
                 rt_hw_context_switch_interrupt((rt_uint32_t)&from_thread->sp,
                                                (rt_uint32_t)&to_thread->sp);
-                /* enable interrupt */
-                rt_hw_interrupt_enable(level);
             }
         }
-        else
-        {
-            /* enable interrupt */
-            rt_hw_interrupt_enable(level);
-        }
     }
-    else
-    {
-        /* enable interrupt */
-        rt_hw_interrupt_enable(level);
-    }
+
+    /* enable interrupt */
+    rt_hw_interrupt_enable(level);
 }
 
 /*

--- a/src/signal.c
+++ b/src/signal.c
@@ -59,10 +59,19 @@ static void _signal_entry(void *parameter)
         if (tid->stat & RT_THREAD_STAT_SIGNAL)
         {
             rt_hw_interrupt_enable(level);
+
             /* handle signal */
             rt_thread_handle_sig();
         }
-        else break;
+        else
+        {
+            /*
+             * Note: interrupt is disabled and no reentrant issue.
+             * 
+             * no signal status in tid->stat. 
+            */
+            break;
+        }
     }
 
     /* never come back... */

--- a/src/signal.c
+++ b/src/signal.c
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2017/10/5      Bernard      the first version
+ * 2019/02/15     Jesven       fixed the problem of si_list
  */
 
 #include <stdint.h>
@@ -80,10 +81,15 @@ static void _signal_deliver(rt_thread_t tid)
 {
     rt_ubase_t level;
 
-    /* thread is not interested in pended signals */
-    if (!(tid->sig_pending & tid->sig_mask)) return;
-
     level = rt_hw_interrupt_disable();
+
+    /* thread is not interested in pended signals */
+    if (!(tid->sig_pending & tid->sig_mask))
+    {
+        rt_hw_interrupt_enable(level);
+        return;
+    }
+
     if ((tid->stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND)
     {
         /* resume thread to handle signal */
@@ -133,12 +139,13 @@ static void _signal_deliver(rt_thread_t tid)
 
 rt_sighandler_t rt_signal_install(int signo, rt_sighandler_t handler)
 {
+    rt_base_t level;
     rt_sighandler_t old = RT_NULL;
     rt_thread_t tid = rt_thread_self();
 
     if (!sig_valid(signo)) return SIG_ERR;
 
-    rt_enter_critical();
+    level = rt_hw_interrupt_disable();
     if (tid->sig_vectors == RT_NULL)
     {
         rt_thread_alloc_sig(tid);
@@ -152,7 +159,7 @@ rt_sighandler_t rt_signal_install(int signo, rt_sighandler_t handler)
         else if (handler == SIG_DFL) tid->sig_vectors[signo] = _signal_default_handler;
         else tid->sig_vectors[signo] = handler;
     }
-    rt_exit_critical();
+    rt_hw_interrupt_enable(level);
 
     return old;
 }
@@ -270,7 +277,20 @@ __done:
 
             LOG_D("sigwait: %d sig raised!", signo);
             if (si_prev) si_prev->list.next = si_node->list.next;
-            else tid->si_list = si_node->list.next;
+            else
+            {
+                struct siginfo_node *node_next;
+
+                if (si_node->list.next)
+                {
+                    node_next = (void *)rt_slist_entry(si_node->list.next, struct siginfo_node, list);
+                    tid->si_list = node_next;
+                }
+                else
+                {
+                    tid->si_list = RT_NULL;
+                }
+            }
 
             /* clear pending */
             tid->sig_pending &= ~sig_mask(signo);
@@ -279,7 +299,14 @@ __done:
         }
 
         si_prev = si_node;
-        si_node = (void *)rt_slist_entry(si_node->list.next, struct siginfo_node, list);
+        if (si_node->list.next)
+        {
+            si_node = (void *)rt_slist_entry(si_node->list.next, struct siginfo_node, list);
+        }
+        else
+        {
+            si_node = RT_NULL;
+        }
      }
 
 __done_int:
@@ -318,13 +345,13 @@ void rt_thread_handle_sig(rt_bool_t clean_state)
 
                 signo   = si_node->si.si_signo;
                 handler = tid->sig_vectors[signo];
+                tid->sig_pending &= ~sig_mask(signo);
                 rt_hw_interrupt_enable(level);
 
                 LOG_D("handle signal: %d, handler 0x%08x", signo, handler);
                 if (handler) handler(signo);
 
                 level = rt_hw_interrupt_disable();
-                tid->sig_pending &= ~sig_mask(signo);
                 error = -RT_EINTR;
 
                 rt_mp_free(si_node); /* release this siginfo node */
@@ -333,10 +360,16 @@ void rt_thread_handle_sig(rt_bool_t clean_state)
             }
 
             /* whether clean signal status */
-            if (clean_state == RT_TRUE) tid->stat &= ~RT_THREAD_STAT_SIGNAL;
+            if (clean_state == RT_TRUE)
+            {
+                tid->stat &= ~RT_THREAD_STAT_SIGNAL;
+            }
+            else
+            {
+                return;
+            }
         }
     }
-
     rt_hw_interrupt_enable(level);
 }
 
@@ -362,30 +395,30 @@ void rt_thread_alloc_sig(rt_thread_t tid)
 void rt_thread_free_sig(rt_thread_t tid)
 {
     rt_base_t level;
-    struct siginfo_node *si_list;
+    struct siginfo_node *si_node;
     rt_sighandler_t *sig_vectors;
 
     level = rt_hw_interrupt_disable();
-    si_list = (struct siginfo_node *)tid->si_list;
+    si_node = (struct siginfo_node *)tid->si_list;
     tid->si_list = RT_NULL;
 
     sig_vectors = tid->sig_vectors;
     tid->sig_vectors = RT_NULL;
     rt_hw_interrupt_enable(level);
 
-    if (si_list)
+    if (si_node)
     {
         struct rt_slist_node *node;
-        struct siginfo_node  *si_node;
+        struct rt_slist_node *node_to_free;
 
         LOG_D("free signal info list");
-        node = &(si_list->list);
+        node = &(si_node->list);
         do
         {
-            si_node = rt_slist_entry(node, struct siginfo_node, list);
-            rt_mp_free(si_node);
-
+            node_to_free = node;
             node = node->next;
+            si_node = rt_slist_entry(node_to_free, struct siginfo_node, list);
+            rt_mp_free(si_node);
         } while (node);
     }
 
@@ -416,30 +449,23 @@ int rt_thread_kill(rt_thread_t tid, int sig)
         struct rt_slist_node *node;
         struct siginfo_node  *entry;
 
-        node = (struct rt_slist_node *)tid->si_list;
-        rt_hw_interrupt_enable(level);
+        si_node = (struct siginfo_node *)tid->si_list;
+        if (si_node)
+            node = (struct rt_slist_node *)&si_node->list;
+        else
+            node = RT_NULL;
 
         /* update sig info */
-        rt_enter_critical();
         for (; (node) != RT_NULL; node = node->next)
         {
             entry = rt_slist_entry(node, struct siginfo_node, list);
             if (entry->si.si_signo == sig)
             {
                 memcpy(&(entry->si), &si, sizeof(siginfo_t));
-                rt_exit_critical();
+                rt_hw_interrupt_enable(level);
                 return 0;
             }
         }
-        rt_exit_critical();
-
-        /* disable interrupt to protect tcb */
-        level = rt_hw_interrupt_disable();
-    }
-    else
-    {
-        /* a new signal */
-        tid->sig_pending |= sig_mask(sig);
     }
     rt_hw_interrupt_enable(level);
 
@@ -450,14 +476,22 @@ int rt_thread_kill(rt_thread_t tid, int sig)
         memcpy(&(si_node->si), &si, sizeof(siginfo_t));
 
         level = rt_hw_interrupt_disable();
-        if (!tid->si_list) tid->si_list = si_node;
-        else
+
+        if (tid->si_list)
         {
             struct siginfo_node *si_list;
 
             si_list = (struct siginfo_node *)tid->si_list;
             rt_slist_append(&(si_list->list), &(si_node->list));
         }
+        else
+        {
+            tid->si_list = si_node;
+        }
+
+        /* a new signal */
+        tid->sig_pending |= sig_mask(sig);
+
         rt_hw_interrupt_enable(level);
     }
     else


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

Disable interrupt to check thread->stat in _signal_entry to ensure the signal is not lost.

At the same time, remove the disable interrupt return code from rt_thread_handle_sig function.

test on qemu-vexpress-a9.

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
