### PR TITLE
[net][sal_socket] improve closesocke/shutdown error handling

### DIFF
--- a/components/net/sal_socket/socket/net_sockets.c
+++ b/components/net/sal_socket/socket/net_sockets.c
@@ -78,29 +78,39 @@ RTM_EXPORT(bind);
 
 int shutdown(int s, int how)
 {
-    int socket;
+    int error = 0;
+    int socket = -1;
     struct dfs_fd *d;
+
+    socket = dfs_net_getsocket(s);
+    if (socket < 0)
+    {
+        rt_set_errno(-ENOTSOCK);
+        return -1;
+    }
 
     d = fd_get(s);
     if (d == NULL)
     {
         rt_set_errno(-EBADF);
-
         return -1;
     }
-
-    socket = dfs_net_getsocket(s);
+    
     if (sal_shutdown(socket, how) == 0)
     {
-        /* socket has been closed, delete it from file system fd */
-        fd_put(d);
-        fd_put(d);
-
-        return 0;
+        error = 0;
+    }
+    else
+    {
+        rt_set_errno(-ENOTSOCK);
+        error = -1;
     }
 
-    return -1;
+    /* socket has been closed, delete it from file system fd */
+    fd_put(d);
+    fd_put(d);
 
+    return error;
 }
 RTM_EXPORT(shutdown);
 
@@ -228,7 +238,7 @@ int socket(int domain, int type, int protocol)
 
         rt_set_errno(-ENOMEM);
 
-       return -1;
+        return -1;
     }
 
     /* release the ref-count of fd */
@@ -240,25 +250,39 @@ RTM_EXPORT(socket);
 
 int closesocket(int s)
 {
-    int socket = dfs_net_getsocket(s);
+    int error = 0;
+    int socket = -1;
     struct dfs_fd *d;
 
-    d = fd_get(s);
-    if(!d)
+    socket = dfs_net_getsocket(s);
+    if (socket < 0)
     {
+        rt_set_errno(-ENOTSOCK);
+        return -1;
+    }
+
+    d = fd_get(s);
+    if (d == RT_NULL)
+    {
+        rt_set_errno(-EBADF);
         return -1;
     }
 
     if (sal_closesocket(socket) == 0)
     {
-        /* socket has been closed, delete it from file system fd */
-        fd_put(d);
-        fd_put(d);
-
-        return 0;
+        error = 0;
+    }
+    else
+    {
+        rt_set_errno(-ENOTSOCK);
+        error = -1;
     }
 
-    return -1;
+    /* socket has been closed, delete it from file system fd */
+    fd_put(d);
+    fd_put(d);
+
+    return error;
 }
 RTM_EXPORT(closesocket);
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[
[net][sal_socket] improve closesocke/shutdown error handling
完善 closesocket()/shutdown() 函数在关闭失败的错误处理，添加 socket 关闭错误时 errno 的设置。
在 qemu 环境下测试通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
