### PR TITLE
[finsh] change return type of finsh_getchar from ch to int

### DIFF
--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -134,12 +134,12 @@ void finsh_set_prompt_mode(rt_uint32_t prompt_mode)
     shell->prompt_mode = prompt_mode;
 }
 
-static char finsh_getchar(void)
+static int finsh_getchar(void)
 {
 #ifdef RT_USING_POSIX
     return getchar();
 #else
-    char ch;
+    int ch;
 
     RT_ASSERT(shell != RT_NULL);
     while (rt_device_read(shell->device, -1, &ch, 1) != 1)
@@ -279,7 +279,7 @@ const char *finsh_get_password(void)
 
 static void finsh_wait_auth(void)
 {
-    char ch;
+    int ch;
     rt_bool_t input_finish = RT_FALSE;
     char password[FINSH_PASSWORD_MAX] = { 0 };
     rt_size_t cur_pos = 0;
@@ -295,6 +295,11 @@ static void finsh_wait_auth(void)
             {
                 /* read one character from device */
                 ch = finsh_getchar();
+                if (ch < 0)
+                {
+                    rt_kprintf("finsh getchar error\n");
+                    continue;
+                }
 
                 if (ch >= ' ' && ch <= '~' && cur_pos < FINSH_PASSWORD_MAX)
                 {
@@ -460,7 +465,7 @@ static void shell_push_history(struct finsh_shell *shell)
 
 void finsh_thread_entry(void *parameter)
 {
-    char ch;
+    int ch;
 
     /* normal is echo mode */
 #ifndef FINSH_ECHO_DISABLE_DEFAULT
@@ -503,6 +508,11 @@ void finsh_thread_entry(void *parameter)
     while (1)
     {
         ch = finsh_getchar();
+        if (ch < 0)
+        {
+            rt_kprintf("finsh getchar error\n");
+            continue;
+        }
 
         /*
          * handle control key


### PR DESCRIPTION


## 拉取/合并请求描述：(PR description)

[
- Fix issue #2099 
- finsh_getchar invokes getchar, who's return type is int, and return value may < 0, which means error occurred or EOF.
- finsh should handle that situation properly, and inform user about the error.

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
