### PR TITLE
Delete the unused '--keep' link flag when used RT_USED marco.

### DIFF
--- a/components/finsh/SConscript
+++ b/components/finsh/SConscript
@@ -28,19 +28,12 @@ msh_file.c
 ''')
 
 CPPPATH = [cwd]
-if rtconfig.CROSS_TOOL == 'keil':
-    LINKFLAGS = ' --keep *.o(FSymTab)'
-
-    if not GetDepend('FINSH_USING_MSH_ONLY'):
-        LINKFLAGS = LINKFLAGS + ' --keep *.o(VSymTab) '
-else:
-    LINKFLAGS = '' 
 
 if GetDepend('FINSH_USING_MSH'):
 	src = src + msh_src
 if not GetDepend('FINSH_USING_MSH_ONLY'):
     src = src + fsh_src
 
-group = DefineGroup('finsh', src, depend = ['RT_USING_FINSH'], CPPPATH = CPPPATH, LINKFLAGS = LINKFLAGS)
+group = DefineGroup('finsh', src, depend = ['RT_USING_FINSH'], CPPPATH = CPPPATH)
 
 Return('group')

--- a/src/SConscript
+++ b/src/SConscript
@@ -5,15 +5,6 @@ from building import *
 src = Glob('*.c')
 
 CPPPATH = [RTT_ROOT + '/include']
-if rtconfig.CROSS_TOOL == 'keil':
-    # add more link flags for module and components_init.
-    LINKFLAGS = ''
-    if GetDepend('RT_USING_MODULE'):
-        LINKFLAGS += ' --keep *.o(RTMSymTab) '
-    if GetDepend('RT_USING_COMPONENTS_INIT'):
-        LINKFLAGS += ' --keep *.o(.rti_fn.*) '
-else:
-    LINKFLAGS = ''
 
 if GetDepend('RT_USING_COMPONENTS_INIT') == False:
     SrcRemove(src, ['components.c'])
@@ -38,6 +29,6 @@ if GetDepend('RT_USING_MEMHEAP') == False:
 if GetDepend('RT_USING_DEVICE') == False:
     SrcRemove(src, ['device.c'])
 
-group = DefineGroup('Kernel', src, depend = [''], CPPPATH = CPPPATH, LINKFLAGS = LINKFLAGS)
+group = DefineGroup('Kernel', src, depend = [''], CPPPATH = CPPPATH)
 
 Return('group')


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

删除 `--keep` 链接配置，因为：
- 相关导出变量及函数已经使用 `RT_USED` 宏修饰，这个选项显得多余
- 同时这个选项会导致 AC6 链接过程产生警告

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
