### PR TITLE
【修复】修复ms转tick时计算溢出问题

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -75,7 +75,7 @@ void rt_system_tick_init(void);
 rt_tick_t rt_tick_get(void);
 void rt_tick_set(rt_tick_t tick);
 void rt_tick_increase(void);
-int  rt_tick_from_millisecond(rt_int32_t ms);
+rt_tick_t  rt_tick_from_millisecond(rt_int32_t ms);
 
 void rt_system_timer_init(void);
 void rt_system_timer_thread_init(void);

--- a/src/clock.c
+++ b/src/clock.c
@@ -107,15 +107,20 @@ void rt_tick_increase(void)
  *
  * @return the calculated tick
  */
-int rt_tick_from_millisecond(rt_int32_t ms)
+rt_tick_t rt_tick_from_millisecond(rt_int32_t ms)
 {
-    int tick;
+    rt_tick_t tick;
 
     if (ms < 0)
+    {    
         tick = RT_WAITING_FOREVER;
+    }
     else
-        tick = (RT_TICK_PER_SECOND * ms + 999) / 1000;
-
+    {
+        tick = RT_TICK_PER_SECOND * (ms / 1000);
+        tick += (RT_TICK_PER_SECOND * (ms%1000) + 999) / 1000;
+    }
+    
     /* return the calculated tick */
     return tick;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修复 rt_tick_from_millisecond 转换较大入参时计算溢出问题
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
