### PR TITLE
[components]add rt_device_ops for adc device and fix finsh_getchar() bug.

### DIFF
--- a/components/drivers/misc/adc.c
+++ b/components/drivers/misc/adc.c
@@ -60,19 +60,37 @@ static rt_err_t _adc_control(rt_device_t dev, int cmd, void *args)
     return result;
 }
 
+#ifdef RT_USING_DEVICE_OPS
+const static struct rt_device_ops adc_ops =
+{
+    RT_NULL,
+    RT_NULL,
+    RT_NULL,
+    _adc_read,
+    RT_NULL,
+    _adc_control,
+};
+#endif
+
 rt_err_t rt_hw_adc_register(rt_adc_device_t device, const char *name, const struct rt_adc_ops *ops, const void *user_data)
 {
     rt_err_t result = RT_EOK;
     RT_ASSERT(ops != RT_NULL && ops->convert != RT_NULL);
 
     device->parent.type = RT_Device_Class_Miscellaneous;
-    device->parent.init = RT_NULL;
-    device->parent.open = RT_NULL;
-    device->parent.close = RT_NULL;
-    device->parent.read = _adc_read;
-    device->parent.write = RT_NULL;
-    device->parent.control = _adc_control;
+    device->parent.rx_indicate = RT_NULL;
+    device->parent.tx_complete = RT_NULL;
 
+#ifdef RT_USING_DEVICE_OPS
+    device->parent.ops         = &adc_ops;
+#else
+    device->parent.init        = RT_NULL;
+    device->parent.open        = RT_NULL;
+    device->parent.close       = RT_NULL;
+    device->parent.read        = _adc_read;
+    device->parent.write       = RT_NULL;
+    device->parent.control     = _adc_control;
+#endif
     device->ops = ops;
     device->parent.user_data = (void *)user_data;
 

--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -139,13 +139,13 @@ static int finsh_getchar(void)
 #ifdef RT_USING_POSIX
     return getchar();
 #else
-    int ch = 0;
+    char ch = 0;
 
     RT_ASSERT(shell != RT_NULL);
     while (rt_device_read(shell->device, -1, &ch, 1) != 1)
         rt_sem_take(&shell->rx_sem, RT_WAITING_FOREVER);
 
-    return ch;
+    return (int)ch;
 #endif
 }
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1. add rt_device_ops for adc device 
2. fix finsh_getchar() return wrong value in Big-endian status.
3. 开启设备OPS后编译通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
