### PR TITLE
X1000:drv_uart.c:修复引脚路由中的问题/Fix bugs in pin routing

### DIFF
--- a/bsp/x1000/drivers/drv_gpio.h
+++ b/bsp/x1000/drivers/drv_gpio.h
@@ -115,6 +115,7 @@ enum gpio_function
     GPIO_INT_HI     = 0x09,  //1001, High Level trigger interrupt
     GPIO_INT_FE     = 0x0a,  //1010, Fall Edge trigger interrupt
     GPIO_INT_RE     = 0x0b,  //1011, Rise Edge trigger interrupt
+    GPIO_PULL 		= 0x10,  //0001 0000, GPIO enable pull
     GPIO_INPUT_PULL = 0x16,  //0001 0110, GPIO as input and enable pull
 };
 

--- a/bsp/x1000/drivers/drv_gpio.h
+++ b/bsp/x1000/drivers/drv_gpio.h
@@ -1,21 +1,7 @@
 /*
- * File      : board_gpio.h
- * This file is part of RT-Thread RTOS
- * COPYRIGHT (C) 2008 - 2016, RT-Thread Development Team
+ * Copyright (c) 2006-2018, RT-Thread Development Team
  *
- *  This program is free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
- *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along
- *  with this program; if not, write to the Free Software Foundation, Inc.,
- *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes
@@ -115,7 +101,7 @@ enum gpio_function
     GPIO_INT_HI     = 0x09,  //1001, High Level trigger interrupt
     GPIO_INT_FE     = 0x0a,  //1010, Fall Edge trigger interrupt
     GPIO_INT_RE     = 0x0b,  //1011, Rise Edge trigger interrupt
-    GPIO_PULL 		= 0x10,  //0001 0000, GPIO enable pull
+    GPIO_PULL       = 0x10,  //0001 0000, GPIO enable pull
     GPIO_INPUT_PULL = 0x16,  //0001 0110, GPIO as input and enable pull
 };
 

--- a/bsp/x1000/drivers/drv_uart.c
+++ b/bsp/x1000/drivers/drv_uart.c
@@ -285,11 +285,14 @@ void rt_hw_uart_init(void)
         strcpy(uart->name, "uart2");
 
 #ifdef CONFIG_SYS_UART2_PD
+        gpio_set_func(GPIO_PORT_C,GPIO_Pin_31,GPIO_INPUT | GPIO_PULL);
         gpio_set_func(GPIO_PORT_D,GPIO_Pin_4,GPIO_FUNC_0);
         gpio_set_func(GPIO_PORT_D,GPIO_Pin_5,GPIO_FUNC_0);
 #else
         //USE JTAG IO for UART2
-        gpio_set_func(GPIO_PORT_C,GPIO_Pin_31,GPIO_FUNC_1);
+        gpio_set_func(GPIO_PORT_D,GPIO_Pin_4,GPIO_INPUT | GPIO_PULL);
+        gpio_set_func(GPIO_PORT_D,GPIO_Pin_5,GPIO_INPUT | GPIO_PULL);
+        gpio_set_func(GPIO_PORT_C,GPIO_Pin_31,GPIO_FUNC_1 | GPIO_PULL);
 #endif
 
         serial->ops              = &_uart_ops;


### PR DESCRIPTION
在配置引脚路由时需要将未使用的引脚配置为输入模式，
否则有可能同u-boot中的配置产生冲突。

Unused pins need to be configured as input mode when
configuring pin routing, otherwise there may be
conflicts with the configuration in u-boot.

Signed-off-by: Zhou Yanjie <zhouyanjie@zoho.com>

## 拉取/合并请求描述：(PR description)

[
在配置引脚路由时需要将未使用的引脚配置为输入模式，
否则有可能同u-boot中的配置产生冲突。
已在RatCharm平台和Realboard平台测试通过。

Unused pins need to be configured as input mode when
configuring pin routing, otherwise there may be
conflicts with the configuration in u-boot. 
Tested on the RatCharm platform and the Realboard platform.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
