### PR TITLE
[Kernel] Support ARCH data types definitions

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -58,6 +58,7 @@ extern "C" {
                                          (RT_SUBVERSION * 100) + RT_REVISION)
 
 /* RT-Thread basic data type definitions */
+#ifndef RT_USING_ARCH_DATA_TYPE
 typedef signed   char                   rt_int8_t;      /**<  8bit integer type */
 typedef signed   short                  rt_int16_t;     /**< 16bit integer type */
 typedef signed   int                    rt_int32_t;     /**< 32bit integer type */
@@ -71,6 +72,7 @@ typedef unsigned long                   rt_uint64_t;    /**< 64bit unsigned inte
 #else
 typedef signed long long                rt_int64_t;     /**< 64bit integer type */
 typedef unsigned long long              rt_uint64_t;    /**< 64bit unsigned integer type */
+#endif
 #endif
 
 typedef int                             rt_bool_t;      /**< boolean type */

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -15,7 +15,7 @@ config RT_USING_ARCH_DATA_TYPE
         For the data type like, `rt_uint8/int8_t, rt_uint16/int16_t, rt_uint32/int32_t`,
         BSP can define these basic data types in ARCH_CPU level.
 
-        Please re-define these data types in bsp_project.h file.
+        Please re-define these data types in rtconfig_project.h file.
 
 config RT_USING_SMP
     bool "Enable SMP(Symmetric multiprocessing)"

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -8,6 +8,15 @@ config RT_NAME_MAX
         Each kernel object, such as thread, timer, semaphore etc, has a name,
         the RT_NAME_MAX is the maximal size of this object name.
 
+config RT_USING_ARCH_DATA_TYPE
+    bool "Use the data types defined in ARCH_CPU"
+    default n
+    help
+        For the data type like, `rt_uint8/int8_t, rt_uint16/int16_t, rt_uint32/int32_t`,
+        BSP can define these basic data types in ARCH_CPU level.
+
+        Please re-define these data types in bsp_project.h file.
+
 config RT_USING_SMP
     bool "Enable SMP(Symmetric multiprocessing)"
     default n


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

加入RT_USING_ARCH_DATA_TYPE配置，可以由bsp来提供基础的数据类型定义，包括

`rt_int8/uint8_t, rt_int16/uint16_t, rt_int32/uint32_t`

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
