### PR TITLE
[Kernel] Fix the critical issue under smp

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -792,6 +792,12 @@ void rt_enter_critical(void)
     level = rt_hw_local_irq_disable();
 
     current_thread = rt_cpu_self()->current_thread;
+    if (!current_thread)
+    {
+        rt_hw_local_irq_enable(level);
+        return ;
+    }
+
     /*
      * the maximal number of nest is RT_UINT16_MAX, which is big
      * enough and does not check here
@@ -842,6 +848,11 @@ void rt_exit_critical(void)
     level = rt_hw_local_irq_disable();
 
     current_thread = rt_cpu_self()->current_thread;
+    if (!current_thread)
+    {
+        rt_hw_local_irq_enable(level);
+        return ;
+    }
 
     current_thread->scheduler_lock_nest --;
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -884,14 +884,17 @@ void rt_exit_critical(void)
     level = rt_hw_interrupt_disable();
 
     rt_scheduler_lock_nest --;
-
     if (rt_scheduler_lock_nest <= 0)
     {
         rt_scheduler_lock_nest = 0;
         /* enable interrupt */
         rt_hw_interrupt_enable(level);
 
-        rt_schedule();
+        if (rt_current_thread)
+        {
+            /* if scheduler is started, do a schedule */
+            rt_schedule();
+        }
     }
     else
     {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

Fix the enter/exit critical issue under SMP when scheduler not started. Test on qemu-vexpress-a9

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
