### PR TITLE
revise rt_schedule in rt_thread_idle_init

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -245,8 +245,9 @@ void rt_object_init(struct rt_object         *object,
 #ifdef RT_USING_MODULE
     struct rt_dlmodule *module = dlmodule_self();
 #endif
+#ifdef RT_USING_SMP
     extern rt_thread_t *rt_current_thread;
-
+#endif
     /* get object information */
     information = rt_object_get_information(type);
     RT_ASSERT(information != RT_NULL);
@@ -254,7 +255,9 @@ void rt_object_init(struct rt_object         *object,
     /* check object type to avoid re-initialization */
 
     /* enter critical */
+#ifdef RT_USING_SMP
     if(rt_current_thread != RT_NULL)
+#endif
         rt_enter_critical();
     /* try to find object */
     for (node  = information->object_list.next;
@@ -267,7 +270,9 @@ void rt_object_init(struct rt_object         *object,
         RT_ASSERT(obj != object);
     }
     /* leave critical */
+#ifdef RT_USING_SMP
     if(rt_current_thread != RT_NULL)
+#endif
         rt_exit_critical();
 
     /* initialize object's parameters */

--- a/src/object.c
+++ b/src/object.c
@@ -245,6 +245,7 @@ void rt_object_init(struct rt_object         *object,
 #ifdef RT_USING_MODULE
     struct rt_dlmodule *module = dlmodule_self();
 #endif
+    extern rt_thread_t *rt_current_thread;
 
     /* get object information */
     information = rt_object_get_information(type);
@@ -253,7 +254,8 @@ void rt_object_init(struct rt_object         *object,
     /* check object type to avoid re-initialization */
 
     /* enter critical */
-    rt_enter_critical();
+    if(rt_current_thread != RT_NULL)
+        rt_enter_critical();
     /* try to find object */
     for (node  = information->object_list.next;
             node != &(information->object_list);
@@ -265,7 +267,8 @@ void rt_object_init(struct rt_object         *object,
         RT_ASSERT(obj != object);
     }
     /* leave critical */
-    rt_exit_critical();
+    if(rt_current_thread != RT_NULL)
+        rt_exit_critical();
 
     /* initialize object's parameters */
     /* set object type to static */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
我在使用最新的rtthread过程中发现rt_application_init中创建的线程不能被正常调度，经过调查，发现在rt_system_scheduler_start()之前就执行了一次rt_schedule();使得线程状态不正确，原因是rt_thread_idle_init();函数中调用了rt_object_init函数，其中又调用了rt_exit_critical()函数，导致调用了一次rt_schedule()，我增加了一个条件判断if(rt_current_thread != RT_NULL)来判定是否执行了rt_system_scheduler_start()，来解决我的问题，我在板级stm32F429-applo上验证了我的解决方案
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
