### PR TITLE
Fix libc&errno

### DIFF
--- a/components/libc/compilers/newlib/syscalls.c
+++ b/components/libc/compilers/newlib/syscalls.c
@@ -27,6 +27,14 @@
 
 /* Reentrant versions of system calls.  */
 
+#ifndef _REENT_ONLY
+int *
+__errno ()
+{
+  return _rt_errno();
+}
+#endif
+
 int
 _close_r(struct _reent *ptr, int fd)
 {

--- a/components/net/lwip-1.4.1/src/arch/include/arch/cc.h
+++ b/components/net/lwip-1.4.1/src/arch/include/arch/cc.h
@@ -64,8 +64,6 @@ typedef uintptr_t mem_ptr_t;
 			in arch.h has been assigned to another error code. */
 #define ESHUTDOWN 180
 #endif /* __CC_ARM/__IAR_SYSTEMS_ICC__ */
-#else
-#define LWIP_PROVIDE_ERRNO
 #endif
 
 #if defined(RT_USING_LIBC) || defined(RT_USING_MINILIBC)

--- a/components/net/lwip-1.4.1/src/arch/include/arch/cc.h
+++ b/components/net/lwip-1.4.1/src/arch/include/arch/cc.h
@@ -55,10 +55,8 @@ typedef uintptr_t mem_ptr_t;
 #define X32_F "lx"
 
 #ifdef RT_USING_LIBC
-#if defined(__CC_ARM) || defined(__IAR_SYSTEMS_ICC__)
-#include <sys/errno.h>
-#else
-#include <errno.h>
+#if !defined(__CC_ARM) && !defined(__IAR_SYSTEMS_ICC__)
+
 /* some errno not defined in newlib */
 #define ENSRNOTFOUND 163  /* Domain name not found */
 /* WARNING: ESHUTDOWN also not defined in newlib. We chose

--- a/include/libc/libc_errno.h
+++ b/include/libc/libc_errno.h
@@ -13,7 +13,7 @@
 
 #include <rtconfig.h>
 
-#if defined(RT_USING_NEWLIB) || defined(_WIN32) || defined(__CC_ARM) || defined(__IAR_SYSTEMS_ICC__)
+#if defined(RT_USING_NEWLIB) || defined(_WIN32)
 /* use errno.h file in toolchains */
 #include <errno.h>
 #endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

- [components/net/lwip-1.4.1] 修复不开启 RT_USING_LIBC 时 errno 错误码重复定义的问题
- [components/net/lwip-1.4.1] 移除对 errno.h 的引入
- [include/libc] 在使用 ARMCC 和 IAR 时，移除对 errno.h 的引入。如果引入了 errno.h，errno 就不会被重定向到 _rt_errno。
- [compilers/newlib] 在 syscalls.c 增加 __errno () 函数实现，解决在使用 newlib 编译时 errno 无法重定向到 _rt_errno 的问题

> 基于 stm32.stm32f429-atk-apollo BSP 测试，分别测试了 lwip141 和 lwip202 两个版本。

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
