### PR TITLE
修改sem中的value成员变量和赋值参数类型相同

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -655,7 +655,7 @@ struct rt_semaphore
 {
     struct rt_ipc_object parent;                        /**< inherit from ipc_object */
 
-    rt_uint16_t          value;                         /**< value of semaphore. */
+    rt_uint32_t          value;                         /**< value of semaphore. */
 };
 typedef struct rt_semaphore *rt_sem_t;
 #endif

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -655,7 +655,8 @@ struct rt_semaphore
 {
     struct rt_ipc_object parent;                        /**< inherit from ipc_object */
 
-    rt_uint32_t          value;                         /**< value of semaphore. */
+    rt_uint16_t          value;                         /**< value of semaphore. */
+    rt_uint16_t          reserved;                      /**< reserved field */
 };
 typedef struct rt_semaphore *rt_sem_t;
 #endif

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -201,6 +201,7 @@ rt_err_t rt_sem_init(rt_sem_t    sem,
                      rt_uint8_t  flag)
 {
     RT_ASSERT(sem != RT_NULL);
+    RT_ASSERT(value < 0x10000U);
 
     /* init object */
     rt_object_init(&(sem->parent.parent), RT_Object_Class_Semaphore, name);
@@ -209,7 +210,7 @@ rt_err_t rt_sem_init(rt_sem_t    sem,
     rt_ipc_object_init(&(sem->parent));
 
     /* set init value */
-    sem->value = value;
+    sem->value = (rt_uint16_t)value;
 
     /* set parent */
     sem->parent.parent.flag = flag;
@@ -261,6 +262,7 @@ rt_sem_t rt_sem_create(const char *name, rt_uint32_t value, rt_uint8_t flag)
     rt_sem_t sem;
 
     RT_DEBUG_NOT_IN_INTERRUPT;
+    RT_ASSERT(value < 0x10000U);
 
     /* allocate object */
     sem = (rt_sem_t)rt_object_allocate(RT_Object_Class_Semaphore, name);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

修改struct rt_semaphore的成员变量value类型为rt_uint32_t，以和初始化时的参数类型一致

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
