### PR TITLE
[net][netdev] Add default netdev automatic change features configuration 

### DIFF
--- a/components/net/Kconfig
+++ b/components/net/Kconfig
@@ -73,6 +73,9 @@ config RT_USING_NETDEV
             bool "Enable netstat features"
             default y
 
+        config NETDEV_USING_AUTO_DEFAULT
+            bool "Enable default netdev automatic change features"
+            default y
     endif
 
 endmenu

--- a/components/net/sal_socket/src/sal_socket.c
+++ b/components/net/sal_socket/src/sal_socket.c
@@ -387,14 +387,7 @@ static int socket_init(int family, int type, int protocol, struct sal_socket **r
     sock->type = type;
     sock->protocol = protocol;
 
-    /* get socket operations from network interface device */
-    if (netdv_def == RT_NULL)
-    {
-        LOG_E("not find default network interface device for socket create.");
-        return -3;
-    }
-
-    if (netdev_is_up(netdv_def) && netdev_is_link_up(netdv_def))
+    if (netdv_def && netdev_is_up(netdv_def) && netdev_is_link_up(netdv_def))
     {
         /* check default network interface device protocol family */
         pf = (struct sal_proto_family *) netdv_def->sal_user_data;

--- a/components/net/sal_socket/src/sal_socket.c
+++ b/components/net/sal_socket/src/sal_socket.c
@@ -387,7 +387,7 @@ static int socket_init(int family, int type, int protocol, struct sal_socket **r
     sock->type = type;
     sock->protocol = protocol;
 
-    if (netdv_def && netdev_is_up(netdv_def) && netdev_is_link_up(netdv_def))
+    if (netdv_def && netdev_is_up(netdv_def))
     {
         /* check default network interface device protocol family */
         pf = (struct sal_proto_family *) netdv_def->sal_user_data;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
- 删除创建 socket 时对默认网卡的判断条件
- 添加默认网卡自动切换功能选项

该提交已经在 IoT-Board 开发板、STM32F429 开发板上验证通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
