### PR TITLE
[bsp][stm32][atk-f767] 修改 QSPI FLASH 名称以及设备初始化顺序

### DIFF
--- a/bsp/stm32/stm32f767-atk-apollo/board/Kconfig
+++ b/bsp/stm32/stm32f767-atk-apollo/board/Kconfig
@@ -24,7 +24,7 @@ menu "Onboard Peripheral Drivers"
         default n
 
     config BSP_USING_QSPI_FLASH
-        bool "Enable QSPI FLASH (w25q128 qspi)"
+        bool "Enable QSPI FLASH (W25Q256 qspi)"
         select BSP_USING_QSPI
         select RT_USING_SFUD
         select RT_SFUD_USING_QSPI

--- a/bsp/stm32/stm32f767-atk-apollo/board/ports/drv_qspi_flash.c
+++ b/bsp/stm32/stm32f767-atk-apollo/board/ports/drv_qspi_flash.c
@@ -64,14 +64,14 @@ static int rt_hw_qspi_flash_with_sfud_init(void)
 {
     stm32_qspi_bus_attach_device("qspi1", "qspi10", RT_NULL, 4, w25qxx_enter_qspi_mode, RT_NULL);
     
-    /* init w25q128 */
-    if (RT_NULL == rt_sfud_flash_probe("W25Q128", "qspi10"))
+    /* init W25Q256 */
+    if (RT_NULL == rt_sfud_flash_probe("W25Q256", "qspi10"))
     {
         return -RT_ERROR;
     }
 
     return RT_EOK;
 }
-INIT_COMPONENT_EXPORT(rt_hw_qspi_flash_with_sfud_init);
+INIT_DEVICE_EXPORT(rt_hw_qspi_flash_with_sfud_init);
 
 #endif/* BSP_USING_QSPI_FLASH */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[

修改：

- 该开发板上 SPI FLASH 的名称实际型号为 W25Q256，修改为正确名称
- 修改 QSPI FLASH 的初始化顺序为 device。

    已经在 正点原子 F767 开发板上做过测试。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
