### PR TITLE
[net][sal][netdev] Delete the link_up status judgment in the send/recv interface

### DIFF
--- a/components/net/netdev/include/netdev.h
+++ b/components/net/netdev/include/netdev.h
@@ -133,7 +133,7 @@ int netdev_register(struct netdev *netdev, const char *name, void *user_data);
 int netdev_unregister(struct netdev *netdev);
 
 /* Get network interface device object */
-struct netdev *netdev_get_first_link_up(void);
+struct netdev *netdev_get_first_by_flags(uint16_t flags);
 struct netdev *netdev_get_by_ipaddr(ip_addr_t *ip_addr);
 struct netdev *netdev_get_by_name(const char *name);
 #ifdef RT_USING_SAL

--- a/components/net/netdev/src/netdev.c
+++ b/components/net/netdev/src/netdev.c
@@ -134,12 +134,14 @@ int netdev_unregister(struct netdev *netdev)
 
 /**
  * This function will get the first network interface device
- * with the link_up status in network interface device list.
+ * with the flags in network interface device list.
+ * 
+ * @param flags the network interface device flags
  * 
  * @return != NULL: network interface device object
  *            NULL: get failed 
  */
-struct netdev *netdev_get_first_link_up(void)
+struct netdev *netdev_get_first_by_flags(uint16_t flags)
 {
     rt_base_t level;
     rt_slist_t *node = RT_NULL;
@@ -155,7 +157,7 @@ struct netdev *netdev_get_first_link_up(void)
     for (node = &(netdev_list->list); node; node = rt_slist_next(node))
     {
         netdev = rt_slist_entry(node, struct netdev, list);
-        if (netdev && netdev_is_up(netdev) && netdev_is_link_up(netdev))
+        if (netdev && (netdev->flags & flags) != 0)
         {
             rt_hw_interrupt_enable(level);
             return netdev;
@@ -679,7 +681,7 @@ static void netdev_auto_change_default(struct netdev *netdev)
 
     if (rt_memcmp(netdev, netdev_default, sizeof(struct netdev)) == 0)
     {
-        new_netdev = netdev_get_first_link_up();
+        new_netdev = netdev_get_first_by_flags(NETDEV_FLAG_LINK_UP);
         if (new_netdev)
         {
             netdev_set_default(new_netdev);
@@ -964,7 +966,7 @@ static int netdev_cmd_ping(char* target_name, rt_uint32_t times, rt_size_t size)
     else
     {
         /* using first internet up status network interface device */
-        netdev = netdev_get_first_link_up();
+        netdev = netdev_get_first_by_flags(NETDEV_FLAG_LINK_UP);
         if (netdev == RT_NULL || NETDEV_PING_IS_COMMONICABLE(netdev) == 0)
         {
             rt_kprintf("ping: network interface device get error.\n");

--- a/components/net/sal_socket/src/sal_socket.c
+++ b/components/net/sal_socket/src/sal_socket.c
@@ -70,9 +70,9 @@ do {                                                                            
     }                                                                             \
 }while(0)                                                                         \
 
-#define SAL_NETDEV_IS_COMMONICABLE(netdev)                                        \
+#define SAL_NETDEV_IS_UP(netdev)                                                  \
 do {                                                                              \
-    if (!netdev_is_up(netdev) || !netdev_is_link_up(netdev)){                     \
+    if (!netdev_is_up(netdev)) {                                                  \
         return -1;                                                                \
     }                                                                             \
 }while(0)                                                                         \
@@ -86,9 +86,9 @@ do {                                                                            
 }while(0)                                                                         \
 
 #define SAL_NETDEV_NETDBOPS_VALID(netdev, pf, ops)                                \
-((netdev) && netdev_is_up(netdev) && netdev_is_link_up(netdev) &&                 \
+    ((netdev) && netdev_is_up(netdev) &&                                          \
     ((pf) = (struct sal_proto_family *) (netdev)->sal_user_data) != RT_NULL &&    \
-        (pf)->netdb_ops->ops)                                                     \
+    (pf)->netdb_ops->ops)                                                         \
 
 /**
  * SAL (Socket Abstraction Layer) initialize.
@@ -748,8 +748,8 @@ int sal_connect(int socket, const struct sockaddr *name, socklen_t namelen)
     /* get the socket object by socket descriptor */
     SAL_SOCKET_OBJ_GET(sock, socket);
 
-    /* check the network interface is commonicable  */
-    SAL_NETDEV_IS_COMMONICABLE(sock->netdev);
+    /* check the network interface is up status */
+    SAL_NETDEV_IS_UP(sock->netdev);
     /* check the network interface socket opreation */
     SAL_NETDEV_SOCKETOPS_VALID(sock->netdev, pf, connect);
 
@@ -792,8 +792,8 @@ int sal_recvfrom(int socket, void *mem, size_t len, int flags,
     /* get the socket object by socket descriptor */
     SAL_SOCKET_OBJ_GET(sock, socket);
 
-    /* check the network interface is commonicable  */
-    SAL_NETDEV_IS_COMMONICABLE(sock->netdev);
+    /* check the network interface is up status  */
+    SAL_NETDEV_IS_UP(sock->netdev);
     /* check the network interface socket opreation */
     SAL_NETDEV_SOCKETOPS_VALID(sock->netdev, pf, recvfrom);
 
@@ -826,8 +826,8 @@ int sal_sendto(int socket, const void *dataptr, size_t size, int flags,
     /* get the socket object by socket descriptor */
     SAL_SOCKET_OBJ_GET(sock, socket);
 
-    /* check the network interface is commonicable  */
-    SAL_NETDEV_IS_COMMONICABLE(sock->netdev);
+    /* check the network interface is up status  */
+    SAL_NETDEV_IS_UP(sock->netdev);
     /* check the network interface socket opreation */
     SAL_NETDEV_SOCKETOPS_VALID(sock->netdev, pf, sendto);
 
@@ -965,8 +965,8 @@ int sal_poll(struct dfs_fd *file, struct rt_pollreq *req)
     /* get the socket object by socket descriptor */
     SAL_SOCKET_OBJ_GET(sock, socket);
 
-    /* check the network interface is commonicable  */
-    SAL_NETDEV_IS_COMMONICABLE(sock->netdev);
+    /* check the network interface is up status  */
+    SAL_NETDEV_IS_UP(sock->netdev);
     /* check the network interface socket opreation */
     SAL_NETDEV_SOCKETOPS_VALID(sock->netdev, pf, poll);
 
@@ -985,8 +985,8 @@ struct hostent *sal_gethostbyname(const char *name)
     }
     else
     {
-        /* get the first network interface device with the link up status */
-        netdev = netdev_get_first_link_up();
+        /* get the first network interface device with up status */
+        netdev = netdev_get_first_by_flags(NETDEV_FLAG_UP);
         if (SAL_NETDEV_NETDBOPS_VALID(netdev, pf, gethostbyname))
         {
             return pf->netdb_ops->gethostbyname(name);
@@ -1008,8 +1008,8 @@ int sal_gethostbyname_r(const char *name, struct hostent *ret, char *buf,
     }
     else
     {
-        /* get the first network interface device with the link up status */
-        netdev = netdev_get_first_link_up();
+        /* get the first network interface device with up status */
+        netdev = netdev_get_first_by_flags(NETDEV_FLAG_UP);
         if (SAL_NETDEV_NETDBOPS_VALID(netdev, pf, gethostbyname_r))
         {
             return pf->netdb_ops->gethostbyname_r(name, ret, buf, buflen, result, h_errnop);
@@ -1033,8 +1033,8 @@ int sal_getaddrinfo(const char *nodename,
     }
     else
     {
-        /* get the first network interface device with the link up status */
-        netdev = netdev_get_first_link_up();
+        /* get the first network interface device with up status */
+        netdev = netdev_get_first_by_flags(NETDEV_FLAG_UP);
         if (SAL_NETDEV_NETDBOPS_VALID(netdev, pf, getaddrinfo))
         {
             return pf->netdb_ops->getaddrinfo(nodename, servname, hints, res);
@@ -1055,8 +1055,8 @@ void sal_freeaddrinfo(struct addrinfo *ai)
     }
     else
     {
-        /* get the first network interface device with the link up status */
-        netdev = netdev_get_first_link_up();
+        /* get the first network interface device with up status */
+        netdev = netdev_get_first_by_flags(NETDEV_FLAG_UP);
         if (SAL_NETDEV_NETDBOPS_VALID(netdev, pf, freeaddrinfo))
         {
             pf->netdb_ops->freeaddrinfo(ai);


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

[
- 删除 sal_send/sal_recv 等接口中对于网卡 link_up 状态的判断限制；
- 已在 IoT_Board、STM32F429、QEMU 等环境下测试通过；
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
