### PR TITLE
[stm32][driver] flash 驱动擦除接口与 fal 不匹配的问题

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f0.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f0.c
@@ -167,7 +167,7 @@ __exit:
     }
 
     LOG_D("erase done: addr (0x%p), size %d", (void *)addr, size);
-    return result;
+    return size;
 }
 
 #if defined(PKG_USING_FAL)

--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f1.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f1.c
@@ -167,7 +167,7 @@ __exit:
     }
 
     LOG_D("erase done: addr (0x%p), size %d", (void *)addr, size);
-    return result;
+    return size;
 }
 
 #if defined(PKG_USING_FAL)

--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f4.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f4.c
@@ -310,7 +310,7 @@ __exit:
     }
 
     LOG_D("erase done: addr (0x%p), size %d", (void*)addr, size);
-    return result;
+    return size;
 }
 
 #if defined(PKG_USING_FAL)

--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f7.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f7.c
@@ -382,7 +382,7 @@ __exit:
     }
 
     LOG_D("erase done: addr (0x%p), size %d", (void *)addr, size);
-    return result;
+    return size;
 }
 
 #if defined(PKG_USING_FAL)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
【修复】f0 f1 f4 f7 系列 flash 擦除函数返回值与 fal 接口不匹配的问题。

在 fal 函数 `fal_partition_erase()` 中 flash 擦除返回值是擦除大小，如果不是擦除大小，返回错误值。而在 flash 驱动中擦写成功返回 RT_EOK，这就造成返回值不匹配的问题。

可以通过将 flash 驱动中的擦除成功返回值修改为擦除的字节数来解决这个问题。

已经在正点原子 f767 开发板上测试。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
