### PR TITLE
[net][at] Fix socket create failed issue when default netdev mismatch.

### DIFF
--- a/components/net/at/at_socket/at_socket.c
+++ b/components/net/at/at_socket/at_socket.c
@@ -359,20 +359,21 @@ __err:
     return RT_NULL;
 }
 
-static struct at_socket *alloc_socket(int domain)
+static struct at_socket *alloc_socket(void)
 {
     extern struct netdev *netdev_default;
     struct netdev *netdev = RT_NULL;
     struct at_device *device = RT_NULL;
 
-    if (netdev_default && netdev_is_up(netdev_default))
+    if (netdev_default && netdev_is_up(netdev_default) &&
+            netdev_family_get(netdev_default) == AF_AT)
     {
         netdev = netdev_default;
     }
     else
     {
-        /* get network interface device by protocol family */
-        netdev = netdev_get_by_family(domain);
+        /* get network interface device by protocol family AF_AT */
+        netdev = netdev_get_by_family(AF_AT);
         if (netdev == RT_NULL)
         {
             return RT_NULL;
@@ -414,7 +415,7 @@ int at_socket(int domain, int type, int protocol)
     }
 
     /* allocate and initialize a new AT socket */
-    sock = alloc_socket(domain);
+    sock = alloc_socket();
     if (sock == RT_NULL)
     {
         return -1;

--- a/components/net/netdev/include/netdev.h
+++ b/components/net/netdev/include/netdev.h
@@ -138,6 +138,7 @@ struct netdev *netdev_get_by_ipaddr(ip_addr_t *ip_addr);
 struct netdev *netdev_get_by_name(const char *name);
 #ifdef RT_USING_SAL
 struct netdev *netdev_get_by_family(int family);
+int netdev_family_get(struct netdev *netdev);
 #endif /* RT_USING_SAL */
 
 /* Set default network interface device in list */

--- a/components/net/netdev/src/netdev.c
+++ b/components/net/netdev/src/netdev.c
@@ -294,6 +294,20 @@ struct netdev *netdev_get_by_family(int family)
     return RT_NULL;
 }
 
+/**
+ * This function will get the family type from network interface device
+ * 
+ * @param netdev network interface device object
+ * 
+ * @return the network interface device family type
+ */
+int netdev_family_get(struct netdev *netdev)
+{
+    RT_ASSERT(netdev); 
+    
+    return ((struct sal_proto_family *)netdev->sal_user_data)->family;
+}
+
 #endif /* RT_USING_SAL */
 
 /**


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
- 默认网卡不匹配时，使用 at_socket 接口创建 socket 失败问题。
- 已经在stm32f429 开发板上验证问题。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
