### PR TITLE
解决shell auth认证可能出现password越界问题

### DIFF
--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -309,8 +309,8 @@ static void finsh_wait_auth(void)
                 else if (ch == '\b' && cur_pos > 0)
                 {
                     /* backspace */
+		    cur_pos--;
                     password[cur_pos] = '\0';
-                    cur_pos--;
                     rt_kprintf("\b \b");
                 }
                 else if (ch == '\r' || ch == '\n')

--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -281,7 +281,7 @@ static void finsh_wait_auth(void)
 {
     int ch;
     rt_bool_t input_finish = RT_FALSE;
-    char password[FINSH_PASSWORD_MAX] = { 0 };
+    char password[FINSH_PASSWORD_MAX + 1] = { 0 };
     rt_size_t cur_pos = 0;
     /* password not set */
     if (rt_strlen(finsh_get_password()) == 0) return;
@@ -309,8 +309,8 @@ static void finsh_wait_auth(void)
                 else if (ch == '\b' && cur_pos > 0)
                 {
                     /* backspace */
-		    cur_pos--;
                     password[cur_pos] = '\0';
+		    cur_pos--;
                     rt_kprintf("\b \b");
                 }
                 else if (ch == '\r' || ch == '\n')


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
当cur_pos为8时，按backspace键 出现password[8]导致越界问题。调整cur_pos--的位置
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
