### PR TITLE
[components][drivers] 硬件大数适应性调整

### DIFF
--- a/components/drivers/Kconfig
+++ b/components/drivers/Kconfig
@@ -278,7 +278,7 @@ menu "Using Hardware Crypto drivers"
             int "IV max size"
             default "16"
 
-        config HWCRYPTO_KEYBIT_MAX_SIZE
+        config RT_HWCRYPTO_KEYBIT_MAX_SIZE
             int "Key max bit length"
             default 256
 

--- a/components/drivers/hwcrypto/hw_bignum.c
+++ b/components/drivers/hwcrypto/hw_bignum.c
@@ -14,7 +14,7 @@
 
 static struct rt_hwcrypto_ctx *bignum_default;
 
-rt_inline rt_err_t rt_hwcrypto_bignum_init(void)
+rt_inline rt_err_t hwcrypto_bignum_dev_is_init(void)
 {
     struct rt_hwcrypto_device *dev;
 
@@ -55,20 +55,18 @@ rt_err_t rt_hwcrypto_bignum_default(struct rt_hwcrypto_device *device)
 }
 
 /**
- * @brief           Allocate memory for bignum
- *
- * @return          Pointer to allocated bignum obj
+ * @brief           Init bignum obj
+ * 
+ * @param n         bignum obj
  */
-struct hw_bignum_mpi *rt_hwcrypto_bignum_alloc(void)
+void rt_hwcrypto_bignum_init(struct hw_bignum_mpi *n)
 {
-    struct hw_bignum_mpi *n;
+    if(n == RT_NULL)
+        return;
 
-    n = rt_malloc(sizeof(struct hw_bignum_mpi));
-    if (n)
-    {
-        rt_memset(n, 0, sizeof(struct hw_bignum_mpi));
-    }
-    return n;
+    n->sign = 1;
+    n->total = 0;
+    n->p = RT_NULL;
 }
 
 /**
@@ -81,7 +79,9 @@ void rt_hwcrypto_bignum_free(struct hw_bignum_mpi *n)
     if (n)
     {
         rt_free(n->p);
-        rt_free(n);
+        n->sign = 0;
+        n->total = 0;
+        n->p = RT_NULL;
     }
 }
 
@@ -90,7 +90,7 @@ void rt_hwcrypto_bignum_free(struct hw_bignum_mpi *n)
  * 
  * @param n         bignum obj
  * 
- * @return          binary buffer Length
+ * @return          binary buffer length
  */
 int rt_hwcrypto_bignum_get_len(const struct hw_bignum_mpi *n)
 {
@@ -111,29 +111,34 @@ int rt_hwcrypto_bignum_get_len(const struct hw_bignum_mpi *n)
 }
 
 /**
- * @brief           Get length of bignum as an unsigned binary buffer
+ * @brief           Export n into unsigned binary data, big endian
  * 
  * @param n         bignum obj
  * @param buf       Buffer for the binary number
  * @param len       Length of the buffer
  * 
- * @return          binary buffer Length
+ * @return          export bin length
  */
-int rt_hwcrypto_bignum_get_bin(struct hw_bignum_mpi *n, rt_uint8_t *buf, int len)
+int rt_hwcrypto_bignum_export_bin(struct hw_bignum_mpi *n, rt_uint8_t *buf, int len)
 {
-    int cp_len;
+    int cp_len, i, j;
 
-    if (n == RT_NULL || n->p == RT_NULL || buf == RT_NULL)
+    if (n == RT_NULL || buf == RT_NULL)
     {
         return 0;
     }
+    rt_memset(buf, 0, len);
     cp_len = n->total > len ? len : n->total;
-    rt_memcpy(n->p, buf, cp_len);
+    for(i = cp_len, j = 0; i > 0; i--, j++)
+    {
+        buf[i - 1] = n->p[j];
+    }
+
     return cp_len;
 }
 
 /**
- * @brief           Set binary buffer to unsigned bignum
+ * @brief           Import n from unsigned binary data, big endian
  * 
  * @param n         bignum obj
  * @param buf       Buffer for the binary number
@@ -141,82 +146,39 @@ int rt_hwcrypto_bignum_get_bin(struct hw_bignum_mpi *n, rt_uint8_t *buf, int len
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t rt_hwcrypto_bignum_set_bin(struct hw_bignum_mpi *n, rt_uint8_t *buf, int len)
+rt_err_t rt_hwcrypto_bignum_import_bin(struct hw_bignum_mpi *n, rt_uint8_t *buf, int len)
 {
+    int cp_len, i, j;
     void *temp_p;
 
-    if (n == RT_NULL)
+    if (n == RT_NULL || buf == RT_NULL)
     {
-        return -RT_EINVAL;
+        return 0;
     }
-    if (n->p && n->total >= len)
+    if (n->total < len)
     {
-        rt_memcpy(n->p, buf, len);
-        return RT_EOK;
-    }
-    temp_p = rt_malloc(len);
-    if (temp_p == RT_NULL)
-    {
-        return -RT_ENOMEM;
-    }
-    if (n->p)
-    {
+        temp_p = rt_malloc(len);
+        if (temp_p == RT_NULL)
+        {
+            return 0;
+        }
+        rt_memset(temp_p, 0, len);
         rt_free(n->p);
         n->p = temp_p;
-        n->total = 0;
+        n->total = len;
     }
-    rt_memcpy(n->p, buf, len);
-    n->total = len;
-    return RT_EOK;
-}
+    cp_len = n->total > len ? len : n->total;
 
-/**
- * @brief           Unsigned comparison
- * 
- * @param a         bignum obj
- * @param b         bignum obj
- * 
- * @return          0 is equal
- */
-int rt_hwcrypto_bignum_cmp(const struct hw_bignum_mpi *a,
-                           const struct hw_bignum_mpi *b)
-{
-    int a_len, b_len;
-
-    if (a == RT_NULL || a->p == RT_NULL
-            || b == RT_NULL || b->p == RT_NULL)
+    for(i = cp_len, j = 0; i > 0; i--, j++)
     {
-        return -1;
+        n->p[j] = buf[i - 1];
     }
-    a_len = rt_hwcrypto_bignum_get_len(a);
-    b_len = rt_hwcrypto_bignum_get_len(b);
-    if (a_len != b_len)
-    {
-        return a_len - b_len;
-    }
-    return rt_memcmp(a->p, b->p, a_len);
+
+    return cp_len;
 }
 
 /**
- * @brief           Compare bignum to standard Unsigned integer
- * 
- * @param a         bignum obj
- * @param b         Unsigned integer
- * 
- * @return          0 is equal
- */
-int rt_hwcrypto_bignum_cmp_d(const struct hw_bignum_mpi *a, unsigned long b)
-{
-    struct hw_bignum_mpi tmp_b;
-
-    b = b <= 0 ? -b : b;
-    tmp_b.total = sizeof(unsigned long);
-    tmp_b.p = &b;
-    return rt_hwcrypto_bignum_cmp(a, &tmp_b);
-}
-
-/**
- * @brief           a = b + c
+ * @brief           x = a + b
  * 
  * @param a         bignum obj
  * @param b         bignum obj
@@ -224,26 +186,26 @@ int rt_hwcrypto_bignum_cmp_d(const struct hw_bignum_mpi *a, unsigned long b)
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t rt_hwcrypto_bignum_add(struct hw_bignum_mpi *a,
-                                const struct hw_bignum_mpi *b,
-                                const struct hw_bignum_mpi *c)
+rt_err_t rt_hwcrypto_bignum_add(struct hw_bignum_mpi *x,
+                                const struct hw_bignum_mpi *a,
+                                const struct hw_bignum_mpi *b)
 {
     struct hwcrypto_bignum *bignum_ctx;
 
-    if (rt_hwcrypto_bignum_init() != RT_EOK)
+    if (hwcrypto_bignum_dev_is_init() != RT_EOK)
     {
         return -RT_ERROR;
     }
     bignum_ctx = (struct hwcrypto_bignum *)bignum_default;
     if (bignum_ctx->ops->add)
     {
-        return bignum_ctx->ops->add(bignum_ctx, a, b, c);
+        return bignum_ctx->ops->add(bignum_ctx, x, a, b);
     }
     return -RT_ERROR;
 }
 
 /**
- * @brief           a = b - c
+ * @brief           x = a - b
  * 
  * @param a         bignum obj
  * @param b         bignum obj
@@ -251,26 +213,26 @@ rt_err_t rt_hwcrypto_bignum_add(struct hw_bignum_mpi *a,
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t rt_hwcrypto_bignum_sub(struct hw_bignum_mpi *a,
-                                const struct hw_bignum_mpi *b,
-                                const struct hw_bignum_mpi *c)
+rt_err_t rt_hwcrypto_bignum_sub(struct hw_bignum_mpi *x,
+                                const struct hw_bignum_mpi *a,
+                                const struct hw_bignum_mpi *b)
 {
     struct hwcrypto_bignum *bignum_ctx;
 
-    if (rt_hwcrypto_bignum_init() != RT_EOK)
+    if (hwcrypto_bignum_dev_is_init() != RT_EOK)
     {
         return -RT_ERROR;
     }
     bignum_ctx = (struct hwcrypto_bignum *)bignum_default;
     if (bignum_ctx->ops->sub)
     {
-        return bignum_ctx->ops->sub(bignum_ctx, a, b, c);
+        return bignum_ctx->ops->sub(bignum_ctx, x, a, b);
     }
     return -RT_ERROR;
 }
 
 /**
- * @brief           a = b * c
+ * @brief           x = a * b
  * 
  * @param a         bignum obj
  * @param b         bignum obj
@@ -278,26 +240,26 @@ rt_err_t rt_hwcrypto_bignum_sub(struct hw_bignum_mpi *a,
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t rt_hwcrypto_bignum_mul(struct hw_bignum_mpi *a,
-                                const struct hw_bignum_mpi *b,
-                                const struct hw_bignum_mpi *c)
+rt_err_t rt_hwcrypto_bignum_mul(struct hw_bignum_mpi *x,
+                                const struct hw_bignum_mpi *a,
+                                const struct hw_bignum_mpi *b)
 {
     struct hwcrypto_bignum *bignum_ctx;
 
-    if (rt_hwcrypto_bignum_init() != RT_EOK)
+    if (hwcrypto_bignum_dev_is_init() != RT_EOK)
     {
         return -RT_ERROR;
     }
     bignum_ctx = (struct hwcrypto_bignum *)bignum_default;
     if (bignum_ctx->ops->mul)
     {
-        return bignum_ctx->ops->mul(bignum_ctx, a, b, c);
+        return bignum_ctx->ops->mul(bignum_ctx, x, a, b);
     }
     return -RT_ERROR;
 }
 
 /**
- * @brief           a = b * c (mod d)
+ * @brief           x = a * b (mod c)
  * 
  * @param a         bignum obj
  * @param b         bignum obj
@@ -305,27 +267,27 @@ rt_err_t rt_hwcrypto_bignum_mul(struct hw_bignum_mpi *a,
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t rt_hwcrypto_bignum_mulmod(struct hw_bignum_mpi *a,
+rt_err_t rt_hwcrypto_bignum_mulmod(struct hw_bignum_mpi *x,
+                                   const struct hw_bignum_mpi *a,
                                    const struct hw_bignum_mpi *b,
-                                   const struct hw_bignum_mpi *c,
-                                   const struct hw_bignum_mpi *d)
+                                   const struct hw_bignum_mpi *c)
 {
     struct hwcrypto_bignum *bignum_ctx;
 
-    if (rt_hwcrypto_bignum_init() != RT_EOK)
+    if (hwcrypto_bignum_dev_is_init() != RT_EOK)
     {
         return -RT_ERROR;
     }
     bignum_ctx = (struct hwcrypto_bignum *)bignum_default;
     if (bignum_ctx->ops->mulmod)
     {
-        return bignum_ctx->ops->mulmod(bignum_ctx, a, b, c, d);
+        return bignum_ctx->ops->mulmod(bignum_ctx, x, a, b, c);
     }
     return -RT_ERROR;
 }
 
 /**
- * @brief           a = b ^ c (mod d)
+ * @brief           x = a ^ b (mod c)
  * 
  * @param a         bignum obj
  * @param b         bignum obj
@@ -333,21 +295,21 @@ rt_err_t rt_hwcrypto_bignum_mulmod(struct hw_bignum_mpi *a,
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t bignum_exptmod(struct hw_bignum_mpi *a,
-                        const struct hw_bignum_mpi *b,
-                        const struct hw_bignum_mpi *c,
-                        const struct hw_bignum_mpi *d)
+rt_err_t rt_hwcrypto_bignum_exptmod(struct hw_bignum_mpi *x,
+                                    const struct hw_bignum_mpi *a,
+                                    const struct hw_bignum_mpi *b,
+                                    const struct hw_bignum_mpi *c)
 {
     struct hwcrypto_bignum *bignum_ctx;
 
-    if (rt_hwcrypto_bignum_init() != RT_EOK)
+    if (hwcrypto_bignum_dev_is_init() != RT_EOK)
     {
         return -RT_ERROR;
     }
     bignum_ctx = (struct hwcrypto_bignum *)bignum_default;
     if (bignum_ctx->ops->exptmod)
     {
-        return bignum_ctx->ops->exptmod(bignum_ctx, a, b, c, d);
+        return bignum_ctx->ops->exptmod(bignum_ctx, x, a, b, c);
     }
     return -RT_ERROR;
 }

--- a/components/drivers/hwcrypto/hw_bignum.h
+++ b/components/drivers/hwcrypto/hw_bignum.h
@@ -22,34 +22,35 @@ struct hwcrypto_bignum;
 /* bignum obj */
 struct hw_bignum_mpi
 {
-    rt_size_t total;            /**< Total length of data  */
-    rt_ubase_t *p;              /**< pointer to data  */
+    int sign;                   /**< integer sign */
+    rt_size_t total;            /**< total of limbs */
+    rt_uint8_t *p;              /**< pointer to limbs */
 };
 
 struct hwcrypto_bignum_ops
 {
     rt_err_t (*add)(struct hwcrypto_bignum *bignum_ctx,
-                    struct hw_bignum_mpi *a,
-                    const struct hw_bignum_mpi *b,
-                    const struct hw_bignum_mpi *c);             /**< a = b + c */
+                    struct hw_bignum_mpi *x,
+                    const struct hw_bignum_mpi *a,
+                    const struct hw_bignum_mpi *b);             /**< x = a + b */
     rt_err_t (*sub)(struct hwcrypto_bignum *bignum_ctx,
-                    struct hw_bignum_mpi *a,
-                    const struct hw_bignum_mpi *b,
-                    const struct hw_bignum_mpi *c);             /**< a = b - c */
+                    struct hw_bignum_mpi *x,
+                    const struct hw_bignum_mpi *a,
+                    const struct hw_bignum_mpi *b);             /**< x = a - b */
     rt_err_t (*mul)(struct hwcrypto_bignum *bignum_ctx,
-                    struct hw_bignum_mpi *a,
-                    const struct hw_bignum_mpi *b,
-                    const struct hw_bignum_mpi *c);             /**< a = b * c */
+                    struct hw_bignum_mpi *x,
+                    const struct hw_bignum_mpi *a,
+                    const struct hw_bignum_mpi *b);             /**< x = a * b */
     rt_err_t (*mulmod)(struct hwcrypto_bignum *bignum_ctx,
-                       struct hw_bignum_mpi *a,
+                       struct hw_bignum_mpi *x,
+                       const struct hw_bignum_mpi *a,
                        const struct hw_bignum_mpi *b,
-                       const struct hw_bignum_mpi *c,
-                       const struct hw_bignum_mpi *d);          /**< a = b * c (mod d) */
+                       const struct hw_bignum_mpi *c);          /**< x = a * b (mod c) */
     rt_err_t (*exptmod)(struct hwcrypto_bignum *bignum_ctx,
-                        struct hw_bignum_mpi *a,
+                        struct hw_bignum_mpi *x,
+                        const struct hw_bignum_mpi *a,
                         const struct hw_bignum_mpi *b,
-                        const struct hw_bignum_mpi *c,
-                        const struct hw_bignum_mpi *d);         /**< a = b ^ c (mod d) */
+                        const struct hw_bignum_mpi *c);         /**< x = a ^ b (mod c) */
 };
 
 /**
@@ -69,11 +70,9 @@ struct hwcrypto_bignum
 rt_err_t rt_hwcrypto_bignum_default(struct rt_hwcrypto_device *device);
 
 /**
- * @brief           Allocate memory for bignum
- *
- * @return          Pointer to allocated bignum obj
+ * @brief           Init bignum obj
  */
-struct hw_bignum_mpi *rt_hwcrypto_bignum_alloc(void);
+void rt_hwcrypto_bignum_init(struct hw_bignum_mpi *n);
 
 /**
  * @brief           free a bignum obj
@@ -92,18 +91,18 @@ void rt_hwcrypto_bignum_free(struct hw_bignum_mpi *n);
 int rt_hwcrypto_bignum_get_len(const struct hw_bignum_mpi *n);
 
 /**
- * @brief           Get length of bignum as an unsigned binary buffer
+ * @brief           Export n into unsigned binary data, big endian
  * 
  * @param n         bignum obj
  * @param buf       Buffer for the binary number
  * @param len       Length of the buffer
  * 
- * @return          binary buffer Length
+ * @return          export bin length
  */
-int rt_hwcrypto_bignum_get_bin(struct hw_bignum_mpi *n, rt_uint8_t *buf, int len);
+int rt_hwcrypto_bignum_export_bin(struct hw_bignum_mpi *n, rt_uint8_t *buf, int len);
 
 /**
- * @brief           Set binary buffer to unsigned bignum
+ * @brief           Import n from unsigned binary data, big endian
  * 
  * @param n         bignum obj
  * @param buf       Buffer for the binary number
@@ -111,31 +110,10 @@ int rt_hwcrypto_bignum_get_bin(struct hw_bignum_mpi *n, rt_uint8_t *buf, int len
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t rt_hwcrypto_bignum_set_bin(struct hw_bignum_mpi *n, rt_uint8_t *buf, int len);
+rt_err_t rt_hwcrypto_bignum_import_bin(struct hw_bignum_mpi *n, rt_uint8_t *buf, int len);
 
 /**
- * @brief           Unsigned comparison
- * 
- * @param a         bignum obj
- * @param b         bignum obj
- * 
- * @return          0 is equal
- */
-int rt_hwcrypto_bignum_cmp(const struct hw_bignum_mpi *a,
-                           const struct hw_bignum_mpi *b);
-
-/**
- * @brief           Compare bignum to standard Unsigned integer
- * 
- * @param a         bignum obj
- * @param b         Unsigned integer
- * 
- * @return          0 is equal
- */
-int rt_hwcrypto_bignum_cmp_d(const struct hw_bignum_mpi *a, unsigned long b);
-
-/**
- * @brief           a = b + c
+ * @brief           x = a + b
  * 
  * @param a         bignum obj
  * @param b         bignum obj
@@ -143,12 +121,12 @@ int rt_hwcrypto_bignum_cmp_d(const struct hw_bignum_mpi *a, unsigned long b);
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t rt_hwcrypto_bignum_add(struct hw_bignum_mpi *a,
-                                const struct hw_bignum_mpi *b,
-                                const struct hw_bignum_mpi *c);
+rt_err_t rt_hwcrypto_bignum_add(struct hw_bignum_mpi *x,
+                                const struct hw_bignum_mpi *a,
+                                const struct hw_bignum_mpi *b);
 
 /**
- * @brief           a = b - c
+ * @brief           x = a - b
  * 
  * @param a         bignum obj
  * @param b         bignum obj
@@ -156,12 +134,12 @@ rt_err_t rt_hwcrypto_bignum_add(struct hw_bignum_mpi *a,
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t rt_hwcrypto_bignum_sub(struct hw_bignum_mpi *a,
-                                const struct hw_bignum_mpi *b,
-                                const struct hw_bignum_mpi *c);
+rt_err_t rt_hwcrypto_bignum_sub(struct hw_bignum_mpi *x,
+                                const struct hw_bignum_mpi *a,
+                                const struct hw_bignum_mpi *b);
 
 /**
- * @brief           a = b * c
+ * @brief           x = a * b
  * 
  * @param a         bignum obj
  * @param b         bignum obj
@@ -169,12 +147,12 @@ rt_err_t rt_hwcrypto_bignum_sub(struct hw_bignum_mpi *a,
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t rt_hwcrypto_bignum_mul(struct hw_bignum_mpi *a,
-                                const struct hw_bignum_mpi *b,
-                                const struct hw_bignum_mpi *c);
+rt_err_t rt_hwcrypto_bignum_mul(struct hw_bignum_mpi *x,
+                                const struct hw_bignum_mpi *a,
+                                const struct hw_bignum_mpi *b);
 
 /**
- * @brief           a = b * c (mod d)
+ * @brief           x = a * b (mod c)
  * 
  * @param a         bignum obj
  * @param b         bignum obj
@@ -182,13 +160,13 @@ rt_err_t rt_hwcrypto_bignum_mul(struct hw_bignum_mpi *a,
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t rt_hwcrypto_bignum_mulmod(struct hw_bignum_mpi *a,
+rt_err_t rt_hwcrypto_bignum_mulmod(struct hw_bignum_mpi *x,
+                                   const struct hw_bignum_mpi *a,
                                    const struct hw_bignum_mpi *b,
-                                   const struct hw_bignum_mpi *c,
-                                   const struct hw_bignum_mpi *d);
+                                   const struct hw_bignum_mpi *c);
 
 /**
- * @brief           a = b ^ c (mod d)
+ * @brief           x = a ^ b (mod c)
  * 
  * @param a         bignum obj
  * @param b         bignum obj
@@ -196,10 +174,10 @@ rt_err_t rt_hwcrypto_bignum_mulmod(struct hw_bignum_mpi *a,
  * 
  * @return          RT_EOK on success.
  */
-rt_err_t bignum_exptmod(struct hw_bignum_mpi *a,
-                        const struct hw_bignum_mpi *b,
-                        const struct hw_bignum_mpi *c,
-                        const struct hw_bignum_mpi *d);
+rt_err_t rt_hwcrypto_bignum_exptmod(struct hw_bignum_mpi *x,
+                                    const struct hw_bignum_mpi *a,
+                                    const struct hw_bignum_mpi *b,
+                                    const struct hw_bignum_mpi *c);
 
 #ifdef __cplusplus
 }

--- a/components/drivers/hwcrypto/hw_hash.h
+++ b/components/drivers/hwcrypto/hw_hash.h
@@ -101,7 +101,7 @@ void rt_hwcrypto_hash_reset(struct rt_hwcrypto_ctx *ctx);
  *
  * @return          RT_EOK on success.
  */
-rt_err_t rt_hwcrypto_hash_type(struct rt_hwcrypto_ctx *ctx, hwcrypto_type type);
+rt_err_t rt_hwcrypto_hash_set_type(struct rt_hwcrypto_ctx *ctx, hwcrypto_type type);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
根据实际使用情况，对大数进行了相应的调整

- 大数对象增加符号成员。
- 将 bignum_alloc 创建大数对象，更换成 bignum_init 初始化大数对象。实际使用中初始化用起来方便
- 移除大数比较功能，这个功能在硬件大数中使用不到
- bignum_set_bin 更名为 bignum_export_bin ，函数表意更加明确
- bignum_import_bin / bignum_export_bin 导入导出均是大端格式。之前是原始数据，意义不大

其他改动

- 更正一处函数命名错误
- 更正一处配置定义错误

上述改动均是实际使用中发现了问题，做出的合理调整。

上述改动在 W60X 及 QEMU 上进行过验证
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
