### PR TITLE
 [Components][USB][RNDIS/ECM] 修复热插拔鲁棒性和delay linkup 使用硬件定时器时报错的问题

### DIFF
--- a/components/drivers/Kconfig
+++ b/components/drivers/Kconfig
@@ -644,6 +644,7 @@ menu "Using USB"
                 if RT_USB_DEVICE_RNDIS
                     config RNDIS_DELAY_LINK_UP
                         bool "Delay linkup media connection"
+                        select RT_USING_TIMER_SOFT
                         default n
                 endif
 

--- a/components/drivers/usb/usbdevice/class/rndis.c
+++ b/components/drivers/usb/usbdevice/class/rndis.c
@@ -644,8 +644,6 @@ static rt_err_t _rndis_reset_response(ufunction_t func,rndis_set_msg_t msg)
     /* reset eth rx tx */
     ((rt_rndis_eth_t)func->user_data)->rx_frist = RT_TRUE;
     ((rt_rndis_eth_t)func->user_data)->rx_flag = RT_FALSE;
-    rt_sem_release(&((rt_rndis_eth_t)func->user_data)->tx_buffer_free);
-    eth_device_ready(&(((rt_rndis_eth_t)func->user_data)->parent));
 
 
     resp->MessageType = REMOTE_NDIS_RESET_CMPLT;
@@ -719,9 +717,6 @@ static rt_err_t _rndis_msg_parser(ufunction_t func, rt_uint8_t *msg)
         /* reset eth rx tx */
         ((rt_rndis_eth_t)func->user_data)->rx_frist = RT_TRUE;
         ((rt_rndis_eth_t)func->user_data)->rx_flag = RT_FALSE;
-        rt_sem_release(&((rt_rndis_eth_t)func->user_data)->tx_buffer_free);
-        eth_device_ready(&(((rt_rndis_eth_t)func->user_data)->parent));
-
         break;
 
     case REMOTE_NDIS_QUERY_MSG:
@@ -964,7 +959,7 @@ static rt_err_t _function_enable(ufunction_t func)
 
     ((rt_rndis_eth_t)func->user_data)->rx_flag = RT_FALSE;
     ((rt_rndis_eth_t)func->user_data)->rx_frist = RT_TRUE;
-    eth_device_ready(&(((rt_rndis_eth_t)func->user_data)->parent));
+    // eth_device_ready(&(((rt_rndis_eth_t)func->user_data)->parent));
 
 #ifdef  RNDIS_DELAY_LINK_UP
     /* stop link up timer. */
@@ -1034,8 +1029,6 @@ static rt_err_t _function_disable(ufunction_t func)
     /* reset eth rx tx */
     ((rt_rndis_eth_t)func->user_data)->rx_frist = RT_TRUE;
     ((rt_rndis_eth_t)func->user_data)->rx_flag = RT_FALSE;
-    rt_sem_release(&((rt_rndis_eth_t)func->user_data)->tx_buffer_free);
-    eth_device_ready(&(((rt_rndis_eth_t)func->user_data)->parent));
 
     return RT_EOK;
 }
@@ -1173,7 +1166,7 @@ rt_err_t rt_rndis_eth_tx(rt_device_t dev, struct pbuf* p)
         return RT_EOK;
     }
 
-    RT_ASSERT(p->tot_len < sizeof(device->tx_buffer));
+    //RT_ASSERT(p->tot_len < sizeof(device->tx_buffer));
     if(p->tot_len > sizeof(device->tx_buffer))
     {
         LOG_W("RNDIS MTU is:%d, but the send packet size is %d",
@@ -1182,9 +1175,12 @@ rt_err_t rt_rndis_eth_tx(rt_device_t dev, struct pbuf* p)
     }
 
     /* wait for buffer free. */
-    result = rt_sem_take(&device->tx_buffer_free, RT_WAITING_FOREVER);
+    result = rt_sem_take(&device->tx_buffer_free, rt_tick_from_millisecond(1000));
     if(result != RT_EOK)
     {
+        LOG_W("wait for buffer free timeout");
+        /* if cost 1s to wait send done it said that connection is close . drop it */
+        rt_sem_release(&device->tx_buffer_free);
         return result;
     }
 

--- a/components/drivers/usb/usbdevice/class/rndis.c
+++ b/components/drivers/usb/usbdevice/class/rndis.c
@@ -1391,7 +1391,7 @@ ufunction_t rt_usbd_function_rndis_create(udevice_t device)
                   timer_timeout,
                   _rndis,
                   RT_TICK_PER_SECOND * 2,
-                  RT_TIMER_FLAG_ONE_SHOT);
+                  RT_TIMER_FLAG_ONE_SHOT | RT_TIMER_FLAG_SOFT_TIMER);
 #endif  /* RNDIS_DELAY_LINK_UP */
 
     /* OUI 00-00-00, only for test. */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
    修复RNDIS和ECM在低数据量时热插拔依然存在一定问题的bug，强制delay linkup 使用软件定时器实现。
    感谢 @cris8259 提供的问题复现场景和分析以及稳定性测试，已通过STM32F469I-DISCO和F407的鲁棒性测试。
  相关issue
  #2724 
] 

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
