### PR TITLE
修复 sensor 设备关闭后分配的内存不释放的问题

### DIFF
--- a/components/drivers/sensors/sensor.c
+++ b/components/drivers/sensors/sensor.c
@@ -139,6 +139,7 @@ static rt_err_t rt_sensor_open(rt_device_t dev, rt_uint16_t oflag)
 {
     rt_sensor_t sensor = (rt_sensor_t)dev;
     RT_ASSERT(dev != RT_NULL);
+    rt_err_t res = RT_EOK;
 
     if (sensor->module)
     {
@@ -152,7 +153,8 @@ static rt_err_t rt_sensor_open(rt_device_t dev, rt_uint16_t oflag)
         sensor->data_buf = rt_malloc(sizeof(struct rt_sensor_data) * sensor->info.fifo_max);
         if (sensor->data_buf == RT_NULL)
         {
-            return -RT_ENOMEM;
+            res = -RT_ENOMEM;
+            goto __exit;
         }
     }
 
@@ -186,12 +188,8 @@ static rt_err_t rt_sensor_open(rt_device_t dev, rt_uint16_t oflag)
     }
     else
     {
-        if (sensor->module)
-        {
-            /* release the module mutex */
-            rt_mutex_release(sensor->module->lock);
-        }
-        return -RT_EINVAL;
+        res = -RT_EINVAL;
+        goto __exit;
     }
 
     /* Configure power mode to normal mode */
@@ -200,13 +198,14 @@ static rt_err_t rt_sensor_open(rt_device_t dev, rt_uint16_t oflag)
         sensor->config.power = RT_SENSOR_POWER_NORMAL;
     }
 
+__exit:
     if (sensor->module)
     {
         /* release the module mutex */
         rt_mutex_release(sensor->module->lock);
     }
 
-    return RT_EOK;
+    return res;
 }
 
 static rt_err_t  rt_sensor_close(rt_device_t dev)

--- a/components/drivers/sensors/sensor_cmd.c
+++ b/components/drivers/sensors/sensor_cmd.c
@@ -55,7 +55,7 @@ static void sensor_show_data(rt_size_t num, rt_sensor_t sensor, struct rt_sensor
     }
 }
 
-rt_err_t rx_callback(rt_device_t dev, rt_size_t size)
+static rt_err_t rx_callback(rt_device_t dev, rt_size_t size)
 {
     rt_sem_release(sensor_rx_sem);
     return 0;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

之前 数据缓冲区的内存分配是在 sensor 设备的 init 接口里完成的，而且在设备关闭的时候没有释放这一部分的内存，造成了资源的浪费。因此在 close 的接口中添加 释放内存的操作，为了保证设备的正常工作，将分配内存的操作从只在设备第一次打开的时候才会运行的 init 接口转移到了设备每次打开都会运行的 open 接口，修复了 sensor 设备关闭后内存不释放的问题。已在 F411-Nuclleo 开发板上做了验证。

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
