### PR TITLE
[bsp][stm32] drv_wdt.c | 完善 stm32 看门狗驱动

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_wdt.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_wdt.c
@@ -23,7 +23,7 @@ static rt_watchdog_t watchdog;
 static rt_err_t wdt_init(rt_watchdog_t *wdt)
 {
     hiwdg.Instance = IWDG;
-    hiwdg.Init.Prescaler = IWDG_PRESCALER_32;
+    hiwdg.Init.Prescaler = IWDG_PRESCALER_256;
 
     hiwdg.Init.Reload = 0x00000FFF;
 #if defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32F7)
@@ -48,12 +48,42 @@ static rt_err_t wdt_control(rt_watchdog_t *wdt, int cmd, void *arg)
         break;
         /* set watchdog timeout */
     case RT_DEVICE_CTRL_WDT_SET_TIMEOUT:
-        hiwdg.Init.Reload = *((rt_uint32_t*)arg);
+#if defined(LSI_VALUE)
+        if(LSI_VALUE)
+        {
+            hiwdg.Init.Reload = (*((rt_uint32_t*)arg)) * LSI_VALUE / 256 ;
+        }
+        else
+        {
+            LOG_E("Please defined LSI_VALUE`s value!");
+        }
+#else
+  #error "Please defined LSI_VALUE`s value!"
+#endif
+        if(hiwdg.Init.Reload > 0xFFF)
+        {
+            LOG_E("wdg set timeout parameter too large.");
+            return -RT_EINVAL;
+        }
         if (HAL_IWDG_Init(&hiwdg) != HAL_OK)
         {
             LOG_E("wdg set timeout failed.");
             return -RT_ERROR;
         }
+        break;
+    case RT_DEVICE_CTRL_WDT_GET_TIMEOUT:
+#if defined(LSI_VALUE)
+        if(LSI_VALUE)
+        {
+            (*((rt_uint32_t*)arg)) = hiwdg.Init.Reload * 256 / LSI_VALUE;
+        }
+        else
+        {
+            LOG_E("Please defined LSI_VALUE`s value!");
+        }
+#else
+  #error "Please defined LSI_VALUE`s value!"
+#endif
         break;
     default:
         return -RT_ERROR;

--- a/bsp/stm32/libraries/HAL_Drivers/drv_wdt.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_wdt.c
@@ -55,10 +55,10 @@ static rt_err_t wdt_control(rt_watchdog_t *wdt, int cmd, void *arg)
         }
         else
         {
-            LOG_E("Please defined LSI_VALUE`s value!");
+            LOG_E("Please define the value of LSI_VALUE!");
         }
 #else
-  #error "Please defined LSI_VALUE`s value!"
+  #error "Please define the value of LSI_VALUE!"
 #endif
         if(hiwdg.Init.Reload > 0xFFF)
         {
@@ -79,10 +79,10 @@ static rt_err_t wdt_control(rt_watchdog_t *wdt, int cmd, void *arg)
         }
         else
         {
-            LOG_E("Please defined LSI_VALUE`s value!");
+            LOG_E("Please define the value of LSI_VALUE!");
         }
 #else
-  #error "Please defined LSI_VALUE`s value!"
+  #error "Please define the value of LSI_VALUE!"
 #endif
         break;
     default:


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

利用 stm32fxxx_hal_conf.h 提供的 LSI_VALUE 宏计算看门狗超时时间。

 1. 在野火 f103 测试通过。（32KHZ 看门狗时钟源）
 2. 在正点原子 f407 测试通过。（40KHZ 看门狗时钟源）

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
