### PR TITLE
[bsp][stm32][f103-dofly-m3s]Add support for nRF24L01 extension module

### DIFF
--- a/bsp/stm32/stm32f103-dofly-M3S/README.md
+++ b/bsp/stm32/stm32f103-dofly-M3S/README.md
@@ -50,7 +50,7 @@ STM32F103 德飞莱-尼莫 M3S 是徳飞莱推出的一款基于 ARM Cortex-M3 �
 | I2C | 支持 | 软件I2C |
 | FLASH | 支持 | 已适配 [FAL](https://github.com/RT-Thread-packages/fal) |
 | **扩展模块** | **支持情况** | **备注** |
-| NRF24L01 | 暂不支持 | 即将支持 |
+| NRF24L01 | 支持 | 根据实际板子接线情况修改 NRF24L01 软件包中的 `NRF24L01_CE_PIN` 和 `NRF24_IRQ_PIN` 的宏定义，以及 SPI 设备名 |
 
 ## 使用说明
 

--- a/bsp/stm32/stm32f103-dofly-M3S/applications/nrf24l01_init.c
+++ b/bsp/stm32/stm32f103-dofly-M3S/applications/nrf24l01_init.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2006-2018, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author        Notes
+ * 2019-06-29     WillianChan   first version
+ */
+
+#include <rtthread.h>
+
+#ifdef PKG_USING_NRF24L01
+
+#include "drv_spi.h"
+static int rt_hw_nrf24l01_init(void)
+{
+    rt_hw_spi_device_attach("spi2", "spi20", GPIOG, GPIO_PIN_7);
+    return RT_EOK;
+}
+INIT_COMPONENT_EXPORT(rt_hw_nrf24l01_init);
+
+#endif

--- a/bsp/stm32/stm32f103-dofly-M3S/board/Kconfig
+++ b/bsp/stm32/stm32f103-dofly-M3S/board/Kconfig
@@ -130,6 +130,13 @@ endmenu
 
 menu "Board extended module Drivers"
 
+    config BSP_USING_NRF24L01
+        bool "Enable NRF24L01"
+        select BSP_USING_SPI
+        select BSP_USING_SPI2
+        select PKG_USING_NRF24L01
+        default n
+
 endmenu
 
 endmenu


### PR DESCRIPTION
Signed-off-by: Willian Chan <chentingwei@rt-thread.com>

## 拉取/合并请求描述：(PR description)

[
添加对NRF24L01扩展模块的支持
Add support for nRF24L01 extension module
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [X] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [X] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [X] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [X] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [X] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [X] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [X] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
