### PR TITLE
 [net][netdev] Add RT_USING_FINSH control for netdev network commands 

### DIFF
--- a/components/net/lwip-1.4.1/src/netif/ethernetif.c
+++ b/components/net/lwip-1.4.1/src/netif/ethernetif.c
@@ -146,8 +146,8 @@ static int lwip_netdev_set_addr_info(struct netdev *netif, ip_addr_t *ip_addr, i
 #ifdef RT_LWIP_DNS
 static int lwip_netdev_set_dns_server(struct netdev *netif, uint8_t dns_num, ip_addr_t *dns_server)
 {
-    extern void set_dns(uint8_t dns_num, char* dns_server);
-    set_dns(dns_num, ipaddr_ntoa(dns_server));
+    extern void dns_setserver(uint8_t dns_num, ip_addr_t *dns_server);
+    dns_setserver(dns_num, dns_server);
     return ERR_OK;
 }
 #endif /* RT_LWIP_DNS */
@@ -160,6 +160,7 @@ static int lwip_netdev_set_dhcp(struct netdev *netif, rt_bool_t is_enabled)
 }
 #endif /* RT_LWIP_DHCP */
 
+#ifdef FINSH_USING_MSH
 #ifdef RT_LWIP_USING_PING
 extern int lwip_ping_recv(int s, int *ttl);
 extern err_t lwip_ping_send(int s, ip_addr_t *addr, int size);
@@ -250,6 +251,7 @@ void lwip_netdev_netstat(struct netdev *netif)
 #endif
 }
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
+#endif /* FINSH_USING_MSH */
 
 const struct netdev_ops lwip_netdev_ops =
 {
@@ -269,6 +271,7 @@ const struct netdev_ops lwip_netdev_ops =
     NULL,
 #endif /* RT_LWIP_DHCP */
 
+#ifdef FINSH_USING_MSH
 #ifdef RT_LWIP_USING_PING
     lwip_netdev_ping,
 #else
@@ -278,6 +281,7 @@ const struct netdev_ops lwip_netdev_ops =
 #if defined (RT_LWIP_TCP) || defined (RT_LWIP_UDP)
     lwip_netdev_netstat,
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
+#endif /* FINSH_USING_MSH */
 };
 
 static int netdev_add(struct netif *lwip_netif)

--- a/components/net/lwip-1.4.1/src/netif/ethernetif.c
+++ b/components/net/lwip-1.4.1/src/netif/ethernetif.c
@@ -160,7 +160,7 @@ static int lwip_netdev_set_dhcp(struct netdev *netif, rt_bool_t is_enabled)
 }
 #endif /* RT_LWIP_DHCP */
 
-#ifdef FINSH_USING_MSH
+#ifdef RT_USING_FINSH
 #ifdef RT_LWIP_USING_PING
 extern int lwip_ping_recv(int s, int *ttl);
 extern err_t lwip_ping_send(int s, ip_addr_t *addr, int size);
@@ -251,7 +251,7 @@ void lwip_netdev_netstat(struct netdev *netif)
 #endif
 }
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
-#endif /* FINSH_USING_MSH */
+#endif /* RT_USING_FINSH */
 
 const struct netdev_ops lwip_netdev_ops =
 {
@@ -271,7 +271,7 @@ const struct netdev_ops lwip_netdev_ops =
     NULL,
 #endif /* RT_LWIP_DHCP */
 
-#ifdef FINSH_USING_MSH
+#ifdef RT_USING_FINSH
 #ifdef RT_LWIP_USING_PING
     lwip_netdev_ping,
 #else
@@ -281,7 +281,7 @@ const struct netdev_ops lwip_netdev_ops =
 #if defined (RT_LWIP_TCP) || defined (RT_LWIP_UDP)
     lwip_netdev_netstat,
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
-#endif /* FINSH_USING_MSH */
+#endif /* RT_USING_FINSH */
 };
 
 static int netdev_add(struct netif *lwip_netif)

--- a/components/net/lwip-2.0.2/src/netif/ethernetif.c
+++ b/components/net/lwip-2.0.2/src/netif/ethernetif.c
@@ -154,8 +154,8 @@ static int lwip_netdev_set_addr_info(struct netdev *netif, ip_addr_t *ip_addr, i
 #ifdef RT_LWIP_DNS
 static int lwip_netdev_set_dns_server(struct netdev *netif, uint8_t dns_num, ip_addr_t *dns_server)
 {
-    extern void set_dns(uint8_t dns_num, char* dns_server);
-    set_dns(dns_num, ipaddr_ntoa(dns_server));
+    extern void dns_setserver(uint8_t dns_num, const ip_addr_t *dns_server);
+    dns_setserver(dns_num, dns_server);
     return ERR_OK;
 }
 #endif /* RT_LWIP_DNS */
@@ -168,6 +168,7 @@ static int lwip_netdev_set_dhcp(struct netdev *netif, rt_bool_t is_enabled)
 }
 #endif /* RT_LWIP_DHCP */
 
+#ifdef FINSH_USING_MSH
 #ifdef RT_LWIP_USING_PING
 extern int lwip_ping_recv(int s, int *ttl);
 extern err_t lwip_ping_send(int s, ip_addr_t *addr, int size);
@@ -258,6 +259,7 @@ void lwip_netdev_netstat(struct netdev *netif)
 #endif
 }
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
+#endif /* FINSH_USING_MSH */
 
 const struct netdev_ops lwip_netdev_ops =
 {
@@ -277,6 +279,7 @@ const struct netdev_ops lwip_netdev_ops =
     NULL,
 #endif /* RT_LWIP_DHCP */
 
+#ifdef FINSH_USING_MSH
 #ifdef RT_LWIP_USING_PING
     lwip_netdev_ping,
 #else
@@ -286,6 +289,7 @@ const struct netdev_ops lwip_netdev_ops =
 #if defined (RT_LWIP_TCP) || defined (RT_LWIP_UDP)
     lwip_netdev_netstat,
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
+#endif /* FINSH_USING_MSH */
 };
 
 static int netdev_add(struct netif *lwip_netif)

--- a/components/net/lwip-2.0.2/src/netif/ethernetif.c
+++ b/components/net/lwip-2.0.2/src/netif/ethernetif.c
@@ -168,7 +168,7 @@ static int lwip_netdev_set_dhcp(struct netdev *netif, rt_bool_t is_enabled)
 }
 #endif /* RT_LWIP_DHCP */
 
-#ifdef FINSH_USING_MSH
+#ifdef RT_USING_FINSH
 #ifdef RT_LWIP_USING_PING
 extern int lwip_ping_recv(int s, int *ttl);
 extern err_t lwip_ping_send(int s, ip_addr_t *addr, int size);
@@ -259,7 +259,7 @@ void lwip_netdev_netstat(struct netdev *netif)
 #endif
 }
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
-#endif /* FINSH_USING_MSH */
+#endif /* RT_USING_FINSH */
 
 const struct netdev_ops lwip_netdev_ops =
 {
@@ -279,7 +279,7 @@ const struct netdev_ops lwip_netdev_ops =
     NULL,
 #endif /* RT_LWIP_DHCP */
 
-#ifdef FINSH_USING_MSH
+#ifdef RT_USING_FINSH
 #ifdef RT_LWIP_USING_PING
     lwip_netdev_ping,
 #else
@@ -289,7 +289,7 @@ const struct netdev_ops lwip_netdev_ops =
 #if defined (RT_LWIP_TCP) || defined (RT_LWIP_UDP)
     lwip_netdev_netstat,
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
-#endif /* FINSH_USING_MSH */
+#endif /* RT_USING_FINSH */
 };
 
 static int netdev_add(struct netif *lwip_netif)

--- a/components/net/lwip-2.1.0/src/netif/ethernetif.c
+++ b/components/net/lwip-2.1.0/src/netif/ethernetif.c
@@ -169,7 +169,7 @@ static int lwip_netdev_set_dhcp(struct netdev *netif, rt_bool_t is_enabled)
 }
 #endif /* RT_LWIP_DHCP */
 
-#ifdef FINSH_USING_MSH
+#ifdef RT_USING_FINSH
 #ifdef RT_LWIP_USING_PING
 extern int lwip_ping_recv(int s, int *ttl);
 extern err_t lwip_ping_send(int s, ip_addr_t *addr, int size);
@@ -260,7 +260,7 @@ void lwip_netdev_netstat(struct netdev *netif)
 #endif
 }
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
-#endif /* FINSH_USING_MSH */
+#endif /* RT_USING_FINSH */
 
 const struct netdev_ops lwip_netdev_ops =
 {
@@ -280,7 +280,7 @@ const struct netdev_ops lwip_netdev_ops =
     NULL,
 #endif /* RT_LWIP_DHCP */
 
-#ifdef FINSH_USING_MSH
+#ifdef RT_USING_FINSH
 #ifdef RT_LWIP_USING_PING
     lwip_netdev_ping,
 #else
@@ -290,7 +290,7 @@ const struct netdev_ops lwip_netdev_ops =
 #if defined (RT_LWIP_TCP) || defined (RT_LWIP_UDP)
     lwip_netdev_netstat,
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
-#endif /* FINSH_USING_MSH */
+#endif /* RT_USING_FINSH */
 };
 
 static int netdev_add(struct netif *lwip_netif)

--- a/components/net/lwip-2.1.0/src/netif/ethernetif.c
+++ b/components/net/lwip-2.1.0/src/netif/ethernetif.c
@@ -155,8 +155,8 @@ static int lwip_netdev_set_addr_info(struct netdev *netif, ip_addr_t *ip_addr, i
 #ifdef RT_LWIP_DNS
 static int lwip_netdev_set_dns_server(struct netdev *netif, uint8_t dns_num, ip_addr_t *dns_server)
 {
-    extern void set_dns(uint8_t dns_num, char* dns_server);
-    set_dns(dns_num, ipaddr_ntoa(dns_server));
+    extern void dns_setserver(uint8_t dns_num, const ip_addr_t *dns_server);
+    dns_setserver(dns_num, dns_server);
     return ERR_OK;
 }
 #endif /* RT_LWIP_DNS */
@@ -169,6 +169,7 @@ static int lwip_netdev_set_dhcp(struct netdev *netif, rt_bool_t is_enabled)
 }
 #endif /* RT_LWIP_DHCP */
 
+#ifdef FINSH_USING_MSH
 #ifdef RT_LWIP_USING_PING
 extern int lwip_ping_recv(int s, int *ttl);
 extern err_t lwip_ping_send(int s, ip_addr_t *addr, int size);
@@ -259,6 +260,7 @@ void lwip_netdev_netstat(struct netdev *netif)
 #endif
 }
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
+#endif /* FINSH_USING_MSH */
 
 const struct netdev_ops lwip_netdev_ops =
 {
@@ -278,6 +280,7 @@ const struct netdev_ops lwip_netdev_ops =
     NULL,
 #endif /* RT_LWIP_DHCP */
 
+#ifdef FINSH_USING_MSH
 #ifdef RT_LWIP_USING_PING
     lwip_netdev_ping,
 #else
@@ -287,6 +290,7 @@ const struct netdev_ops lwip_netdev_ops =
 #if defined (RT_LWIP_TCP) || defined (RT_LWIP_UDP)
     lwip_netdev_netstat,
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
+#endif /* FINSH_USING_MSH */
 };
 
 static int netdev_add(struct netif *lwip_netif)

--- a/components/net/netdev/include/netdev.h
+++ b/components/net/netdev/include/netdev.h
@@ -132,7 +132,7 @@ struct netdev_ops
     int (*set_dns_server)(struct netdev *netdev, uint8_t dns_num, ip_addr_t *dns_server);
     int (*set_dhcp)(struct netdev *netdev, rt_bool_t is_enabled);
 
-#ifdef FINSH_USING_MSH
+#ifdef RT_USING_FINSH
     /* set network interface device common network interface device operations */
     int (*ping)(struct netdev *netdev, const char *host, size_t data_len, uint32_t timeout, struct netdev_ping_resp *ping_resp);
     void (*netstat)(struct netdev *netdev);

--- a/components/net/netdev/include/netdev.h
+++ b/components/net/netdev/include/netdev.h
@@ -132,10 +132,11 @@ struct netdev_ops
     int (*set_dns_server)(struct netdev *netdev, uint8_t dns_num, ip_addr_t *dns_server);
     int (*set_dhcp)(struct netdev *netdev, rt_bool_t is_enabled);
 
+#ifdef FINSH_USING_MSH
     /* set network interface device common network interface device operations */
     int (*ping)(struct netdev *netdev, const char *host, size_t data_len, uint32_t timeout, struct netdev_ping_resp *ping_resp);
     void (*netstat)(struct netdev *netdev);
-
+#endif
 };
 
 /* The network interface device registered and unregistered*/

--- a/components/net/netdev/src/netdev.c
+++ b/components/net/netdev/src/netdev.c
@@ -821,7 +821,7 @@ void netdev_low_level_set_dhcp_status(struct netdev *netdev, rt_bool_t is_enable
     }
 }
 
-#ifdef FINSH_USING_MSH
+#ifdef RT_USING_FINSH
 
 #include <finsh.h>
 
@@ -832,7 +832,6 @@ static void netdev_list_if(void)
 #define NETDEV_IFCONFIG_IEMI_MAX_LEN   8
 
     rt_ubase_t index;
-    rt_base_t level;
     rt_slist_t *node  = RT_NULL;
     struct netdev *netdev = RT_NULL;
     struct netdev *cur_netdev_list = netdev_list;
@@ -843,14 +842,12 @@ static void netdev_list_if(void)
         return;
     }
 
-    level = rt_hw_interrupt_disable();
-
     for (node = &(cur_netdev_list->list); node; node = rt_slist_next(node))
     {
         netdev = rt_list_entry(node, struct netdev, list);
 
-        rt_kprintf("network interface device: %s%s\n",
-                   netdev->name,
+        rt_kprintf("network interface device: %.*s%s\n",
+                   RT_NAME_MAX, netdev->name,
                    (netdev == netdev_default) ? " (Default)" : "");
         rt_kprintf("MTU: %d\n", netdev->mtu);
 
@@ -925,8 +922,6 @@ static void netdev_list_if(void)
             rt_kprintf("\n");
         }
     }
-
-    rt_hw_interrupt_enable(level);
 }
 
 static void netdev_set_if(char* netdev_name, char* ip_addr, char* gw_addr, char* nm_addr)
@@ -1075,19 +1070,16 @@ FINSH_FUNCTION_EXPORT_ALIAS(netdev_ping, __cmd_ping, ping network host);
 
 static void netdev_list_dns(void)
 {
-    rt_base_t level;
     int index = 0;
     struct netdev *netdev = RT_NULL;
     rt_slist_t *node  = RT_NULL;
-
-    level = rt_hw_interrupt_disable();
 
     for (node = &(netdev_list->list); node; node = rt_slist_next(node))
     {
         netdev = rt_list_entry(node, struct netdev, list);
 
-        rt_kprintf("network interface device: %s%s\n",
-                netdev->name,
+        rt_kprintf("network interface device: %.*s%s\n",
+                RT_NAME_MAX, netdev->name,
                 (netdev == netdev_default)?" (Default)":"");
 
         for(index = 0; index < NETDEV_DNS_SERVERS_NUM; index++)
@@ -1100,8 +1092,6 @@ static void netdev_list_dns(void)
             rt_kprintf("\n");
         }
     }
-
-    rt_hw_interrupt_enable(level);
 }
 
 static void netdev_set_dns(char *netdev_name, uint8_t dns_num, char *dns_server)
@@ -1149,7 +1139,6 @@ FINSH_FUNCTION_EXPORT_ALIAS(netdev_dns, __cmd_dns, list and set the information 
 #ifdef NETDEV_USING_NETSTAT
 static void netdev_cmd_netstat(void)
 {
-    rt_base_t level;
     rt_slist_t *node  = RT_NULL;
     struct netdev *netdev = RT_NULL;
     struct netdev *cur_netdev_list = netdev_list;
@@ -1160,8 +1149,6 @@ static void netdev_cmd_netstat(void)
         return;
     }
 
-    level = rt_hw_interrupt_disable();
-
     for (node = &(cur_netdev_list->list); node; node = rt_slist_next(node))
     {
         netdev = rt_list_entry(node, struct netdev, list);
@@ -1171,8 +1158,6 @@ static void netdev_cmd_netstat(void)
             break;
         }
     }
-
-    rt_hw_interrupt_enable(level);
 
     netdev->ops->netstat(netdev);
 }
@@ -1193,4 +1178,4 @@ int netdev_netstat(int argc, char **argv)
 FINSH_FUNCTION_EXPORT_ALIAS(netdev_netstat, __cmd_netstat, list the information of TCP / IP);
 #endif /* NETDEV_USING_NETSTAT */
 
-#endif /* FINSH_USING_MSH */
+#endif /* RT_USING_FINSH */

--- a/components/net/netdev/src/netdev.c
+++ b/components/net/netdev/src/netdev.c
@@ -985,7 +985,7 @@ FINSH_FUNCTION_EXPORT_ALIAS(netdev_ifconfig, __cmd_ifconfig, list the informatio
 #endif /* NETDEV_USING_IFCONFIG */
 
 #ifdef NETDEV_USING_PING
-static int netdev_cmd_ping(char* target_name, rt_uint32_t times, rt_size_t size)
+int netdev_cmd_ping(char* target_name, rt_uint32_t times, rt_size_t size)
 {
 #define NETDEV_PING_DATA_SIZE       32
 /** ping receive timeout - in milliseconds */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
- 在网络相关命令中添加 RT_USING_FINSH  判断；
- 删除网络命令中关中断操作；
- 该测试已经在 QEMU 和 STM32F407 开发板上验证通过。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
