### PR TITLE
[libcpu][c28x]Add __rt_ffs support

### DIFF
--- a/libcpu/ti-dsp/c28x/context.s
+++ b/libcpu/ti-dsp/c28x/context.s
@@ -6,6 +6,8 @@
 ; Change Logs:
 ; Date           Author       Notes
 ; 2018-09-01     xuzhuoyi     the first version.
+; 2019-06-17     zhaoxiaowei  fix bugs of old c28x interrupt api.
+; 2019-07-03     zhaoxiaowei  add _rt_hw_calc_csb function to support __rt_ffs.
 ;
 
     .ref   _rt_interrupt_to_thread
@@ -15,6 +17,7 @@
     .def   _RTOSINT_Handler
     .def   _rt_hw_get_st0
     .def   _rt_hw_get_st1
+    .def   _rt_hw_calc_csb
     .def   _rt_hw_context_switch_interrupt
     .def   _rt_hw_context_switch
     .def   _rt_hw_context_switch_to
@@ -227,6 +230,25 @@ _rt_hw_get_st1:
     PUSH    ST1
     POP     AL
     LRETR
+    .endasmfunc
+
+; C28x do not have a build-in "__ffs" func in its C compiler.
+; We can use the "Count Sign Bits" (CSB) instruction to make one.
+; CSB will return the number of 0's minus 1 above the highest set bit.
+; The count is placed in T. For example:
+;    ACC        T     maxbit
+; 0x00000001    30      0
+; 0x00000010    26      4
+; 0x000001FF    22      8
+; 0x000001F0    22      8
+    .asmfunc
+_rt_hw_calc_csb:
+    MOV     AH, #0
+    CSB     ACC                   ; T = no. of sign bits - 1
+    MOVU    ACC, T                ; ACC = no. of sign bits - 1
+    SUBB    ACC, #30              ; ACC = ACC - 30
+    ABS     ACC                   ; ACC = |ACC|
+    lretr
     .endasmfunc
 
 ;

--- a/libcpu/ti-dsp/c28x/cpuport.c
+++ b/libcpu/ti-dsp/c28x/cpuport.c
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-09-01     xuzhuoyi     the first version.
+ * 2019-07-03     zhaoxiaowei  add support for __rt_ffs.
  */
 
 #include <rtthread.h>
@@ -19,6 +20,7 @@ static rt_err_t (*rt_exception_hook)(void *context) = RT_NULL;
 
 extern rt_uint16_t rt_hw_get_st0(void);
 extern rt_uint16_t rt_hw_get_st1(void);
+extern int rt_hw_calc_csb(int value);
 
 struct exception_stack_frame
 {
@@ -102,6 +104,19 @@ struct exception_info
     struct stack_frame stack_frame;
 };
 
+#ifdef RT_USING_CPU_FFS
+/*
+ * This function called rt_hw_calc_csb to finds the first bit set in value.
+ * rt_hw_calc_csb is a native assembly program that use "CSB" instruction in C28x.
+ * When you use this function, remember that "int" is only 16-bit in C28x's C compiler.
+ * If value is a number bigger that 0xFFFF, trouble may be caused.
+ * Maybe change "int __rt_ffs(int value)" to "rt_int32_t __rt_ffs(rt_int32_t value)" will be better.
+ */
+int __rt_ffs(int value)
+{
+    return rt_hw_calc_csb(value);
+}
+#endif
 
 /**
  * shutdown CPU


### PR DESCRIPTION
Use a native instruction "Count Sign Bits" to support fast ffs function, then add __rt_ffs support in C28x.

## 拉取/合并请求描述：(PR description)

[
增加了C28x对int __rt_ffs(int value)的原生支持，使用C28x指令集中的“CSB(Count Sign Bits)”指令来实现ffs
功能快速计算
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
