### PR TITLE
[net][lwip][dhcpd] Fix dhcp server compile error in lwIP 2.1.0

### DIFF
--- a/components/net/lwip-1.4.1/src/netif/ethernetif.c
+++ b/components/net/lwip-1.4.1/src/netif/ethernetif.c
@@ -686,8 +686,6 @@ int eth_system_device_init(void)
 }
 INIT_PREV_EXPORT(eth_system_device_init);
 
-#ifdef RT_USING_FINSH
-#include <finsh.h>
 void set_if(char* netif_name, char* ip_addr, char* gw_addr, char* nm_addr)
 {
     struct ip_addr *ip;
@@ -733,6 +731,9 @@ void set_if(char* netif_name, char* ip_addr, char* gw_addr, char* nm_addr)
         netif_set_netmask(netif, ip);
     }
 }
+
+#ifdef RT_USING_FINSH
+#include <finsh.h>
 FINSH_FUNCTION_EXPORT(set_if, set network interface address);
 
 #if LWIP_DNS

--- a/components/net/lwip-2.0.2/src/netif/ethernetif.c
+++ b/components/net/lwip-2.0.2/src/netif/ethernetif.c
@@ -715,8 +715,6 @@ int eth_system_device_init_private(void)
     return (int)result;
 }
 
-#ifdef RT_USING_FINSH
-#include <finsh.h>
 void set_if(char* netif_name, char* ip_addr, char* gw_addr, char* nm_addr)
 {
     ip4_addr_t *ip;
@@ -762,6 +760,9 @@ void set_if(char* netif_name, char* ip_addr, char* gw_addr, char* nm_addr)
         netif_set_netmask(netif, ip);
     }
 }
+
+#ifdef RT_USING_FINSH
+#include <finsh.h>
 FINSH_FUNCTION_EXPORT(set_if, set network interface address);
 
 #if LWIP_DNS

--- a/components/net/lwip-2.1.0/src/netif/ethernetif.c
+++ b/components/net/lwip-2.1.0/src/netif/ethernetif.c
@@ -720,8 +720,6 @@ int eth_system_device_init_private(void)
     return (int)result;
 }
 
-#ifdef RT_USING_FINSH
-#include <finsh.h>
 void set_if(char* netif_name, char* ip_addr, char* gw_addr, char* nm_addr)
 {
     ip4_addr_t *ip;
@@ -767,6 +765,9 @@ void set_if(char* netif_name, char* ip_addr, char* gw_addr, char* nm_addr)
         netif_set_netmask(netif, ip);
     }
 }
+
+#ifdef RT_USING_FINSH
+#include <finsh.h>
 FINSH_FUNCTION_EXPORT(set_if, set network interface address);
 
 #if LWIP_DNS

--- a/components/net/lwip_dhcpd/SConscript
+++ b/components/net/lwip_dhcpd/SConscript
@@ -2,7 +2,7 @@ from building import *
 
 cwd = GetCurrentDir()
 
-if GetDepend('RT_USING_LWIP202'):
+if GetDepend('RT_USING_LWIP202') or GetDepend('RT_USING_LWIP210') :
     src = ['dhcp_server_raw.c']
 else:
     src = ['dhcp_server.c']

--- a/components/net/lwip_dhcpd/dhcp_server_raw.c
+++ b/components/net/lwip_dhcpd/dhcp_server_raw.c
@@ -97,6 +97,10 @@
 #define LWIP_NETIF_LOCK(...)
 #define LWIP_NETIF_UNLOCK(...)
 
+#ifndef DHCP_SERVER_PORT
+#define DHCP_SERVER_PORT 67
+#endif
+
 /**
 * The dhcp client node struct.
 */


### PR DESCRIPTION

[net][lwip] Fix set_if() compile error when enable dhcpd fucntion and close finsh
[net][dhcpd] Fix dhcpd fucntion compile error in lwIP 2.1.0.

## 拉取/合并请求描述：(PR description)

[
- 修复关闭 Finsh 功能时 DHCP Server 功能编译错误；
- 修复在 lwIP 2.1.0 版本中 DHCP Server 功能编译错误；
- 该问题已经在 STM32F407 开发板中验证。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
