### PR TITLE
bug fix : change GPIO_PE_LOW to GPIO_PV_LOW, change GPIO_PE_HIGH to G…

### DIFF
--- a/bsp/k210/driver/drv_gpio.c
+++ b/bsp/k210/driver/drv_gpio.c
@@ -146,14 +146,14 @@ static void pin_irq(int vector, void *param)
         set_gpio_bit(gpiohs->rise_ie.u32, pin_channel, 1);
     }
 
-    if(irq_table[pin_channel].edge & GPIO_PE_LOW)
+    if(irq_table[pin_channel].edge & GPIO_PV_LOW)
     {
         set_gpio_bit(gpiohs->low_ie.u32, pin_channel, 0);
         set_gpio_bit(gpiohs->low_ip.u32, pin_channel, 1);
         set_gpio_bit(gpiohs->low_ie.u32, pin_channel, 1);
     }
 
-    if(irq_table[pin_channel].edge & GPIO_PE_HIGH)
+    if(irq_table[pin_channel].edge & GPIO_PV_HIGH)
     {
         set_gpio_bit(gpiohs->high_ie.u32, pin_channel, 0);
         set_gpio_bit(gpiohs->high_ip.u32, pin_channel, 1);
@@ -189,10 +189,10 @@ static rt_err_t drv_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
             irq_table[pin_channel].edge = GPIO_PE_BOTH;
             break;
         case PIN_IRQ_MODE_HIGH_LEVEL:
-            irq_table[pin_channel].edge = GPIO_PE_LOW;
+            irq_table[pin_channel].edge = GPIO_PV_LOW;
             break;
         case PIN_IRQ_MODE_LOW_LEVEL:
-            irq_table[pin_channel].edge = GPIO_PE_HIGH;
+            irq_table[pin_channel].edge = GPIO_PV_HIGH;
             break;
         default:
             break;


### PR DESCRIPTION
…PIO_PV_HIGH

## 拉取/合并请求描述：(PR description)

[
GPIO_PE_LOW和GPIO_PE_HIGH并没有定义，通过阅读源码，它们应该指的是GPIO_PV_LOW和GPIO_PV_HIGH。
在修改了此处，并注释掉未定义函数plic_get_instance后，可以成功编译rt-thread for k210，并在k210开发板上跑运行。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
