### PR TITLE
X1000: MMC: 添加MSC0数据位宽选项/Add MSC0 data bus width options.

### DIFF
--- a/bsp/x1000/drivers/Kconfig
+++ b/bsp/x1000/drivers/Kconfig
@@ -50,6 +50,19 @@ if RT_USING_SDIO
         bool "Using MMC/SD 0"
         default y
 
+    if RT_USING_MSC0
+        choice
+            prompt "GPIO function pins select"
+            default CONFIG_MSC0_PA_4BIT
+
+            config CONFIG_MSC0_PA_1BIT
+                bool "PORT A, data with 1 bit"
+
+            config CONFIG_MSC0_PA_4BIT
+                bool "PORT A, data with 4 bit"
+        endchoice
+    endif
+
     config RT_USING_MSC1
         bool "Using MMC/SD 1"
         default y

--- a/bsp/x1000/drivers/Kconfig
+++ b/bsp/x1000/drivers/Kconfig
@@ -60,6 +60,9 @@ if RT_USING_SDIO
 
             config CONFIG_MSC0_PA_4BIT
                 bool "PORT A, data with 4 bit"
+
+            config CONFIG_MSC0_PA_8BIT
+                bool "PORT A, data with 8 bit"
         endchoice
     endif
 

--- a/bsp/x1000/drivers/mmc/drv_mmc.c
+++ b/bsp/x1000/drivers/mmc/drv_mmc.c
@@ -10,6 +10,7 @@
  * 2013-04-01     aozima       add interrupt support for JZ4770.
  * 2019-04-04     Jean-Luc     fix bug in jzmmc_submit_dma.
  *                             add 4bit mode support for msc0.
+ * 2019-07-20     wickkid      add 8bit mode support for msc0.
  */
 
 #include <rthw.h>

--- a/bsp/x1000/drivers/mmc/drv_mmc.c
+++ b/bsp/x1000/drivers/mmc/drv_mmc.c
@@ -966,9 +966,11 @@ int jzmmc_sdio_init(void)
      * X1000  MSC0_CLK: PA24  1
      */
     {
+#ifdef CONFIG_MSC0_PA_4BIT
         gpio_set_func(GPIO_PORT_A, GPIO_Pin_20, GPIO_FUNC_1);
         gpio_set_func(GPIO_PORT_A, GPIO_Pin_21, GPIO_FUNC_1);
         gpio_set_func(GPIO_PORT_A, GPIO_Pin_22, GPIO_FUNC_1);
+#endif
         gpio_set_func(GPIO_PORT_A, GPIO_Pin_23, GPIO_FUNC_1);
         gpio_set_func(GPIO_PORT_A, GPIO_Pin_24, GPIO_FUNC_1);
         gpio_set_func(GPIO_PORT_A, GPIO_Pin_25, GPIO_FUNC_1);
@@ -991,8 +993,14 @@ int jzmmc_sdio_init(void)
     host->ops = &ops;
     host->valid_ocr = VDD_27_28 | VDD_28_29 | VDD_29_30 | VDD_30_31 | VDD_31_32 |
         VDD_32_33 | VDD_33_34 | VDD_34_35 | VDD_35_36;
-    // host->flags = MMCSD_BUSWIDTH_4 | MMCSD_MUTBLKWRITE | MMCSD_SUP_SDIO_IRQ | MMCSD_SUP_HIGHSPEED;
-    host->flags = MMCSD_MUTBLKWRITE | MMCSD_SUP_SDIO_IRQ | MMCSD_SUP_HIGHSPEED;
+
+#ifdef CONFIG_MSC0_PA_1BIT
+	host->flags = MMCSD_MUTBLKWRITE | MMCSD_SUP_SDIO_IRQ | MMCSD_SUP_HIGHSPEED;
+#endif
+#ifdef CONFIG_MSC0_PA_4BIT
+    host->flags = MMCSD_BUSWIDTH_4 | MMCSD_MUTBLKWRITE | MMCSD_SUP_SDIO_IRQ | MMCSD_SUP_HIGHSPEED;
+#endif
+
     host->max_seg_size = 65535;
     host->max_dma_segs = 2;
     host->max_blk_size = 512;

--- a/bsp/x1000/drivers/mmc/drv_mmc.c
+++ b/bsp/x1000/drivers/mmc/drv_mmc.c
@@ -9,6 +9,7 @@
  * 2013-03-29     aozima       support JZ4770.
  * 2013-04-01     aozima       add interrupt support for JZ4770.
  * 2019-04-04     Jean-Luc     fix bug in jzmmc_submit_dma.
+ *                             add 4bit mode support for msc0.
  */
 
 #include <rthw.h>


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
X1000: MMC: 添加MSC0数据位宽选项/Add MSC0 data bus width options.

已在RatCharm、CU Neo、Realboard上通过测试/Tested on RatCharm and CU Neo and Realboard.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
