### PR TITLE
[BSP][QEMU-VExress] fix the automac issue under rtthread-apps

### DIFF
--- a/bsp/qemu-vexpress-a9/rtconfig.py
+++ b/bsp/qemu-vexpress-a9/rtconfig.py
@@ -21,7 +21,8 @@ end = '''
 #endif
 '''
 
-with open('drivers/automac.h', 'w') as f:
+automac_h_fn = os.path.join(os.path.dirname(__file__), 'drivers', 'automac.h')
+with open(automac_h_fn, 'w') as f:
     f.write(header + get_mac_address() + end)
 
 # toolchains options


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

修正编译动态模块时，qemu-vexpress-a9中mac地址文件生成报错的问题。

Fixed the issue of generation MAC address file in qemu-vexpress-a9 BSP when building dynamic module.

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
