### PR TITLE
fix bug: free rbb after have freed its members

### DIFF
--- a/components/drivers/src/ringblk_buf.c
+++ b/components/drivers/src/ringblk_buf.c
@@ -95,9 +95,9 @@ void rt_rbb_destroy(rt_rbb_t rbb)
 {
     RT_ASSERT(rbb);
 
-    rt_free(rbb);
     rt_free(rbb->buf);
     rt_free(rbb->blk_set);
+	rt_free(rbb);
 
 }
 RTM_EXPORT(rt_rbb_destroy);

--- a/components/drivers/src/ringblk_buf.c
+++ b/components/drivers/src/ringblk_buf.c
@@ -143,7 +143,7 @@ rt_rbb_blk_t rt_rbb_blk_alloc(rt_rbb_t rbb, rt_size_t blk_size)
 
     new_rbb = find_empty_blk_in_set(rbb);
 
-    if (rt_slist_len(&rbb->blk_list) < rbb->blk_max_num && new_rbb)
+    if (new_rbb)
     {
         if (rt_slist_len(&rbb->blk_list) > 0)
         {
@@ -214,10 +214,6 @@ rt_rbb_blk_t rt_rbb_blk_alloc(rt_rbb_t rbb, rt_size_t blk_size)
             new_rbb->buf = rbb->buf;
             new_rbb->size = blk_size;
         }
-    }
-    else
-    {
-        new_rbb = NULL;
     }
 
     rt_hw_interrupt_enable(level);

--- a/components/drivers/src/ringblk_buf.c
+++ b/components/drivers/src/ringblk_buf.c
@@ -97,7 +97,7 @@ void rt_rbb_destroy(rt_rbb_t rbb)
 
     rt_free(rbb->buf);
     rt_free(rbb->blk_set);
-	rt_free(rbb);
+    rt_free(rbb);
 
 }
 RTM_EXPORT(rt_rbb_destroy);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
改为最后才释放 rbb. 
先释放 rbb 的话， rbb->buf 和 rbb->blk_set 的值可能会被篡改。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
