### PR TITLE
[bsp][stm32] fix RT_ASSERT location error

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -44,9 +44,8 @@ static struct stm32_adc stm32_adc_obj[sizeof(adc_config) / sizeof(adc_config[0])
 
 static rt_err_t stm32_adc_enabled(struct rt_adc_device *device, rt_uint32_t channel, rt_bool_t enabled)
 {
-    ADC_HandleTypeDef *stm32_adc_handler = device->parent.user_data;
-
     RT_ASSERT(device != RT_NULL);
+    ADC_HandleTypeDef *stm32_adc_handler = device->parent.user_data;
 
     if (enabled)
     {
@@ -141,10 +140,11 @@ static rt_uint32_t stm32_adc_get_channel(rt_uint32_t channel)
 static rt_err_t stm32_get_adc_value(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value)
 {
     ADC_ChannelConfTypeDef ADC_ChanConf;
-    ADC_HandleTypeDef *stm32_adc_handler = device->parent.user_data;
 
     RT_ASSERT(device != RT_NULL);
     RT_ASSERT(value != RT_NULL);
+
+    ADC_HandleTypeDef *stm32_adc_handler = device->parent.user_data;
 
     rt_memset(&ADC_ChanConf, 0, sizeof(ADC_ChanConf));
 

--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -44,8 +44,9 @@ static struct stm32_adc stm32_adc_obj[sizeof(adc_config) / sizeof(adc_config[0])
 
 static rt_err_t stm32_adc_enabled(struct rt_adc_device *device, rt_uint32_t channel, rt_bool_t enabled)
 {
+    ADC_HandleTypeDef *stm32_adc_handler;
     RT_ASSERT(device != RT_NULL);
-    ADC_HandleTypeDef *stm32_adc_handler = device->parent.user_data;
+    stm32_adc_handler = device->parent.user_data;
 
     if (enabled)
     {
@@ -140,11 +141,12 @@ static rt_uint32_t stm32_adc_get_channel(rt_uint32_t channel)
 static rt_err_t stm32_get_adc_value(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value)
 {
     ADC_ChannelConfTypeDef ADC_ChanConf;
+    ADC_HandleTypeDef *stm32_adc_handler;
 
     RT_ASSERT(device != RT_NULL);
     RT_ASSERT(value != RT_NULL);
 
-    ADC_HandleTypeDef *stm32_adc_handler = device->parent.user_data;
+    stm32_adc_handler = device->parent.user_data;
 
     rt_memset(&ADC_ChanConf, 0, sizeof(ADC_ChanConf));
 


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

修复 stm32 bsp 中的 adc 驱动中 RT_ASSERT 使用位置错误问题。

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
