### PR TITLE
更改SysTick中断优先级

### DIFF
--- a/libcpu/arm/cortex-m0/context_gcc.S
+++ b/libcpu/arm/cortex-m0/context_gcc.S
@@ -22,7 +22,7 @@
 	.equ 	SCB_VTOR, 0xE000ED08            /* Vector Table Offset Register */
 	.equ 	NVIC_INT_CTRL, 0xE000ED04       /* interrupt control state register */
 	.equ 	NVIC_SHPR3, 0xE000ED20          /* system priority register (3) */
-	.equ 	NVIC_PENDSV_PRI, 0x00FF0000     /* PendSV priority value (lowest) */
+	.equ 	NVIC_PENDSV_PRI, 0xF0F00000     /* PendSV priority value (lowest) */
 	.equ 	NVIC_PENDSVSET, 0x10000000      /* value to trigger PendSV exception */
 
 /*

--- a/libcpu/arm/cortex-m0/context_iar.S
+++ b/libcpu/arm/cortex-m0/context_iar.S
@@ -19,7 +19,7 @@
 SCB_VTOR        EQU     0xE000ED08               ; Vector Table Offset Register
 NVIC_INT_CTRL   EQU     0xE000ED04               ; interrupt control state register
 NVIC_SHPR3      EQU     0xE000ED20               ; system priority register (2)
-NVIC_PENDSV_PRI EQU     0x00FF0000               ; PendSV priority value (lowest)
+NVIC_PENDSV_PRI EQU     0xF0F00000               ; PendSV priority value (lowest)
 NVIC_PENDSVSET  EQU     0x10000000               ; value to trigger PendSV exception
 
     SECTION    .text:CODE(2)

--- a/libcpu/arm/cortex-m0/context_rvds.S
+++ b/libcpu/arm/cortex-m0/context_rvds.S
@@ -19,7 +19,7 @@
 SCB_VTOR        EQU     0xE000ED08               ; Vector Table Offset Register
 NVIC_INT_CTRL   EQU     0xE000ED04               ; interrupt control state register
 NVIC_SHPR3      EQU     0xE000ED20               ; system priority register (2)
-NVIC_PENDSV_PRI EQU     0x00FF0000               ; PendSV priority value (lowest)
+NVIC_PENDSV_PRI EQU     0xF0F00000               ; PendSV priority value (lowest)
 NVIC_PENDSVSET  EQU     0x10000000               ; value to trigger PendSV exception
 
     AREA |.text|, CODE, READONLY, ALIGN=2

--- a/libcpu/arm/cortex-m3/context_gcc.S
+++ b/libcpu/arm/cortex-m3/context_gcc.S
@@ -24,7 +24,7 @@
     .equ    PENDSVSET_BIT, 0x10000000       /* value to trigger PendSV exception */
     
     .equ    SHPR3, 0xE000ED20               /* system priority register (3) */
-    .equ    PENDSV_PRI_LOWEST, 0x00FF0000   /* PendSV priority value (lowest) */
+    .equ    PENDSV_PRI_LOWEST, 0xF0F00000   /* systic/PendSV priority value (lowest) */
 
 /*
  * rt_base_t rt_hw_interrupt_disable();

--- a/libcpu/arm/cortex-m3/context_iar.S
+++ b/libcpu/arm/cortex-m3/context_iar.S
@@ -19,7 +19,7 @@
 SCB_VTOR        EQU     0xE000ED08               ; Vector Table Offset Register
 NVIC_INT_CTRL   EQU     0xE000ED04               ; interrupt control state register
 NVIC_SYSPRI2    EQU     0xE000ED20               ; system priority register (2)
-NVIC_PENDSV_PRI EQU     0x00FF0000               ; PendSV priority value (lowest)
+NVIC_PENDSV_PRI EQU     0xF0F00000               ; systic/PendSV priority value (lowest)
 NVIC_PENDSVSET  EQU     0x10000000               ; value to trigger PendSV exception
 
     SECTION    .text:CODE(2)

--- a/libcpu/arm/cortex-m3/context_rvds.S
+++ b/libcpu/arm/cortex-m3/context_rvds.S
@@ -18,7 +18,7 @@
 SCB_VTOR        EQU     0xE000ED08               ; Vector Table Offset Register
 NVIC_INT_CTRL   EQU     0xE000ED04               ; interrupt control state register
 NVIC_SYSPRI2    EQU     0xE000ED20               ; system priority register (2)
-NVIC_PENDSV_PRI EQU     0x00FF0000               ; PendSV priority value (lowest)
+NVIC_PENDSV_PRI EQU     0xF0F00000               ; systic/PendSV priority value (lowest)
 NVIC_PENDSVSET  EQU     0x10000000               ; value to trigger PendSV exception
 
     AREA |.text|, CODE, READONLY, ALIGN=2

--- a/libcpu/arm/cortex-m4/context_gcc.S
+++ b/libcpu/arm/cortex-m4/context_gcc.S
@@ -25,7 +25,7 @@
 .equ    SCB_VTOR,           0xE000ED08              /* Vector Table Offset Register */
 .equ    NVIC_INT_CTRL,      0xE000ED04              /* interrupt control state register */
 .equ    NVIC_SYSPRI2,       0xE000ED20              /* system priority register (2) */
-.equ    NVIC_PENDSV_PRI,    0x00FF0000              /* PendSV priority value (lowest) */
+.equ    PENDSV_PRI_LOWEST,  0xF0F00000   /* systic/PendSV priority value (lowest) */
 .equ    NVIC_PENDSVSET,     0x10000000              /* value to trigger PendSV exception */
 
 /*

--- a/libcpu/arm/cortex-m4/context_iar.S
+++ b/libcpu/arm/cortex-m4/context_iar.S
@@ -21,7 +21,7 @@
 SCB_VTOR        EQU     0xE000ED08               ; Vector Table Offset Register
 NVIC_INT_CTRL   EQU     0xE000ED04               ; interrupt control state register
 NVIC_SYSPRI2    EQU     0xE000ED20               ; system priority register (2)
-NVIC_PENDSV_PRI EQU     0x00FF0000               ; PendSV priority value (lowest)
+NVIC_PENDSV_PRI EQU     0xF0F00000               ; PendSV priority value (lowest)
 NVIC_PENDSVSET  EQU     0x10000000               ; value to trigger PendSV exception
 
     SECTION    .text:CODE(2)

--- a/libcpu/arm/cortex-m4/context_rvds.S
+++ b/libcpu/arm/cortex-m4/context_rvds.S
@@ -20,7 +20,7 @@
 SCB_VTOR        EQU     0xE000ED08               ; Vector Table Offset Register
 NVIC_INT_CTRL   EQU     0xE000ED04               ; interrupt control state register
 NVIC_SYSPRI2    EQU     0xE000ED20               ; system priority register (2)
-NVIC_PENDSV_PRI EQU     0x00FF0000               ; PendSV priority value (lowest)
+NVIC_PENDSV_PRI EQU     0xF0F00000               ; systic/PendSV priority value (lowest)
 NVIC_PENDSVSET  EQU     0x10000000               ; value to trigger PendSV exception
 
     AREA |.text|, CODE, READONLY, ALIGN=2


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
经测试SysTick和pendSV的中断优先级默认分别设置为0和15，SysTick的中断优先级默认设置为0，会打断用户低优先级中断不合理，SysTick的中断优先级默认设置为低优先级更合理。
具体细节在这个帖子：https://www.rt-thread.org/qa/thread-421383-1-1.html
更改...\rt-thread\libcpu\arm\cortex-m0、3、4、7中的context_rvds.S文件，其中
NVIC_PENDSV_PRI EQU     0x00FF0000改为
NVIC_PENDSV_PRI EQU     0xF0F00000
已经在stm32f429-fire-challenger做过了测试。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [√] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [√] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [√] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [√] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [√] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [√] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [√] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
