### PR TITLE
[stm32][driver_eth] 修复开启自动协商时出错的 bug 

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_eth.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_eth.c
@@ -102,7 +102,6 @@ static rt_err_t rt_stm32_eth_init(rt_device_t dev)
     if (HAL_ETH_Init(&EthHandle) != HAL_OK)
     {
         LOG_E("eth hardware init failed");
-        return -RT_ERROR;
     }
     else
     {

--- a/bsp/stm32/stm32f407-atk-explorer/board/ports/phy_reset.c
+++ b/bsp/stm32/stm32f407-atk-explorer/board/ports/phy_reset.c
@@ -25,4 +25,4 @@ int phy_init(void)
     rt_pin_write(RESET_IO, PIN_HIGH);
     return RT_EOK;
 }
-INIT_APP_EXPORT(phy_init);
+INIT_BOARD_EXPORT(phy_init);

--- a/components/net/lwip-1.4.1/src/arch/sys_arch.c
+++ b/components/net/lwip-1.4.1/src/arch/sys_arch.c
@@ -198,7 +198,7 @@ int lwip_system_init(void)
 
 	return 0;
 }
-INIT_COMPONENT_EXPORT(lwip_system_init);
+INIT_PREV_EXPORT(lwip_system_init);
 
 void sys_init(void)
 {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
之前提交的pr不符合新的ci脚本要求，现重新提交。
解决问题:
1、修复因LAN8720A以太网芯片重启无效而导致无法进行自动协商，引起网卡初始化失败。
2、修复因LWIP-1.4.1版本中tcp协议栈的初始化顺序有误，导致使用netdev组件时，网卡无法正常注册。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
