### PR TITLE
fix stm32 tim set mode bug

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_hwtimer.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_hwtimer.c
@@ -235,7 +235,7 @@ static rt_err_t timer_start(rt_hwtimer_t *timer, rt_uint32_t t, rt_hwtimer_mode_
         /* set timer to single mode */
         tim->Instance->CR1 |= TIM_OPMODE_SINGLE;
     }
-	else
+    else
     {
         tim->Instance->CR1 &= (~TIM_OPMODE_SINGLE);
     }

--- a/bsp/stm32/libraries/HAL_Drivers/drv_hwtimer.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_hwtimer.c
@@ -235,11 +235,15 @@ static rt_err_t timer_start(rt_hwtimer_t *timer, rt_uint32_t t, rt_hwtimer_mode_
         /* set timer to single mode */
         tim->Instance->CR1 |= TIM_OPMODE_SINGLE;
     }
+	else
+    {
+        tim->Instance->CR1 &= (~TIM_OPMODE_SINGLE);
+    }
 
     /* start timer */
     if (HAL_TIM_Base_Start_IT(tim) != HAL_OK)
     {
-        LOG_E("TIM2 start failed");
+        LOG_E("TIM start failed");
         result = -RT_ERROR;
     }
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[
原因：
使用canfestival包用来发送sdo数据超时时不能正确复位sdo line
发现rtt 定时器框架对stm32 定时器模式设置只能设置HWTIMER_MODE_ONESHOT而不能设置HWTIMER_MODE_PERIOD模式
 方案：
添加分支设置HWTIMER_MODE_PERIOD模式
已经在stm32f429IGT6 野火开发板上面验证通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [✓ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [✓ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [✓ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [✓ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [✓ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [✓ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ✓] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
