### PR TITLE
Fix dns server address set error and improve the default netdev set operations

### DIFF
--- a/components/net/lwip-1.4.1/src/core/dns.c
+++ b/components/net/lwip-1.4.1/src/core/dns.c
@@ -279,13 +279,14 @@ dns_setserver(u8_t numdns, ip_addr_t *dnsserver)
     dns_servers[numdns] = (*dnsserver);
     
 #ifdef RT_USING_NETDEV
-      extern struct netif *netif_default;
+      extern struct netif *netif_list;
       extern struct netdev *netdev_get_by_name(const char *name);
       extern void netdev_low_level_set_dns_server(struct netdev *netdev, uint8_t dns_num, const ip_addr_t *dns_server);
+      struct netif *netif = NULL;
 
       /* set network interface device DNS server address */
-      if (netif_default) {
-        netdev_low_level_set_dns_server(netdev_get_by_name(netif_default->name), numdns, dnsserver);
+      for (netif = netif_list; netif != NULL; netif = netif->next) {
+        netdev_low_level_set_dns_server(netdev_get_by_name(netif->name), numdns, dnsserver);
       }
 #endif /* RT_USING_NETDEV */
   }

--- a/components/net/lwip-1.4.1/src/netif/ethernetif.c
+++ b/components/net/lwip-1.4.1/src/netif/ethernetif.c
@@ -253,6 +253,12 @@ void lwip_netdev_netstat(struct netdev *netif)
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
 #endif /* RT_USING_FINSH */
 
+static int lwip_netdev_set_default(struct netdev *netif)
+{
+    netif_set_default((struct netif *)netif->user_data);
+    return ERR_OK;
+}
+
 const struct netdev_ops lwip_netdev_ops =
 {
     lwip_netdev_set_up,
@@ -282,6 +288,8 @@ const struct netdev_ops lwip_netdev_ops =
     lwip_netdev_netstat,
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
 #endif /* RT_USING_FINSH */
+
+    lwip_netdev_set_default,
 };
 
 static int netdev_add(struct netif *lwip_netif)

--- a/components/net/lwip-2.0.2/src/core/dns.c
+++ b/components/net/lwip-2.0.2/src/core/dns.c
@@ -370,13 +370,14 @@ dns_setserver(u8_t numdns, const ip_addr_t *dnsserver)
       dns_servers[numdns] = (*dnsserver);
         
 #ifdef RT_USING_NETDEV
-      extern struct netif *netif_default;
+      extern struct netif *netif_list;
       extern struct netdev *netdev_get_by_name(const char *name);
       extern void netdev_low_level_set_dns_server(struct netdev *netdev, uint8_t dns_num, const ip_addr_t *dns_server);
+      struct netif *netif = NULL;
 
       /* set network interface device DNS server address */
-      if (netif_default) {
-        netdev_low_level_set_dns_server(netdev_get_by_name(netif_default->name), numdns, dnsserver);
+      for (netif = netif_list; netif != NULL; netif = netif->next) {
+        netdev_low_level_set_dns_server(netdev_get_by_name(netif->name), numdns, dnsserver);
       }
 #endif /* RT_USING_NETDEV */
     } else {

--- a/components/net/lwip-2.0.2/src/netif/ethernetif.c
+++ b/components/net/lwip-2.0.2/src/netif/ethernetif.c
@@ -261,6 +261,12 @@ void lwip_netdev_netstat(struct netdev *netif)
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
 #endif /* RT_USING_FINSH */
 
+static int lwip_netdev_set_default(struct netdev *netif)
+{
+    netif_set_default((struct netif *)netif->user_data);
+    return ERR_OK;
+}
+
 const struct netdev_ops lwip_netdev_ops =
 {
     lwip_netdev_set_up,
@@ -290,6 +296,8 @@ const struct netdev_ops lwip_netdev_ops =
     lwip_netdev_netstat,
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
 #endif /* RT_USING_FINSH */
+
+    lwip_netdev_set_default,
 };
 
 static int netdev_add(struct netif *lwip_netif)

--- a/components/net/lwip-2.1.0/src/core/dns.c
+++ b/components/net/lwip-2.1.0/src/core/dns.c
@@ -367,13 +367,14 @@ dns_setserver(u8_t numdns, const ip_addr_t *dnsserver)
       dns_servers[numdns] = (*dnsserver);
 
 #ifdef RT_USING_NETDEV
-      extern struct netif *netif_default;
+      extern struct netif *netif_list;
       extern struct netdev *netdev_get_by_name(const char *name);
       extern void netdev_low_level_set_dns_server(struct netdev *netdev, uint8_t dns_num, const ip_addr_t *dns_server);
+      struct netif *netif = NULL;
 
       /* set network interface device DNS server address */
-      if (netif_default) {
-        netdev_low_level_set_dns_server(netdev_get_by_name(netif_default->name), numdns, dnsserver);
+      for (netif = netif_list; netif != NULL; netif = netif->next) {
+          netdev_low_level_set_dns_server(netdev_get_by_name(netif->name), numdns, dnsserver);
       }
 #endif /* RT_USING_NETDEV */
     } else {

--- a/components/net/lwip-2.1.0/src/netif/ethernetif.c
+++ b/components/net/lwip-2.1.0/src/netif/ethernetif.c
@@ -262,6 +262,12 @@ void lwip_netdev_netstat(struct netdev *netif)
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
 #endif /* RT_USING_FINSH */
 
+static int lwip_netdev_set_default(struct netdev *netif)
+{
+    netif_set_default((struct netif *)netif->user_data);
+    return ERR_OK;
+}
+
 const struct netdev_ops lwip_netdev_ops =
 {
     lwip_netdev_set_up,
@@ -291,6 +297,8 @@ const struct netdev_ops lwip_netdev_ops =
     lwip_netdev_netstat,
 #endif /* RT_LWIP_TCP || RT_LWIP_UDP */
 #endif /* RT_USING_FINSH */
+
+    lwip_netdev_set_default,
 };
 
 static int netdev_add(struct netif *lwip_netif)

--- a/components/net/netdev/include/netdev.h
+++ b/components/net/netdev/include/netdev.h
@@ -137,6 +137,9 @@ struct netdev_ops
     int (*ping)(struct netdev *netdev, const char *host, size_t data_len, uint32_t timeout, struct netdev_ping_resp *ping_resp);
     void (*netstat)(struct netdev *netdev);
 #endif
+
+    /* set default network interface device in current network stack*/
+    int (*set_default)(struct netdev *netdev);
 };
 
 /* The network interface device registered and unregistered*/

--- a/components/net/netdev/src/netdev.c
+++ b/components/net/netdev/src/netdev.c
@@ -34,11 +34,11 @@ struct netdev *netdev_default;
 /**
  * This function will register network interface device and
  * add it to network interface device list.
- * 
+ *
  * @param netdev the network interface device object
  * @param name the network interface device name
  * @param user_data user-specific data
- * 
+ *
  * @return  0: registered successfully
  *         -1: registered failed
  */
@@ -105,9 +105,9 @@ int netdev_register(struct netdev *netdev, const char *name, void *user_data)
 /**
  * This function will unregister network interface device and
  * delete it from network interface device list.
- * 
+ *
  * @param netdev the network interface device object
- * 
+ *
  * @return  0: unregistered successfully
  *         -1: unregistered failed
  */
@@ -164,11 +164,11 @@ int netdev_unregister(struct netdev *netdev)
 /**
  * This function will get the first network interface device
  * with the flags in network interface device list.
- * 
+ *
  * @param flags the network interface device flags
- * 
+ *
  * @return != NULL: network interface device object
- *            NULL: get failed 
+ *            NULL: get failed
  */
 struct netdev *netdev_get_first_by_flags(uint16_t flags)
 {
@@ -201,11 +201,11 @@ struct netdev *netdev_get_first_by_flags(uint16_t flags)
 /**
  * This function will get the first network interface device
  * in network interface device list by IP address.
- * 
+ *
  * @param addr the network interface device IP address
- * 
+ *
  * @return != NULL: network interface device object
- *            NULL: get failed 
+ *            NULL: get failed
  */
 struct netdev *netdev_get_by_ipaddr(ip_addr_t *ip_addr)
 {
@@ -238,11 +238,11 @@ struct netdev *netdev_get_by_ipaddr(ip_addr_t *ip_addr)
 /**
  * This function will get network interface device
  * in network interface device list by netdev name.
- * 
+ *
  * @param name the network interface device name
- * 
+ *
  * @return != NULL: network interface device object
- *            NULL: get failed 
+ *            NULL: get failed
  */
 struct netdev *netdev_get_by_name(const char *name)
 {
@@ -276,11 +276,11 @@ struct netdev *netdev_get_by_name(const char *name)
 /**
  * This function will get the first network interface device
  * in network interface device list by protocol family type.
- * 
+ *
  * @param family the network interface device protocol family type
- * 
+ *
  * @return != NULL: network interface device object
- *            NULL: get failed 
+ *            NULL: get failed
  */
 struct netdev *netdev_get_by_family(int family)
 {
@@ -325,15 +325,15 @@ struct netdev *netdev_get_by_family(int family)
 
 /**
  * This function will get the family type from network interface device
- * 
+ *
  * @param netdev network interface device object
- * 
+ *
  * @return the network interface device family type
  */
 int netdev_family_get(struct netdev *netdev)
 {
-    RT_ASSERT(netdev); 
-    
+    RT_ASSERT(netdev);
+
     return ((struct sal_proto_family *)netdev->sal_user_data)->family;
 }
 
@@ -341,7 +341,7 @@ int netdev_family_get(struct netdev *netdev)
 
 /**
  * This function will set default network interface device.
- * 
+ *
  * @param netdev the network interface device to change
  */
 void netdev_set_default(struct netdev *netdev)
@@ -349,15 +349,21 @@ void netdev_set_default(struct netdev *netdev)
     if (netdev)
     {
         netdev_default = netdev;
+
+        if (netdev->ops->set_default)
+        {
+            /* set default network interface device in the current network stack */
+            netdev->ops->set_default(netdev);
+        }
         LOG_D("Setting default network interface device name(%s) successfully.", netdev->name);       
     }
 }
 
 /**
  * This function will enable network interface device .
- * 
+ *
  * @param netdev the network interface device to change
- * 
+ *
  * @return  0: set status successfully
  *         -1: set status failed
  */
@@ -370,7 +376,7 @@ int netdev_set_up(struct netdev *netdev)
         LOG_E("The network interface device(%s) not support to set status.", netdev->name);
         return -RT_ERROR;
     }
-    
+
     /* network interface device status flags check */
     if (netdev_is_up(netdev))
     {
@@ -382,9 +388,9 @@ int netdev_set_up(struct netdev *netdev)
 }
 /**
  * This function will disable network interface device.
- * 
+ *
  * @param netdev the network interface device to change
- * 
+ *
  * @return  0: set status successfully
  *         -1: set sttaus failed
  */
@@ -397,7 +403,7 @@ int netdev_set_down(struct netdev *netdev)
         LOG_E("The network interface device(%s) not support to set status.", netdev->name);
         return -RT_ERROR;
     }
-    
+
     /* network interface device status flags check */
     if (!netdev_is_up(netdev))
     {
@@ -410,10 +416,10 @@ int netdev_set_down(struct netdev *netdev)
 
 /**
  * This function will control network interface device DHCP capability enable or disable.
- * 
+ *
  * @param netdev the network interface device device to change
  * @param is_enable the new DHCP status
- * 
+ *
  * @return  0: set DHCP status successfully
  *         -1: set DHCP status failed
  */
@@ -432,17 +438,17 @@ int netdev_dhcp_enabled(struct netdev *netdev, rt_bool_t is_enabled)
     {
         return RT_EOK;
     }
-    
+
     /* execute network interface device DHCP capability control operations */
     return netdev->ops->set_dhcp(netdev, is_enabled);
 }
 
 /**
  * This function will set network interface device IP address.
- * 
+ *
  * @param netdev the network interface device to change
  * @param ipaddr the new IP address
- * 
+ *
  * @return  0: set IP address successfully
  *         -1: set IP address failed
  */
@@ -456,7 +462,7 @@ int netdev_set_ipaddr(struct netdev *netdev, const ip_addr_t *ip_addr)
         LOG_E("The network interface device(%s) not support to set IP address.", netdev->name);
         return -RT_ERROR;
     }
-    
+
     if (netdev_is_dhcp_enabled(netdev))
     {
         LOG_E("The network interface device(%s) DHCP capability is enable, not support set IP address.", netdev->name);
@@ -469,10 +475,10 @@ int netdev_set_ipaddr(struct netdev *netdev, const ip_addr_t *ip_addr)
 
 /**
  * This function will set network interface device netmask address.
- * 
+ *
  * @param netdev the network interface device to change
  * @param netmask the new netmask address
- * 
+ *
  * @return  0: set netmask address successfully
  *         -1: set netmask address failed
  */
@@ -486,7 +492,7 @@ int netdev_set_netmask(struct netdev *netdev, const ip_addr_t *netmask)
         LOG_E("The network interface device(%s) not support to set netmask address.", netdev->name);
         return -RT_ERROR;
     }
-    
+
     if (netdev_is_dhcp_enabled(netdev))
     {
         LOG_E("The network interface device(%s) DHCP capability is enable, not support set netmask address.", netdev->name);
@@ -499,10 +505,10 @@ int netdev_set_netmask(struct netdev *netdev, const ip_addr_t *netmask)
 
 /**
  * This function will set network interface device gateway address.
- * 
+ *
  * @param netdev the network interface device to change
- * @param gateway the new gateway address 
- * 
+ * @param gateway the new gateway address
+ *
  * @return  0: set gateway address successfully
  *         -1: set gateway address failed
  */
@@ -516,7 +522,7 @@ int netdev_set_gw(struct netdev *netdev, const ip_addr_t *gw)
         LOG_E("The network interface device(%s) not support to set gateway address.", netdev->name);
         return -RT_ERROR;
     }
-    
+
     if (netdev_is_dhcp_enabled(netdev))
     {
         LOG_E("The network interface device(%s) DHCP capability is enable, not support set gateway address.", netdev->name);
@@ -529,10 +535,10 @@ int netdev_set_gw(struct netdev *netdev, const ip_addr_t *gw)
 
 /**
  * This function will set network interface device DNS server address.
- * 
+ *
  * @param netdev the network interface device to change
  * @param dns_server the new DNS server address
- * 
+ *
  * @return  0: set netmask address successfully
  *         -1: set netmask address failed
  */
@@ -559,7 +565,7 @@ int netdev_set_dns_server(struct netdev *netdev, uint8_t dns_num, const ip_addr_
 
 /**
  * This function will set callback to be called when the network interface device status has been changed.
- * 
+ *
  * @param netdev the network interface device to change
  * @param status_callback the callback be called when the status has been changed.
  */
@@ -573,7 +579,7 @@ void netdev_set_status_callback(struct netdev *netdev, netdev_callback_fn status
 
 /**
  * This function will set callback to be called when the network interface device address has been changed.
- * 
+ *
  * @param netdev the network interface device to change
  * @param addr_callback the callback be called when the address has been changed.
  */
@@ -589,7 +595,7 @@ void netdev_set_addr_callback(struct netdev *netdev, netdev_callback_fn addr_cal
 /**
  * This function will set network interface device IP address.
  * @NOTE it can only be called in the network interface device driver.
- * 
+ *
  * @param netdev the network interface device to change
  * @param ipaddr the new IP address
  */
@@ -620,7 +626,7 @@ void netdev_low_level_set_ipaddr(struct netdev *netdev, const ip_addr_t *ip_addr
 /**
  * This function will set network interface device netmask address.
  * @NOTE it can only be called in the network interface device driver.
- * 
+ *
  * @param netdev the network interface device to change
  * @param netmask the new netmask address
  */
@@ -634,7 +640,7 @@ void netdev_low_level_set_netmask(struct netdev *netdev, const ip_addr_t *netmas
 
 #ifdef RT_USING_SAL
         /* set network interface device flags to internet up */
-        if (netdev_is_up(netdev) && netdev_is_link_up(netdev) && 
+        if (netdev_is_up(netdev) && netdev_is_link_up(netdev) &&
                 !ip_addr_isany(&(netdev->ip_addr)))
         {
             sal_check_netdev_internet_up(netdev);
@@ -652,7 +658,7 @@ void netdev_low_level_set_netmask(struct netdev *netdev, const ip_addr_t *netmas
 /**
  * This function will set network interface device gateway address.
  * @NOTE it can only be called in the network interface device driver.
- * 
+ *
  * @param netdev the network interface device to change
  * @param gateway the new gateway address
  */
@@ -666,7 +672,7 @@ void netdev_low_level_set_gw(struct netdev *netdev, const ip_addr_t *gw)
 
 #ifdef RT_USING_SAL
         /* set network interface device flags to internet up */
-        if (netdev_is_up(netdev) && netdev_is_link_up(netdev) && 
+        if (netdev_is_up(netdev) && netdev_is_link_up(netdev) &&
                 !ip_addr_isany(&(netdev->ip_addr)))
         {
             sal_check_netdev_internet_up(netdev);
@@ -684,10 +690,10 @@ void netdev_low_level_set_gw(struct netdev *netdev, const ip_addr_t *gw)
 /**
  * This function will set network interface device DNS server address.
  * @NOTE it can only be called in the network interface device driver.
- * 
+ *
  * @param netdev the network interface device to change
  * @param dns_server the new DNS server address
- * 
+ *
  */
 void netdev_low_level_set_dns_server(struct netdev *netdev, uint8_t dns_num, const ip_addr_t *dns_server)
 {
@@ -740,7 +746,7 @@ static void netdev_auto_change_default(struct netdev *netdev)
 /**
  * This function will set network interface device status.
  * @NOTE it can only be called in the network interface device driver.
- * 
+ *
  * @param netdev the network interface device to change
  * @param is_up the new status
  */
@@ -773,14 +779,14 @@ void netdev_low_level_set_status(struct netdev *netdev, rt_bool_t is_up)
 /**
  * This function will set network interface device active link status.
  * @NOTE it can only be called in the network interface device driver.
- * 
+ *
  * @param netdev the network interface device to change
  * @param is_up the new link status
  */
 void netdev_low_level_set_link_status(struct netdev *netdev, rt_bool_t is_up)
 {
     if (netdev && netdev_is_link_up(netdev) != is_up)
-    {   
+    {
         if (is_up)
         {
             netdev->flags |= NETDEV_FLAG_LINK_UP;
@@ -796,7 +802,7 @@ void netdev_low_level_set_link_status(struct netdev *netdev, rt_bool_t is_up)
         else
         {
             netdev->flags &= ~NETDEV_FLAG_LINK_UP;
-            
+
             /* set network interface device flags to internet down */
             netdev->flags &= ~NETDEV_FLAG_INTERNET_UP;
 
@@ -817,7 +823,7 @@ void netdev_low_level_set_link_status(struct netdev *netdev, rt_bool_t is_up)
 /**
  * This function will set network interface device DHCP status.
  * @NOTE it can only be called in the network interface device driver.
- * 
+ *
  * @param netdev the network interface device to change
  * @param is_up the new DHCP status
  */
@@ -889,7 +895,7 @@ static void netdev_list_if(void)
                 /* two numbers are displayed at one time*/
                 if (netdev->hwaddr[index] < 10 && index != netdev->hwaddr_len - 1)
                     rt_kprintf("0");
-                
+
                 rt_kprintf("%d", netdev->hwaddr[index]);
             }
         }
@@ -915,9 +921,9 @@ static void netdev_list_if(void)
         {
             ip_addr_t *addr;
             int i;
-            
+
             addr = &netdev->ip6_addr[0];
-            
+
             if (!ip_addr_isany(addr))
             {
                 rt_kprintf("ipv6 link-local: %s %s\n", inet_ntoa(*addr),
@@ -929,7 +935,7 @@ static void netdev_list_if(void)
                     rt_kprintf("ipv6[%d] address: %s %s\n", i, inet_ntoa(*addr),
                             !ip_addr_isany(addr) ? "VALID" : "INVALID");
                 }
-            }    
+            }
         }
 #endif /* NETDEV_IPV6 */
 
@@ -937,7 +943,7 @@ static void netdev_list_if(void)
         {
             rt_kprintf("dns server #%d: %s\n", index, inet_ntoa(netdev->dns_servers[index]));
         }
-        
+
         if (rt_slist_next(node))
         {
             rt_kprintf("\n");
@@ -1016,7 +1022,7 @@ int netdev_cmd_ping(char* target_name, rt_uint32_t times, rt_size_t size)
     struct netdev *netdev = RT_NULL;
     struct netdev_ping_resp ping_resp;
     int index, ret = 0;
-    
+
     if (size == 0)
     {
         size = NETDEV_PING_DATA_SIZE;
@@ -1044,7 +1050,7 @@ int netdev_cmd_ping(char* target_name, rt_uint32_t times, rt_size_t size)
         ret = netdev->ops->ping(netdev, (const char *)target_name, size, NETDEV_PING_RECV_TIMEO, &ping_resp);
         if (ret == -RT_ETIMEOUT)
         {
-            rt_kprintf("ping: from %s icmp_seq=%d timeout\n", 
+            rt_kprintf("ping: from %s icmp_seq=%d timeout\n",
                 (ip_addr_isany(&(ping_resp.ip_addr))) ? target_name : inet_ntoa(ping_resp.ip_addr), index);
         }
         else if (ret == -RT_ERROR)
@@ -1057,16 +1063,16 @@ int netdev_cmd_ping(char* target_name, rt_uint32_t times, rt_size_t size)
         {
             if (ping_resp.ttl == 0)
             {
-                rt_kprintf("%d bytes from %s icmp_seq=%d time=%d ms\n", 
+                rt_kprintf("%d bytes from %s icmp_seq=%d time=%d ms\n",
                             ping_resp.data_len, inet_ntoa(ping_resp.ip_addr), index, ping_resp.ticks);
             }
             else
             {
-                rt_kprintf("%d bytes from %s icmp_seq=%d ttl=%d time=%d ms\n", 
+                rt_kprintf("%d bytes from %s icmp_seq=%d ttl=%d time=%d ms\n",
                             ping_resp.data_len, inet_ntoa(ping_resp.ip_addr), index, ping_resp.ttl, ping_resp.ticks);
             }
         }
-        
+
         rt_thread_mdelay(NETDEV_PING_DELAY);
     }
 
@@ -1107,7 +1113,7 @@ static void netdev_list_dns(void)
         {
             rt_kprintf("dns server #%d: %s\n", index, inet_ntoa(netdev->dns_servers[index]));
         }
-        
+
         if (rt_slist_next(node))
         {
             rt_kprintf("\n");
@@ -1128,9 +1134,10 @@ static void netdev_set_dns(char *netdev_name, uint8_t dns_num, char *dns_server)
     }
 
     inet_aton(dns_server, &dns_addr);
-    netdev_set_dns_server(netdev, dns_num, &dns_addr);
-
-    rt_kprintf("set network interface device(%s) dns server #0: %s\n", netdev_name, dns_server);
+    if (netdev_set_dns_server(netdev, dns_num, &dns_addr) == RT_EOK)
+    {
+        rt_kprintf("set network interface device(%s) dns server #%d: %s\n", netdev_name, dns_num, dns_server);
+    }
 }
 
 int netdev_dns(int argc, char **argv)
@@ -1196,7 +1203,7 @@ int netdev_netstat(int argc, char **argv)
     {
         rt_kprintf("Please input: netstat \n");
     }
-    else 
+    else
     {
         netdev_cmd_netstat();
     }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
- 多网卡时，修复 DNS 服务器地址设置错误问题
- 完善默认网卡设置处理，同步 netdev 和 lwip 底层默认网卡设置
- 该修改已经在 STM32F407 开发板和 QEMU 环境中验证通过

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
