### PR TITLE
[network][at] Fix the end sign "\r\n" conversion error in AT server，and at_server_send、at_server_recv function

### DIFF
--- a/components/net/at/include/at.h
+++ b/components/net/at/include/at.h
@@ -96,7 +96,7 @@ struct at_server
     rt_device_t device;
 
     at_status_t status;
-    char (*get_char)(void);
+    rt_err_t (*get_char)(struct at_server *server, char *ch, rt_int32_t timeout);
     rt_bool_t echo_mode;
 
     char recv_buffer[AT_SERVER_RECV_BUFF_LEN];
@@ -194,6 +194,8 @@ int at_server_init(void);
 void at_server_printf(const char *format, ...);
 void at_server_printfln(const char *format, ...);
 void at_server_print_result(at_result_t result);
+rt_size_t at_server_send(at_server_t server, const char *buf, rt_size_t size);
+rt_size_t at_server_recv(at_server_t server, char *buf, rt_size_t size, rt_int32_t timeout);
 
 /* AT server request arguments parse */
 int at_req_parse_args(const char *req_args, const char *req_expr, ...);

--- a/components/net/at/src/at_cli.c
+++ b/components/net/at/src/at_cli.c
@@ -100,6 +100,12 @@ void at_cli_deinit(void)
 }
 
 #ifdef AT_USING_SERVER
+static rt_err_t at_server_console_getchar(struct at_server *server, char *ch, rt_int32_t timeout)
+{
+    *ch = console_getchar();
+    return RT_EOK;
+}
+
 static void server_cli_parser(void)
 {
     extern at_server_t at_get_server(void);
@@ -107,7 +113,7 @@ static void server_cli_parser(void)
     at_server_t server = at_get_server();
     rt_base_t int_lvl;
     static rt_device_t device_bak;
-    static char (*getchar_bak)(void);
+    static rt_err_t (*getchar_bak)(struct at_server *server, char *ch, rt_int32_t timeout);
     static char endmark_back[AT_END_MARK_LEN];
 
     /* backup server device and getchar function */
@@ -122,7 +128,7 @@ static void server_cli_parser(void)
 
         /* setup server device as console device */
         server->device = rt_console_get_device();
-        server->get_char = console_getchar;
+        server->get_char = at_server_console_getchar;
 
         memset(server->end_mark, 0x00, AT_END_MARK_LEN);
         server->end_mark[0] = '\r';


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

[

- 修复 AT Server 中 "\r\n" 结束符获取后错误处理问题；
- 添加 at_server_send、at_server_recv 接口，用于直接通过串口接收和发送数据；
- 该修改已经在 IoT-Board 开发板上验证。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
