### PR TITLE
[bsp][tms320f28379d] Fix an issue that interrupts are disabled in the thread

### DIFF
--- a/bsp/tms320f28379d/applications/startup.c
+++ b/bsp/tms320f28379d/applications/startup.c
@@ -47,8 +47,6 @@ void rtthread_startup(void)
     /* init board */
     rt_hw_board_init();
 
-    rt_hw_interrupt_disable();
-
     /* show version */
     rt_show_version();
 

--- a/bsp/tms320f28379d/drivers/drv_sci.c
+++ b/bsp/tms320f28379d/drivers/drv_sci.c
@@ -223,7 +223,6 @@ int rt_hw_sci_init(void)
     PieCtrlRegs.PIECTRL.bit.ENPIE = 1;   // Enable the PIE block
     PieCtrlRegs.PIEIER9.bit.INTx1 = 1;   // PIE Group 9, INT1
     IER |= 0x100;                        // Enable CPU INT
-    EINT;
 
     struct serial_configure config = RT_SERIAL_CONFIG_DEFAULT;
     rt_err_t result = 0;

--- a/libcpu/ti-dsp/c28x/cpuport.c
+++ b/libcpu/ti-dsp/c28x/cpuport.c
@@ -78,7 +78,7 @@ rt_uint8_t *rt_hw_stack_init(void       *tentry,
     stack_frame->exception_stack_frame.acc     = 0x33332222;
     stack_frame->exception_stack_frame.ar1_ar0 = 0x00001111 & (unsigned long)parameter; /* ar0 : argument */
     stack_frame->exception_stack_frame.p       = 0x55554444;                            /* p */
-    stack_frame->exception_stack_frame.dp_st1  = (0x00000000) | rt_hw_get_st1();        /* dp_st1 */
+    stack_frame->exception_stack_frame.dp_st1  = (0x00000000) | rt_hw_get_st1() & 0xFFFFFFFE;        /* dp_st1 */
     stack_frame->exception_stack_frame.dbgstat_ier    = 0;                              /* dbgstat_ier */
     stack_frame->exception_stack_frame.return_address = (unsigned long)tentry;          /* return_address */
     stack_frame->rpc = (unsigned long)texit;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

在 /libcpu/ti-dsp/c28x/context.s 修改相关 API 后，发现会存在在在线程中无法响应中断的问题。经检查发现线程栈初始化的时候，INTM 初始化值有可能被置1，使得新线程中总中断被关闭。修改了线程栈 ST1 寄存器初始化值来避免这个问题。
所有更改在 TMS320F28379D LaunchPad 开发板上测试通过。

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
