### PR TITLE
修复IAR8.1之后出现的__localtime32等重定义错误

### DIFF
--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -8,13 +8,10 @@
  * 2019-08-21     zhangjun     copy from minilibc
  */
 
-#if defined(__CC_ARM) || defined(__CLANG_ARM) || defined (__IAR_SYSTEMS_ICC__)  
 #include <time.h>
 #include <rtthread.h>
 
-/* seconds per day */
-#define SPD 24*60*60
-
+#if !defined (__IAR_SYSTEMS_ICC__)
 
 /* days per month -- nonleap! */
 const short __spm[13] =
@@ -93,15 +90,7 @@ struct tm *gmtime_r(const time_t *timep, struct tm *r)
     return r;
 }
 
-#if defined (__IAR_SYSTEMS_ICC__) &&  (__VER__) >= 6020000
-#if _DLIB_TIME_USES_64
-struct tm* __gmtime64(const time_t* t)
-#else
-struct tm* __gmtime32(const time_t* t)
-#endif
-#else
 struct tm* gmtime(const time_t* t)
-#endif
 {
     static struct tm tmp;
     return gmtime_r(t, &tmp);
@@ -113,29 +102,13 @@ struct tm* localtime_r(const time_t* t, struct tm* r)
     return gmtime_r(t, r);
 }
 
-#if defined (__IAR_SYSTEMS_ICC__) &&  (__VER__) >= 6020000
-#if _DLIB_TIME_USES_64
-struct tm* __localtime64(const time_t* t)
-#else
-struct tm* __localtime32(const time_t* t)
-#endif
-#else
 struct tm* localtime(const time_t* t)
-#endif
 {
     static struct tm tmp;
     return localtime_r(t, &tmp);
 }
 
-#if defined (__IAR_SYSTEMS_ICC__) &&  (__VER__) >= 6020000
-#if _DLIB_TIME_USES_64
-time_t __mktime64(struct tm * const t)
-#else
-time_t __mktime32(struct tm * const t)
-#endif
-#else
 time_t mktime(struct tm * const t)
-#endif
 {
     register time_t day;
     register time_t i;
@@ -242,15 +215,7 @@ char* asctime(const struct tm *timeptr)
     return asctime_r(timeptr, buf);
 }
 
-#if defined (__IAR_SYSTEMS_ICC__) &&  (__VER__) >= 6020000
-#if _DLIB_TIME_USES_64
-char* __ctime64(const time_t *timep)
-#else
-char* __ctime32(const time_t *timep)
-#endif
-#else
 char* ctime(const time_t *timep)
-#endif
 {
     return asctime(localtime(timep));
 }
@@ -284,6 +249,8 @@ int _gettimeofday( struct timeval *tv, void *ignore)
     return 0;  // return non-zero for error
 }
 #endif
+
+#endif /* __IAR_SYSTEMS_ICC__ */
 
 /**
  * Returns the current time.
@@ -340,4 +307,3 @@ RT_WEAK clock_t clock(void)
 {
     return rt_tick_get();
 }
-#endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
* 解决的问题:IAR8.1之后出现__localtime32等函数重定义错误

* 解决方法: 根据查询的IAR手册中的描述只重新实现__time32和__time64函数，不再重新实现__localtime32等函数，这些函数采用IAR标准库里面的实现

* 测试平台:
    芯片:STM32F103ZET6(使用硬件RTC)
    软件:IAR8.4+IAR7.3

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
