### PR TITLE
bsp: fix stm32 rtc hal library error.

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
@@ -110,6 +110,9 @@ static rt_err_t rt_rtc_config(struct rt_device *dev)
 #endif
     HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct);
 
+    /* Enable RTC Clock */
+    __HAL_RCC_RTC_ENABLE();
+
     RTC_Handler.Instance = RTC;
     if (HAL_RTCEx_BKUPRead(&RTC_Handler, RTC_BKP_DR1) != BKUP_REG_DATA)
     {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
1. 在使用 drv_rtc.c 驱动时发现, rt_rtc_config() 并未对 RTC时钟进行使能, 导致程序卡死.
2. 目前已经在 STM32F4 板卡上进行测试 并成功运行

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
