### PR TITLE
fix i2c flags bug

### DIFF
--- a/components/drivers/i2c/i2c_core.c
+++ b/components/drivers/i2c/i2c_core.c
@@ -83,7 +83,7 @@ rt_size_t rt_i2c_master_send(struct rt_i2c_bus_device *bus,
     struct rt_i2c_msg msg;
 
     msg.addr  = addr;
-    msg.flags = flags & RT_I2C_ADDR_10BIT;
+    msg.flags = flags;
     msg.len   = count;
     msg.buf   = (rt_uint8_t *)buf;
 
@@ -103,8 +103,7 @@ rt_size_t rt_i2c_master_recv(struct rt_i2c_bus_device *bus,
     RT_ASSERT(bus != RT_NULL);
 
     msg.addr   = addr;
-    msg.flags  = flags & RT_I2C_ADDR_10BIT;
-    msg.flags |= RT_I2C_RD;
+    msg.flags  = flags | RT_I2C_RD;
     msg.len    = count;
     msg.buf    = buf;
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

rt_i2c_master_send和rt_i2c_master_recv函数设置flag无效
因为未修改前  `msg.flags = flags & RT_I2C_ADDR_10BIT;`，这个操作会把其他设置的标志给清除了
所以函数传进来的flag不会被正确写入到msg.flag，比如外部flag设置RT_I2C_IGNORE_NACK等

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
