### PR TITLE
Fix CORTEX-M0 Cannot Execute Reboot

### DIFF
--- a/libcpu/arm/cortex-m0/cpuport.c
+++ b/libcpu/arm/cortex-m0/cpuport.c
@@ -119,7 +119,7 @@ void rt_hw_hard_fault_exception(struct exception_stack_frame *contex)
 #define SCB_HFSR        (*(volatile const unsigned *)0xE000ED2C) /* HardFault Status Register */
 #define SCB_MMAR        (*(volatile const unsigned *)0xE000ED34) /* MemManage Fault Address register */
 #define SCB_BFAR        (*(volatile const unsigned *)0xE000ED38) /* Bus Fault Address Register */
-#define SCB_AIRCR       (*(volatile unsigned long *)0xE000ED00)  /* Reset control Address Register */
+#define SCB_AIRCR       (*(volatile unsigned long *)0xE000ED0C)  /* Reset control Address Register */
 #define SCB_RESET_VALUE 0x05FA0004                               /* Reset value, write to SCB_AIRCR can reset cpu */
 
 #define SCB_CFSR_MFSR   (*(volatile const unsigned char*)0xE000ED28)  /* Memory-management Fault Status Register */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

修复AIRCR地址错误导致M0系列处理器无法成功执行reboot命令。
在ARMv6-M系列的CPU中，AIRCR地址均为0xE000ED0C

参考
https://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0497a/CIHFDJCA.html
https://static.docs.arm.com/ddi0419/e/DDI0419E_armv6m_arm.pdf#page=227

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
