### PR TITLE
[net] Remove libc select in SAL and AT Socket function

### DIFF
--- a/components/net/Kconfig
+++ b/components/net/Kconfig
@@ -1,18 +1,17 @@
 menu "Network"
 
 menu "Socket abstraction layer"
-    
+
 config RT_USING_SAL
     bool "Enable socket abstraction layer"
     select RT_USING_NETDEV
-    select RT_USING_LIBC
     select RT_USING_SYSTEM_WORKQUEUE
     default n
 
     if RT_USING_SAL
 
         if RT_USING_LWIP || AT_USING_SOCKET
-        
+
             menu "protocol stack implement"
 
                 config SAL_USING_LWIP
@@ -24,29 +23,30 @@ config RT_USING_SAL
                     bool "Support AT Commands stack"
                     default y
                     depends on AT_USING_SOCKET
-                    
+
                 config SAL_USING_TLS
                     bool "Support MbedTLS protocol"
                     default y
                     depends on PKG_USING_MBEDTLS
             endmenu
-        
+
         endif
 
         config SAL_USING_POSIX
             bool "Enable BSD socket operated by file system API"
             default n
             select RT_USING_DFS
+            select RT_USING_LIBC
             select RT_USING_POSIX
             help
                 Let BSD socket operated by file system API, such as read/write and involveed in select/poll POSIX APIs.
-                
+
         if !SAL_USING_POSIX
-            
+
             config SAL_SOCKETS_NUM
                 int "the maximum number of sockets"
                 default 16
-       
+
         endif
 
     endif
@@ -68,7 +68,7 @@ config RT_USING_NETDEV
         config NETDEV_USING_PING
             bool "Enable ping features"
             default y
-        
+
         config NETDEV_USING_NETSTAT
             bool "Enable netstat features"
             default y
@@ -76,8 +76,8 @@ config RT_USING_NETDEV
         config NETDEV_USING_AUTO_DEFAULT
             bool "Enable default netdev automatic change features"
             default y
-        
-        config NETDEV_USING_IPV6 
+
+        config NETDEV_USING_IPV6
             bool "Enable IPV6 protocol support"
             default n
 
@@ -94,7 +94,7 @@ config RT_USING_NETDEV
             bool
             help
                 Defined to synchronize the ip6_addr structure state
-            default n 
+            default n
     endif
 
 endmenu
@@ -277,7 +277,7 @@ config RT_USING_LWIP
         config LWIP_NETIF_STATUS_CALLBACK
             int "Enable netif status callback"
             default 1
-        
+
         config LWIP_NETIF_LINK_CALLBACK
             int "Enable netif link status callback"
             default 1
@@ -314,7 +314,7 @@ config RT_USING_LWIP
         config RT_LWIP_USING_HW_CHECKSUM
             bool "Enable hardware checksum"
             default n
-        
+
         config RT_LWIP_USING_PING
             bool "Enable ping features"
             default y

--- a/components/net/at/Kconfig
+++ b/components/net/at/Kconfig
@@ -9,11 +9,11 @@ if RT_USING_AT
     config AT_DEBUG
         bool "Enable debug log output"
         default n
-    
+
     config AT_USING_SERVER
         bool "Enable AT commands server"
         default n
-    
+
     if AT_USING_SERVER
 
         config AT_SERVER_DEVICE
@@ -44,33 +44,32 @@ if RT_USING_AT
         endchoice
 
     endif
-    
+
     config AT_USING_CLIENT
         bool "Enable AT commands client"
         default n
-    
+
     if AT_USING_CLIENT
 
         config AT_CLIENT_NUM_MAX
             int "The maximum number of supported clients"
             default 1
             range 1 65535
-        
+
         config AT_USING_SOCKET
             bool "Enable BSD Socket API support by AT commnads"
-            select RT_USING_LIBC
             select RT_USING_SAL
             default n
-           
+
     endif
 
     if AT_USING_SERVER || AT_USING_CLIENT
-    
+
         config AT_USING_CLI
             bool "Enable CLI(Command-Line Interface) for AT commands"
             default y
             depends on FINSH_USING_MSH
-         
+
        config AT_PRINT_RAW_CMD
             bool "Enable print RAW format AT command communication data"
             default n
@@ -78,7 +77,7 @@ if RT_USING_AT
         config AT_CMD_MAX_LEN
             int "The maximum lenght of AT Commonds buffer"
             default 128
-         
+
     endif
 
     config AT_SW_VERSION_NUM


### PR DESCRIPTION
拉取/合并请求描述：(PR description)

[
- 移除 SAL 组件开启或者 AT Socket 功能开启后对 LIBC 功能依赖（time 相关功能支持）
- 该提交已经在 STM32F429 + ESP8266 设备上验证通过。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
