### PR TITLE
Fix a warning.

### DIFF
--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -30,7 +30,7 @@ const short __spm[13] =
     (31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30),
     (31 + 28 + 31 + 30 + 31 + 30 + 31 + 31 + 30 + 31 + 30 + 31),
 };
-static long int timezone;
+
 static const char days[] = "Sun Mon Tue Wed Thu Fri Sat ";
 static const char months[] = "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec ";
 


### PR DESCRIPTION
现象：When compiling，you may found "timezone" was declared but never referenced.
测试环境：Keil V5
测试开发板：EVB_M1