### PR TITLE
GetGCCRoot() for usual toolchain dir structures

### DIFF
--- a/tools/gcc.py
+++ b/tools/gcc.py
@@ -37,6 +37,24 @@ def GetGCCRoot(rtconfig):
     else:
         root_path = os.path.join(exec_path, '..', prefix)
 
+    # Usually the cross compiling gcc toolchain has directory as:
+    #
+    # bin
+    # lib
+    # share
+    # arm-none-eabi
+    #    bin
+    #    include
+    #    lib
+    #    share
+    prefix = rtconfig.PREFIX
+    if prefix.endswith('-'):
+        prefix = prefix[:-1]
+
+    fn = os.path.join(root, prefix, 'include', filename)
+    if os.path.isfile(fn):
+        return True
+    
     return root_path
 
 def CheckHeader(rtconfig, filename):

--- a/tools/gcc.py
+++ b/tools/gcc.py
@@ -37,6 +37,15 @@ def GetGCCRoot(rtconfig):
     else:
         root_path = os.path.join(exec_path, '..', prefix)
 
+    return root_path
+
+def CheckHeader(rtconfig, filename):
+    root = GetGCCRoot(rtconfig)
+
+    fn = os.path.join(root, 'include', filename)
+    if os.path.isfile(fn):
+        return True
+
     # Usually the cross compiling gcc toolchain has directory as:
     #
     # bin
@@ -55,15 +64,6 @@ def GetGCCRoot(rtconfig):
     if os.path.isfile(fn):
         return True
     
-    return root_path
-
-def CheckHeader(rtconfig, filename):
-    root = GetGCCRoot(rtconfig)
-
-    fn = os.path.join(root, 'include', filename)
-    if os.path.isfile(fn):
-        return True
-
     return False
 
 def GetNewLibVersion(rtconfig):


### PR DESCRIPTION
So don't depend on any special assumptions, especially the layout in debain/ubuntu package. See comments in the codes.

## 拉取/合并请求描述：(PR description)

[
This PR fixed the issue that gcc.py didn't work in the cross-compiling gcc toolchain that installed from a whole downloaded tarball instead of a Linux distribution package.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
