### PR TITLE
[components/utilities/utest]修正无测试用例时,执行utest_run时跑飞问题. utest_init增加__…

### DIFF
--- a/components/utilities/utest/utest.c
+++ b/components/utilities/utest/utest.c
@@ -63,20 +63,20 @@ void utest_log_lv_set(rt_uint8_t lv)
 int utest_init(void)
 {
     /* initialize the utest commands table.*/
-#if defined(__CC_ARM)                                 /* ARM C Compiler */
+#if defined(__CC_ARM) || defined(__CLANG_ARM)       /* ARM C Compiler */
     extern const int UtestTcTab$$Base;
     extern const int UtestTcTab$$Limit;
     tc_table = (utest_tc_export_t)&UtestTcTab$$Base;
     tc_num = (utest_tc_export_t)&UtestTcTab$$Limit - tc_table;
-#elif defined (__ICCARM__) || defined(__ICCRX__)      /* for IAR Compiler */
+#elif defined (__ICCARM__) || defined(__ICCRX__)    /* for IAR Compiler */
     tc_table = (utest_tc_export_t)__section_begin("UtestTcTab");
     tc_num = (utest_tc_export_t)__section_end("UtestTcTab") - tc_table;
-#elif defined (__GNUC__)                              /* for GCC Compiler */
+#elif defined (__GNUC__)                            /* for GCC Compiler */
     extern const int __rt_utest_tc_tab_start;
     extern const int __rt_utest_tc_tab_end;
     tc_table = (utest_tc_export_t)&__rt_utest_tc_tab_start;
     tc_num = (utest_tc_export_t) &__rt_utest_tc_tab_end - tc_table;
-#endif /* defined(__CC_ARM) */
+#endif
 
     LOG_I("utest is initialize success.");
     LOG_I("total utest testcase num: (%d)", tc_num);
@@ -215,7 +215,7 @@ static void utest_run(const char *utest_name)
             i++;
         }
 
-        if (i == tc_num && is_find == RT_FALSE)
+        if (i == tc_num && is_find == RT_FALSE && utest_name != RT_NULL)
         {
             LOG_I("[==========] [ utest    ] Not find (%s)", utest_name);
             LOG_I("[==========] [ utest    ] finished");


### PR DESCRIPTION
…CLANG_ARM编译开关判断

## 拉取/合并请求描述：(PR description)

[
修正无测试用例时,执行utest_run时跑飞问题. utest_init增加__CLANG_ARM编译开关判断
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
