### PR TITLE
修正rt_mp_free有可能唤醒一个错误任务指针的问题

### DIFF
--- a/components/finsh/cmd.c
+++ b/components/finsh/cmd.c
@@ -675,6 +675,8 @@ long list_mempool(void)
             {
                 struct rt_object *obj;
                 struct rt_mempool *mp;
+                int suspend_thread_count;
+                rt_list_t *node;
 
                 obj = rt_list_entry(obj_list[i], struct rt_object, list);
                 level = rt_hw_interrupt_disable();
@@ -687,7 +689,14 @@ long list_mempool(void)
                 rt_hw_interrupt_enable(level);
 
                 mp = (struct rt_mempool *)obj;
-                if (mp->suspend_thread_count > 0)
+
+                suspend_thread_count = 0;
+                for (node = mp->suspend_thread.next; node != &mp->suspend_thread; node = node->next)
+                {
+                    suspend_thread_count++;
+                }
+
+                if (suspend_thread_count > 0)
                 {
                     rt_kprintf("%-*.*s %04d  %04d  %04d %d:",
                             maxlen, RT_NAME_MAX,
@@ -695,7 +704,7 @@ long list_mempool(void)
                             mp->block_size,
                             mp->block_total_count,
                             mp->block_free_count,
-                            mp->suspend_thread_count);
+                            suspend_thread_count);
                     show_wait_queue(&(mp->suspend_thread));
                     rt_kprintf("\n");
                 }
@@ -707,7 +716,7 @@ long list_mempool(void)
                             mp->block_size,
                             mp->block_total_count,
                             mp->block_free_count,
-                            mp->suspend_thread_count);
+                            suspend_thread_count);
                 }
             }
         }

--- a/components/finsh/cmd.c
+++ b/components/finsh/cmd.c
@@ -691,7 +691,7 @@ long list_mempool(void)
                 mp = (struct rt_mempool *)obj;
 
                 suspend_thread_count = 0;
-                for (node = mp->suspend_thread.next; node != &mp->suspend_thread; node = node->next)
+                rt_list_for_each(node, &mp->suspend_thread)
                 {
                     suspend_thread_count++;
                 }

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -815,7 +815,6 @@ struct rt_mempool
     rt_size_t        block_free_count;                  /**< numbers of free memory block */
 
     rt_list_t        suspend_thread;                    /**< threads pended on this resource */
-    rt_size_t        suspend_thread_count;              /**< numbers of thread pended on this resource */
 };
 typedef struct rt_mempool *rt_mp_t;
 #endif

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -103,7 +103,6 @@ rt_err_t rt_mp_init(struct rt_mempool *mp,
 
     /* initialize suspended thread list */
     rt_list_init(&(mp->suspend_thread));
-    mp->suspend_thread_count = 0;
 
     /* initialize free block list */
     block_ptr = (rt_uint8_t *)mp->start_address;
@@ -156,9 +155,6 @@ rt_err_t rt_mp_detach(struct rt_mempool *mp)
          * suspend list
          */
         rt_thread_resume(thread);
-
-        /* decrease suspended thread count */
-        mp->suspend_thread_count --;
 
         /* enable interrupt */
         rt_hw_interrupt_enable(temp);
@@ -219,7 +215,6 @@ rt_mp_t rt_mp_create(const char *name,
 
     /* initialize suspended thread list */
     rt_list_init(&(mp->suspend_thread));
-    mp->suspend_thread_count = 0;
 
     /* initialize free block list */
     block_ptr = (rt_uint8_t *)mp->start_address;
@@ -274,9 +269,6 @@ rt_err_t rt_mp_delete(rt_mp_t mp)
          * suspend list
          */
         rt_thread_resume(thread);
-
-        /* decrease suspended thread count */
-        mp->suspend_thread_count --;
 
         /* enable interrupt */
         rt_hw_interrupt_enable(temp);
@@ -334,7 +326,6 @@ void *rt_mp_alloc(rt_mp_t mp, rt_int32_t time)
         /* need suspend thread */
         rt_thread_suspend(thread);
         rt_list_insert_after(&(mp->suspend_thread), &(thread->tlist));
-        mp->suspend_thread_count++;
 
         if (time > 0)
         {
@@ -418,7 +409,7 @@ void rt_mp_free(void *block)
     *block_ptr = mp->block_list;
     mp->block_list = (rt_uint8_t *)block_ptr;
 
-    if (mp->suspend_thread_count > 0)
+    if (!rt_list_isempty(&(mp->suspend_thread)))
     {
         /* get the suspended thread */
         thread = rt_list_entry(mp->suspend_thread.next,
@@ -430,9 +421,6 @@ void rt_mp_free(void *block)
 
         /* resume thread */
         rt_thread_resume(thread);
-
-        /* decrease suspended thread count */
-        mp->suspend_thread_count --;
 
         /* enable interrupt */
         rt_hw_interrupt_enable(level);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

在申请内存时被挂起的任务超时后，定时器超时函数是直接把任务从mp挂起队列中摘除，并不会将suspend_thread_count减1，从而造成suspend_thread_count和挂起队列上的实际任务数不一致，最后当挂起队列为空时，后续操作会出错。
修改方式
去除此成员变量suspend_thread_count，rt_mp_free的最后部分修改为判断挂起队列是否为空。此修改会影响到finsh/cmd.c中的list_mempool。

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
