### PR TITLE
pm组件bug修正

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_pm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pm.c
@@ -85,6 +85,12 @@ static void run(struct rt_pm *pm, uint8_t mode)
 
     if (mode == last_mode)
         return;
+	
+	if (last_mode == PM_RUN_MODE_LOW_SPEED)
+    {
+		/* Exit LP RUN mode */
+        HAL_PWREx_DisableLowPowerRunMode();
+    }
     last_mode = mode;
 
     /* 1. 设置 MSI 作为 SYSCLK 时钟源,以修改 PLL */

--- a/components/drivers/pm/pm.c
+++ b/components/drivers/pm/pm.c
@@ -444,7 +444,10 @@ int rt_pm_run_enter(uint8_t mode)
     if (mode < pm->run_mode)
     {
         /* change system runing mode */
-        pm->ops->run(pm, mode);
+		if (pm->ops->run != RT_NULL)
+		{
+			pm->ops->run(pm, mode);
+		}
         /* changer device frequency */
         _pm_device_frequency_change(mode);
     }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1.pm组件如果run函数为空，调用rt_pm_run_enter出现bug；
2.drv_pm.c当时钟切换为2M之后，必须退出低功耗模式才能切换到80M，否则无法切换到80M，此处修改已在stm32L476 上测试
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
