### PR TITLE
修复pwm初始化时，相应的时钟没有使能的问题

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -323,13 +323,6 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     tim->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
 #endif
 
-    if (HAL_TIM_PWM_Init(tim) != HAL_OK)
-    {
-        LOG_E("%s pwm init failed", device->name);
-        result = -RT_ERROR;
-        goto __exit;
-    }
-
     if (HAL_TIM_Base_Init(tim) != HAL_OK)
     {
         LOG_E("%s time base init failed", device->name);
@@ -341,6 +334,13 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     if (HAL_TIM_ConfigClockSource(tim, &clock_config) != HAL_OK)
     {
         LOG_E("%s clock init failed", device->name);
+        result = -RT_ERROR;
+        goto __exit;
+    }
+
+    if (HAL_TIM_PWM_Init(tim) != HAL_OK)
+    {
+        LOG_E("%s pwm init failed", device->name);
         result = -RT_ERROR;
         goto __exit;
     }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
当前版本的pwm初始化有BUG，初始化代码执行完后，相应的时钟并没有使能。这是由于`HAL_TIM_Base_Init()`与`HAL_TIM_PWM_Init()`调用顺序不对，导致执行`HAL_TIM_Base_Init()`时，`HAL_TIM_Base_MspInit()`没有被调用，继而导致相应的时钟没被使能。

现在参照STM32CubeMx生成PWM初始化代码，修改了`HAL_TIM_Base_Init()`与`HAL_TIM_PWM_Init()`调用顺序。

已在STM32F429 野火挑战者开发板上测试通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
