### PR TITLE
STM32以太网驱动改进

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_eth.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_eth.c
@@ -35,6 +35,9 @@ struct rt_stm32_eth
 {
     /* inherit from ethernet device */
     struct eth_device parent;
+#ifndef PHY_USING_INTERRUPT_MODE
+    rt_timer_t poll_link_timer;
+#endif
 
     /* interface address info, hw address */
     rt_uint8_t  dev_addr[MAX_ADDR_LEN];
@@ -515,35 +518,26 @@ static void phy_monitor_thread_entry(void *parameter)
     rt_thread_mdelay(2000);
     HAL_ETH_WritePHYRegister(&EthHandle, PHY_BASIC_CONTROL_REG, PHY_AUTO_NEGOTIATION_MASK);
 
-    while (1)
-    {
-        phy_linkchange();
-
-        if (stm32_eth_device.parent.netif->flags & NETIF_FLAG_LINK_UP)
-        {
+    phy_linkchange();
 #ifdef PHY_USING_INTERRUPT_MODE
-            /* configuration intterrupt pin */
-            rt_pin_mode(PHY_INT_PIN, PIN_MODE_INPUT_PULLUP);
-            rt_pin_attach_irq(PHY_INT_PIN, PIN_IRQ_MODE_FALLING, eth_phy_isr, (void *)"callbackargs");
-            rt_pin_irq_enable(PHY_INT_PIN, PIN_IRQ_ENABLE);
+    /* configuration intterrupt pin */
+    rt_pin_mode(PHY_INT_PIN, PIN_MODE_INPUT_PULLUP);
+    rt_pin_attach_irq(PHY_INT_PIN, PIN_IRQ_MODE_FALLING, eth_phy_isr, (void *)"callbackargs");
+    rt_pin_irq_enable(PHY_INT_PIN, PIN_IRQ_ENABLE);
 
-            /* enable phy interrupt */
-            HAL_ETH_WritePHYRegister(&EthHandle, PHY_INTERRUPT_MASK_REG, PHY_INT_MASK);
+    /* enable phy interrupt */
+    HAL_ETH_WritePHYRegister(&EthHandle, PHY_INTERRUPT_MASK_REG, PHY_INT_MASK);
 #if defined(PHY_INTERRUPT_CTRL_REG)
-            HAL_ETH_WritePHYRegister(&EthHandle, PHY_INTERRUPT_CTRL_REG, PHY_INTERRUPT_EN);
+    HAL_ETH_WritePHYRegister(&EthHandle, PHY_INTERRUPT_CTRL_REG, PHY_INTERRUPT_EN);
 #endif
-            break;
-#endif
-        } /* link up. */
-        else
-        {
-            LOG_I("link down");
-            /* send link down. */
-            eth_device_linkchange(&stm32_eth_device.parent, RT_FALSE);
-        }
-
-        rt_thread_delay(RT_TICK_PER_SECOND);
+#else /* PHY_USING_INTERRUPT_MODE */
+    stm32_eth_device.poll_link_timer = rt_timer_create("phylnk", (void (*)(void*))phy_linkchange,
+                                        NULL, RT_TICK_PER_SECOND, RT_TIMER_FLAG_PERIODIC);
+    if (!stm32_eth_device.poll_link_timer || rt_timer_start(stm32_eth_device.poll_link_timer) != RT_EOK)
+    {
+        LOG_E("Start link change detection timer failed");
     }
+#endif /* PHY_USING_INTERRUPT_MODE */
 }
 
 /* Register the EMAC device */

--- a/bsp/stm32/libraries/HAL_Drivers/drv_eth.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_eth.c
@@ -426,7 +426,8 @@ static void phy_linkchange()
         }
     }
 
-    if (phy_speed != phy_speed_new) {
+    if (phy_speed != phy_speed_new)
+    {
         phy_speed = phy_speed_new;
         if (phy_speed & PHY_LINK)
         {


### PR DESCRIPTION
### STM32 以太网驱动改进 ###
1. 中断模式下：以太网驱动不必等待网卡变为UP状态时再退出线程，尽快退出驱动内部线程以节约系统资源。
2. 轮循模式下：以太网驱动不必在自身线程里轮循网卡状态，使用rt_timer进行定时检测并退出当前线程以节约系统资源。

在STM32F107开发板上测试，中断模式和轮循模式均测试通过。

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
