### PR TITLE
[components] remove libc dependency in ulog and RTC driver.

### DIFF
--- a/components/drivers/Kconfig
+++ b/components/drivers/Kconfig
@@ -125,7 +125,6 @@ config RT_USING_PM
 
 config RT_USING_RTC
     bool "Using RTC device drivers"
-    select RT_USING_LIBC
     default n
 
     if RT_USING_RTC

--- a/components/utilities/Kconfig
+++ b/components/utilities/Kconfig
@@ -146,7 +146,6 @@ config RT_USING_ULOG
             config ULOG_TIME_USING_TIMESTAMP
                 bool "Enable timestamp format for time."
                 default n
-                select RT_USING_LIBC
                 depends on ULOG_OUTPUT_TIME
 
             config ULOG_OUTPUT_LEVEL


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

pr https://github.com/RT-Thread/rt-thread/pull/2983 合并后，个别组件对于 libc 的无需强依赖，现移除

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
