### PR TITLE
[libcpu][c28x]add support for c28x mcu hardware fpu

### DIFF
--- a/libcpu/ti-dsp/c28x/context.s
+++ b/libcpu/ti-dsp/c28x/context.s
@@ -27,14 +27,14 @@
     .def   _rt_hw_interrupt_enable
     
 ;workaround for importing fpu settings from the compiler
-	.cdecls C,NOLIST
-	%{
-		#ifdef __TMS320C28XX_FPU32__
-			#define __FPU32__ 1
-		#else
-			#define __FPU32__ 0
-		#endif
-	%}
+    .cdecls C,NOLIST
+    %{
+        #ifdef __TMS320C28XX_FPU32__
+            #define __FPU32__ 1
+        #else
+            #define __FPU32__ 0
+        #endif
+    %}
 
 
 RT_CTX_SAVE  .macro      
@@ -50,36 +50,36 @@ RT_CTX_SAVE  .macro
     PUSH    XT
     PUSH    RPC
     
-	.if __FPU32__
-	PUSH	RB
-	MOV32	*SP++, STF
-	MOV32	*SP++, R0H
-	MOV32	*SP++, R1H
-	MOV32	*SP++, R2H
-	MOV32	*SP++, R3H
-	MOV32	*SP++, R4H
-	MOV32	*SP++, R5H
-	MOV32	*SP++, R6H
-	MOV32	*SP++, R7H
-	.endif
+    .if __FPU32__
+    PUSH	RB
+    MOV32	*SP++, STF
+    MOV32	*SP++, R0H
+    MOV32	*SP++, R1H
+    MOV32	*SP++, R2H
+    MOV32	*SP++, R3H
+    MOV32	*SP++, R4H
+    MOV32	*SP++, R5H
+    MOV32	*SP++, R6H
+    MOV32	*SP++, R7H
+    .endif
  
     .endm
 
 
 RT_CTX_RESTORE  .macro
 
-	.if __FPU32__
-	MOV32	R7H, *--SP, UNCF
-	MOV32	R6H, *--SP, UNCF
-	MOV32	R5H, *--SP, UNCF
-	MOV32	R4H, *--SP, UNCF
-	MOV32	R3H, *--SP, UNCF
-	MOV32	R2H, *--SP, UNCF
-	MOV32	R1H, *--SP, UNCF
-	MOV32	R0H, *--SP, UNCF
-	MOV32	STF, *--SP
-	POP		RB
-	.endif
+    .if __FPU32__
+    MOV32	R7H, *--SP, UNCF
+    MOV32	R6H, *--SP, UNCF
+    MOV32	R5H, *--SP, UNCF
+    MOV32	R4H, *--SP, UNCF
+    MOV32	R3H, *--SP, UNCF
+    MOV32	R2H, *--SP, UNCF
+    MOV32	R1H, *--SP, UNCF
+    MOV32	R0H, *--SP, UNCF
+    MOV32	STF, *--SP
+    POP		RB
+    .endif
                                   
     POP     RPC
     POP     XT

--- a/libcpu/ti-dsp/c28x/context.s
+++ b/libcpu/ti-dsp/c28x/context.s
@@ -8,6 +8,7 @@
 ; 2018-09-01     xuzhuoyi     the first version.
 ; 2019-06-17     zhaoxiaowei  fix bugs of old c28x interrupt api.
 ; 2019-07-03     zhaoxiaowei  add _rt_hw_calc_csb function to support __rt_ffs.
+; 2019-12-05     xiaolifan    add support for hardware fpu32
 ;
 
     .ref   _rt_interrupt_to_thread
@@ -24,6 +25,16 @@
     .def   _rt_hw_interrupt_thread_switch
     .def   _rt_hw_interrupt_disable
     .def   _rt_hw_interrupt_enable
+    
+;workaround for importing fpu settings from the compiler
+	.cdecls C,NOLIST
+	%{
+		#ifdef __TMS320C28XX_FPU32__
+			#define __FPU32__ 1
+		#else
+			#define __FPU32__ 0
+		#endif
+	%}
 
 
 RT_CTX_SAVE  .macro      
@@ -38,12 +49,37 @@ RT_CTX_SAVE  .macro
     PUSH    XAR7
     PUSH    XT
     PUSH    RPC
-
+    
+	.if __FPU32__
+	PUSH	RB
+	MOV32	*SP++, STF
+	MOV32	*SP++, R0H
+	MOV32	*SP++, R1H
+	MOV32	*SP++, R2H
+	MOV32	*SP++, R3H
+	MOV32	*SP++, R4H
+	MOV32	*SP++, R5H
+	MOV32	*SP++, R6H
+	MOV32	*SP++, R7H
+	.endif
  
     .endm
 
 
 RT_CTX_RESTORE  .macro
+
+	.if __FPU32__
+	MOV32	R7H, *--SP, UNCF
+	MOV32	R6H, *--SP, UNCF
+	MOV32	R5H, *--SP, UNCF
+	MOV32	R4H, *--SP, UNCF
+	MOV32	R3H, *--SP, UNCF
+	MOV32	R2H, *--SP, UNCF
+	MOV32	R1H, *--SP, UNCF
+	MOV32	R0H, *--SP, UNCF
+	MOV32	STF, *--SP
+	POP		RB
+	.endif
                                   
     POP     RPC
     POP     XT

--- a/libcpu/ti-dsp/c28x/cpuport.c
+++ b/libcpu/ti-dsp/c28x/cpuport.c
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-09-01     xuzhuoyi     the first version.
  * 2019-07-03     zhaoxiaowei  add support for __rt_ffs.
+ * 2019-12-05     xiaolifan    add support for hardware fpu32
  */
 
 #include <rtthread.h>
@@ -21,6 +22,7 @@ static rt_err_t (*rt_exception_hook)(void *context) = RT_NULL;
 extern rt_uint16_t rt_hw_get_st0(void);
 extern rt_uint16_t rt_hw_get_st1(void);
 extern int rt_hw_calc_csb(int value);
+
 
 struct exception_stack_frame
 {
@@ -49,6 +51,18 @@ struct stack_frame
     rt_uint32_t xt;
     rt_uint32_t rpc;
 
+#ifdef __TMS320C28XX_FPU32__
+    rt_uint32_t rb;
+    rt_uint32_t stf;
+    rt_uint32_t r0h;
+    rt_uint32_t r1h;
+    rt_uint32_t r2h;
+    rt_uint32_t r3h;
+    rt_uint32_t r4h;
+    rt_uint32_t r5h;
+    rt_uint32_t r6h;
+    rt_uint32_t r7h;
+#endif
 
 };
 
@@ -82,6 +96,11 @@ rt_uint8_t *rt_hw_stack_init(void       *tentry,
     stack_frame->exception_stack_frame.dbgstat_ier    = 0;                              /* dbgstat_ier */
     stack_frame->exception_stack_frame.return_address = (unsigned long)tentry;          /* return_address */
     stack_frame->rpc = (unsigned long)texit;
+
+#ifdef __TMS320C28XX_FPU32__
+    stack_frame->stf = 0x00000200;
+    stack_frame->rb = 0;
+#endif
 
     /* return task's current stack address */
     return stk + sizeof(struct stack_frame);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
[libcpu][c28x]add support for c28x hardware fpu. (only support FPU32)

Tested on mcu TMS320F28335.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
