### PR TITLE
Sdio mmc fix 20191206

### DIFF
--- a/components/drivers/sdio/block_dev.c
+++ b/components/drivers/sdio/block_dev.c
@@ -357,6 +357,7 @@ rt_int32_t rt_mmcsd_blk_probe(struct rt_mmcsd_card *card)
     rt_int32_t err = 0;
     rt_uint8_t i, status;
     rt_uint8_t *sector;
+    rt_bool_t no_part_table = RT_FALSE;
     char dname[4];
     char sname[8];
     struct mmcsd_blk_device *blk_dev = RT_NULL;
@@ -460,8 +461,7 @@ rt_int32_t rt_mmcsd_blk_probe(struct rt_mmcsd_card *card)
                     rt_device_register(&blk_dev->dev, "sd0",
                         RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_REMOVABLE | RT_DEVICE_FLAG_STANDALONE);
                     rt_list_insert_after(&blk_devices, &blk_dev->list);
-    
-                    break;
+                    no_part_table = RT_TRUE;
                 }
                 else
                 {
@@ -479,6 +479,9 @@ rt_int32_t rt_mmcsd_blk_probe(struct rt_mmcsd_card *card)
             	dfs_mount_device(&(blk_dev->dev));
             }
 #endif
+            /* only mount the whole block device as a partion once */
+            if (no_part_table)
+                break;
         }
     }
     else

--- a/components/drivers/sdio/mmc.c
+++ b/components/drivers/sdio/mmc.c
@@ -123,7 +123,7 @@ static int mmc_get_ext_csd(struct rt_mmcsd_card *card, rt_uint8_t **new_ext_csd)
   *new_ext_csd = RT_NULL;
   
   if (GET_BITS(card->resp_cid, 122, 4) < 4)
-     return 0;
+     LOG_E("Invalid SPEC_VERS %d!\n", GET_BITS(card->resp_cid, 122, 4));
   
   /*
   * As the ext_csd is so large and mostly unused, we don't store the


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修正SDIO协议栈关于无分区设备的DFS自动挂载问题，以及增强eMMC版本识别兼容性。
关于DFS自动挂载问题，其原始代码在检查无分区表的情况时，注册完block device后直接break了，
导致在for循环内的自动挂载代码没有办法被执行；我的修复是将break操作移动到自动挂载之后。
关于eMMC版本识别兼容性问题，目前有一些颗粒读取的system spec version信息不正确，但是
其功能其实是正常的；我的修复是希望能抛出异常，并不要直接结束探测流程；

这个PR在RT_USING_DFS_MNTTABLE开启，贴有无分区表eMMC颗粒(Foresee NCEMAD9D-16G)的MCU上测试过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
