### PR TITLE
[net][lwip] fix assert in the sys_arch_mbox_fetch function when close socket

### DIFF
--- a/components/net/lwip-1.4.1/src/lwipopts.h
+++ b/components/net/lwip-1.4.1/src/lwipopts.h
@@ -499,6 +499,14 @@
 
 /* no read/write/close for socket */
 #define LWIP_POSIX_SOCKETS_IO_NAMES 0
+
+/**
+ * LWIP_NETIF_HOSTNAME==1: Support netif hostname
+ */
+#ifndef LWIP_NETIF_HOSTNAME
+#define LWIP_NETIF_HOSTNAME             1
+#endif
+
 #define LWIP_NETIF_API  1
 
 /* MEMP_NUM_SYS_TIMEOUT: the number of simulateously active timeouts. */

--- a/components/net/lwip-1.4.1/src/netif/ethernetif.c
+++ b/components/net/lwip-1.4.1/src/netif/ethernetif.c
@@ -440,8 +440,13 @@ static err_t eth_netif_device_init(struct netif *netif)
 rt_err_t eth_device_init_with_flag(struct eth_device *dev, const char *name, rt_uint16_t flags)
 {
     struct netif* netif;
-
+#if LWIP_NETIF_HOSTNAME
+#define LWIP_HOSTNAME_LEN 16
+    char *hostname = RT_NULL;
+    netif = (struct netif*) rt_malloc (sizeof(struct netif) + LWIP_HOSTNAME_LEN);
+#else
     netif = (struct netif*) rt_malloc (sizeof(struct netif));
+#endif
     if (netif == RT_NULL)
     {
         rt_kprintf("malloc netif failed\n");
@@ -475,6 +480,13 @@ rt_err_t eth_device_init_with_flag(struct eth_device *dev, const char *name, rt_
     /* set output */
     netif->output		= etharp_output;
     netif->linkoutput	= ethernetif_linkoutput;
+
+#if LWIP_NETIF_HOSTNAME
+    /* Initialize interface hostname */
+	hostname = (char *)netif + sizeof(struct netif);
+    rt_sprintf(hostname, "RT-Thread_%02x%02x", name[0], name[1]);
+    netif->hostname = hostname;
+#endif /* LWIP_NETIF_HOSTNAME */
 
     /* if tcp thread has been started up, we add this netif to the system */
     if (rt_thread_find("tcpip") != RT_NULL)

--- a/components/net/lwip-2.0.2/src/lwipopts.h
+++ b/components/net/lwip-2.0.2/src/lwipopts.h
@@ -532,6 +532,13 @@
 #endif
 
 /**
+ * LWIP_NETIF_HOSTNAME==1: Support netif hostname
+ */
+#ifndef LWIP_NETIF_HOSTNAME
+#define LWIP_NETIF_HOSTNAME             1
+#endif
+
+/**
  * LWIP_NETIF_API==1: Support netif api (in netifapi.c)
  */
 #ifndef LWIP_NETIF_API

--- a/components/net/lwip-2.0.2/src/netif/ethernetif.c
+++ b/components/net/lwip-2.0.2/src/netif/ethernetif.c
@@ -481,8 +481,13 @@ static err_t eth_netif_device_init(struct netif *netif)
 rt_err_t eth_device_init_with_flag(struct eth_device *dev, const char *name, rt_uint16_t flags)
 {
     struct netif* netif;
-
+#if LWIP_NETIF_HOSTNAME
+#define LWIP_HOSTNAME_LEN 16
+    char *hostname = RT_NULL;
+    netif = (struct netif*) rt_malloc (sizeof(struct netif) + LWIP_HOSTNAME_LEN);
+#else
     netif = (struct netif*) rt_malloc (sizeof(struct netif));
+#endif
     if (netif == RT_NULL)
     {
         rt_kprintf("malloc netif failed\n");
@@ -519,7 +524,9 @@ rt_err_t eth_device_init_with_flag(struct eth_device *dev, const char *name, rt_
 
 #if LWIP_NETIF_HOSTNAME
     /* Initialize interface hostname */
-    netif->hostname = "rtthread";
+	hostname = (char *)netif + sizeof(struct netif);
+    rt_sprintf(hostname, "RT-Thread_%02x%02x", name[0], name[1]);
+    netif->hostname = hostname;
 #endif /* LWIP_NETIF_HOSTNAME */
 
     /* if tcp thread has been started up, we add this netif to the system */


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

[

- 修复在一个线程在等待接收数据，另一个线程关闭 socket 引起的断言问题
- 已在 STM32F407 平台上测试过

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
