### PR TITLE
Fix BUG for ethernetif.c

### DIFF
--- a/components/net/lwip-2.0.2/src/netif/ethernetif.c
+++ b/components/net/lwip-2.0.2/src/netif/ethernetif.c
@@ -59,6 +59,8 @@
 
 #include "lwip/inet.h"
 
+extern volatile uint32_t enet_init_status;
+
 #if LWIP_IPV6
 #include "lwip/ethip6.h"
 #endif /* LWIP_IPV6 */
@@ -105,274 +107,6 @@ static char eth_rx_thread_stack[RT_LWIP_ETHTHREAD_STACKSIZE];
 #endif
 #endif
 
-#ifdef RT_USING_NETDEV
-
-#include "lwip/ip.h"
-#include "lwip/init.h"
-#include "lwip/netdb.h"
-#include <netdev.h>
-
-static int lwip_netdev_set_up(struct netdev *netif)
-{
-    netif_set_up((struct netif *)netif->user_data);
-    return ERR_OK;
-}
-
-static int lwip_netdev_set_down(struct netdev *netif)
-{
-    netif_set_down((struct netif *)netif->user_data);
-    return ERR_OK;
-}
-
-static int lwip_netdev_set_addr_info(struct netdev *netif, ip_addr_t *ip_addr, ip_addr_t *netmask, ip_addr_t *gw)
-{
-    if (ip_addr && netmask && gw)
-    {
-        netif_set_addr((struct netif *)netif->user_data, ip_2_ip4(ip_addr), ip_2_ip4(netmask), ip_2_ip4(gw));
-    }
-    else
-    {
-        if (ip_addr)
-        {
-            netif_set_ipaddr((struct netif *)netif->user_data, ip_2_ip4(ip_addr));
-        }
-
-        if (netmask)
-        {
-            netif_set_netmask((struct netif *)netif->user_data, ip_2_ip4(netmask));
-        }
-
-        if (gw)
-        {
-            netif_set_gw((struct netif *)netif->user_data, ip_2_ip4(gw));
-        }
-    }
-
-    return ERR_OK;
-}
-
-#ifdef RT_LWIP_DNS
-static int lwip_netdev_set_dns_server(struct netdev *netif, uint8_t dns_num, ip_addr_t *dns_server)
-{
-    extern void dns_setserver(uint8_t dns_num, const ip_addr_t *dns_server);
-    dns_setserver(dns_num, dns_server);
-    return ERR_OK;
-}
-#endif /* RT_LWIP_DNS */
-
-#ifdef RT_LWIP_DHCP
-static int lwip_netdev_set_dhcp(struct netdev *netif, rt_bool_t is_enabled)
-{
-    netdev_low_level_set_dhcp_status(netif, is_enabled);
-    return ERR_OK;
-}
-#endif /* RT_LWIP_DHCP */
-
-#ifdef RT_USING_FINSH
-#ifdef RT_LWIP_USING_PING
-extern int lwip_ping_recv(int s, int *ttl);
-extern err_t lwip_ping_send(int s, ip_addr_t *addr, int size);
-
-int lwip_netdev_ping(struct netdev *netif, const char *host, size_t data_len, 
-                        uint32_t timeout, struct netdev_ping_resp *ping_resp)
-{
-    int s, ttl, recv_len, result = 0;
-    int elapsed_time;
-    rt_tick_t recv_start_tick;
-#if LWIP_VERSION_MAJOR >= 2U
-    struct timeval recv_timeout = { timeout / RT_TICK_PER_SECOND, timeout % RT_TICK_PER_SECOND };
-#else
-    int recv_timeout = timeout * 1000UL / RT_TICK_PER_SECOND;
-#endif
-    ip_addr_t target_addr;
-    struct addrinfo hint, *res = RT_NULL;
-    struct sockaddr_in *h = RT_NULL;
-    struct in_addr ina;
-    
-    RT_ASSERT(netif);
-    RT_ASSERT(host);
-    RT_ASSERT(ping_resp);
-
-    rt_memset(&hint, 0x00, sizeof(hint));
-    /* convert URL to IP */
-    if (lwip_getaddrinfo(host, RT_NULL, &hint, &res) != 0)
-    {
-        return -RT_ERROR;
-    }
-    rt_memcpy(&h, &res->ai_addr, sizeof(struct sockaddr_in *));
-    rt_memcpy(&ina, &h->sin_addr, sizeof(ina));
-    lwip_freeaddrinfo(res);
-    if (inet_aton(inet_ntoa(ina), &target_addr) == 0)
-    {
-        return -RT_ERROR;
-    }
-    rt_memcpy(&(ping_resp->ip_addr), &target_addr, sizeof(ip_addr_t));
-    
-    /* new a socket */
-    if ((s = lwip_socket(AF_INET, SOCK_RAW, IP_PROTO_ICMP)) < 0)
-    {
-        return -RT_ERROR;
-    }
-
-    lwip_setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, sizeof(recv_timeout));
-
-    if (lwip_ping_send(s, &target_addr, data_len) == ERR_OK)
-    {
-        recv_start_tick = rt_tick_get();
-        if ((recv_len = lwip_ping_recv(s, &ttl)) >= 0)
-        {
-            elapsed_time = (rt_tick_get() - recv_start_tick) * 1000UL / RT_TICK_PER_SECOND;
-            ping_resp->data_len = recv_len;
-            ping_resp->ttl = ttl;
-            ping_resp->ticks = elapsed_time;
-        }
-        else
-        {
-            result = -RT_ETIMEOUT;
-            goto __exit;
-        }
-    }
-    else
-    {
-        result = -RT_ETIMEOUT;
-        goto __exit;
-    }
-
-__exit:
-    lwip_close(s);
-
-    return result;
-}
-#endif /* RT_LWIP_USING_PING */
-
-#if defined (RT_LWIP_TCP) || defined (RT_LWIP_UDP)
-void lwip_netdev_netstat(struct netdev *netif)
-{
-    extern void list_tcps(void);
-    extern void list_udps(void);
-
-#ifdef RT_LWIP_TCP
-    list_tcps();
-#endif
-#ifdef RT_LWIP_UDP
-    list_udps();
-#endif
-}
-#endif /* RT_LWIP_TCP || RT_LWIP_UDP */
-#endif /* RT_USING_FINSH */
-
-static int lwip_netdev_set_default(struct netdev *netif)
-{
-    netif_set_default((struct netif *)netif->user_data);
-    return ERR_OK;
-}
-
-const struct netdev_ops lwip_netdev_ops =
-{
-    lwip_netdev_set_up,
-    lwip_netdev_set_down,
-
-    lwip_netdev_set_addr_info,
-#ifdef RT_LWIP_DNS
-    lwip_netdev_set_dns_server,
-#else 
-    NULL,
-#endif /* RT_LWIP_DNS */
-
-#ifdef RT_LWIP_DHCP
-    lwip_netdev_set_dhcp,
-#else
-    NULL,
-#endif /* RT_LWIP_DHCP */
-
-#ifdef RT_USING_FINSH
-#ifdef RT_LWIP_USING_PING
-    lwip_netdev_ping,
-#else
-    NULL,
-#endif /* RT_LWIP_USING_PING */
-
-#if defined (RT_LWIP_TCP) || defined (RT_LWIP_UDP)
-    lwip_netdev_netstat,
-#endif /* RT_LWIP_TCP || RT_LWIP_UDP */
-#endif /* RT_USING_FINSH */
-
-    lwip_netdev_set_default,
-};
-
-static int netdev_add(struct netif *lwip_netif)
-{
-#define LWIP_NETIF_NAME_LEN 2
-    int result = 0;
-    struct netdev *netdev = RT_NULL;
-    char name[LWIP_NETIF_NAME_LEN + 1] = {0};
-
-    RT_ASSERT(lwip_netif);
-
-    netdev = (struct netdev *)rt_calloc(1, sizeof(struct netdev));
-    if (netdev == RT_NULL)
-    {
-        return -ERR_IF;
-    }
-
-#ifdef SAL_USING_LWIP
-    extern int sal_lwip_netdev_set_pf_info(struct netdev *netdev);
-    /* set the lwIP network interface device protocol family information */
-    sal_lwip_netdev_set_pf_info(netdev);
-#endif /* SAL_USING_LWIP */
-
-    rt_strncpy(name, lwip_netif->name, LWIP_NETIF_NAME_LEN);
-    result = netdev_register(netdev, name, (void *)lwip_netif);
-	
-    /* Update netdev info after registered */	
-    netdev->flags = lwip_netif->flags;
-    netdev->mtu = lwip_netif->mtu;
-    netdev->ops = &lwip_netdev_ops;
-    netdev->hwaddr_len =  lwip_netif->hwaddr_len;
-    rt_memcpy(netdev->hwaddr, lwip_netif->hwaddr, lwip_netif->hwaddr_len);
-    netdev->ip_addr = lwip_netif->ip_addr;
-    netdev->gw = lwip_netif->gw;
-    netdev->netmask = lwip_netif->netmask;
-	
-#ifdef RT_LWIP_DHCP
-    netdev_low_level_set_dhcp_status(netdev, RT_TRUE);
-#endif
-
-    return result;
-}
-
-static void netdev_del(struct netif *lwip_netif)
-{
-    char name[LWIP_NETIF_NAME_LEN + 1];
-    struct netdev *netdev;
-
-    RT_ASSERT(lwip_netif);
-
-    rt_strncpy(name, lwip_netif->name, LWIP_NETIF_NAME_LEN);
-    netdev = netdev_get_by_name(name);
-    netdev_unregister(netdev);
-    rt_free(netdev);
-}
-
-/* synchronize lwIP network interface device and network interface device flags */
-static int netdev_flags_sync(struct netif *lwip_netif)
-{
-    struct netdev *netdev = NULL;
-
-    RT_ASSERT(lwip_netif);
-
-    netdev = netdev_get_by_name(lwip_netif->name);
-    if (netdev == RT_NULL)
-    {
-        return -ERR_IF;
-    }
-
-    netdev->flags |= lwip_netif->flags;
-
-    return ERR_OK;
-}
-#endif /* RT_USING_NETDEV */
-
 static err_t ethernetif_linkoutput(struct netif *netif, struct pbuf *p)
 {
 #ifndef LWIP_NO_TX_THREAD
@@ -408,11 +142,6 @@ static err_t eth_netif_device_init(struct netif *netif)
 {
     struct eth_device *ethif;
 
-#ifdef RT_USING_NETDEV
-    /* network interface device register */
-    netdev_add(netif);
-#endif /* RT_USING_NETDEV */
-    
     ethif = (struct eth_device*)netif->state;
     if (ethif != RT_NULL)
     {
@@ -465,7 +194,7 @@ static err_t eth_netif_device_init(struct netif *netif)
         netif_set_up(ethif->netif);
 #endif
 
-        if (ethif->flags & ETHIF_LINK_PHYUP)
+        if(enet_init_status != 0)
         {
             /* set link_up for this netif */
             netif_set_link_up(ethif->netif);
@@ -478,7 +207,7 @@ static err_t eth_netif_device_init(struct netif *netif)
 }
 
 /* Keep old drivers compatible in RT-Thread */
-rt_err_t eth_device_init_with_flag(struct eth_device *dev, const char *name, rt_uint16_t flags)
+rt_err_t eth_device_init_with_flag(struct eth_device *dev, char *name, rt_uint16_t flags)
 {
     struct netif* netif;
 
@@ -532,22 +261,17 @@ rt_err_t eth_device_init_with_flag(struct eth_device *dev, const char *name, rt_
         gw.addr = inet_addr(RT_LWIP_GWADDR);
         netmask.addr = inet_addr(RT_LWIP_MSKADDR);
 #else        
-        IP4_ADDR(&ipaddr, 0, 0, 0, 0);
-        IP4_ADDR(&gw, 0, 0, 0, 0);
-        IP4_ADDR(&netmask, 0, 0, 0, 0);
+        IP4_ADDR(&ipaddr, 192, 168, 56, 58);
+        IP4_ADDR(&gw, 192, 168, 56, 1);
+        IP4_ADDR(&netmask, 255, 255, 255, 0);
 #endif
         netifapi_netif_add(netif, &ipaddr, &netmask, &gw, dev, eth_netif_device_init, tcpip_input);
     }
 
-#ifdef RT_USING_NETDEV
-    /* network interface device flags synchronize */
-    netdev_flags_sync(netif);
-#endif /* RT_USING_NETDEV */
-
     return RT_EOK;
 }
 
-rt_err_t eth_device_init(struct eth_device * dev, const char *name)
+rt_err_t eth_device_init(struct eth_device * dev, char *name)
 {
     rt_uint16_t flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP;
 
@@ -557,25 +281,6 @@ rt_err_t eth_device_init(struct eth_device * dev, const char *name)
 #endif
 
     return eth_device_init_with_flag(dev, name, flags);
-}
-
-void eth_device_deinit(struct eth_device *dev)
-{
-    struct netif* netif = dev->netif;
-
-#if LWIP_DHCP
-    dhcp_stop(netif);
-    dhcp_cleanup(netif);
-#endif
-    netif_set_down(netif);
-    netif_remove(netif);
-#ifdef RT_USING_NETDEV
-    netdev_del(netif);
-#endif
-    rt_device_close(&(dev->parent));
-    rt_device_unregister(&(dev->parent));
-    rt_sem_detach(&(dev->tx_ack));
-    rt_free(netif);
 }
 
 #ifndef LWIP_NO_RX_THREAD
@@ -626,7 +331,7 @@ static void eth_tx_thread_entry(void* parameter)
 
     while (1)
     {
-        if (rt_mb_recv(&eth_tx_thread_mb, (rt_ubase_t *)&msg, RT_WAITING_FOREVER) == RT_EOK)
+        if (rt_mb_recv(&eth_tx_thread_mb, (rt_uint32_t*)&msg, RT_WAITING_FOREVER) == RT_EOK)
         {
             struct eth_device* enetif;
 
@@ -658,7 +363,7 @@ static void eth_rx_thread_entry(void* parameter)
 
     while (1)
     {
-        if (rt_mb_recv(&eth_rx_thread_mb, (rt_ubase_t *)&device, RT_WAITING_FOREVER) == RT_EOK)
+        if (rt_mb_recv(&eth_rx_thread_mb, (rt_uint32_t*)&device, RT_WAITING_FOREVER) == RT_EOK)
         {
             struct pbuf *p;
 
@@ -755,6 +460,8 @@ int eth_system_device_init_private(void)
     return (int)result;
 }
 
+#ifdef RT_USING_FINSH
+#include <finsh.h>
 void set_if(char* netif_name, char* ip_addr, char* gw_addr, char* nm_addr)
 {
     ip4_addr_t *ip;
@@ -800,20 +507,17 @@ void set_if(char* netif_name, char* ip_addr, char* gw_addr, char* nm_addr)
         netif_set_netmask(netif, ip);
     }
 }
-
-#ifdef RT_USING_FINSH
-#include <finsh.h>
 FINSH_FUNCTION_EXPORT(set_if, set network interface address);
 
 #if LWIP_DNS
 #include <lwip/dns.h>
-void set_dns(uint8_t dns_num, char* dns_server)
+void set_dns(char* dns_server)
 {
     ip_addr_t addr;
 
     if ((dns_server != RT_NULL) && ipaddr_aton(dns_server, &addr))
     {
-        dns_setserver(dns_num, &addr);
+        dns_setserver(0, &addr);
     }
 }
 FINSH_FUNCTION_EXPORT(set_dns, set DNS server address);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
源文件主要存在以下问题：
1> 在eth_netif_device_init函数中通过判断ethif->flags中ETHIF_LINK_PHYUP标志置位后再调用netif_set_link_up函数，然而工程中并没有对PHY的状态进行获取，所以判断一直不成立，无法调用该函数，从而导致了RT官方的examples中network文件夹里的TCP通信不能使用

修改方案：通过判断前面提交的修改后的synopsys_emac.c文件中提供的enet_init_status状态来调用netif_set_link_up函数

已在GD32450Z-EVAL开发板上测试，修改后没有再出现以上问题。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [√] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [√] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [√] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [√] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [√] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [√] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
