### PR TITLE
[net][netdev] fix ipaddr type set issue in netdev register function

### DIFF
--- a/components/net/netdev/src/netdev.c
+++ b/components/net/netdev/src/netdev.c
@@ -66,13 +66,13 @@ int netdev_register(struct netdev *netdev, const char *name, void *user_data)
     for (index = 0; index < NETDEV_IPV6_NUM_ADDRESSES; index++)
     {
         ip_addr_set_zero(&(netdev->ip6_addr[index]));
-        IP_SET_TYPE_VAL(netdev->ip_addr, IPADDR_TYPE_V6);
+        IP_SET_TYPE_VAL(netdev->ip6_addr[index], IPADDR_TYPE_V6);
     }
 #endif /* NETDEV_IPV6 */
     for (index = 0; index < NETDEV_DNS_SERVERS_NUM; index++)
     {
         ip_addr_set_zero(&(netdev->dns_servers[index]));
-        IP_SET_TYPE_VAL(netdev->ip_addr, IPADDR_TYPE_V4);
+        IP_SET_TYPE_VAL(netdev->dns_servers[index], IPADDR_TYPE_V4);
     }
     netdev->status_callback = RT_NULL;
     netdev->addr_callback = RT_NULL;

--- a/components/net/netdev/src/netdev_ipaddr.c
+++ b/components/net/netdev/src/netdev_ipaddr.c
@@ -564,7 +564,7 @@ netdev_inet_ntop(int af, const void *src, char *dst, int32_t size)
     }
     switch (af)
     {
-#if NTEDEV_IPV4
+#if NETDEV_IPV4
     case AF_INET:
         return netdev_ip4addr_ntoa_r((const ip4_addr_t *)src, dst, size_int);
 #endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

- 修复 netdev_register 函数中 ipaddr 类型参数类型设置错误问题
- 该问题已经在 STM32F407 和 QEMU 环境下验证

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
