### PR TITLE
fix the bug that rx_notice out of sync when data received after last rt_device_read() is zero

### DIFF
--- a/components/net/at/src/at_client.c
+++ b/components/net/at/src/at_client.c
@@ -434,18 +434,20 @@ static rt_err_t at_client_getchar(at_client_t client, char *ch, rt_int32_t timeo
 {
     rt_err_t result = RT_EOK;
 
-    while (rt_device_read(client->device, 0, ch, 1) == 0)
+__retry:
+    result = rt_sem_take(client->rx_notice, rt_tick_from_millisecond(timeout));
+    if (result != RT_EOK)
     {
-        rt_sem_control(client->rx_notice, RT_IPC_CMD_RESET, RT_NULL);
-
-        result = rt_sem_take(client->rx_notice, rt_tick_from_millisecond(timeout));
-        if (result != RT_EOK)
-        {
-            return result;
-        }
+        return result;
     }
-
-    return RT_EOK;
+    if(rt_device_read(client->device, 0, ch, 1) == 1)
+    {
+        return RT_EOK;
+    }
+    else
+    {
+        goto __retry;
+    }
 }
 
 /**


### PR DESCRIPTION
Signed-off-by: RGW <rgw5267@gmail.com>

## 拉取/合并请求描述：(PR description)
假如串口接收数据在箭头处收到，那么后面的指令会清除掉上次中断中释放的信号量，但此时serial设备中还缓存着接收到的数据，下次收到新数据时，才会因为收到新信号量而老数据被接收到。
![image](https://user-images.githubusercontent.com/1254990/71448717-6a3b8380-277a-11ea-84b1-c1441db1666d.png)

修改后与原函数行为一致，引用``at_client_getchar()``函数的地方有
``at_recv_readline()``和``at_client_obj_recv()``，测试无问题。
[
这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board have been tested.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
