### PR TITLE
Fix bug for drv_enet.c

### DIFF
--- a/bsp/gd32450z-eval/drivers/drv_enet.c
+++ b/bsp/gd32450z-eval/drivers/drv_enet.c
@@ -652,7 +652,10 @@ int rt_hw_gd32_eth_init(void)
     /* init tx buffer free semaphore */
     rt_sem_init(&gd32_emac_device0.tx_buf_free, "tx_buf0", EMAC_TXBUFNB, RT_IPC_FLAG_FIFO);
     eth_device_init(&(gd32_emac_device0.parent), "e0");
-    
+
+    /* change device link status */
+    eth_device_linkchange(&(gd32_emac_device0.parent), RT_TRUE);
+
     return 0;
 }
 INIT_DEVICE_EXPORT(rt_hw_gd32_eth_init);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
源文件主要存在以下问题：
1> rt_hw_gd32_eth_init函数中对MAC初始化完成后并没有修改PHY的连接状态，这会导致测试TCP例程时无法建立TCP链接，应在初始化完成后将PHY的连接状态修改成linkup；

已在GD32450Z-EVAL开发板上测试，修改后没有再出现以上问题。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [√] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [√] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [√] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [√] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [√] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [√] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [√] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
