### PR TITLE
[net][lwip] fix assert in the sys_arch_mbox_fetch function when close socket

### DIFF
--- a/components/net/lwip-1.4.1/src/arch/sys_arch.c
+++ b/components/net/lwip-1.4.1/src/arch/sys_arch.c
@@ -27,7 +27,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2012-12-8      Bernard      add file header
- *                             export bsd socket symbol for RT-Thread Application Module 
+ *                             export bsd socket symbol for RT-Thread Application Module
  * 2017-11-15     Bernard      add lock for init_done callback.
  */
 
@@ -259,7 +259,7 @@ void sys_sem_signal(sys_sem_t *sem)
  *
  * @return If the timeout argument is non-zero, it will return the number of milliseconds
  *         spent waiting for the semaphore to be signaled; If the semaphore isn't signaled
- *         within the specified time, it will return SYS_ARCH_TIMEOUT; If the thread doesn't 
+ *         within the specified time, it will return SYS_ARCH_TIMEOUT; If the thread doesn't
  *         wait for the semaphore, it will return zero
  */
 u32_t sys_arch_sem_wait(sys_sem_t *sem, u32_t timeout)
@@ -498,13 +498,9 @@ u32_t sys_arch_mbox_fetch(sys_mbox_t *mbox, void **msg, u32_t timeout)
     }
 
     ret = rt_mb_recv(*mbox, (rt_ubase_t *)msg, t);
-    if(ret == -RT_ETIMEOUT)
+    if(ret != RT_EOK)
     {
         return SYS_ARCH_TIMEOUT;
-    }
-    else
-    {
-        LWIP_ASSERT("rt_mb_recv returned with error!", ret == RT_EOK);
     }
 
     /* get elapse msecond */
@@ -536,7 +532,7 @@ u32_t sys_arch_mbox_tryfetch(sys_mbox_t *mbox, void **msg)
     }
     else
     {
-        if (ret == RT_EOK) 
+        if (ret == RT_EOK)
             ret = 1;
     }
 

--- a/components/net/lwip-2.0.2/src/arch/sys_arch.c
+++ b/components/net/lwip-2.0.2/src/arch/sys_arch.c
@@ -27,7 +27,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2012-12-8      Bernard      add file header
- *                             export bsd socket symbol for RT-Thread Application Module 
+ *                             export bsd socket symbol for RT-Thread Application Module
  * 2017-11-15     Bernard      add lock for init_done callback.
  */
 
@@ -270,7 +270,7 @@ void sys_sem_signal(sys_sem_t *sem)
  *
  * @return If the timeout argument is non-zero, it will return the number of milliseconds
  *         spent waiting for the semaphore to be signaled; If the semaphore isn't signaled
- *         within the specified time, it will return SYS_ARCH_TIMEOUT; If the thread doesn't 
+ *         within the specified time, it will return SYS_ARCH_TIMEOUT; If the thread doesn't
  *         wait for the semaphore, it will return zero
  */
 u32_t sys_arch_sem_wait(sys_sem_t *sem, u32_t timeout)
@@ -509,12 +509,9 @@ u32_t sys_arch_mbox_fetch(sys_mbox_t *mbox, void **msg, u32_t timeout)
     }
 
     ret = rt_mb_recv(*mbox, (rt_ubase_t *)msg, t);
-
-    if(ret == -RT_ETIMEOUT)
-        return SYS_ARCH_TIMEOUT;
-    else
+    if(ret != RT_EOK)
     {
-        LWIP_ASSERT("rt_mb_recv returned with error!", ret == RT_EOK);
+        return SYS_ARCH_TIMEOUT;
     }
 
     /* get elapse msecond */
@@ -545,7 +542,7 @@ u32_t sys_arch_mbox_tryfetch(sys_mbox_t *mbox, void **msg)
         return SYS_ARCH_TIMEOUT;
     else
     {
-        if (ret == RT_EOK) 
+        if (ret == RT_EOK)
             ret = 1;
     }
 

--- a/components/net/lwip-2.1.0/src/arch/sys_arch.c
+++ b/components/net/lwip-2.1.0/src/arch/sys_arch.c
@@ -27,7 +27,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2012-12-8      Bernard      add file header
- *                             export bsd socket symbol for RT-Thread Application Module 
+ *                             export bsd socket symbol for RT-Thread Application Module
  * 2017-11-15     Bernard      add lock for init_done callback.
  * 2018-11-02     MurphyZhao   port to lwip2.1.0
  */
@@ -78,7 +78,7 @@ static err_t netif_device_init(struct netif *netif)
         /* copy device flags to netif flags */
         netif->flags = ethif->flags;
         netif->mtu = ETHERNET_MTU;
-        
+
         /* set output */
         netif->output = etharp_output;
 
@@ -278,7 +278,7 @@ void sys_sem_signal(sys_sem_t *sem)
  *
  * @return If the timeout argument is non-zero, it will return the number of milliseconds
  *         spent waiting for the semaphore to be signaled; If the semaphore isn't signaled
- *         within the specified time, it will return SYS_ARCH_TIMEOUT; If the thread doesn't 
+ *         within the specified time, it will return SYS_ARCH_TIMEOUT; If the thread doesn't
  *         wait for the semaphore, it will return zero
  */
 u32_t sys_arch_sem_wait(sys_sem_t *sem, u32_t timeout)
@@ -523,12 +523,9 @@ u32_t sys_arch_mbox_fetch(sys_mbox_t *mbox, void **msg, u32_t timeout)
     }
 
     ret = rt_mb_recv(*mbox, (rt_ubase_t *)msg, t);
-
-    if(ret == -RT_ETIMEOUT)
-        return SYS_ARCH_TIMEOUT;
-    else
+    if(ret != RT_EOK)
     {
-        LWIP_ASSERT("rt_mb_recv returned with error!", ret == RT_EOK);
+        return SYS_ARCH_TIMEOUT;
     }
 
     /* get elapse msecond */
@@ -559,7 +556,7 @@ u32_t sys_arch_mbox_tryfetch(sys_mbox_t *mbox, void **msg)
         return SYS_ARCH_TIMEOUT;
     else
     {
-        if (ret == RT_EOK) 
+        if (ret == RT_EOK)
             ret = 1;
     }
 

--- a/components/net/lwip-2.1.0/src/netif/ethernetif.c
+++ b/components/net/lwip-2.1.0/src/netif/ethernetif.c
@@ -487,8 +487,13 @@ static err_t eth_netif_device_init(struct netif *netif)
 rt_err_t eth_device_init_with_flag(struct eth_device *dev, const char *name, rt_uint16_t flags)
 {
     struct netif* netif;
-
+#if LWIP_NETIF_HOSTNAME
+#define LWIP_HOSTNAME_LEN 16
+    char *hostname = RT_NULL;
+    netif = (struct netif*) rt_malloc (sizeof(struct netif) + LWIP_HOSTNAME_LEN);
+#else
     netif = (struct netif*) rt_malloc (sizeof(struct netif));
+#endif
     if (netif == RT_NULL)
     {
         rt_kprintf("malloc netif failed\n");


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

- 修复在一个线程在等待接收数据，另一个线程关闭 socket 引起的断言问题
- 提交上次未提交的 lwIP 2.1.0 里的 hostname 相关代码
- 已在 STM32F407 平台上测试过

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
