### PR TITLE
[BSP][STM32][STM32F469-DISCO]fix build error with qspi

### DIFF
--- a/bsp/stm32/stm32f469-st-disco/board/SConscript
+++ b/bsp/stm32/stm32f469-st-disco/board/SConscript
@@ -26,9 +26,6 @@ if GetDepend(['BSP_USING_TOUCH']):
     
 if GetDepend(['BSP_USING_SDCARD']):
     src += ['ports/drv_sdcard.c']
-    
-if GetDepend(['BSP_USING_QSPI']):
-    src += ['ports/drv_qspi_flash.c']
 
 path =  [cwd]
 path += [cwd + '/CubeMX_Config/Inc']


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
 修复STM32F469-DISCO在开启QSPI后出现两次引用文件导致编译错误的问题
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
