### PR TITLE
:bug: fix compile warning, undefine var

### DIFF
--- a/components/drivers/audio/audio.c
+++ b/components/drivers/audio/audio.c
@@ -33,7 +33,7 @@ static rt_err_t _audio_send_replay_frame(struct rt_audio_device *audio)
     rt_err_t result = RT_EOK;
     rt_uint8_t *data;
     rt_size_t dst_size, src_size;
-    rt_uint16_t position, remain_bytes, index = 0;
+    rt_uint16_t position, remain_bytes = 0, index = 0;
     struct rt_audio_buf_info *buf_info;
 
     RT_ASSERT(audio != RT_NULL);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
问题：rt-thread/components/drivers/audio.c中_audio_send_replay_frame函数，使用了未初始化变量remain_bytes编译会报warning。
解决方案：remain_bytes初始化为0。
测试： 云知声自研芯片平台验证通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
