### PR TITLE
Add priority & stack_size parameters for dlmodule custom

### DIFF
--- a/components/libc/libdl/dlmodule.c
+++ b/components/libc/libdl/dlmodule.c
@@ -709,6 +709,7 @@ __exit:
 struct rt_dlmodule* dlmodule_exec_custom(const char* pgname, const char* cmd, int cmd_size, struct rt_dlmodule_ops* ops)
 {
     struct rt_dlmodule *module = RT_NULL;
+    rt_uint32_t tick = 10;
 
     module = dlmodule_load_custom(pgname, ops);
     if (module)
@@ -721,11 +722,14 @@ struct rt_dlmodule* dlmodule_exec_custom(const char* pgname, const char* cmd, in
             module->cmd_line = rt_strdup(cmd);
 
             /* check stack size and priority */
+            if (ops->priority) module->priority = ops->priority;
+            if (ops->stack_size) module->stack_size = ops->stack_size;
+            if (ops->tick) tick = ops->tick;
             if (module->priority > RT_THREAD_PRIORITY_MAX) module->priority = RT_THREAD_PRIORITY_MAX - 1;
             if (module->stack_size < 2048 || module->stack_size > (1024 * 32)) module->stack_size = 2048;
 
             tid = rt_thread_create(module->parent.name, _dlmodule_thread_entry, (void*)module, 
-                module->stack_size, module->priority, 10);
+                module->stack_size, module->priority, tick);
             if (tid)
             {
                 tid->module_id = module;

--- a/components/libc/libdl/dlmodule.h
+++ b/components/libc/libdl/dlmodule.h
@@ -63,6 +63,10 @@ struct rt_dlmodule_ops
 {
     rt_uint8_t *(*load)(const char* filename);  /* load dlmodule file data */
     rt_err_t (*unload)(rt_uint8_t *param);  /* unload dlmodule file data */
+
+    rt_uint16_t priority;
+    rt_uint32_t stack_size;
+    rt_uint32_t tick;
 };
 
 struct rt_dlmodule *dlmodule_create(void);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
由于dlmodule中默认将动态模块线程优先级固定最低（RT_THREAD_PRIORITY_MAX - 1）、堆栈大小固定（2048）、运行时间固定（10），用户加载动态模块无法设置这些参数，导致加载的动态模块运行效率低，堆栈大小无法根据需求修改配置等问题。

为了解决这些问题，在dlmodule_exec_custom()接口函数中，参考创建线程接口，增加优先级、堆栈大小、运行时间等参数，解决以上问题。

该方案已经在RK2108 SDK上进行了验证，确认解决了优先级固定最小带来的效率问题等。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
