### PR TITLE
Bugfix drvflashf7

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f7.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f7.c
@@ -42,122 +42,122 @@
   */
 static rt_uint32_t GetSector(rt_uint32_t Address)
 {
-  uint32_t sector = 0;
+    uint32_t sector = 0;
   
 #if defined (FLASH_OPTCR_nDBANK)
-  FLASH_OBProgramInitTypeDef OBInit;
-  uint32_t nbank = 0;
+    FLASH_OBProgramInitTypeDef OBInit;
+    uint32_t nbank = 0;
 
-  //get duel bank ability:nDBANK(Bit29)
-  HAL_FLASHEx_OBGetConfig(&OBInit);
-  nbank = ((OBInit.USERConfig & 0x20000000U) >> 29);
-  //1:single bank mode
-  if(1 == nbank)
-  {  
+    //get duel bank ability:nDBANK(Bit29)
+    HAL_FLASHEx_OBGetConfig(&OBInit);
+    nbank = ((OBInit.USERConfig & 0x20000000U) >> 29);
+    //1:single bank mode
+    if(1 == nbank)
+    {  
+        if((Address < ADDR_FLASH_SECTOR_1) && (Address >= ADDR_FLASH_SECTOR_0))
+        {
+            sector = FLASH_SECTOR_0;
+        }
+        else if((Address < ADDR_FLASH_SECTOR_2) && (Address >= ADDR_FLASH_SECTOR_1))
+        {
+            sector = FLASH_SECTOR_1;
+        }
+        else if((Address < ADDR_FLASH_SECTOR_3) && (Address >= ADDR_FLASH_SECTOR_2))
+        {
+            sector = FLASH_SECTOR_2;
+        }
+        else if((Address < ADDR_FLASH_SECTOR_4) && (Address >= ADDR_FLASH_SECTOR_3))
+        {
+            sector = FLASH_SECTOR_3;
+        }
+        else if((Address < ADDR_FLASH_SECTOR_5) && (Address >= ADDR_FLASH_SECTOR_4))
+        {
+            sector = FLASH_SECTOR_4;
+        }
+        else if((Address < ADDR_FLASH_SECTOR_6) && (Address >= ADDR_FLASH_SECTOR_5))
+        {
+            sector = FLASH_SECTOR_5;
+        }
+        else if((Address < ADDR_FLASH_SECTOR_7) && (Address >= ADDR_FLASH_SECTOR_6))
+        {
+            sector = FLASH_SECTOR_6;
+        }
+        else if((Address < ADDR_FLASH_SECTOR_8) && (Address >= ADDR_FLASH_SECTOR_7))
+        {
+            sector = FLASH_SECTOR_7;
+        }
+        else if((Address < ADDR_FLASH_SECTOR_9) && (Address >= ADDR_FLASH_SECTOR_8))
+        {
+            sector = FLASH_SECTOR_8;
+        }
+        else if((Address < ADDR_FLASH_SECTOR_10) && (Address >= ADDR_FLASH_SECTOR_9))
+        {
+            sector = FLASH_SECTOR_9;
+        }
+        else if((Address < ADDR_FLASH_SECTOR_11) && (Address >= ADDR_FLASH_SECTOR_10))
+        {
+            sector = FLASH_SECTOR_10;
+        }
+        else 
+        {
+            sector = FLASH_SECTOR_11;
+        }
+    }
+    else  //0:dual bank mode
+    {
+        RT_ASSERT("rtthread doesn't support duel bank mode yet!");
+    }
+#else //no dual bank ability
     if((Address < ADDR_FLASH_SECTOR_1) && (Address >= ADDR_FLASH_SECTOR_0))
     {
-      sector = FLASH_SECTOR_0;
+        sector = FLASH_SECTOR_0;
     }
     else if((Address < ADDR_FLASH_SECTOR_2) && (Address >= ADDR_FLASH_SECTOR_1))
     {
-      sector = FLASH_SECTOR_1;
+        sector = FLASH_SECTOR_1;
     }
     else if((Address < ADDR_FLASH_SECTOR_3) && (Address >= ADDR_FLASH_SECTOR_2))
     {
-      sector = FLASH_SECTOR_2;
+        sector = FLASH_SECTOR_2;
     }
     else if((Address < ADDR_FLASH_SECTOR_4) && (Address >= ADDR_FLASH_SECTOR_3))
     {
-      sector = FLASH_SECTOR_3;
+        sector = FLASH_SECTOR_3;
     }
     else if((Address < ADDR_FLASH_SECTOR_5) && (Address >= ADDR_FLASH_SECTOR_4))
     {
-      sector = FLASH_SECTOR_4;
+        sector = FLASH_SECTOR_4;
     }
     else if((Address < ADDR_FLASH_SECTOR_6) && (Address >= ADDR_FLASH_SECTOR_5))
     {
-      sector = FLASH_SECTOR_5;
+        sector = FLASH_SECTOR_5;
     }
     else if((Address < ADDR_FLASH_SECTOR_7) && (Address >= ADDR_FLASH_SECTOR_6))
     {
-      sector = FLASH_SECTOR_6;
+        sector = FLASH_SECTOR_6;
     }
     else if((Address < ADDR_FLASH_SECTOR_8) && (Address >= ADDR_FLASH_SECTOR_7))
     {
-      sector = FLASH_SECTOR_7;
+        sector = FLASH_SECTOR_7;
     }
     else if((Address < ADDR_FLASH_SECTOR_9) && (Address >= ADDR_FLASH_SECTOR_8))
     {
-      sector = FLASH_SECTOR_8;
+        sector = FLASH_SECTOR_8;
     }
     else if((Address < ADDR_FLASH_SECTOR_10) && (Address >= ADDR_FLASH_SECTOR_9))
     {
-      sector = FLASH_SECTOR_9;
+        sector = FLASH_SECTOR_9;
     }
     else if((Address < ADDR_FLASH_SECTOR_11) && (Address >= ADDR_FLASH_SECTOR_10))
     {
-      sector = FLASH_SECTOR_10;
+        sector = FLASH_SECTOR_10;
     }
     else 
     {
-      sector = FLASH_SECTOR_11;
+        sector = FLASH_SECTOR_11;
     }
-  }
-  else  //0:dual bank mode
-  {
-    RT_ASSERT("rtthread doesn't support duel bank mode yet!");
-  }
-#else //no dual bank ability
-  if((Address < ADDR_FLASH_SECTOR_1) && (Address >= ADDR_FLASH_SECTOR_0))
-  {
-    sector = FLASH_SECTOR_0;
-  }
-  else if((Address < ADDR_FLASH_SECTOR_2) && (Address >= ADDR_FLASH_SECTOR_1))
-  {
-    sector = FLASH_SECTOR_1;
-  }
-  else if((Address < ADDR_FLASH_SECTOR_3) && (Address >= ADDR_FLASH_SECTOR_2))
-  {
-    sector = FLASH_SECTOR_2;
-  }
-  else if((Address < ADDR_FLASH_SECTOR_4) && (Address >= ADDR_FLASH_SECTOR_3))
-  {
-    sector = FLASH_SECTOR_3;
-  }
-  else if((Address < ADDR_FLASH_SECTOR_5) && (Address >= ADDR_FLASH_SECTOR_4))
-  {
-    sector = FLASH_SECTOR_4;
-  }
-  else if((Address < ADDR_FLASH_SECTOR_6) && (Address >= ADDR_FLASH_SECTOR_5))
-  {
-    sector = FLASH_SECTOR_5;
-  }
-  else if((Address < ADDR_FLASH_SECTOR_7) && (Address >= ADDR_FLASH_SECTOR_6))
-  {
-    sector = FLASH_SECTOR_6;
-  }
-  else if((Address < ADDR_FLASH_SECTOR_8) && (Address >= ADDR_FLASH_SECTOR_7))
-  {
-    sector = FLASH_SECTOR_7;
-  }
-  else if((Address < ADDR_FLASH_SECTOR_9) && (Address >= ADDR_FLASH_SECTOR_8))
-  {
-    sector = FLASH_SECTOR_8;
-  }
-  else if((Address < ADDR_FLASH_SECTOR_10) && (Address >= ADDR_FLASH_SECTOR_9))
-  {
-    sector = FLASH_SECTOR_9;
-  }
-  else if((Address < ADDR_FLASH_SECTOR_11) && (Address >= ADDR_FLASH_SECTOR_10))
-  {
-    sector = FLASH_SECTOR_10;
-  }
-  else 
-  {
-    sector = FLASH_SECTOR_11;
-  }
 #endif
-  return sector;
+    return sector;
 }
 
 

--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f7.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f7.c
@@ -52,49 +52,49 @@ static rt_uint32_t GetSector(rt_uint32_t Address)
     HAL_FLASHEx_OBGetConfig(&OBInit);
     nbank = ((OBInit.USERConfig & 0x20000000U) >> 29);
     //1:single bank mode
-    if(1 == nbank)
+    if (1 == nbank)
     {  
-        if((Address < ADDR_FLASH_SECTOR_1) && (Address >= ADDR_FLASH_SECTOR_0))
+        if ((Address < ADDR_FLASH_SECTOR_1) && (Address >= ADDR_FLASH_SECTOR_0))
         {
             sector = FLASH_SECTOR_0;
         }
-        else if((Address < ADDR_FLASH_SECTOR_2) && (Address >= ADDR_FLASH_SECTOR_1))
+        else if ((Address < ADDR_FLASH_SECTOR_2) && (Address >= ADDR_FLASH_SECTOR_1))
         {
             sector = FLASH_SECTOR_1;
         }
-        else if((Address < ADDR_FLASH_SECTOR_3) && (Address >= ADDR_FLASH_SECTOR_2))
+        else if ((Address < ADDR_FLASH_SECTOR_3) && (Address >= ADDR_FLASH_SECTOR_2))
         {
             sector = FLASH_SECTOR_2;
         }
-        else if((Address < ADDR_FLASH_SECTOR_4) && (Address >= ADDR_FLASH_SECTOR_3))
+        else if ((Address < ADDR_FLASH_SECTOR_4) && (Address >= ADDR_FLASH_SECTOR_3))
         {
             sector = FLASH_SECTOR_3;
         }
-        else if((Address < ADDR_FLASH_SECTOR_5) && (Address >= ADDR_FLASH_SECTOR_4))
+        else if ((Address < ADDR_FLASH_SECTOR_5) && (Address >= ADDR_FLASH_SECTOR_4))
         {
             sector = FLASH_SECTOR_4;
         }
-        else if((Address < ADDR_FLASH_SECTOR_6) && (Address >= ADDR_FLASH_SECTOR_5))
+        else if ((Address < ADDR_FLASH_SECTOR_6) && (Address >= ADDR_FLASH_SECTOR_5))
         {
             sector = FLASH_SECTOR_5;
         }
-        else if((Address < ADDR_FLASH_SECTOR_7) && (Address >= ADDR_FLASH_SECTOR_6))
+        else if ((Address < ADDR_FLASH_SECTOR_7) && (Address >= ADDR_FLASH_SECTOR_6))
         {
             sector = FLASH_SECTOR_6;
         }
-        else if((Address < ADDR_FLASH_SECTOR_8) && (Address >= ADDR_FLASH_SECTOR_7))
+        else if ((Address < ADDR_FLASH_SECTOR_8) && (Address >= ADDR_FLASH_SECTOR_7))
         {
             sector = FLASH_SECTOR_7;
         }
-        else if((Address < ADDR_FLASH_SECTOR_9) && (Address >= ADDR_FLASH_SECTOR_8))
+        else if ((Address < ADDR_FLASH_SECTOR_9) && (Address >= ADDR_FLASH_SECTOR_8))
         {
             sector = FLASH_SECTOR_8;
         }
-        else if((Address < ADDR_FLASH_SECTOR_10) && (Address >= ADDR_FLASH_SECTOR_9))
+        else if ((Address < ADDR_FLASH_SECTOR_10) && (Address >= ADDR_FLASH_SECTOR_9))
         {
             sector = FLASH_SECTOR_9;
         }
-        else if((Address < ADDR_FLASH_SECTOR_11) && (Address >= ADDR_FLASH_SECTOR_10))
+        else if ((Address < ADDR_FLASH_SECTOR_11) && (Address >= ADDR_FLASH_SECTOR_10))
         {
             sector = FLASH_SECTOR_10;
         }
@@ -108,47 +108,47 @@ static rt_uint32_t GetSector(rt_uint32_t Address)
         RT_ASSERT("rtthread doesn't support duel bank mode yet!");
     }
 #else //no dual bank ability
-    if((Address < ADDR_FLASH_SECTOR_1) && (Address >= ADDR_FLASH_SECTOR_0))
+    if ((Address < ADDR_FLASH_SECTOR_1) && (Address >= ADDR_FLASH_SECTOR_0))
     {
         sector = FLASH_SECTOR_0;
     }
-    else if((Address < ADDR_FLASH_SECTOR_2) && (Address >= ADDR_FLASH_SECTOR_1))
+    else if ((Address < ADDR_FLASH_SECTOR_2) && (Address >= ADDR_FLASH_SECTOR_1))
     {
         sector = FLASH_SECTOR_1;
     }
-    else if((Address < ADDR_FLASH_SECTOR_3) && (Address >= ADDR_FLASH_SECTOR_2))
+    else if ((Address < ADDR_FLASH_SECTOR_3) && (Address >= ADDR_FLASH_SECTOR_2))
     {
         sector = FLASH_SECTOR_2;
     }
-    else if((Address < ADDR_FLASH_SECTOR_4) && (Address >= ADDR_FLASH_SECTOR_3))
+    else if ((Address < ADDR_FLASH_SECTOR_4) && (Address >= ADDR_FLASH_SECTOR_3))
     {
         sector = FLASH_SECTOR_3;
     }
-    else if((Address < ADDR_FLASH_SECTOR_5) && (Address >= ADDR_FLASH_SECTOR_4))
+    else if ((Address < ADDR_FLASH_SECTOR_5) && (Address >= ADDR_FLASH_SECTOR_4))
     {
         sector = FLASH_SECTOR_4;
     }
-    else if((Address < ADDR_FLASH_SECTOR_6) && (Address >= ADDR_FLASH_SECTOR_5))
+    else if ((Address < ADDR_FLASH_SECTOR_6) && (Address >= ADDR_FLASH_SECTOR_5))
     {
         sector = FLASH_SECTOR_5;
     }
-    else if((Address < ADDR_FLASH_SECTOR_7) && (Address >= ADDR_FLASH_SECTOR_6))
+    else if ((Address < ADDR_FLASH_SECTOR_7) && (Address >= ADDR_FLASH_SECTOR_6))
     {
         sector = FLASH_SECTOR_6;
     }
-    else if((Address < ADDR_FLASH_SECTOR_8) && (Address >= ADDR_FLASH_SECTOR_7))
+    else if ((Address < ADDR_FLASH_SECTOR_8) && (Address >= ADDR_FLASH_SECTOR_7))
     {
         sector = FLASH_SECTOR_7;
     }
-    else if((Address < ADDR_FLASH_SECTOR_9) && (Address >= ADDR_FLASH_SECTOR_8))
+    else if ((Address < ADDR_FLASH_SECTOR_9) && (Address >= ADDR_FLASH_SECTOR_8))
     {
         sector = FLASH_SECTOR_8;
     }
-    else if((Address < ADDR_FLASH_SECTOR_10) && (Address >= ADDR_FLASH_SECTOR_9))
+    else if ((Address < ADDR_FLASH_SECTOR_10) && (Address >= ADDR_FLASH_SECTOR_9))
     {
         sector = FLASH_SECTOR_9;
     }
-    else if((Address < ADDR_FLASH_SECTOR_11) && (Address >= ADDR_FLASH_SECTOR_10))
+    else if ((Address < ADDR_FLASH_SECTOR_11) && (Address >= ADDR_FLASH_SECTOR_10))
     {
         sector = FLASH_SECTOR_10;
     }

--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f7.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f7.c
@@ -105,7 +105,8 @@ static rt_uint32_t GetSector(rt_uint32_t Address)
     }
     else  //0:dual bank mode
     {
-        RT_ASSERT("rtthread doesn't support duel bank mode yet!");
+        LOG_E("rtthread doesn't support duel bank mode yet!");
+        RT_ASSERT(0);
     }
 #else //no dual bank ability
     if ((Address < ADDR_FLASH_SECTOR_1) && (Address >= ADDR_FLASH_SECTOR_0))
@@ -306,13 +307,13 @@ __exit:
 }
 
 #if defined(PKG_USING_FAL)
-#define FLASH_SIZE_GRANULARITY_32K      4 * 32 * 1024
-#define FLASH_SIZE_GRANULARITY_128K     128 * 1024
-#define FLASH_SIZE_GRANULARITY_256K     7 * 256 *1024
+#define FLASH_SIZE_GRANULARITY_32K      (4 * 32 * 1024)
+#define FLASH_SIZE_GRANULARITY_128K     (128 * 1024)
+#define FLASH_SIZE_GRANULARITY_256K     (7 * 256 *1024)
 
-#define STM32_FLASH_START_ADRESS_32K    STM32_FLASH_START_ADRESS
-#define STM32_FLASH_START_ADRESS_128K   STM32_FLASH_START_ADRESS_32K + FLASH_SIZE_GRANULARITY_32K
-#define STM32_FLASH_START_ADRESS_256K   STM32_FLASH_START_ADRESS_128K + FLASH_SIZE_GRANULARITY_128K
+#define STM32_FLASH_START_ADRESS_32K    (STM32_FLASH_START_ADRESS)
+#define STM32_FLASH_START_ADRESS_128K   (STM32_FLASH_START_ADRESS_32K + FLASH_SIZE_GRANULARITY_32K)
+#define STM32_FLASH_START_ADRESS_256K   (STM32_FLASH_START_ADRESS_128K + FLASH_SIZE_GRANULARITY_128K)
 
 static int fal_flash_read_32k(long offset, rt_uint8_t *buf, size_t size);
 static int fal_flash_read_128k(long offset, rt_uint8_t *buf, size_t size);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
问题场景：
移植rt-thread到stm32f767开发板时发现，flash擦除功能不可用，调试发现f7的flash芯片上电默认是single bank mode而rt-thread的驱动只支持duel bank mode 导致获取的sector号错误，flash擦除失败

解决方案：
这个PR将f7的flash驱动修改为仅支持single bank mode，如果用户需要使用duel bank mode需要自己额外修改驱动代码。

测试场景：
stm32f767：上电flash默认为single bank mode模式时进行擦除、写数据、读数据均成功。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [Y] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [Y ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [Y] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [Y] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [Y] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [Y] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [Y] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
