### PR TITLE
[stm32/libraries/HAL_Drivers/drv_eth.c]fixed read phy SR register return value

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_eth.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_eth.c
@@ -411,11 +411,11 @@ static void phy_linkchange()
 
     if (status & (PHY_AUTONEGO_COMPLETE_MASK | PHY_LINKED_STATUS_MASK))
     {
-        rt_uint32_t SR;
+        rt_uint32_t SR = 0;
 
         phy_speed_new |= PHY_LINK;
 
-        SR = HAL_ETH_ReadPHYRegister(&EthHandle, PHY_Status_REG, (uint32_t *)&SR);
+        HAL_ETH_ReadPHYRegister(&EthHandle, PHY_Status_REG, (uint32_t *)&SR);
         LOG_D("phy control status reg is 0x%X", SR);
 
         if (PHY_Status_SPEED_100M(SR))


### PR DESCRIPTION
…urn value conflicts with function's parameter

## 拉取/合并请求描述：(PR description)

[

- fixed drv_eth.c read phy SR register function's return value conflicts with the parameter.

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [√] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [√] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [√] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [√] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [√] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [√] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [√] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
