### PR TITLE
修复因串口接收缓冲区满且没有开启ULOG_USING_ISR_LOG而造成的死机问题

### DIFF
--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -333,7 +333,7 @@ static void _serial_check_buffer_size(void)
 
     if (already_output == RT_FALSE)
     {
-#if defined(ULOG_USING_ISR_LOG)
+#if !defined(RT_USING_ULOG) || defined(ULOG_USING_ISR_LOG)
         LOG_W("Warning: There is no enough buffer for saving data,"
               " please increase the RT_SERIAL_RB_BUFSZ option.");
 #endif

--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -330,14 +330,16 @@ rt_inline int _serial_int_tx(struct rt_serial_device *serial, const rt_uint8_t *
 static void _serial_check_buffer_size(void)
 {
     static rt_bool_t already_output = RT_FALSE;
-		
+
     if (already_output == RT_FALSE)
     {
+#if defined(ULOG_USING_ISR_LOG)
         LOG_W("Warning: There is no enough buffer for saving data,"
               " please increase the RT_SERIAL_RB_BUFSZ option.");
+#endif
         already_output = RT_TRUE;
     }
-}	
+}
 
 #if defined(RT_USING_POSIX) || defined(RT_SERIAL_USING_DMA)
 static rt_size_t _serial_fifo_calc_recved_len(struct rt_serial_device *serial)
@@ -1286,4 +1288,3 @@ void rt_hw_serial_isr(struct rt_serial_device *serial, int event)
 #endif /* RT_SERIAL_USING_DMA */
     }
 }
-


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
由于串口接收缓冲区满了的时候会调用`void _serial_check_buffer_size(void)`，而该函数会使用ulog输出一些Warning信息且该函数是在中断中被调用的。

因此，当串口接收缓冲区满了的时候当若用户没有开启ULOG_USING_ISR_LOG就会造成死机。

目前手头上没有常规的开发板，只在自己的开发板上测试过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
