### PR TITLE
fix: 为W60x添加rt_hw_us_delay

### DIFF
--- a/bsp/w60x/drivers/board.c
+++ b/bsp/w60x/drivers/board.c
@@ -213,6 +213,42 @@ void rt_hw_cpu_reset(void)
     tls_sys_reset();
 }
 
+/**
+ * The time delay function.
+ *
+ * @param microseconds.
+ */
+#include "wm_regs.h"
+void rt_hw_us_delay(rt_uint32_t us)
+{
+    rt_uint32_t ticks;
+    rt_uint32_t told, tnow, tcnt = 0;
+    rt_uint32_t reload = SysTick->LOAD;
+
+    ticks = us * reload / (1000000 / RT_TICK_PER_SECOND);
+    told = SysTick->VAL;
+    while (1)
+    {
+        tnow = SysTick->VAL;
+        if (tnow != told)
+        {
+            if (tnow < told)
+            {
+                tcnt += told - tnow;
+            }
+            else
+            {
+                tcnt += reload - tnow + told;
+            }
+            told = tnow;
+            if (tcnt >= ticks)
+            {
+                break;
+            }
+        }
+    }
+}
+
 #ifdef RT_USING_FINSH
 #include <finsh.h>
 static void reboot(uint8_t argc, char **argv)

--- a/bsp/w60x/drivers/drv_soft_i2c.c
+++ b/bsp/w60x/drivers/drv_soft_i2c.c
@@ -138,40 +138,7 @@ static rt_int32_t w60x_get_scl(void *data)
 
     return tls_gpio_read((enum tls_io_name)scl);
 }
-/**
- * The time delay function.
- *
- * @param microseconds.
- */
-static void w60x_udelay(rt_uint32_t us)
-{
-    rt_uint32_t ticks;
-    rt_uint32_t told, tnow, tcnt = 0;
-    rt_uint32_t reload = SysTick->LOAD;
 
-    ticks = us * reload / (1000000 / RT_TICK_PER_SECOND);
-    told = SysTick->VAL;
-    while (1)
-    {
-        tnow = SysTick->VAL;
-        if (tnow != told)
-        {
-            if (tnow < told)
-            {
-                tcnt += told - tnow;
-            }
-            else
-            {
-                tcnt += reload - tnow + told;
-            }
-            told = tnow;
-            if (tcnt >= ticks)
-            {
-                break;
-            }
-        }
-    }
-}
 
 static const struct rt_i2c_bit_ops w60x_bit_ops_default =
 {
@@ -180,7 +147,7 @@ static const struct rt_i2c_bit_ops w60x_bit_ops_default =
     .set_scl  = w60x_set_scl,
     .get_sda  = w60x_get_sda,
     .get_scl  = w60x_get_scl,
-    .udelay   = w60x_udelay,
+    .udelay   = rt_hw_us_delay,
     .delay_us = 1,
     .timeout  = 100
 };
@@ -201,9 +168,9 @@ static rt_err_t w60x_i2c_bus_unlock(const struct w60x_soft_i2c_config *cfg)
         while (i++ < 9)
         {
             rt_pin_write(cfg->scl, PIN_HIGH);
-            w60x_udelay(100);
+            rt_hw_us_delay(100);
             rt_pin_write(cfg->scl, PIN_LOW);
-            w60x_udelay(100);
+            rt_hw_us_delay(100);
         }
     }
     if (PIN_LOW == rt_pin_read(cfg->sda))


### PR DESCRIPTION
为W60x添加rt_hw_us_delay

## 拉取/合并请求描述：(PR description)

[


原因: 因为W60x的BSP缺少rt_hw_us_delay方法,导致online packages中的ds18b20/dht11无法使用
解决的问题: 使得ds18b20/dht11直接被支持
解决方案是: 将drv_soft_i2c的w60x_udelay, 改名为rt_hw_us_delay, 并搬到broad.c

已经在W600 Arduino板进行测试,运行正常
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
