### PR TITLE
component sdio fix

### DIFF
--- a/components/drivers/sdio/block_dev.c
+++ b/components/drivers/sdio/block_dev.c
@@ -460,8 +460,6 @@ rt_int32_t rt_mmcsd_blk_probe(struct rt_mmcsd_card *card)
                     rt_device_register(&blk_dev->dev, "sd0",
                         RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_REMOVABLE | RT_DEVICE_FLAG_STANDALONE);
                     rt_list_insert_after(&blk_devices, &blk_dev->list);
-    
-                    break;
                 }
                 else
                 {

--- a/components/drivers/sdio/mmc.c
+++ b/components/drivers/sdio/mmc.c
@@ -318,8 +318,17 @@ static int mmc_select_bus_width(struct rt_mmcsd_card *card, rt_uint8_t *ext_csd)
     * the device to work in 8bit transfer mode. If the
     * mmc switch command returns error then switch to
     * 4bit transfer mode. On success set the corresponding
-    * bus width on the host.
+    * bus width on the host. Meanwhile, mmc core would
+    * bail out early if corresponding bus capable wasn't
+    * set by drivers.
     */
+     if ((!(host->flags & MMCSD_BUSWIDTH_8) &&
+	  ext_csd_bits[idx] == EXT_CSD_BUS_WIDTH_8) ||
+         (!(host->flags & MMCSD_BUSWIDTH_4) &&
+	  (ext_csd_bits[idx] == EXT_CSD_BUS_WIDTH_4 ||
+	  ext_csd_bits[idx] == EXT_CSD_BUS_WIDTH_8)))
+	     continue;
+
     err = mmc_switch(card, EXT_CSD_CMD_SET_NORMAL,
                      EXT_CSD_BUS_WIDTH,
                      ext_csd_bits[idx]);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
本次PR主要解决以下两个问题：
(1) SD卡整个磁盘格式化成一个分区时无法被使用；
原因：代码中错误增加了一个break条件，导致跳出了整个for循环，后续的mount流程都不执行了，导致SD卡不可用；
解决办法：删除break
(2) 协议栈尝试无效的线宽导致启动时间过长
原因：协议栈export了线宽的cap给驱动或者BSP来配置，所以协议栈应该respect这个规则。
否则无论BSP或者驱动怎么配置，协议栈仍然强制按照841的顺序来测试。这极大消耗了
启动时间，特别是对启动时间很敏感而固件又保存再eMMC中的时候。

以上提交在Rockchip RK2108上基于主线版本测试过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
