### PR TITLE
[drv_adc.c]修复了STM32F0系列中某些型号由于没有ADC通道18而产生的编译错误

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -128,7 +128,8 @@ static rt_uint32_t stm32_adc_get_channel(rt_uint32_t channel)
     case 17:
         stm32_channel = ADC_CHANNEL_17;
         break;
-#if defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4)
+#if defined(SOC_SERIES_STM32F0) && !defined(STM32F030x6) && !defined(STM32F030x8) && !defined(STM32F070x6) && !defined(STM32F070xB) && !defined(STM32F030xC) || \
+    defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4)
     case 18:
         stm32_channel = ADC_CHANNEL_18;
         break;
@@ -150,7 +151,7 @@ static rt_err_t stm32_get_adc_value(struct rt_adc_device *device, rt_uint32_t ch
 
     rt_memset(&ADC_ChanConf, 0, sizeof(ADC_ChanConf));
 
-#if defined(SOC_SERIES_STM32F1)
+#if defined(SOC_SERIES_STM32F1) || defined(STM32F030x6) || defined(STM32F030x8) || defined(STM32F070x6) || defined(STM32F070xB) || defined(STM32F030xC)
     if (channel <= 17)
 #elif defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32F2)  || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) \
         || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0)
@@ -162,7 +163,7 @@ static rt_err_t stm32_get_adc_value(struct rt_adc_device *device, rt_uint32_t ch
     }
     else
     {
-#if defined(SOC_SERIES_STM32F1)
+#if defined(SOC_SERIES_STM32F1) || defined(STM32F030x6) || defined(STM32F030x8) || defined(STM32F070x6) || defined(STM32F070xB) || defined(STM32F030xC)
         LOG_E("ADC channel must be between 0 and 17.");
 #elif defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32F2)  || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) \
         || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
由于STM32F0系列中的STM32F030x6/x8/xB/xC和STM32F070x6/xB只有ADC_CHANNEL_0到ADC_CHANNEL_17，没有ADC_CHANNEL_18的宏定义，会产生未定义错误，修改后在定制的STM32F030CCT6芯片上经过测试。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
