### PR TITLE
component: sdio: fix potential ricky clock setting

### DIFF
--- a/components/drivers/sdio/mmc.c
+++ b/components/drivers/sdio/mmc.c
@@ -191,7 +191,7 @@ static int mmc_parse_ext_csd(struct rt_mmcsd_card *card, rt_uint8_t *ext_csd)
   }
 
   card->flags |=  CARD_FLAG_HIGHSPEED;
-  card->hs_max_data_rate = 200000000;
+  card->hs_max_data_rate = 52000000;
   
   card_capacity = *((rt_uint32_t *)&ext_csd[EXT_CSD_SEC_CNT]);
   card_capacity *= card->card_blksize;
@@ -513,16 +513,10 @@ static rt_int32_t mmcsd_mmc_init_card(struct rt_mmcsd_host *host,
         card->flags |= CARD_FLAG_SDHC;
  
     /* set bus speed */
-    max_data_rate = (unsigned int)-1;
     if (card->flags & CARD_FLAG_HIGHSPEED) 
-    {
-        if (max_data_rate > card->hs_max_data_rate)
-            max_data_rate = card->hs_max_data_rate;
-    } 
-    else if (max_data_rate > card->max_data_rate) 
-    {
+        max_data_rate = card->hs_max_data_rate;
+    else
         max_data_rate = card->max_data_rate;
-    }
 
     mmcsd_set_clock(host, max_data_rate);
 


### PR DESCRIPTION
Currently RTT mmc stack only support Highspeed mode or
blow, which means the max speed should be 52MHz according
to JEDEC spec. Two problems show here:

(1) max_data_rate = (unsigned int)-1. The value of unsigned int
depends on compilers/arch. Moreover, it makes no sense to assume
cpu addressing width with IP clock rate limit.
(1)hs_max_data_rate was set to 200MHz.

So what should BSP drivers do if 52MHz < max_data_rate < 200MHz?
Either it blindly sets a spec-violated clock rate to drive a Highspeed
card, or just adjust the clock rate internally. Both cases are
really bad for practice.

If the card claims to support Highspeed, we set the clock to not
to exceed 52MHz. Otherwise it should be set according to
card->max_data_rate parsed by ext_csd. This patch fixes it as-is,
and also simplify the code a lot.

Signed-off-by: Shawn Lin <shawn.lin@rock-chips.com>

## 拉取/合并请求描述：(PR description)

[
MMC协议栈让驱动设置一个超过highspeed频率来驱动eMMC。原因是代码中用了一个
编译环境依赖的变量来做中间媒介，并且原来代码错误地将HS模式的最大频率设置为
200MHz。HS模式最大频率是52MHz, 200MHz是HS200模式，目前协议栈不支持的。
所以两个因素导致了过驱的问题。

本PR修复了这个问题，也简化了软件逻辑。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
