### PR TITLE
[kservice] Add hook for rt_printf function

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -525,6 +525,9 @@ rt_device_t rt_console_set_device(const char *name);
 rt_device_t rt_console_get_device(void);
 #endif
 
+typedef void (* console_hook)(const char *str, int flush);
+void rt_console_set_output_hook(console_hook hook);
+
 rt_err_t rt_get_errno(void);
 void rt_set_errno(rt_err_t no);
 int *_rt_errno(void);

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -1175,6 +1175,13 @@ void rt_kputs(const char *str)
 #endif
 }
 
+console_hook console_output_hook = RT_NULL;
+
+void rt_console_set_output_hook(console_hook hook)
+{
+    console_output_hook = hook;
+}
+
 /**
  * This function will print a formatted string on system console
  *
@@ -1195,6 +1202,11 @@ void rt_kprintf(const char *fmt, ...)
     length = rt_vsnprintf(rt_log_buf, sizeof(rt_log_buf) - 1, fmt, args);
     if (length > RT_CONSOLEBUF_SIZE - 1)
         length = RT_CONSOLEBUF_SIZE - 1;
+
+    if (console_output_hook) {
+        console_output_hook(rt_log_buf, 0);
+    }
+
 #ifdef RT_USING_DEVICE
     if (_console_device == RT_NULL)
     {


### PR DESCRIPTION
Signed-off-by: Cliff Chen <cliff.chen@rock-chips.com>

## 拉取/合并请求描述：(PR description)

[
大部分消费电子产品都是没有串口的，此时调试就比较麻烦了，增加rt_printf的hook，可以在需要的时候把串口打印，转发到其他外设（如flash和network），方便调试
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
