### PR TITLE
[components/usb]Fixed a stack overflow bug

### DIFF
--- a/components/drivers/usb/usbdevice/class/cdc_vcom.c
+++ b/components/drivers/usb/usbdevice/class/cdc_vcom.c
@@ -493,6 +493,7 @@ static rt_err_t _function_enable(ufunction_t func)
     
     data = (struct vcom*)func->user_data;
     data->ep_out->buffer = rt_malloc(CDC_RX_BUFSIZE);
+    RT_ASSERT(data->ep_out->buffer != RT_NULL);
 
     data->ep_out->request.buffer = data->ep_out->buffer;
     data->ep_out->request.size = EP_MAXPACKET(data->ep_out);
@@ -593,6 +594,7 @@ ufunction_t rt_usbd_function_cdc_create(udevice_t device)
     
     /* allocate memory for cdc vcom data */
     data = (struct vcom*)rt_malloc(sizeof(struct vcom));
+    RT_ASSERT(data != RT_NULL);
     rt_memset(data, 0, sizeof(struct vcom));
     func->user_data = (void*)data;
     

--- a/components/drivers/usb/usbdevice/class/ecm.c
+++ b/components/drivers/usb/usbdevice/class/ecm.c
@@ -565,7 +565,8 @@ ufunction_t rt_usbd_function_ecm_create(udevice_t device)
     /* create a cdc class */
     cdc = rt_usbd_function_new(device, &_dev_desc, &ops);
     rt_usbd_device_set_qualifier(device, &dev_qualifier);
-    _ecm_eth= rt_malloc(sizeof(struct rt_ecm_eth)); 
+    _ecm_eth= rt_malloc(sizeof(struct rt_ecm_eth));
+    RT_ASSERT(_ecm_eth != RT_NULL);
     rt_memset(_ecm_eth, 0, sizeof(struct rt_ecm_eth));
     cdc->user_data = _ecm_eth;
 

--- a/components/drivers/usb/usbhost/core/hub.c
+++ b/components/drivers/usb/usbhost/core/hub.c
@@ -508,6 +508,7 @@ static rt_err_t rt_usbh_hub_enable(void *arg)
 
     /* create a hub instance */
     hub = rt_malloc(sizeof(struct uhub));
+    RT_ASSERT(hub != RT_NULL);
     rt_memset(hub, 0, sizeof(struct uhub));
     
     /* make interface instance's user data point to hub instance */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
    Added 'RT_ASSERT' after 'rt_malloc'
    `RT_ASSERT(var!= RT_NULL);`
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
