### PR TITLE
fix return type error of rt_strcasecmp: rt_uint32_t to rt_int32_t

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -554,7 +554,7 @@ rt_int32_t rt_sscanf(const char *buf, const char *fmt, ...);
 char *rt_strncpy(char *dest, const char *src, rt_ubase_t n);
 void *rt_memmove(void *dest, const void *src, rt_ubase_t n);
 rt_int32_t rt_memcmp(const void *cs, const void *ct, rt_ubase_t count);
-rt_uint32_t rt_strcasecmp(const char *a, const char *b);
+rt_int32_t rt_strcasecmp(const char *a, const char *b);
 
 void rt_show_version(void);
 

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -370,7 +370,7 @@ RTM_EXPORT(rt_strstr);
  *
  * @return the result
  */
-rt_uint32_t rt_strcasecmp(const char *a, const char *b)
+rt_int32_t rt_strcasecmp(const char *a, const char *b)
 {
     int ca, cb;
 


### PR DESCRIPTION
Signed-off-by: lihui <leehui_hrbeu71102@163.com>

## 拉取/合并请求描述：(PR description)

[
this change is done for fixing the following warning while I execute "scons" under rt-thread/bsp/hifive1
Note the compiler is [master of riscv-gnu-toolchain](https://github.com/riscv/riscv-gnu-toolchain.git)

rt-thread/src/kservice.c:1391:5: warning: 'strcasecmp' alias between functions of incompatible types 'int(const char *, const char *)' and 'rt_uint32_t(const char *, const char *)' {aka 'unsigned int(const char *, const char *)'} [-Wattribute-alias=]
 1391 | int strcasecmp(const char *a, const char *b) __attribute__((weak, alias("rt_strcasecmp")));
      |     ^~~~~~~~~~
rt-thread/rt-thread/src/kservice.c:373:13: note: aliased declaration here
  373 | rt_uint32_t rt_strcasecmp(const char *a, const char *b)
      |             ^~~~~~~~~~~~~


comiled whith no error and warning with both  riscv-gnu-toolchain and arm-none-elf
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality