### PR TITLE
Update mem.c

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -489,6 +489,12 @@ void *rt_realloc(void *rmem, rt_size_t newsize)
         {
             ((struct heap_mem *)&heap_ptr[mem2->next])->prev = ptr2;
         }
+        
+        if (mem2 < lfree)
+        {
+            /* the splited struct is now the lowest */
+            lfree = mem2;
+        }
 
         plug_holes(mem2);
 


### PR DESCRIPTION
rt_realloc may cause "lfree" change, if we don't change "lfree" timely, it may cause memory leakage