### PR TITLE
posix_termios.h头文件修改

### DIFF
--- a/components/libc/termios/posix_termios.c
+++ b/components/libc/termios/posix_termios.c
@@ -12,8 +12,6 @@
 #include <rtthread.h>
 #include <dfs_posix.h>
 
-#include <termios.h>
-
 int tcgetattr(int fd, struct termios *tio)
 {
     /* Get the current serial port settings. */

--- a/components/libc/termios/posix_termios.c
+++ b/components/libc/termios/posix_termios.c
@@ -11,8 +11,8 @@
 #include <string.h>
 #include <rtthread.h>
 #include <dfs_posix.h>
-#include <termios.h>
 
+#include <termios.h>
 
 int tcgetattr(int fd, struct termios *tio)
 {

--- a/components/libc/termios/posix_termios.c
+++ b/components/libc/termios/posix_termios.c
@@ -11,6 +11,8 @@
 #include <string.h>
 #include <rtthread.h>
 #include <dfs_posix.h>
+#include <termios.h>
+
 
 int tcgetattr(int fd, struct termios *tio)
 {

--- a/components/libc/termios/posix_termios.h
+++ b/components/libc/termios/posix_termios.h
@@ -11,6 +11,7 @@
 #define TERMIOS_H__
 
 #include <rtthread.h>
+#include <termios.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

问题在rt-thread\components\libc\termios中出现.

1. 为什么PR：
在使用libc时编译无法通过，提示错误为：pid_t未定义.

2. 原因：
pid_t是在sys/types.h中定义 --> termios.h文件中引用了sys/types.h --> posix_termios.h文件未引用termios.h --> 导致编译无法通过

3. 解决办法：
把posix_termios.c文件中的
`#include <termios.h>`
放在posix_termios.h中即可

4. 已在stm32f103-atk-nano板上进行了测试通过

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [X] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [X] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [X] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [X] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [X] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [X] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
