### PR TITLE
关于 _rt_scheduler_stack_check 的一个小建议。

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -375,7 +375,7 @@ void rt_schedule(void)
                          RT_NAME_MAX, current_thread->name, current_thread->sp));
 
 #ifdef RT_USING_OVERFLOW_CHECK
-                _rt_scheduler_stack_check(to_thread);
+                _rt_scheduler_stack_check(current_thread);
 #endif
 
                 rt_hw_context_switch((rt_ubase_t)&current_thread->sp,
@@ -480,7 +480,7 @@ void rt_schedule(void)
                          RT_NAME_MAX, from_thread->name, from_thread->sp));
 
 #ifdef RT_USING_OVERFLOW_CHECK
-                _rt_scheduler_stack_check(to_thread);
+                _rt_scheduler_stack_check(from_thread);
 #endif
 
                 if (rt_interrupt_nest == 0)


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

[

关于 _rt_scheduler_stack_check 的一个小建议。
代码里用的是：_rt_scheduler_stack_check(to_thread)，我觉得应该改成：_rt_scheduler_stack_check(from_thread)。
基于以下理由：
（1）首先，一个刚创建的线程的栈肯定是没问题的，不需要检查的。
（2）我们这里讨论的 to_thread 不包括第一次执行的线程，而是那些已经运行过，并曾经作为 from_thread 被切换走的。
（3）如果在线程切换时发现了这个 to_thread 的栈有问题，_rt_scheduler_stack_check 会报错，但其实在它当初作为 from_thread 被切换走的时候，它的栈就已经有问题了，为何不在当初就检查它的栈，尽早进行报错，而是要拖到这个线程要被切换回来的时候才报错呢。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
