### PR TITLE
inline routine should be static here

### DIFF
--- a/bsp/ls1bdev/drivers/board.c
+++ b/bsp/ls1bdev/drivers/board.c
@@ -16,6 +16,7 @@
 
 #include <rtthread.h>
 #include <rthw.h>
+#include <mips_fpu.h>
 
 #include "board.h"
 #include "uart.h"

--- a/bsp/ls1bdev/rtconfig.py
+++ b/bsp/ls1bdev/rtconfig.py
@@ -36,7 +36,7 @@ OBJDUMP = PREFIX + 'objdump'
 OBJCPY = PREFIX + 'objcopy'
 READELF = PREFIX + 'readelf'
 
-DEVICE = ' -mips32'
+DEVICE = ' -mips32r2'
 CFLAGS = DEVICE + ' -EL -G0 -mno-abicalls -fno-pic -fno-builtin -fno-exceptions -ffunction-sections -fomit-frame-pointer'
 AFLAGS = ' -c' + DEVICE + ' -EL -fno-pic -fno-builtin -mno-abicalls -x assembler-with-cpp'
 LFLAGS = DEVICE + ' -nostartfiles -EL -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,Reset_Handler -T ls1b_ram.lds'

--- a/libcpu/mips/common/mips_fpu.h
+++ b/libcpu/mips/common/mips_fpu.h
@@ -18,7 +18,7 @@
  * init hardware FPU
  */
 #ifdef RT_USING_FPU
-inline void rt_hw_fpu_init(void)
+rt_inline void rt_hw_fpu_init(void)
 {
     rt_uint32_t c0_status = 0;
     rt_uint32_t c1_status = 0;
@@ -38,7 +38,7 @@ inline void rt_hw_fpu_init(void)
     return ;
 }
 #else
-    inline void rt_hw_fpu_init(void){} /* Do nothing */
+    rt_inline void rt_hw_fpu_init(void){} /* Do nothing */
 #endif
 
 #endif

--- a/libcpu/mips/common/mips_regs.h
+++ b/libcpu/mips/common/mips_regs.h
@@ -955,7 +955,7 @@ do {									\
 
 #define write_32bit_cp0_set1_register(register,value)           \
         __asm__ __volatile__(                                   \
-        "ctc0\t%0,"STR(register)"\n\t"				\
+        "ctc0\t%0,$"STR(register)"\n\t"				\
     "nop"							\
         : : "r" (value));
 
@@ -993,14 +993,14 @@ do {									\
     __asm__ __volatile__(                                   \
     ".set\tpush\n\t"					\
     ".set\treorder\n\t"					\
-        "cfc1\t%0,"STR(source)"\n\t"                            \
+        "cfc1\t%0,$"STR(source)"\n\t"                            \
     ".set\tpop"						\
         : "=r" (__res));                                        \
         __res;})
 
 #define write_32bit_cp1_register(register,value)                \
         __asm__ __volatile__(                                   \
-        "ctc1\t%0,"STR(register)"\n\t"				\
+        "ctc1\t%0,$"STR(register)"\n\t"				\
     "nop"							\
         : : "r" (value));
 


### PR DESCRIPTION
gcc will remove this "unused" routine and cause a linking error.
symbol not found when linking.

Signed-off-by: duhuanpeng <u74147@gmail.com>