### PR TITLE
[components][dataqueue]add rt_data_queue_deinit

### DIFF
--- a/components/drivers/include/ipc/dataqueue.h
+++ b/components/drivers/include/ipc/dataqueue.h
@@ -22,10 +22,11 @@ struct rt_data_item;
 /* data queue implementation */
 struct rt_data_queue
 {
+    rt_uint32_t magic;
+
     rt_uint16_t size;
     rt_uint16_t lwm;
     rt_bool_t   waiting_lwm;
-    rt_bool_t   is_init;
 
     rt_uint16_t get_index;
     rt_uint16_t put_index;

--- a/components/drivers/include/ipc/dataqueue.h
+++ b/components/drivers/include/ipc/dataqueue.h
@@ -25,6 +25,7 @@ struct rt_data_queue
     rt_uint16_t size;
     rt_uint16_t lwm;
     rt_bool_t   waiting_lwm;
+    rt_bool_t   is_init;
 
     rt_uint16_t get_index;
     rt_uint16_t put_index;
@@ -57,5 +58,6 @@ rt_err_t rt_data_queue_peak(struct rt_data_queue *queue,
                             const void          **data_ptr,
                             rt_size_t            *size);
 void rt_data_queue_reset(struct rt_data_queue *queue);
+rt_err_t rt_data_queue_deinit(struct rt_data_queue *queue);
 
 #endif

--- a/components/drivers/src/dataqueue.c
+++ b/components/drivers/src/dataqueue.c
@@ -13,6 +13,8 @@
 #include <rtdevice.h>
 #include <rthw.h>
 
+#define DATAQUEUE_MAGIC  0xbead0e0e
+
 struct rt_data_item
 {
     const void *data_ptr;
@@ -29,9 +31,9 @@ rt_data_queue_init(struct rt_data_queue *queue,
 
     queue->evt_notify = evt_notify;
 
+    queue->magic = DATAQUEUE_MAGIC;
     queue->size = size;
     queue->lwm = lwm;
-    queue->is_init = RT_TRUE;
 
     queue->get_index = 0;
     queue->put_index = 0;
@@ -58,11 +60,7 @@ rt_err_t rt_data_queue_push(struct rt_data_queue *queue,
     rt_thread_t thread;
     rt_err_t    result;
     
-    if(queue->is_init != RT_TRUE)
-    {
-        return RT_ERROR;
-    }
-    
+    RT_ASSERT(queue->magic == DATAQUEUE_MAGIC);
     RT_ASSERT(queue != RT_NULL);
 
     result = RT_EOK;
@@ -152,11 +150,7 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
     rt_thread_t thread;
     rt_err_t    result;
     
-    if(queue->is_init != RT_TRUE)
-    {
-        return RT_ERROR;
-    }
-
+    RT_ASSERT(queue->magic == DATAQUEUE_MAGIC);
     RT_ASSERT(queue != RT_NULL);
     RT_ASSERT(data_ptr != RT_NULL);
     RT_ASSERT(size != RT_NULL);
@@ -256,11 +250,7 @@ rt_err_t rt_data_queue_peak(struct rt_data_queue *queue,
 {
     rt_ubase_t  level;
     
-    if(queue->is_init != RT_TRUE)
-    {
-        return RT_ERROR;
-    }
-
+    RT_ASSERT(queue->magic == DATAQUEUE_MAGIC);
     RT_ASSERT(queue != RT_NULL);
 
     level = rt_hw_interrupt_disable();
@@ -286,11 +276,8 @@ void rt_data_queue_reset(struct rt_data_queue *queue)
     struct rt_thread *thread;
     register rt_ubase_t temp;
     
-    if(queue->is_init != RT_TRUE)
-    {
-        return;
-    }
-
+    RT_ASSERT(queue->magic == DATAQUEUE_MAGIC);
+    
     rt_enter_critical();
     /* wakeup all suspend threads */
 
@@ -351,11 +338,7 @@ rt_err_t rt_data_queue_deinit(struct rt_data_queue *queue)
 {
     rt_ubase_t level;
 
-    if(queue->is_init != RT_TRUE)
-    {
-        return RT_ERROR;
-    }
-    
+    RT_ASSERT(queue->magic == DATAQUEUE_MAGIC);
     RT_ASSERT(queue != RT_NULL);
 
     level = rt_hw_interrupt_disable();
@@ -363,7 +346,7 @@ rt_err_t rt_data_queue_deinit(struct rt_data_queue *queue)
     /* wakeup all suspend threads */
     rt_data_queue_reset(queue);
 
-    queue->is_init = RT_FALSE;
+    queue->magic = 0;
     rt_free(queue->queue);
     
     rt_hw_interrupt_enable(level);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
[components][dataqueue]add rt_data_queue_deinit
在 stm32f407-atk-explorer 上测试通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
