### PR TITLE
Fix bug cause STM32 HAL SPI timeout

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
@@ -257,8 +257,6 @@ static rt_err_t stm32_spi_init(struct stm32_spi *spi_drv, struct rt_spi_configur
         HAL_NVIC_EnableIRQ(spi_drv->config->dma_tx->dma_irq);
     }
 
-    __HAL_SPI_ENABLE(spi_handle);
-
     LOG_D("%s init done", spi_drv->config->bus_name);
     return RT_EOK;
 }


### PR DESCRIPTION
The bug affects in SPI mode 1 (probably and mode 2)
When changing SPI device, HAL returns timeout error for the first time trying to read/write.

## 拉取/合并请求描述：(PR description)

之前的SPI在设置成 mode 1，并切换SPI 设备后 （重新初始化后）第一次读写设备会导致STM32的hal层返回timeout。 我推测是因为 https://github.com/RT-Thread/rt-thread/blob/5c399d50a759cf778e4dae4e8ceef5a1819621b8/bsp/stm32/libraries/HAL_Drivers/drv_spi.c#L260 这里在初始化时就已经打开了spi导致hal部分时序错误。在调用hal进行数据收发后，不影响mode 0 和mode 3，但是mode 1 和mode2会返回timeout。 而在初始化时打开SPI设备不是必须的操作，因为HAL会在传输开始时使能SPI。 
The previous driver will caues SPI timeout when setting SPI to mode 1, switching device and read/write for the first time (this operation will lead to spi reinitialization.). I think this is the issue  https://github.com/RT-Thread/rt-thread/blob/5c399d50a759cf778e4dae4e8ceef5a1819621b8/bsp/stm32/libraries/HAL_Drivers/drv_spi.c#L260 Enable the SPI after initialisation is not necessary and might cause the timeout issue in mode 1 and mode 2. But it won't affect mode 0 and mode 3. 

已经在自己的STM32H7板子上跟 MODE 1 的设备进行测试
This is tested with customized STM32H7 board to a few SPI mode 1 slaves.

SPI MODE 1 和 MODE 3 在之后测试，可以等待我测试完成通过后再合并 (已测试通过)。
Please do not merge until I finish my test with mode 1 and mode 3 device (test finished).


以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
