### PR TITLE
[bsp/stm32/stm32h743-atk-apollo]support stm32h7 uart dma

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/config/h7/dma_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/h7/dma_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2019-01-02     zylx         first version
  * 2019-01-08     SummerGift   clean up the code
+ * 2020-05-02     whj4674672   support stm32h7 dma1 and dma2
  */
 
 #ifndef __DMA_CONFIG_H__
@@ -19,27 +20,21 @@ extern "C" {
 #endif
 
 /* DMA1 stream0 */
-#if defined(BSP_SPI3_RX_USING_DMA) && !defined(SPI3_RX_DMA_INSTANCE)
-#define SPI3_DMA_RX_IRQHandler           DMA1_Stream0_IRQHandler
-#define SPI3_RX_DMA_RCC                  RCC_AHB1ENR_DMA1EN
-#define SPI3_RX_DMA_INSTANCE             DMA1_Stream0
-#define SPI3_RX_DMA_CHANNEL              DMA_CHANNEL_0
-#define SPI3_RX_DMA_IRQ                  DMA1_Stream0_IRQn
-#elif defined(BSP_UART5_RX_USING_DMA) && !defined(UART5_RX_DMA_INSTANCE)
-#define UART5_DMA_RX_IRQHandler          DMA1_Stream0_IRQHandler
-#define UART5_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
-#define UART5_RX_DMA_INSTANCE            DMA1_Stream0
-#define UART5_RX_DMA_CHANNEL             DMA_CHANNEL_4
-#define UART5_RX_DMA_IRQ                 DMA1_Stream0_IRQn
+#if defined(BSP_UART2_RX_USING_DMA) && !defined(UART2_RX_DMA_INSTANCE)
+#define UART2_DMA_RX_IRQHandler          DMA1_Stream0_IRQHandler
+#define UART2_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define UART2_RX_DMA_INSTANCE            DMA1_Stream0
+#define UART2_RX_DMA_REQUEST             DMA_REQUEST_USART2_RX
+#define UART2_RX_DMA_IRQ                 DMA1_Stream0_IRQn
 #endif
 
 /* DMA1 stream1 */
-#if defined(BSP_UART3_RX_USING_DMA) && !defined(UART3_RX_DMA_INSTANCE)
-#define UART3_DMA_RX_IRQHandler          DMA1_Stream1_IRQHandler
-#define UART3_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
-#define UART3_RX_DMA_INSTANCE            DMA1_Stream1
-#define UART3_RX_DMA_CHANNEL             DMA_CHANNEL_4
-#define UART3_RX_DMA_IRQ                 DMA1_Stream1_IRQn
+#if defined(BSP_UART2_TX_USING_DMA) && !defined(UART2_TX_DMA_INSTANCE)
+#define UART2_DMA_TX_IRQHandler          DMA1_Stream1_IRQHandler
+#define UART2_TX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define UART2_TX_DMA_INSTANCE            DMA1_Stream1
+#define UART2_TX_DMA_REQUEST             DMA_REQUEST_USART2_TX
+#define UART2_TX_DMA_IRQ                 DMA1_Stream1_IRQn
 #endif
 
 /* DMA1 stream2 */
@@ -49,12 +44,6 @@ extern "C" {
 #define SPI3_RX_DMA_INSTANCE             DMA1_Stream2
 #define SPI3_RX_DMA_CHANNEL              DMA_CHANNEL_0
 #define SPI3_RX_DMA_IRQ                  DMA1_Stream2_IRQn
-#elif defined(BSP_UART4_RX_USING_DMA) && !defined(UART4_RX_DMA_INSTANCE)
-#define UART4_DMA_RX_IRQHandler          DMA1_Stream2_IRQHandler
-#define UART4_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
-#define UART4_RX_DMA_INSTANCE            DMA1_Stream2
-#define UART4_RX_DMA_CHANNEL             DMA_CHANNEL_4
-#define UART4_RX_DMA_IRQ                 DMA1_Stream2_IRQn
 #endif
 
 /* DMA1 stream3 */
@@ -83,12 +72,6 @@ extern "C" {
 #define SPI3_TX_DMA_INSTANCE             DMA1_Stream5
 #define SPI3_TX_DMA_CHANNEL              DMA_CHANNEL_0
 #define SPI3_TX_DMA_IRQ                  DMA1_Stream5_IRQn
-#elif defined(BSP_UART2_RX_USING_DMA) && !defined(UART2_RX_DMA_INSTANCE)
-#define UART2_DMA_RX_IRQHandler          DMA1_Stream5_IRQHandler
-#define UART2_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
-#define UART2_RX_DMA_INSTANCE            DMA1_Stream5
-#define UART2_RX_DMA_CHANNEL             DMA_CHANNEL_4
-#define UART2_RX_DMA_IRQ                 DMA1_Stream5_IRQn
 #endif
 
 /* DMA1 stream6 */
@@ -109,12 +92,6 @@ extern "C" {
 #define SPI1_RX_DMA_INSTANCE             DMA2_Stream0
 #define SPI1_RX_DMA_CHANNEL              DMA_CHANNEL_3
 #define SPI1_RX_DMA_IRQ                  DMA2_Stream0_IRQn
-#elif defined(BSP_SPI4_RX_USING_DMA) && !defined(SPI4_RX_DMA_INSTANCE)
-#define SPI4_DMA_RX_IRQHandler           DMA2_Stream0_IRQHandler
-#define SPI4_RX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
-#define SPI4_RX_DMA_INSTANCE             DMA2_Stream0
-#define SPI4_RX_DMA_CHANNEL              DMA_CHANNEL_4
-#define SPI4_RX_DMA_IRQ                  DMA2_Stream0_IRQn
 #endif
 
 /* DMA2 stream1 */
@@ -133,18 +110,6 @@ extern "C" {
 #define SPI1_RX_DMA_INSTANCE             DMA2_Stream2
 #define SPI1_RX_DMA_CHANNEL              DMA_CHANNEL_3
 #define SPI1_RX_DMA_IRQ                  DMA2_Stream2_IRQn
-#elif defined(BSP_UART1_RX_USING_DMA) && !defined(UART1_RX_DMA_INSTANCE)
-#define UART1_DMA_RX_IRQHandler         DMA2_Stream2_IRQHandler
-#define UART1_RX_DMA_RCC                RCC_AHB1ENR_DMA2EN
-#define UART1_RX_DMA_INSTANCE           DMA2_Stream2
-#define UART1_RX_DMA_CHANNEL            DMA_CHANNEL_4
-#define UART1_RX_DMA_IRQ                DMA2_Stream2_IRQn
-#elif defined(BSP_QSPI_USING_DMA) && !defined(QSPI_DMA_INSTANCE)
-#define QSPI_DMA_IRQHandler              DMA2_Stream2_IRQHandler
-#define QSPI_DMA_RCC                     RCC_AHB1ENR_DMA2EN
-#define QSPI_DMA_INSTANCE                DMA2_Stream2
-#define QSPI_DMA_CHANNEL                 DMA_CHANNEL_11
-#define QSPI_DMA_IRQ                     DMA2_Stream2_IRQn
 #endif
 
 /* DMA2 stream3 */
@@ -154,18 +119,6 @@ extern "C" {
 #define SPI5_RX_DMA_INSTANCE             DMA2_Stream3
 #define SPI5_RX_DMA_CHANNEL              DMA_CHANNEL_2
 #define SPI5_RX_DMA_IRQ                  DMA2_Stream3_IRQn
-#elif defined(BSP_SPI1_TX_USING_DMA) && !defined(SPI1_TX_DMA_INSTANCE)
-#define SPI1_DMA_TX_IRQHandler           DMA2_Stream3_IRQHandler
-#define SPI1_TX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
-#define SPI1_TX_DMA_INSTANCE             DMA2_Stream3
-#define SPI1_TX_DMA_CHANNEL              DMA_CHANNEL_3
-#define SPI1_TX_DMA_IRQ                  DMA2_Stream3_IRQn
-#elif defined(BSP_SPI4_RX_USING_DMA) && !defined(SPI4_RX_DMA_INSTANCE)
-#define SPI4_DMA_RX_IRQHandler           DMA2_Stream3_IRQHandler
-#define SPI4_RX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
-#define SPI4_RX_DMA_INSTANCE             DMA2_Stream3
-#define SPI4_RX_DMA_CHANNEL              DMA_CHANNEL_5
-#define SPI4_RX_DMA_IRQ                  DMA2_Stream3_IRQn
 #endif
 
 /* DMA2 stream4 */
@@ -175,12 +128,6 @@ extern "C" {
 #define SPI5_TX_DMA_INSTANCE             DMA2_Stream4
 #define SPI5_TX_DMA_CHANNEL              DMA_CHANNEL_2
 #define SPI5_TX_DMA_IRQ                  DMA2_Stream4_IRQn
-#elif defined(BSP_SPI4_TX_USING_DMA) && !defined(SPI4_TX_DMA_INSTANCE)
-#define SPI4_DMA_TX_IRQHandler           DMA2_Stream4_IRQHandler
-#define SPI4_TX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
-#define SPI4_TX_DMA_INSTANCE             DMA2_Stream4
-#define SPI4_TX_DMA_CHANNEL              DMA_CHANNEL_5
-#define SPI4_TX_DMA_IRQ                  DMA2_Stream4_IRQn
 #endif
 
 /* DMA2 stream5 */
@@ -190,18 +137,6 @@ extern "C" {
 #define SPI1_TX_DMA_INSTANCE             DMA2_Stream5
 #define SPI1_TX_DMA_CHANNEL              DMA_CHANNEL_3
 #define SPI1_TX_DMA_IRQ                  DMA2_Stream5_IRQn
-#elif defined(BSP_UART1_RX_USING_DMA) && !defined(UART1_RX_DMA_INSTANCE)
-#define UART1_DMA_RX_IRQHandler         DMA2_Stream5_IRQHandler
-#define UART1_RX_DMA_RCC                RCC_AHB1ENR_DMA2EN
-#define UART1_RX_DMA_INSTANCE           DMA2_Stream5
-#define UART1_RX_DMA_CHANNEL            DMA_CHANNEL_4
-#define UART1_RX_DMA_IRQ                DMA2_Stream5_IRQn
-#elif defined(BSP_SPI5_RX_USING_DMA) && !defined(SPI5_RX_DMA_INSTANCE)
-#define SPI5_DMA_RX_IRQHandler           DMA2_Stream5_IRQHandler
-#define SPI5_RX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
-#define SPI5_RX_DMA_INSTANCE             DMA2_Stream5
-#define SPI5_RX_DMA_CHANNEL              DMA_CHANNEL_7
-#define SPI5_RX_DMA_IRQ                  DMA2_Stream5_IRQn
 #endif
 
 /* DMA2 stream6 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/h7/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/h7/uart_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-10-30     SummerGift   first version
  * 2019-01-05     zylx         modify dma support
+ * 2020-05-02     whj4674672   support stm32h7 uart dma
  */
  
 #ifndef __UART_CONFIG_H__
@@ -31,12 +32,12 @@ extern "C" {
 
 #if defined(BSP_UART1_RX_USING_DMA)
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                            \
+#define UART1_DMA_RX_CONFIG                                         \
     {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                         \
-        .channel = UART1_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_RX_DMA_RCC,                               \
-        .dma_irq = UART1_RX_DMA_IRQ,                               \
+        .Instance = UART1_RX_DMA_INSTANCE,                          \
+        .request = UART1_RX_DMA_REQUEST,                            \
+        .dma_rcc = UART1_RX_DMA_RCC,                                \
+        .dma_irq = UART1_RX_DMA_IRQ,                                \
     }
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
@@ -54,16 +55,27 @@ extern "C" {
 
 #if defined(BSP_UART2_RX_USING_DMA)
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                            \
+#define UART2_DMA_RX_CONFIG                                         \
     {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                         \
-        .channel = UART2_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_RX_DMA_RCC,                               \
-        .dma_irq = UART2_RX_DMA_IRQ,                               \
+        .Instance = UART2_RX_DMA_INSTANCE,                          \
+        .request = UART2_RX_DMA_REQUEST,                            \
+        .dma_rcc = UART2_RX_DMA_RCC,                                \
+        .dma_irq = UART2_RX_DMA_IRQ,                                \
     }
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
-
+#if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_DMA_TX_CONFIG
+#define UART2_DMA_TX_CONFIG                                         \
+    {                                                               \
+        .Instance = UART2_TX_DMA_INSTANCE,                          \
+        .request = UART2_TX_DMA_REQUEST,                            \
+        .dma_rcc = UART2_TX_DMA_RCC,                                \
+        .dma_irq = UART2_TX_DMA_IRQ,                                \
+    }
+#endif /* UART2_DMA_TX_CONFIG */
+#endif /* BSP_UART2_TX_USING_DMA */
+    
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
 #define UART3_CONFIG                                                \
@@ -77,12 +89,12 @@ extern "C" {
 
 #if defined(BSP_UART3_RX_USING_DMA)
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                            \
+#define UART3_DMA_RX_CONFIG                                         \
     {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                         \
-        .channel = UART3_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_RX_DMA_RCC,                               \
-        .dma_irq = UART3_RX_DMA_IRQ,                               \
+        .Instance = UART3_RX_DMA_INSTANCE,                          \
+        .request = UART3_RX_DMA_REQUEST,                            \
+        .dma_rcc = UART3_RX_DMA_RCC,                                \
+        .dma_irq = UART3_RX_DMA_IRQ,                                \
     }
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
@@ -100,12 +112,12 @@ extern "C" {
 
 #if defined(BSP_UART4_RX_USING_DMA)
 #ifndef UART4_DMA_RX_CONFIG
-#define UART4_DMA_RX_CONFIG                                            \
+#define UART4_DMA_RX_CONFIG                                         \
     {                                                               \
-        .Instance = UART4_RX_DMA_INSTANCE,                         \
-        .channel = UART4_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART4_RX_DMA_RCC,                               \
-        .dma_irq = UART4_RX_DMA_IRQ,                               \
+        .Instance = UART4_RX_DMA_INSTANCE,                          \
+        .request = UART4_RX_DMA_REQUEST,                            \
+        .dma_rcc = UART4_RX_DMA_RCC,                                \
+        .dma_irq = UART4_RX_DMA_IRQ,                                \
     }
 #endif /* UART4_DMA_RX_CONFIG */
 #endif /* BSP_UART4_RX_USING_DMA */
@@ -123,12 +135,12 @@ extern "C" {
 
 #if defined(BSP_UART5_RX_USING_DMA)
 #ifndef UART5_DMA_RX_CONFIG
-#define UART5_DMA_RX_CONFIG                                            \
+#define UART5_DMA_RX_CONFIG                                         \
     {                                                               \
-        .Instance = UART5_RX_DMA_INSTANCE,                         \
-        .channel = UART5_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART5_RX_DMA_RCC,                               \
-        .dma_irq = UART5_RX_DMA_IRQ,                               \
+        .Instance = UART5_RX_DMA_INSTANCE,                          \
+        .request = UART5_RX_DMA_REQUEST,                            \
+        .dma_rcc = UART5_RX_DMA_RCC,                                \
+        .dma_irq = UART5_RX_DMA_IRQ,                                \
     }
 #endif /* UART5_DMA_RX_CONFIG */
 #endif /* BSP_UART5_RX_USING_DMA */

--- a/bsp/stm32/libraries/HAL_Drivers/drv_dma.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_dma.h
@@ -35,7 +35,8 @@ struct dma_config {
     rt_uint32_t channel;
 #endif
 
-#if defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32G4)
+#if defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32G4)\
+    || defined(SOC_SERIES_STM32H7)
     rt_uint32_t request;
 #endif
 };

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
@@ -8,6 +8,7 @@
  * 2018-10-30     SummerGift   first version
  * 2020-03-16     SummerGift   add device close feature
  * 2020-03-20     SummerGift   fix bug caused by ORE
+ * 2020-05-02     whj4674672   support stm32h7 uart dma
  */
 
 #include "board.h"
@@ -864,7 +865,7 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         SET_BIT(RCC->AHBENR, dma_config->dma_rcc);
         tmpreg = READ_BIT(RCC->AHBENR, dma_config->dma_rcc);
 #elif defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4) \
-    || defined(SOC_SERIES_STM32G4)
+    || defined(SOC_SERIES_STM32G4)|| defined(SOC_SERIES_STM32H7)
         /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
         SET_BIT(RCC->AHB1ENR, dma_config->dma_rcc);
         tmpreg = READ_BIT(RCC->AHB1ENR, dma_config->dma_rcc);
@@ -892,7 +893,8 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
 #elif defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
     DMA_Handle->Instance                 = dma_config->Instance;
     DMA_Handle->Init.Channel             = dma_config->channel;
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32G4)
+#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32G4)\
+    || defined(SOC_SERIES_STM32H7)
     DMA_Handle->Instance                 = dma_config->Instance;
     DMA_Handle->Init.Request             = dma_config->request;
 #endif
@@ -913,7 +915,7 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
     }
 
     DMA_Handle->Init.Priority            = DMA_PRIORITY_MEDIUM;
-#if defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
+#if defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32H7)
     DMA_Handle->Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
 #endif
     if (HAL_DMA_DeInit(DMA_Handle) != HAL_OK)

--- a/bsp/stm32/stm32h743-atk-apollo/README.md
+++ b/bsp/stm32/stm32h743-atk-apollo/README.md
@@ -117,7 +117,7 @@ msh >
 
 ## 注意事项
 
-暂无
+1. 使用UART2 DMA模式时，HEAP的CACHE策略设置了WT模式，所以在使用rt_device_read读取数据之前必须调用用SCB_InvalidateDCache_by_Addr或者SCB_InvalidateDCache，已确保读取到数据的正确性。
 
 ## 联系人信息
 

--- a/bsp/stm32/stm32h743-atk-apollo/board/Kconfig
+++ b/bsp/stm32/stm32h743-atk-apollo/board/Kconfig
@@ -56,6 +56,16 @@ menu "On-chip Peripheral Drivers"
             config BSP_USING_UART2
                 bool "Enable UART2"
                 default n
+
+            config BSP_UART2_RX_USING_DMA
+                bool "Enable UART2 RX DMA"
+                depends on BSP_USING_UART2 && RT_SERIAL_USING_DMA
+                default n
+
+            config BSP_UART2_TX_USING_DMA
+                bool "Enable UART2 TX DMA"
+                depends on BSP_USING_UART2 && RT_SERIAL_USING_DMA
+                default n
         endif
 
     config BSP_USING_FMC

--- a/bsp/stm32/stm32h743-atk-apollo/board/drv_mpu.c
+++ b/bsp/stm32/stm32h743-atk-apollo/board/drv_mpu.c
@@ -52,6 +52,10 @@ int mpu_init(void)
     /* Enable the MPU */
     HAL_MPU_Enable(MPU_PRIVILEGED_DEFAULT);
 
+    /* Enable CACHE */
+    SCB_EnableICache();
+    SCB_EnableDCache();
+    
     return 0;
 
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
本次提交已经在stm32h743-atk-apollo 测试通过，修改说明如下：
1.dma_config.h删除了部分宏定义，STM32H7的DMA和F系列的区别在于可以指定到任何外设，而不是几个外设公用一个DMA，所以这里不需要考虑多个DMA使用一个通道的问题；
2.uart_config.h修改channel为reques；
3.在drv_mpu.c中增加了cache使能，方便后续驱动提交都基于使能cache；
4.README.md中增加了使能cache为WT模式之后会出现数据一致性问题的说明，并给出了解决方法；
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
