### PR TITLE
Fix: the PWM clock is not initialized

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -323,7 +323,7 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     tim->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
 #endif
 
-    if (HAL_TIM_PWM_Init(tim) != HAL_OK)
+    if (HAL_TIM_Base_Init(tim) != HAL_OK)   
     {
         LOG_E("%s pwm init failed", device->name);
         result = -RT_ERROR;


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

[
在新版本的cubemx中，当勾选内部时钟时，`stm32f4xx_hal_msp.c`-> `HAL_TIM_Base_MspInit()`包含PWM时钟的初始化，并且不再独立定义`HAL_TIM_PWM_MspInit()`。因此，如果使用`HAL_TIM_PWM_Init()`来初始化PWM时钟 ，将调用一个空的弱函数，并且不会初始化（使能）PWM时钟。
In the new version of cubemx, when the internal clock is checked，`stm32f4xx_hal_msp.c`->`HAL_TIM_Base_MspInit()` contains the initialization of the PWM clock, and `HAL_TIM_PWM_MspInit()` is no longer independently defined.So,if using `HAL_TIM_PWM_Init()` to initialize the clock(PWM), an empty weak function will be called and the PWM clock  will not be initialized (enabled).

在此PR中，将`HAL_TIM_PWM_Init()`替换为`HAL_TIM_Base_Init()`，并且将正确启用PWM时钟，从而解决了使用PWM驱动无输出的问题。
In this PR, `HAL_TIM_PWM_Init()` is replaced by `HAL_TIM_Base_Init()`, and the PWM clock will be correctly enabled, which solves the problem that there is no output using the PWM driver.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
