### PR TITLE
增加ymodem分组大小配置

### DIFF
--- a/components/utilities/Kconfig
+++ b/components/utilities/Kconfig
@@ -5,6 +5,15 @@ config RT_USING_RYM
     default n
 
     if RT_USING_RYM
+        choice
+            prompt "Choose the size of the group"
+            default RYM_SIZE_128
+            config RYM_SIZE_128
+                bool "128 bytes"
+            config RYM_SIZE_1024
+                bool "1024 bytes"
+        endchoice
+        
         config YMODEM_USING_CRC_TABLE
         bool "Enable CRC Table in Ymodem"
         default n

--- a/components/utilities/ymodem/ymodem.c
+++ b/components/utilities/ymodem/ymodem.c
@@ -145,7 +145,8 @@ static rt_size_t _rym_read_data(
 static rt_err_t _rym_send_packet(
     struct rym_ctx *ctx,
     enum rym_code code,
-    rt_uint8_t index, rt_uint16_t pack_size)
+    rt_uint8_t index,
+    rt_uint16_t pack_size)
 {
     rt_uint16_t send_crc;
     rt_uint8_t index_inv = ~index;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
    我的ymodem通讯包大小为1024个字节，但是它只支持128个字节。
    所以给他增加了128bytes和1024bytes的发送配置选择；
    通过kconfig选择ymodem的发送包长，通讯过程中根据配置长度进行打包发送。

    在stm32f407板卡上进行测试，128和1024字节均通过收发验证。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [# ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [#] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [#] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [#] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [#] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [#] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [#] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
