### PR TITLE
[bsp] fix stm32 f1 series rtc bug

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
@@ -12,13 +12,6 @@
 
 #ifdef BSP_USING_ONCHIP_RTC
 
-
-#ifndef HAL_RTCEx_BKUPRead
-#define HAL_RTCEx_BKUPRead(x1, x2) (~BKUP_REG_DATA)
-#endif
-#ifndef HAL_RTCEx_BKUPWrite
-#define HAL_RTCEx_BKUPWrite(x1, x2, x3)
-#endif
 #ifndef RTC_BKP_DR1
 #define RTC_BKP_DR1 RT_NULL
 #endif
@@ -32,6 +25,16 @@
 static struct rt_device rtc;
 
 static RTC_HandleTypeDef RTC_Handler;
+
+RT_WEAK uint32_t HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister)
+{
+    return (~BKUP_REG_DATA);
+}
+
+RT_WEAK void HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data)
+{
+    return;
+}
 
 static time_t get_rtc_timestamp(void)
 {
@@ -84,6 +87,13 @@ static rt_err_t set_rtc_time_stamp(time_t time_stamp)
 
     LOG_D("set rtc time.");
     HAL_RTCEx_BKUPWrite(&RTC_Handler, RTC_BKP_DR1, BKUP_REG_DATA);
+#ifdef SOC_SERIES_STM32F1
+    HAL_RTCEx_BKUPWrite(&RTC_Handler, RTC_BKP_DR2, RTC_DateStruct.Year);
+    HAL_RTCEx_BKUPWrite(&RTC_Handler, RTC_BKP_DR3, RTC_DateStruct.Month);
+    HAL_RTCEx_BKUPWrite(&RTC_Handler, RTC_BKP_DR4, RTC_DateStruct.Date);
+    HAL_RTCEx_BKUPWrite(&RTC_Handler, RTC_BKP_DR5, RTC_DateStruct.WeekDay);
+#endif
+
     return RT_EOK;
 }
 
@@ -107,6 +117,27 @@ static void rt_rtc_init(void)
 #endif
     HAL_RCC_OscConfig(&RCC_OscInitStruct);
 }
+
+#ifdef SOC_SERIES_STM32F1
+/* update RTC_BKP_DRx*/
+static void rt_rtc_bkp_update(void)
+{
+    RTC_DateTypeDef RTC_DateStruct = {0};
+
+    HAL_PWR_EnableBkUpAccess();
+    __HAL_RCC_BKP_CLK_ENABLE();
+
+    HAL_RTC_GetDate(&RTC_Handler, &RTC_DateStruct, RTC_FORMAT_BIN);
+    if (HAL_RTCEx_BKUPRead(&RTC_Handler, RTC_BKP_DR4) != RTC_DateStruct.Date)
+    {
+        HAL_RTCEx_BKUPWrite(&RTC_Handler, RTC_BKP_DR1, BKUP_REG_DATA);
+        HAL_RTCEx_BKUPWrite(&RTC_Handler, RTC_BKP_DR2, RTC_DateStruct.Year);
+        HAL_RTCEx_BKUPWrite(&RTC_Handler, RTC_BKP_DR3, RTC_DateStruct.Month);
+        HAL_RTCEx_BKUPWrite(&RTC_Handler, RTC_BKP_DR4, RTC_DateStruct.Date);
+        HAL_RTCEx_BKUPWrite(&RTC_Handler, RTC_BKP_DR5, RTC_DateStruct.WeekDay);
+    }
+}
+#endif
 
 static rt_err_t rt_rtc_config(struct rt_device *dev)
 {
@@ -167,6 +198,23 @@ static rt_err_t rt_rtc_config(struct rt_device *dev)
             return -RT_ERROR;
         }
     }
+#ifdef SOC_SERIES_STM32F1
+    else
+    {
+        RTC_DateTypeDef RTC_DateStruct = {0};
+
+        RTC_DateStruct.Year    = HAL_RTCEx_BKUPRead(&RTC_Handler, RTC_BKP_DR2);
+        RTC_DateStruct.Month   = HAL_RTCEx_BKUPRead(&RTC_Handler, RTC_BKP_DR3);
+        RTC_DateStruct.Date    = HAL_RTCEx_BKUPRead(&RTC_Handler, RTC_BKP_DR4);
+        RTC_DateStruct.WeekDay = HAL_RTCEx_BKUPRead(&RTC_Handler, RTC_BKP_DR5);
+        if (HAL_RTC_SetDate(&RTC_Handler, &RTC_DateStruct, RTC_FORMAT_BIN) != HAL_OK)
+        {
+            Error_Handler();
+        }
+        rt_rtc_bkp_update();
+    }
+#endif
+
     return RT_EOK;
 }
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

- when cpu reset rtc date is not saved in stm32f1 series.this pr will fix this bug
- verify platform
  - stm32f103-fire-arbitary
  - stm32f407-atk-explorer
  - stm32f767-atk-apollo
  - stm32h743-atk-apollo

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
