### PR TITLE
[ARM32:STM32] Add _sbrk function for STM32

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/SConscript
+++ b/bsp/stm32/libraries/HAL_Drivers/SConscript
@@ -92,6 +92,7 @@ if GetDepend(['BSP_USING_USBH']):
     src += ['drv_usbh.c']
 
 src += ['drv_common.c']
+src += ['sbrk.c']
 
 path =  [cwd]
 path += [cwd + '/config']

--- a/bsp/stm32/libraries/HAL_Drivers/sbrk.c
+++ b/bsp/stm32/libraries/HAL_Drivers/sbrk.c
@@ -1,0 +1,15 @@
+/* See LICENSE of license details. */
+
+#include <stddef.h>
+
+void *_sbrk(ptrdiff_t incr) {
+    extern char _end[];
+
+    static char *curbrk = _end;
+
+    if ((curbrk + incr < _end) )
+        return (void *)-1;
+
+    curbrk += incr;
+    return curbrk - incr;
+}


### PR DESCRIPTION
This patch adds _sbrk function for STM32 for avoiding error when compile
it with AT device support:
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/bin/ld:
/usr/lib/gcc/arm-none-eabi/9.2.0/../../../../arm-none-eabi/lib/thumb/v7e-m+fp/hard/libc.a(lib_a-sbrkr.o):
in function `_sbrk_r':
/builddir/build/BUILD/newlib-3.1.0/build-newlib/arm-none-eabi/thumb/v7e-m+fp/hard/newlib/libc/reent/../../../../../../../../newlib/libc/reent/sbrkr.c:51:
undefined reference to `_sbrk'
collect2: error: ld returned 1 exit status
scons: *** [rtthread.elf] Error 1
scons: building terminated because of errors.

Signed-off-by: Fu Wei <wefu@redhat.com>

## 拉取/合并请求描述：(PR description)
https://github.com/RT-Thread/rt-thread/issues/3595#issue-617395561