### PR TITLE
[bsp][imxrt] fix the gpio drivers warning,'int_mode' may be used unin…

### DIFF
--- a/bsp/imxrt/libraries/drivers/drv_gpio.c
+++ b/bsp/imxrt/libraries/drivers/drv_gpio.c
@@ -559,6 +559,9 @@ static rt_err_t imxrt_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt
         case PIN_IRQ_MODE_LOW_LEVEL:
             int_mode = kGPIO_IntLowLevel;
             break;
+        default:
+            int_mode = kGPIO_IntRisingEdge;
+            break;
         }
         irq_index = (port << 1) + (pin_num >> 4);
         GPIO_PinSetInterruptConfig(mask_tab[port].gpio, pin_num, int_mode);


### PR DESCRIPTION
imxrt的bsp gpio驱动里面中断配置里面int_mode没有给初值，也没有处理default的情况，编译会报警告可能未初始化。