### PR TITLE
bsp: ls2k: initial clk driver

### DIFF
--- a/bsp/ls2kdev/drivers/clk.c
+++ b/bsp/ls2kdev/drivers/clk.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2006-2018, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2017-09-06     勤为本       first version
+ *
+ * Copyright (c) 2020, duhuanpeng<548708880@qq.com>
+ * legacy driver APIs from loongson 1C BSP.
+ */
+
+#include <rtthread.h>
+#include "ls2k1000.h"
+
+
+struct loongson_pll {
+    rt_uint64_t PLL_SYS_0;
+    rt_uint64_t PLL_SYS_1;
+    rt_uint64_t PLL_DDR_0;
+    rt_uint64_t PLL_DDR_1;
+    rt_uint64_t PLL_DC_0;
+    rt_uint64_t PLL_DC_1;
+    rt_uint64_t PLL_PIX0_0;
+    rt_uint64_t PLL_PIX0_1;
+    rt_uint64_t PLL_PIX1_0;
+    rt_uint64_t PLL_PIX1_1;
+    rt_uint64_t FREQSCALE;
+};
+
+/* See the Schematic */
+#define SYS_CLKSEL1 1
+#define SYS_CLKSEL0 0
+
+/* bit field helpers. */
+#define __M(n)               (~(~0<<(n)))
+#define __RBF(number, n)     ((number)&__M(n))
+#define __BF(number, n, m)   __RBF((number>>m), (n-m+1))
+#define BF(number, n, m)     (m<n ? __BF(number, n, m) : __BF(number, m, n))
+
+int refclk = 100;
+int gmac_clock = 125;
+
+volatile struct loongson_pll *pll = (void *)PLL_SYS_BASE;
+
+
+unsigned long clk_get_pll_rate(void)
+{
+    return -RT_ENOSYS;
+
+}
+
+unsigned long clk_get_cpu_rate(void)
+{
+    unsigned long node_clock;
+    int l1_div_ref;
+    int l1_div_loopc;
+    int l2_div_out_node;
+
+    l1_div_ref      = BF(pll->PLL_SYS_0, 26, 31);
+    l1_div_loopc    = BF(pll->PLL_SYS_0, 32, 41);
+    l2_div_out_node = BF(pll->PLL_SYS_1,  5,  0);
+
+    node_clock = refclk / l1_div_ref * l1_div_loopc / l2_div_out_node;
+    return node_clock;
+}
+
+unsigned long clk_get_ddr_rate(void)
+{
+    unsigned long ddr_clock;
+    int l1_div_ref;
+    int l1_div_loopc;
+    int l2_div_out_ddr;
+
+    l1_div_ref     = BF(pll->PLL_DDR_0, 26, 31);
+    l1_div_loopc   = BF(pll->PLL_DDR_0, 32, 41);
+    l2_div_out_ddr = BF(pll->PLL_DDR_1, 0, 5);
+
+    ddr_clock = refclk / l1_div_ref * l1_div_loopc / l2_div_out_ddr;
+    return ddr_clock;
+}
+
+unsigned long clk_get_apb_rate(void)
+{
+    unsigned long apb_clock;
+    int apb_freqscale;
+
+    apb_freqscale = BF(pll->FREQSCALE, 22, 20);
+
+    /* gmac clock is fixed 125MHz */
+    apb_clock = gmac_clock * (apb_freqscale + 1) / 8;
+    return apb_clock;
+
+}
+
+unsigned long clk_get_dc_rate(void)
+{
+    return -RT_ENOSYS;
+}

--- a/bsp/ls2kdev/drivers/clk.h
+++ b/bsp/ls2kdev/drivers/clk.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2006-2018, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2017-09-06     勤为本       first version
+ *
+ * Copyright (c) 2020, Du Huanpeng <548708880@qq.com>
+ * base on bsp/ls1cdev/libraries/ls1c_clock.h
+ */
+
+#ifndef __LOONGSON_CLK_H__
+#define __LOONGSON_CLK_H__
+
+unsigned long clk_get_pll_rate(void);
+unsigned long clk_get_cpu_rate(void);
+unsigned long clk_get_ddr_rate(void);
+unsigned long clk_get_apb_rate(void);
+unsigned long clk_get_dc_rate(void);
+
+#endif

--- a/bsp/ls2kdev/drivers/ls2k1000.h
+++ b/bsp/ls2kdev/drivers/ls2k1000.h
@@ -8,6 +8,7 @@
 #define UART0_BASE CKSEG1ADDR(UART0_BASE_ADDR + UART0_OFF)
 
 #define GPIO_BASE 0xFFFFFFFFBFE10500
+#define PLL_SYS_BASE 0xFFFFFFFFBFE10480
 
 void rt_hw_timer_handler(void);
 void rt_hw_uart_init(void);


### PR DESCRIPTION
Signed-off-by: Du Huanpeng <548708880@qq.com>

## 拉取/合并请求描述：(PR description)

[
龙芯 2K 时钟驱动，沿用 1C 的驱动函数名。
支持 NODE（CPU），DDR，APB三个频率的获取。

下面这个是带有测试代码的分支，可供测试：
https://github.com/imgtec/rt-thread/tree/bsp-ls2k/clk-draft.2020.6.15

另外：
rt_kprintf 不能正常支持 %llx 打印64位整数。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
