### PR TITLE
bsp: ls2k: internal rtc driver

### DIFF
--- a/bsp/ls2kdev/drivers/drv_rtc.c
+++ b/bsp/ls2kdev/drivers/drv_rtc.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2006-2018, RT-Thread Development Team
+ * Copyright (c) 2020, Du Huanpeng <548708880@qq.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2018-01-30     armink       the first version
+ * 2020-06-23     Du Huanpeng  based on components/drivers/rtc/soft_rtc.c
+ */
+
+
+#include <rthw.h>
+#include <rtthread.h>
+#include <rtdevice.h>
+#include <rtthread.h>
+#include "ls2k1000.h"
+
+struct loongson_rtc {
+    rt_uint32_t sys_toytrim;
+    rt_uint32_t sys_toywrite0;
+    rt_uint32_t sys_toywrite1;
+    rt_uint32_t sys_toyread0;
+    rt_uint32_t sys_toyread1;
+    rt_uint32_t sys_toymatch0;
+    rt_uint32_t sys_toymatch1;
+    rt_uint32_t sys_toymatch2;
+    rt_uint32_t sys_rtcctrl;
+    rt_uint32_t __pad4[3];
+    rt_uint32_t __pad5[4];
+    rt_uint32_t sys_rtctrim;
+    rt_uint32_t sys_rtcwrite0;
+    rt_uint32_t sys_rtcread0;
+    rt_uint32_t sys_rtcmatch0;
+    rt_uint32_t sys_rtcmatch1;
+    rt_uint32_t sys_rtcmatch2;
+};
+
+/* bit field helpers. */
+#define __M(n)               (~(~0<<(n)))
+#define __RBF(number, n)     ((number)&__M(n))
+#define __BF(number, n, m)   __RBF((number>>m), (n-m+1))
+#define BF(number, n, m)     (m<n ? __BF(number, n, m) : __BF(number, m, n))
+
+struct rtctime {
+    rt_uint32_t sys_toyread0;
+    rt_uint32_t sys_toyread1;
+    rt_uint32_t sys_rtcread0;
+};
+typedef struct rtctime rtctime_t;
+
+struct tm *localrtctime(const rtctime_t *rtctp)
+{
+    static struct tm time;
+    int msec;
+
+    msec = BF(rtctp->sys_toyread0, 3, 0);
+    msec *= 100;
+
+    time.tm_sec   = BF(rtctp->sys_toyread0,  9,  4);
+    time.tm_min   = BF(rtctp->sys_toyread0, 15, 10);
+    time.tm_hour  = BF(rtctp->sys_toyread0, 20, 16);
+    time.tm_mday  = BF(rtctp->sys_toyread0, 21, 25);
+    time.tm_mon   = BF(rtctp->sys_toyread0, 26, 31);
+    /* struct tm has three more members:
+         time.tm_isdst
+         time.tm_wday
+         time.tm_yday
+    */
+    time.tm_mon -= 1;
+    time.tm_year = rtctp->sys_toyread1;
+    return &time;
+}
+
+rtctime_t mkrtctime(struct tm *tm)
+{
+    rtctime_t rtctm;
+    struct tm tmptime;
+
+    rtctm.sys_toyread0 <<= 31 - 26 + 1;
+    rtctm.sys_toyread0  |= tm->tm_mon + 1;
+    rtctm.sys_toyread0 <<= 25 - 21 + 1;
+    rtctm.sys_toyread0  |= tm->tm_mday;
+    rtctm.sys_toyread0 <<= 20 - 16 + 1;
+    rtctm.sys_toyread0  |= tm->tm_hour;
+    rtctm.sys_toyread0 <<= 15 - 10 + 1;
+    rtctm.sys_toyread0  |= tm->tm_min;
+    rtctm.sys_toyread0 <<= 9 - 4 + 1;
+    rtctm.sys_toyread0  |= tm->tm_sec;
+    /* Fixme: 0.1 second */
+    rtctm.sys_toyread0 <<= 3 - 0 + 1;
+    rtctm.sys_toyread0  |= 0;
+
+    rtctm.sys_toyread1 = tm->tm_year;
+
+    tmptime = *localrtctime(&rtctm);
+
+    return rtctm;
+}
+
+static rt_err_t rt_rtc_open(rt_device_t dev, rt_uint16_t oflag)
+{
+    return RT_EOK;
+}
+
+static rt_size_t rt_rtc_read(rt_device_t dev, rt_off_t pos, void* buffer, rt_size_t size)
+{
+    return 0;
+}
+
+static rt_err_t rt_rtc_ioctl(rt_device_t dev, int cmd, void *args)
+{
+    rt_err_t err = RT_ENOSYS;
+
+    static int count = 0;
+
+    struct loongson_rtc *hw_rtc;
+    rtctime_t rtctm;
+    struct tm time;
+    struct tm tmptime;
+    time_t *t;
+
+    hw_rtc = dev->user_data;
+
+    t = (time_t *)args;
+    time = *localtime(t);
+
+    rtctm.sys_toyread0 = hw_rtc->sys_toyread0;
+    rtctm.sys_toyread1 = hw_rtc->sys_toyread1;
+    rtctm.sys_rtcread0 = hw_rtc->sys_rtcread0;
+    tmptime = *localrtctime(&rtctm);
+
+    switch (cmd) {
+    case RT_DEVICE_CTRL_RTC_GET_TIME:
+        *t = mktime(&tmptime);
+        break;
+    case RT_DEVICE_CTRL_RTC_SET_TIME:
+        tmptime.tm_hour = time.tm_hour;
+        tmptime.tm_min  = time.tm_min;
+        tmptime.tm_sec  = time.tm_sec;
+
+        tmptime.tm_year = time.tm_year;
+        tmptime.tm_mon  = time.tm_mon;
+        tmptime.tm_mday = time.tm_mday;
+
+        rtctm = mkrtctime(&tmptime);
+        /* write to hw RTC */
+        hw_rtc->sys_toywrite0 = rtctm.sys_toyread0;
+        hw_rtc->sys_toywrite1 = rtctm.sys_toyread1;
+        break;
+    case RT_DEVICE_CTRL_RTC_GET_ALARM:
+        break;
+    case RT_DEVICE_CTRL_RTC_SET_ALARM:
+        break;
+    default:
+        break;
+    }
+
+    return RT_EOK;
+}
+
+int rt_hw_rtc_init(void)
+{
+    static struct rt_device rtc = {
+        .type      = RT_Device_Class_RTC,
+        .init      = RT_NULL,
+        .open      = rt_rtc_open,
+        .close     = RT_NULL,
+        .read      = rt_rtc_read,
+        .write     = RT_NULL,
+        .control   = rt_rtc_ioctl,
+        .user_data = (void *)RTC_BASE,
+    };
+    rt_device_register(&rtc, "rtc", RT_DEVICE_FLAG_RDWR);
+}
+
+INIT_DEVICE_EXPORT(rt_hw_rtc_init);

--- a/bsp/ls2kdev/drivers/ls2k1000.h
+++ b/bsp/ls2kdev/drivers/ls2k1000.h
@@ -9,6 +9,7 @@
 
 #define GPIO_BASE 0xFFFFFFFFBFE10500
 #define PLL_SYS_BASE 0xFFFFFFFFBFE10480
+#define RTC_BASE 0xFFFFFFFFBFE07820
 
 void rt_hw_timer_handler(void);
 void rt_hw_uart_init(void);


### PR DESCRIPTION
hardware date format
  year, the same as ctime
  month 1 ~ 12
  no leap second

Signed-off-by: Du Huanpeng <548708880@qq.com>

## 拉取/合并请求描述：(PR description)

[
 支持读取时间，设置时间。
年份储存使用<ctime>格式，即读出值之后，加上1900
月份使用 1 ~ 12 计，（ctime 是 0 ~ 11）

驱动程序中有一对 硬件格式 与 ctime struct tm 格式转换的函数。
ls2k1000 实时时钟直接支持0.1秒，但暂未体现给应用程序。
patches are welcome~
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
