### PR TITLE
1.增加对stm32_flash_erase函数入口参数size为0的检测。

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f4.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_flash/drv_flash_f4.c
@@ -211,6 +211,8 @@ int stm32_flash_write(rt_uint32_t addr, const rt_uint8_t *buf, size_t size)
 {
     rt_err_t result      = RT_EOK;
     rt_uint32_t end_addr = addr + size;
+    rt_uint32_t written_size = 0;
+    rt_uint32_t write_size = 0;
 
     if ((end_addr) > STM32_FLASH_END_ADDRESS)
     {
@@ -227,22 +229,61 @@ int stm32_flash_write(rt_uint32_t addr, const rt_uint8_t *buf, size_t size)
 
     __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR);
 
-    for (size_t i = 0; i < size; i++, addr++, buf++)
+    while (written_size < size)
     {
-        /* write data to flash */
-        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_BYTE, addr, (rt_uint64_t)(*buf)) == HAL_OK)
+        if (((addr + written_size) % 4 == 0) && (size - written_size >= 4))
         {
-            if (*(rt_uint8_t *)addr != *buf)
+            if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, addr + written_size, *((rt_uint32_t *)(buf + written_size))) == HAL_OK)
+            {
+                if (*(rt_uint32_t *)(addr + written_size) != *(rt_uint32_t *)(buf + written_size))
+                {
+                    result = -RT_ERROR;
+                    break;
+                }
+            }
+            else
             {
                 result = -RT_ERROR;
                 break;
             }
+            write_size = 4;
+        }
+        else if (((addr + written_size) % 2 == 0) && (size - written_size >= 2))
+        {
+            if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, addr + written_size, *((rt_uint16_t *)(buf + written_size))) == HAL_OK)
+            {
+                if (*(rt_uint16_t *)(addr + written_size) != *(rt_uint16_t *)(buf + written_size))
+                {
+                    result = -RT_ERROR;
+                    break;
+                }
+            }
+            else
+            {
+                result = -RT_ERROR;
+                break;
+            }
+            write_size = 2;
         }
         else
         {
-            result = -RT_ERROR;
-            break;
+            if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_BYTE, addr + written_size, *((rt_uint8_t *)(buf + written_size))) == HAL_OK)
+            {
+                if (*(rt_uint8_t *)(addr + written_size) != *(rt_uint8_t *)(buf + written_size))
+                {
+                    result = -RT_ERROR;
+                    break;
+                }
+            }
+            else
+            {
+                result = -RT_ERROR;
+                break;
+            }
+            write_size = 1;
         }
+
+        written_size += write_size;
     }
 
     HAL_FLASH_Lock();
@@ -274,6 +315,11 @@ int stm32_flash_erase(rt_uint32_t addr, size_t size)
     if ((addr + size) > STM32_FLASH_END_ADDRESS)
     {
         LOG_E("ERROR: erase outrange flash size! addr is (0x%p)\n", (void*)(addr + size));
+        return -RT_EINVAL;
+    }
+
+    if (size < 1)
+    {
         return -RT_EINVAL;
     }
 


### PR DESCRIPTION
2.stm32_flash_write函数按byte、half word、word对齐写入，提升写入效率。

## 拉取/合并请求描述：(PR description)

[
stm32_flash_erase函数size参数如果传入0会选择flash错误的sector，修改此bug，如果size为0则返回错误。
stm32_flash_write函数当前是按byte写入，效率低，修改此函数按照word、half word、byte的顺序匹配写入地址对齐字节，提升写入效率。double word方式需要外部电压支持，暂不支持。
（另外stm32f4内核使用的汇编指令LDRD应该是不支持硬件非8字节对齐访问，如提供double word写时内存也需要8字节对齐）

对1、2、3、4字节对齐写入进行了测试，块写速度提升将近4倍。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
