### PR TITLE
fix gic ack irq problem

### DIFF
--- a/libcpu/arm/cortex-a/gic.c
+++ b/libcpu/arm/cortex-a/gic.c
@@ -74,9 +74,8 @@ void arm_gic_ack(rt_uint32_t index, int irq)
     irq = irq - _gic_table[index].offset;
     RT_ASSERT(irq >= 0);
 
-    GIC_DIST_ENABLE_CLEAR(_gic_table[index].dist_hw_base, irq) = mask;
+    GIC_DIST_PENDING_CLEAR(_gic_table[index].dist_hw_base, irq) = mask;
     GIC_CPU_EOI(_gic_table[index].cpu_hw_base) = irq;
-    GIC_DIST_ENABLE_SET(_gic_table[index].dist_hw_base, irq) = mask;
 }
 
 void arm_gic_mask(rt_uint32_t index, int irq)

--- a/libcpu/arm/zynq7000/gic.c
+++ b/libcpu/arm/zynq7000/gic.c
@@ -37,7 +37,7 @@ static struct arm_gic _gic_table[ARM_GIC_MAX_NR];
 #define GIC_DIST_ENABLE_SET(hw_base, n)     __REG32((hw_base) + 0x100 + (n/32) * 4)
 #define GIC_DIST_ENABLE_CLEAR(hw_base, n)   __REG32((hw_base) + 0x180 + (n/32) * 4)
 #define GIC_DIST_PENDING_SET(hw_base, n)    __REG32((hw_base) + 0x200)
-#define GIC_DIST_PENDING_CLEAR(hw_base, n)  __REG32((hw_base) + 0x280)
+#define GIC_DIST_PENDING_CLEAR(hw_base, n)  __REG32((hw_base) + 0x280 + (n/32) * 4)
 #define GIC_DIST_ACTIVE_BIT(hw_base)        __REG32((hw_base) + 0x300)
 #define GIC_DIST_PRI(hw_base, n)            __REG32((hw_base) + 0x400 +  (n/4) * 4)
 #define GIC_DIST_TARGET(hw_base, n)         __REG32((hw_base) + 0x800 +  (n/4) * 4)
@@ -68,9 +68,8 @@ void arm_gic_ack(rt_uint32_t index, int irq)
     irq = irq - _gic_table[index].offset;
     RT_ASSERT(irq >= 0);
 
-    GIC_DIST_ENABLE_CLEAR(_gic_table[index].dist_hw_base, irq) = mask;
+    GIC_DIST_PENDING_CLEAR(_gic_table[index].dist_hw_base, irq) = mask;
     GIC_CPU_EOI(_gic_table[index].cpu_hw_base) = irq;
-    GIC_DIST_ENABLE_SET(_gic_table[index].dist_hw_base, irq) = mask;
 }
 
 void arm_gic_mask(rt_uint32_t index, int irq)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
此次提交解决gic代码中对中断进行ack时的问题，原操作是关闭中断分发器，eoi之后再打开，现改为eoi之前清除对应中断标志位。

此修改在zynq7000中测试通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
