### PR TITLE
fix signal process issue in scheduler

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -240,27 +240,13 @@ void rt_schedule(void)
             {
                 rt_hw_context_switch((rt_ubase_t)&from_thread->sp,
                                      (rt_ubase_t)&to_thread->sp);
-
 #ifdef RT_USING_SIGNALS
-                if (rt_current_thread->stat & RT_THREAD_STAT_SIGNAL_PENDING)
-                {
-                    extern void rt_thread_handle_sig(rt_bool_t clean_state);
-
-                    rt_current_thread->stat &= ~RT_THREAD_STAT_SIGNAL_PENDING;
-
-                    rt_hw_interrupt_enable(level);
-
-                    /* check signal status */
-                    rt_thread_handle_sig(RT_TRUE);
-                }
-                else
-#endif
-                {
-                    /* enable interrupt */
-                    rt_hw_interrupt_enable(level);
-                }
-
+                /* enable interrupt */
+                rt_hw_interrupt_enable(level);
+                /* check signal status */
+                rt_thread_handle_sig(RT_TRUE);
                 return ;
+#endif
             }
             else
             {

--- a/src/signal.c
+++ b/src/signal.c
@@ -322,6 +322,15 @@ void rt_thread_handle_sig(rt_bool_t clean_state)
     struct siginfo_node *si_node;
 
     level = rt_hw_interrupt_disable();
+
+    if (!(tid->stat & RT_THREAD_STAT_SIGNAL_PENDING))
+    {
+        rt_hw_interrupt_enable(level);
+        return;
+    }
+
+    tid->stat &= ~RT_THREAD_STAT_SIGNAL_PENDING;
+
     if (tid->sig_pending & tid->sig_mask)
     {
         /* if thread is not waiting for signal */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
若运行线程A调用rt_thread_kill，向阻塞线程B发送signal，A线程在rt_hw_context_switch调用后，需要rt_hw_interrupt_enable(level)才可以切入B线程，但原实现中在A线程上下文中线清除了B线程的RT_THREAD_STAT_SIGNAL_PENDING，导致B线程上下文恢复后，无法正常进入rt_thread_handle_sig。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
