### PR TITLE
[at_socket] support alloc socket dynamically with at device

### DIFF
--- a/components/net/at/Kconfig
+++ b/components/net/at/Kconfig
@@ -82,7 +82,7 @@ if RT_USING_AT
 
     config AT_SW_VERSION_NUM
         hex
-        default 0x10300
+        default 0x10301
         help
             software module version number
 

--- a/components/net/at/at_socket/at_socket.h
+++ b/components/net/at/at_socket/at_socket.h
@@ -56,6 +56,7 @@ typedef enum
 } at_socket_evt_t;
 
 struct at_socket;
+struct at_device;
 
 typedef void (*at_evt_cb_t)(struct at_socket *socket, at_socket_evt_t event, const char *buff, size_t bfsz);
 
@@ -65,6 +66,7 @@ typedef void (* at_socket_callback)(struct at_socket *conn, int event, uint16_t 
 /* AT socket operations function */
 struct at_socket_ops
 {
+    int (*at_socket)(struct at_device *device, enum at_socket_type type);
     int (*at_connect)(struct at_socket *socket, char *ip, int32_t port, enum at_socket_type type, rt_bool_t is_client);
     int (*at_closesocket)(struct at_socket *socket);
     int (*at_send)(struct at_socket *socket, const char *buff, size_t bfsz, enum at_socket_type type);

--- a/components/net/at/at_socket/at_socket.h
+++ b/components/net/at/at_socket/at_socket.h
@@ -66,12 +66,12 @@ typedef void (* at_socket_callback)(struct at_socket *conn, int event, uint16_t 
 /* AT socket operations function */
 struct at_socket_ops
 {
-    int (*at_socket)(struct at_device *device, enum at_socket_type type);
     int (*at_connect)(struct at_socket *socket, char *ip, int32_t port, enum at_socket_type type, rt_bool_t is_client);
     int (*at_closesocket)(struct at_socket *socket);
     int (*at_send)(struct at_socket *socket, const char *buff, size_t bfsz, enum at_socket_type type);
     int (*at_domain_resolve)(const char *name, char ip[16]);
     void (*at_set_event_cb)(at_socket_evt_t event, at_evt_cb_t cb);
+    int (*at_socket)(struct at_device *device, enum at_socket_type type);
 };
 
 /* AT receive package list structure */

--- a/components/net/at/include/at.h
+++ b/components/net/at/include/at.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 
-#define AT_SW_VERSION                  "1.3.0"
+#define AT_SW_VERSION                  "1.3.1"
 
 #define AT_CMD_NAME_LEN                16
 #define AT_END_MARK_LEN                4


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
由于目前 at socket 框架在获取 at_socket 对象是采用固定查询方式进行，具体在 components/net/at/at_socket/at_socket.c 文件中的 alloc_socket_by_device 函数：

```c
    for (idx = 0; idx < device->class->socket_num && device->sockets[idx].magic; idx++);
    if (idx == device->class->socket_num)
    {
        goto __err;
    }
```

这种方式带来了一些限制，比如有些 AT 模块的可用 socket 并非从 0 开始，申请的 socket 也并非一定是按顺序的，由此给 at_device 的实现带来了一些困扰。因此建议在 at_socket_ops 结构体增加 at_socket 函数，为需要动态分配 socket 的 AT 设备提供一个处理的时机。

```c
struct at_socket_ops
{
    int (*at_socket)(struct at_device *device, enum at_socket_type type);
    int (*at_connect)(struct at_socket *socket, char *ip, int32_t port, enum at_socket_type type, rt_bool_t is_client);
    int (*at_closesocket)(struct at_socket *socket);
    int (*at_send)(struct at_socket *socket, const char *buff, size_t bfsz, enum at_socket_type type);
    int (*at_domain_resolve)(const char *name, char ip[16]);
    void (*at_set_event_cb)(at_socket_evt_t event, at_evt_cb_t cb);
};
```

由于修改 at_socket_ops 会影响 at_device 软件包中所有设备，因此我同时对 at_device 软件包进行了修改。

本次修改已在 BC28 和 RW007 上通过进行验证。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
