### PR TITLE
Minor optimization for mempool.c

### DIFF
--- a/src/mempool.c
+++ b/src/mempool.c
@@ -134,7 +134,7 @@ RTM_EXPORT(rt_mp_init);
 rt_err_t rt_mp_detach(struct rt_mempool *mp)
 {
     struct rt_thread *thread;
-    register rt_ubase_t temp;
+    register rt_ubase_t level;
 
     /* parameter check */
     RT_ASSERT(mp != RT_NULL);
@@ -145,7 +145,7 @@ rt_err_t rt_mp_detach(struct rt_mempool *mp)
     while (!rt_list_isempty(&(mp->suspend_thread)))
     {
         /* disable interrupt */
-        temp = rt_hw_interrupt_disable();
+        level = rt_hw_interrupt_disable();
 
         /* get next suspend thread */
         thread = rt_list_entry(mp->suspend_thread.next, struct rt_thread, tlist);
@@ -160,7 +160,7 @@ rt_err_t rt_mp_detach(struct rt_mempool *mp)
         rt_thread_resume(thread);
 
         /* enable interrupt */
-        rt_hw_interrupt_enable(temp);
+        rt_hw_interrupt_enable(level);
     }
 
     /* detach object */
@@ -250,7 +250,7 @@ RTM_EXPORT(rt_mp_create);
 rt_err_t rt_mp_delete(rt_mp_t mp)
 {
     struct rt_thread *thread;
-    register rt_ubase_t temp;
+    register rt_ubase_t level;
 
     RT_DEBUG_NOT_IN_INTERRUPT;
 
@@ -263,7 +263,7 @@ rt_err_t rt_mp_delete(rt_mp_t mp)
     while (!rt_list_isempty(&(mp->suspend_thread)))
     {
         /* disable interrupt */
-        temp = rt_hw_interrupt_disable();
+        level = rt_hw_interrupt_disable();
 
         /* get next suspend thread */
         thread = rt_list_entry(mp->suspend_thread.next, struct rt_thread, tlist);
@@ -278,7 +278,7 @@ rt_err_t rt_mp_delete(rt_mp_t mp)
         rt_thread_resume(thread);
 
         /* enable interrupt */
-        rt_hw_interrupt_enable(temp);
+        rt_hw_interrupt_enable(level);
     }
 
     /* release allocated room */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1. Improved code readability,  unify the variable name  in the likely functions, when some functions used "level", but some other functions used "temp" in functions "rt_hw_interrupt_enable()" and "rt_hw_interrupt_enable()" 
so changed variable  "temp" to "level".

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
