### PR TITLE
fixbug:keep user's lib configuration while running --target=eclipse

### DIFF
--- a/tools/eclipse.py
+++ b/tools/eclipse.py
@@ -22,7 +22,7 @@ from xml.etree.ElementTree import SubElement
 
 from building import *
 
-MODULE_VER_NUM = 4
+MODULE_VER_NUM = 5
 
 source_pattern = ['*.c', '*.cpp', '*.cxx', '*.s', '*.S', '*.asm']
 
@@ -138,6 +138,20 @@ def IsRttEclipsePathFormat(path):
         return True
     else :
         return False
+
+# all libs added by scons should be ends with five whitespace as a flag
+rtt_lib_flag = 5 * " "
+
+
+def ConverToRttEclipseLibFormat(lib):
+    return str(lib) + str(rtt_lib_flag)
+
+
+def IsRttEclipseLibFormat(path):
+    if path.endswith(rtt_lib_flag):
+        return True
+    else:
+        return False
     
     
 def IsCppProject():
@@ -189,7 +203,7 @@ def HandleToolOption(tools, env, project, reset):
                     linker_script_option = option
                 elif option.get('id').find('linker.nostart') != -1:
                     linker_nostart_option = option
-                elif option.get('id').find('linker.libs') != -1 and env.has_key('LIBS'):
+                elif option.get('id').find('linker.libs') != -1:
                     linker_libs_option = option
                 elif option.get('id').find('linker.paths') != -1 and env.has_key('LIBPATH'):
                     linker_paths_option = option
@@ -288,16 +302,22 @@ def HandleToolOption(tools, env, project, reset):
         else:
             option.set('value', 'false')
     # update libs
-    if linker_libs_option is not None :
+    if linker_libs_option is not None:
         option = linker_libs_option
         # remove old libs
         for item in option.findall('listOptionValue'):
-            option.remove(item)
+            if IsRttEclipseLibFormat(item.get("value")):
+                option.remove(item)
+
         # add new libs
-        for lib in env['LIBS']:
-            SubElement(option, 'listOptionValue', {'builtIn': 'false', 'value': lib})
+        if env.has_key('LIBS'):
+            for lib in env['LIBS']:
+                formatedLib = ConverToRttEclipseLibFormat(lib)
+                SubElement(option, 'listOptionValue', {
+                           'builtIn': 'false', 'value': formatedLib})
+
     # update lib paths
-    if linker_paths_option is not None :
+    if linker_paths_option is not None:
         option = linker_paths_option
         # remove old lib paths
         for item in option.findall('listOptionValue'):


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

- 修复：当用户通过 menuconfig 或者 RT-Studio 更改系统配置后，当 LIBS 为空时，应当删除之前链接的库文件

- 新增：对 scons 添加的库文件添加特征后缀，特征后缀为5个空格，当 scons 执行 scons --target=eclipse 更新 eclipse 工程文件时，根据是否具有特征标志来区分用户添加的库和 scons 添加的库，从而保留用户配置

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
