### PR TITLE
解决yield操作不能及时释放cpu的问题

### DIFF
--- a/src/clock.c
+++ b/src/clock.c
@@ -91,8 +91,7 @@ void rt_tick_increase(void)
 
         thread->stat |= RT_THREAD_STAT_YIELD;
 
-        /* yield */
-        rt_thread_yield();
+        rt_schedule();
     }
 
     /* check timer */

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -350,9 +350,9 @@ void rt_schedule(void)
                 }
                 else
                 {
-                    current_thread->stat &= ~RT_THREAD_STAT_YIELD_MASK;
                     rt_schedule_insert_thread(current_thread);
                 }
+                current_thread->stat &= ~RT_THREAD_STAT_YIELD_MASK;
             }
             to_thread->oncpu = cpu_id;
             if (to_thread != current_thread)
@@ -448,9 +448,9 @@ void rt_schedule(void)
                 }
                 else
                 {
-                    rt_current_thread->stat &= ~RT_THREAD_STAT_YIELD_MASK;
                     need_insert_from_thread = 1;
                 }
+                rt_current_thread->stat &= ~RT_THREAD_STAT_YIELD_MASK;
             }
 
             if (to_thread != rt_current_thread)
@@ -599,9 +599,9 @@ void rt_scheduler_do_irq_switch(void *context)
                 }
                 else
                 {
-                    current_thread->stat &= ~RT_THREAD_STAT_YIELD_MASK;
                     rt_schedule_insert_thread(current_thread);
                 }
+                current_thread->stat &= ~RT_THREAD_STAT_YIELD_MASK;
             }
             to_thread->oncpu = cpu_id;
             if (to_thread != current_thread)

--- a/src/thread.c
+++ b/src/thread.c
@@ -478,7 +478,15 @@ RTM_EXPORT(rt_thread_delete);
  */
 rt_err_t rt_thread_yield(void)
 {
+    struct rt_thread *thread;
+    rt_base_t lock;
+
+    thread = rt_thread_self();
+    lock = rt_hw_interrupt_disable();
+    thread->remaining_tick = thread->init_tick;
+    thread->stat |= RT_THREAD_STAT_YIELD;
     rt_schedule();
+    rt_hw_interrupt_enable(lock);
 
     return RT_EOK;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
- 问题描述： 在rt_thread_yield函数中，由于没有设置RT_THREAD_STAT_YIELD标志而导致在调用rt_schedule时可能未能成功切换到相同优先级就绪任务。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
