### PR TITLE
Update drv_adc.c

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -285,6 +285,9 @@ static int stm32_adc_init(void)
         }
         else
         {
+            /* calibration */
+            HAL_ADCEx_Calibration_Start(&&stm32_adc_obj[i].ADC_Handler);
+            
             /* register ADC device */
             if (rt_hw_adc_register(&stm32_adc_obj[i].stm32_adc_device, name_buf, &stm_adc_ops, &stm32_adc_obj[i].ADC_Handler) == RT_EOK)
             {


### PR DESCRIPTION
发现AD读取的数据不准，是因为没有在ADC初始化之后进行校准