### PR TITLE
avoid deadlock (rt_hw_interrupt_disable and rt_enter_critical when en…

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -33,10 +33,6 @@
 #include <rtthread.h>
 #include <rthw.h>
 
-#ifdef RT_USING_SMP
-rt_hw_spinlock_t _rt_critical_lock;
-#endif /*RT_USING_SMP*/
-
 rt_list_t rt_thread_priority_table[RT_THREAD_PRIORITY_MAX];
 rt_uint32_t rt_thread_ready_priority_group;
 #if RT_THREAD_PRIORITY_MAX > 32
@@ -851,7 +847,7 @@ void rt_enter_critical(void)
     if (!current_thread)
     {
         rt_hw_local_irq_enable(level);
-        return ;
+        return;
     }
 
     /*
@@ -859,12 +855,15 @@ void rt_enter_critical(void)
      * enough and does not check here
      */
 
-    /* lock scheduler for all cpus */
-    if (current_thread->critical_lock_nest == 0)
     {
-        rt_hw_spin_lock(&_rt_critical_lock);
+        register rt_uint16_t lock_nest = current_thread->cpus_lock_nest;
+        current_thread->cpus_lock_nest++;
+        if (lock_nest == 0)
+        {
+            current_thread->scheduler_lock_nest ++;
+            rt_hw_spin_lock(&_cpus_lock);
+        }
     }
-
     /* critical for local cpu */
     current_thread->critical_lock_nest ++;
 
@@ -910,16 +909,18 @@ void rt_exit_critical(void)
     if (!current_thread)
     {
         rt_hw_local_irq_enable(level);
-        return ;
+        return;
     }
 
     current_thread->scheduler_lock_nest --;
 
     current_thread->critical_lock_nest --;
 
-    if (current_thread->critical_lock_nest == 0)
+    current_thread->cpus_lock_nest--;
+    if (current_thread->cpus_lock_nest == 0)
     {
-        rt_hw_spin_unlock(&_rt_critical_lock);
+        current_thread->scheduler_lock_nest --;
+        rt_hw_spin_unlock(&_cpus_lock);
     }
 
     if (current_thread->scheduler_lock_nest <= 0)


### PR DESCRIPTION
…able smp)

## 拉取/合并请求描述：(PR description)

[
- 问题描述：在rt-thread的多核实现中，rt_hw_interrupt_disable和rt_enter_critical使用了两把自旋锁(cpus锁和critical锁)，以下情况下有可能发生死锁，一个任务先rt_enter_critical，然后在没有退出critical的情况下再次rt_hw_interrupt_disable, 而另一个任务先rt_hw_interrupt_disable，再在没有rt_hw_interrup_disable的情况下继续rt_enter_critical，在时序发生交叉时，会引发死锁。
比如时序是: cpu0:rt_enter_critical  cpu1:rt_hw_interrupt_disable cpu0:rt_hw_interrupt_disable(此时被spinlock在cpus锁) cpu1:rt_enter_critical(此时也被spinlock在critical)。
- 避免死锁的修改方式：由于历史代码中对这两个函数的使用是嵌套且无序的，要避免死锁问题需要把两把锁联动考虑：要取critical锁必须先持有cpus锁（即若没有持有cpus锁时，以不关中断方式取cpus锁），释放critical锁时，若在取critical锁时锁定了cpus锁则要释放它。综上所述，critical锁必须在持有cpus锁的情况下才能获取，由于cpus锁是针对cpu的，而critical锁又不可能在同一cpu上的任务间竞争（在critical情况下当前cpu不会切换任务），所以任务中不可能发生持有cpus锁而取不到critical锁的情况，因此，最终修改中去除critical锁，但保留进入critical的锁定深度维护操作以支持rt_critical_level函数。
- 此修改在qemu cortex-a, raspi平台测试通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
