### PR TITLE
修复"response+1"导致STM32 SPI HAL库内存非对齐访问的hard fault

### DIFF
--- a/components/drivers/spi/spi_msd.c
+++ b/components/drivers/spi/spi_msd.c
@@ -233,6 +233,7 @@ static rt_err_t _send_cmd(
     }
     else if (type == response_r2)
     {
+    #if !defined(SOC_SERIES_STM32F0) && !defined(SOC_SERIES_STM32L0) !defined(SOC_SERIES_STM32G0)
         /* initial message */
         message.send_buf = RT_NULL;
         message.recv_buf = response + 1;
@@ -241,9 +242,21 @@ static rt_err_t _send_cmd(
 
         /* transfer message */
         device->bus->ops->xfer(device, &message);
+    #else
+        /* initial message */
+        message.send_buf = RT_NULL;
+        message.recv_buf = recv_buffer;
+        message.length = 1;
+        message.cs_take = message.cs_release = 0;
+
+        /* transfer message */
+        device->bus->ops->xfer(device, &message);
+        response[1] = recv_buffer[0];
+    #endif
     }
     else if ((type == response_r3) || (type == response_r7))
     {
+    #if !defined(SOC_SERIES_STM32F0) && !defined(SOC_SERIES_STM32L0) !defined(SOC_SERIES_STM32G0)
         /* initial message */
         message.send_buf = RT_NULL;
         message.recv_buf = response + 1;
@@ -252,6 +265,20 @@ static rt_err_t _send_cmd(
 
         /* transfer message */
         device->bus->ops->xfer(device, &message);
+    #else
+        /* initial message */
+        message.send_buf = RT_NULL;
+        message.recv_buf = recv_buffer;
+        message.length = 4;
+        message.cs_take = message.cs_release = 0;
+
+        /* transfer message */
+        device->bus->ops->xfer(device, &message);
+        response[1] = recv_buffer[0];
+        response[2] = recv_buffer[1];
+        response[3] = recv_buffer[2];
+        response[4] = recv_buffer[3];
+    #endif
     }
     else
     {


### PR DESCRIPTION
Signed-off-by: SimpleInit <63694297@qq.com>

## 拉取/合并请求描述：(PR description)

[修复"response+1"导致STM32 SPI HAL库内存非对齐访问的hard fault]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
