### PR TITLE
[BSP][imxrt]fixed ethernet driver bug for imxrt

### DIFF
--- a/bsp/imxrt/libraries/drivers/drv_eth.c
+++ b/bsp/imxrt/libraries/drivers/drv_eth.c
@@ -22,6 +22,7 @@
 #include "fsl_phy.h"
 #include "fsl_cache.h"
 #include "fsl_iomuxc.h"
+#include "fsl_common.h"
 
 #ifdef RT_USING_LWIP
 
@@ -62,10 +63,10 @@ struct rt_imxrt_eth
     enet_mii_duplex_t duplex;
 };
 
-ALIGN(ENET_BUFF_ALIGNMENT) enet_tx_bd_struct_t g_txBuffDescrip[ENET_TXBD_NUM] SECTION("NonCacheable");
+AT_NONCACHEABLE_SECTION_ALIGN(enet_tx_bd_struct_t g_txBuffDescrip[ENET_TXBD_NUM], ENET_BUFF_ALIGNMENT);
 ALIGN(ENET_BUFF_ALIGNMENT) rt_uint8_t g_txDataBuff[ENET_TXBD_NUM][RT_ALIGN(ENET_TXBUFF_SIZE, ENET_BUFF_ALIGNMENT)];
 
-ALIGN(ENET_BUFF_ALIGNMENT) enet_rx_bd_struct_t g_rxBuffDescrip[ENET_RXBD_NUM] SECTION("NonCacheable");
+AT_NONCACHEABLE_SECTION_ALIGN(enet_rx_bd_struct_t g_rxBuffDescrip[ENET_RXBD_NUM], ENET_BUFF_ALIGNMENT);
 ALIGN(ENET_BUFF_ALIGNMENT) rt_uint8_t g_rxDataBuff[ENET_RXBD_NUM][RT_ALIGN(ENET_RXBUFF_SIZE, ENET_BUFF_ALIGNMENT)];
 
 static struct rt_imxrt_eth imxrt_eth_device;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1. 为什么要提交这份PR
imxrt的BSP中的drv_eth.c对变量g_txBuffDescrip和g_rxBuffDescrip存储位置分配存在问题，在使用GCC版本编译时，会产生错误的数据，使得软件运行异常。
2. 解决方案
使用了NXP官方的AT_NONCACHEABLE_SECTION_ALIGN宏来定义上面两个变量，可以兼容keil, iar, gcc编译器。

使用了imxrt1052-nxp-evk的BSP来进行测试
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
