### PR TITLE
[update] drv_hwtimers.c file error struct member variables

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_hwtimer.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_hwtimer.c
@@ -154,10 +154,10 @@ static struct stm32_hwtimer stm32_hwtimer_obj[] =
 };
 
 /* APBx timer clocks frequency doubler state related to APB1CLKDivider value */
-static void pclkx_doubler_get(uint32_t *pclk1_doubler, uint32_t *pclk2_doubler)
+static void pclkx_doubler_get(rt_uint32_t *pclk1_doubler, rt_uint32_t *pclk2_doubler)
 {
-    uint32_t flatency = 0;
-    RCC_ClkInitTypeDef RCC_ClkInitStruct;
+    rt_uint32_t flatency = 0;
+    RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
 
     RT_ASSERT(pclk1_doubler != RT_NULL);
     RT_ASSERT(pclk1_doubler != RT_NULL);
@@ -167,15 +167,28 @@ static void pclkx_doubler_get(uint32_t *pclk1_doubler, uint32_t *pclk2_doubler)
     *pclk1_doubler = 1;
     *pclk2_doubler = 1;
 
-    if(RCC_ClkInitStruct.APB1CLKDivider != RCC_HCLK_DIV1)
+#if defined(SOC_SERIES_STM32MP1)
+    if (RCC_ClkInitStruct.APB1_Div != RCC_APB1_DIV1)
+    {
+        *pclk1_doubler = 2;
+    }
+    if (RCC_ClkInitStruct.APB2_Div != RCC_APB2_DIV1)
+    {
+       *pclk2_doubler = 2; 
+    }
+#else
+    
+    if (RCC_ClkInitStruct.APB1CLKDivider != RCC_HCLK_DIV1)    
     {
          *pclk1_doubler = 2;
     }
-
-    if(RCC_ClkInitStruct.APB2CLKDivider != RCC_HCLK_DIV1)
+#if !defined(SOC_SERIES_STM32F0) && !defined(SOC_SERIES_STM32G0)
+    if (RCC_ClkInitStruct.APB2CLKDivider != RCC_HCLK_DIV1)
     {
          *pclk2_doubler = 2;
     }
+#endif
+#endif
 }
 
 static void timer_init(struct rt_hwtimer_device *timer, rt_uint32_t state)

--- a/bsp/stm32/libraries/HAL_Drivers/drv_hwtimer.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_hwtimer.c
@@ -177,7 +177,6 @@ static void pclkx_doubler_get(rt_uint32_t *pclk1_doubler, rt_uint32_t *pclk2_dou
        *pclk2_doubler = 2; 
     }
 #else
-    
     if (RCC_ClkInitStruct.APB1CLKDivider != RCC_HCLK_DIV1)    
     {
          *pclk1_doubler = 2;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修复 drv_hwtimes.c 文件内错误的结构体变量使用。
已在 F0，F1，F4，F7，H7，G0，L4，MP1 上编译通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
