### PR TITLE
[timer] 软定时器BUG修复

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -40,6 +40,10 @@ ALIGN(RT_ALIGN_SIZE)
 static rt_uint8_t timer_thread_stack[RT_TIMER_THREAD_STACK_SIZE];
 #endif
 
+#ifdef RT_USING_TIMER_SOFT
+static rt_bool_t timer_idle;
+#endif
+
 #ifdef RT_USING_HOOK
 extern void (*rt_object_take_hook)(struct rt_object *object);
 extern void (*rt_object_put_hook)(struct rt_object *object);
@@ -408,7 +412,7 @@ rt_err_t rt_timer_start(rt_timer_t timer)
     if (timer->parent.flag & RT_TIMER_FLAG_SOFT_TIMER)
     {
         /* check whether timer thread is ready */
-        if ((timer_thread.stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND)
+        if (timer_idle && ((timer_thread.stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND))
         {
             /* resume timer thread to check soft timer */
             rt_thread_resume(&timer_thread);
@@ -445,12 +449,11 @@ rt_err_t rt_timer_stop(rt_timer_t timer)
     level = rt_hw_interrupt_disable();
 
     _rt_timer_remove(timer);
+    /* change stat */
+    timer->parent.flag &= ~RT_TIMER_FLAG_ACTIVATED;
 
     /* enable interrupt */
     rt_hw_interrupt_enable(level);
-
-    /* change stat */
-    timer->parent.flag &= ~RT_TIMER_FLAG_ACTIVATED;
 
     return RT_EOK;
 }
@@ -554,6 +557,11 @@ void rt_timer_check(void)
             RT_OBJECT_HOOK_CALL(rt_timer_exit_hook, (t));
             RT_DEBUG_LOG(RT_DEBUG_TIMER, ("current tick: %d\n", current_tick));
 
+            /* Check whether the timer object is detached or started again */
+            if (rt_object_get_type(&t->parent) != RT_Object_Class_Timer ||
+                !rt_list_isempty(&t->row[RT_TIMER_SKIP_LIST_LEVEL - 1]))
+                continue;
+
             if ((t->parent.flag & RT_TIMER_FLAG_PERIODIC) &&
                 (t->parent.flag & RT_TIMER_FLAG_ACTIVATED))
             {
@@ -596,11 +604,12 @@ void rt_soft_timer_check(void)
 {
     rt_tick_t current_tick;
     struct rt_timer *t;
+    register rt_base_t level;
 
     RT_DEBUG_LOG(RT_DEBUG_TIMER, ("software timer check enter\n"));
 
-    /* lock scheduler */
-    rt_enter_critical();
+    /* disable interrupt */
+    level = rt_hw_interrupt_disable();
 
     while (!rt_list_isempty(&rt_soft_timer_list[RT_TIMER_SKIP_LIST_LEVEL - 1]))
     {
@@ -619,24 +628,35 @@ void rt_soft_timer_check(void)
 
             /* remove timer from timer list firstly */
             _rt_timer_remove(t);
+            timer_idle = RT_FALSE;
+            /* enable interrupt */
+            rt_hw_interrupt_enable(level);
 
-            /* not lock scheduler when performing timeout function */
-            rt_exit_critical();
             /* call timeout function */
             t->timeout_func(t->parameter);
 
+            timer_idle = RT_TRUE;
             RT_OBJECT_HOOK_CALL(rt_timer_exit_hook, (t));
             RT_DEBUG_LOG(RT_DEBUG_TIMER, ("current tick: %d\n", current_tick));
 
-            /* lock scheduler */
-            rt_enter_critical();
+            /* disable interrupt */
+            level = rt_hw_interrupt_disable();
+
+            /* Check whether the timer object is detached or started again */
+            if (rt_object_get_type(&t->parent) != RT_Object_Class_Timer ||
+                !rt_list_isempty(&t->row[RT_TIMER_SKIP_LIST_LEVEL - 1]))
+                continue;
 
             if ((t->parent.flag & RT_TIMER_FLAG_PERIODIC) &&
                 (t->parent.flag & RT_TIMER_FLAG_ACTIVATED))
             {
                 /* start it */
                 t->parent.flag &= ~RT_TIMER_FLAG_ACTIVATED;
+                /* enable interrupt */
+                rt_hw_interrupt_enable(level);
                 rt_timer_start(t);
+                /* disable interrupt */
+                level = rt_hw_interrupt_disable();
             }
             else
             {
@@ -646,9 +666,8 @@ void rt_soft_timer_check(void)
         }
         else break; /* not check anymore */
     }
-
-    /* unlock scheduler */
-    rt_exit_critical();
+    /* enable interrupt */
+    rt_hw_interrupt_enable(level);
 
     RT_DEBUG_LOG(RT_DEBUG_TIMER, ("software timer check leave\n"));
 }
@@ -714,6 +733,7 @@ void rt_system_timer_thread_init(void)
 #ifdef RT_USING_TIMER_SOFT
     int i;
 
+    timer_idle = RT_TRUE;
     for (i = 0;
          i < sizeof(rt_soft_timer_list) / sizeof(rt_soft_timer_list[0]);
          i++)


### PR DESCRIPTION
1. 修复中断中操作软定时器，定时器链表损坏的问题。
2. 修复软定时器执行回调定时器线程被挂起，再次启动其他定时器，误恢复定时器线程的问题

## 拉取/合并请求描述：(PR description)

[
软定时器在中断中操作时，会导致软定时器链表损坏，系统宕机。

将锁调度更改成锁中断。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
