### PR TITLE
[fix] thread control bug about RT_THREAD_CTRL_CLOSE command

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -679,9 +679,17 @@ rt_err_t rt_thread_control(rt_thread_t thread, int cmd, void *arg)
     case RT_THREAD_CTRL_STARTUP:
         return rt_thread_startup(thread);
 
-#ifdef RT_USING_HEAP
     case RT_THREAD_CTRL_CLOSE:
-        return rt_thread_delete(thread);
+
+        if (rt_object_is_systemobject((rt_object_t)thread) == RT_TRUE)
+        {
+            return rt_thread_detach(thread);
+        }
+#ifdef RT_USING_HEAP
+        else
+        {
+            return rt_thread_delete(thread);
+        }
 #endif
 
 #ifdef RT_USING_SMP


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
问题复现描述：代码使用 heap 情况下，某处如果使用 rt_thread_init 初始化的线程，调用 rt_thread_control(&tc_thread_thread7, RT_THREAD_CTRL_CLOSE, RT_NULL) close 线程，直接出错。

分析：当前线程无法区分该线程是 init 还是 create 的，并且 rt_thread_control 使用命令 `RT_THREAD_CTRL_CLOSE` 只有 delete 线程一种方式。

修改后测试结果：stm32f407 与 qemu 测试静态创建、动态创建线程分别使用、不使用 RT_USING_HEAP 情况下，结果均运行正常。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
