### PR TITLE
修正多核rt_schedule_remove_thread时pcpu的ready_table判断问题

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -784,7 +784,7 @@ void rt_schedule_remove_thread(struct rt_thread *thread)
         {
 #if RT_THREAD_PRIORITY_MAX > 32
             pcpu->ready_table[thread->number] &= ~thread->high_mask;
-            if (rt_thread_ready_table[thread->number] == 0)
+            if (pcpu->ready_table[thread->number] == 0)
             {
                 pcpu->priority_group &= ~thread->number_mask;
             }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
smp实现中，在多核且任务数大于32的情况下，rt_schedule_remove_thread对pcpu->priority_group的标志清除时，判断的位置应为pcpu->ready_table[thread->number] ，代码中笔误成了rt_thread_ready_table[thread->number] ，可能导致出现priority_groupw对应就绪位未正确清除，在下面的测试中会出现dabt：

```c
static void thread_entry(void* parameter)
{
    int count = 0;

    while (1)
    {
        rt_thread_mdelay(1000);
    }
}

int task0(void)
{
    rt_thread_t tid;
    int cpuid = 0;

    tid = rt_thread_create("count0", thread_entry, RT_NULL,
            4096, 22, 10);
    if (tid)
    {
        rt_thread_control(tid, RT_THREAD_CTRL_BIND_CPU, (void*)cpuid);
        rt_thread_startup(tid);
    }

    return 0;
}

int task1(void)
{
    rt_thread_t tid;

    tid = rt_thread_create("count1", thread_entry, RT_NULL,
            4096, 22, 10);
    if (tid)
    {
        rt_thread_startup(tid);
    }

    return 0;
}

```

修正后，任务正常运行。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
