### PR TITLE
[components][driver/pin.c]pin 框架增加 rt_pin_get

### DIFF
--- a/bsp/allwinner_tina/drivers/drv_gpio.c
+++ b/bsp/allwinner_tina/drivers/drv_gpio.c
@@ -538,6 +538,7 @@ static const struct rt_pin_ops ops =
     pin_attach_irq,
     pin_detach_irq,
     pin_irq_enable,
+    RT_NULL,
 };
 #endif
 

--- a/bsp/apollo2/board/gpio.c
+++ b/bsp/apollo2/board/gpio.c
@@ -212,6 +212,7 @@ const static struct rt_pin_ops am_pin_ops =
     am_pin_attach_irq,
     am_pin_dettach_irq,
     am_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/at32/Libraries/rt_drivers/drv_gpio.c
+++ b/bsp/at32/Libraries/rt_drivers/drv_gpio.c
@@ -496,6 +496,7 @@ const static struct rt_pin_ops _at32_pin_ops =
     at32_pin_attach_irq,
     at32_pin_dettach_irq,
     at32_pin_irq_enable,
+    RT_NULL,
 };
 
 rt_inline void pin_irq_hdr(int irqno)

--- a/bsp/beaglebone/drivers/gpio.c
+++ b/bsp/beaglebone/drivers/gpio.c
@@ -84,6 +84,10 @@ static struct rt_pin_ops am33xx_pin_ops =
     am33xx_pin_mode,
     am33xx_pin_write,
     am33xx_pin_read,
+    RT_NULL,
+    RT_NULL,
+    RT_NULL,
+    RT_NULL,
 };
 
 int rt_hw_gpio_init(void)

--- a/bsp/essemi/es32f0271/drivers/drv_gpio.c
+++ b/bsp/essemi/es32f0271/drivers/drv_gpio.c
@@ -450,6 +450,7 @@ const static struct rt_pin_ops _es32f0_pin_ops =
     es32f0_pin_attach_irq,
     es32f0_pin_detach_irq,
     es32f0_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/essemi/es32f0334/drivers/drv_gpio.c
+++ b/bsp/essemi/es32f0334/drivers/drv_gpio.c
@@ -408,6 +408,7 @@ const static struct rt_pin_ops _es32f0_pin_ops =
     es32f0_pin_attach_irq,
     es32f0_pin_detach_irq,
     es32f0_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/essemi/es32f0654/drivers/drv_gpio.c
+++ b/bsp/essemi/es32f0654/drivers/drv_gpio.c
@@ -408,6 +408,7 @@ const static struct rt_pin_ops _es32f0_pin_ops =
     es32f0_pin_attach_irq,
     es32f0_pin_detach_irq,
     es32f0_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/essemi/es32f369x/drivers/drv_gpio.c
+++ b/bsp/essemi/es32f369x/drivers/drv_gpio.c
@@ -408,6 +408,7 @@ const static struct rt_pin_ops _es32f3_pin_ops =
     es32f3_pin_attach_irq,
     es32f3_pin_detach_irq,
     es32f3_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/essemi/es8p508x/drivers/drv_gpio.c
+++ b/bsp/essemi/es8p508x/drivers/drv_gpio.c
@@ -382,6 +382,7 @@ const static struct rt_pin_ops _es8p_pin_ops =
     es8p_pin_attach_irq,
     es8p_pin_detach_irq,
     es8p_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/gd32303e-eval/drivers/drv_gpio.c
+++ b/bsp/gd32303e-eval/drivers/drv_gpio.c
@@ -497,6 +497,7 @@ const static struct rt_pin_ops _gd32_pin_ops =
     gd32_pin_attach_irq,
     gd32_pin_detach_irq,
     gd32_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/gd32e230k-start/drivers/drv_gpio.c
+++ b/bsp/gd32e230k-start/drivers/drv_gpio.c
@@ -388,6 +388,7 @@ const static struct rt_pin_ops _gd32_pin_ops =
     gd32_pin_attach_irq,
     gd32_pin_detach_irq,
     gd32_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/gd32vf103v-eval/drivers/drv_gpio.c
+++ b/bsp/gd32vf103v-eval/drivers/drv_gpio.c
@@ -427,6 +427,7 @@ const static struct rt_pin_ops _gd32vf_pin_ops =
     gd32vf_pin_attach_irq,
     gd32vf_pin_dettach_irq,
     gd32vf_pin_irq_enable,
+    RT_NULL,
 };
 
 rt_inline void pin_irq_hdr(int irqno)

--- a/bsp/imxrt/libraries/drivers/drv_gpio.c
+++ b/bsp/imxrt/libraries/drivers/drv_gpio.c
@@ -587,7 +587,8 @@ const static struct rt_pin_ops imxrt_pin_ops =
     imxrt_pin_read,
     imxrt_pin_attach_irq,
     imxrt_pin_detach_irq,
-    imxrt_pin_irq_enable
+    imxrt_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/k210/driver/drv_gpio.c
+++ b/bsp/k210/driver/drv_gpio.c
@@ -251,7 +251,8 @@ const static struct rt_pin_ops drv_pin_ops =
 
     drv_pin_attach_irq,
     drv_pin_detach_irq,
-    drv_pin_irq_enable
+    drv_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/lpc54114-lite/drivers/drv_gpio.c
+++ b/bsp/lpc54114-lite/drivers/drv_gpio.c
@@ -38,6 +38,48 @@ struct rt_pin_irq_hdr pin_irq_hdr_tab[] =
     {-1, 0, RT_NULL, RT_NULL},    
 };
 
+static rt_base_t lpc_pin_get(const char *name)
+{
+    rt_base_t pin = 0;
+    int hw_port_num, hw_pin_num = 0;
+    int i, name_len = 1;
+    int mul = 1;
+
+    name_len = rt_strlen(name);
+
+    if ((name_len < 4) || (name_len >= 6))
+    {
+        return -RT_EINVAL;
+    }
+    if ((name[0] != 'P') || (name[2] != '.'))
+    {
+        return -RT_EINVAL;
+    }
+
+    if ((name[1] >= '0') && (name[1] <= '9'))
+    {
+        hw_port_num = (int)(name[1] - '0');
+    }
+    else
+    {
+        return -RT_EINVAL;
+    }
+
+    for (i = name_len - 1; i > 2; i--)
+    {
+        hw_pin_num += ((int)(name[i] - '0') * mul);
+        mul = mul * 10;
+    }
+
+    pin = 32 * hw_port_num + hw_pin_num;
+
+    if ((pin > PIN_MAX_VAL) || (pin < 0))
+    {
+        return -RT_EINVAL;
+    }
+    return pin;
+}
+
 /* Configure pin mode. pin 0~63 means PIO0_0 ~ PIO1_31 */
 static void lpc_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
 {
@@ -288,7 +330,8 @@ const static struct rt_pin_ops _lpc_pin_ops =
     lpc_pin_read,
     lpc_pin_attach_irq,
     lpc_pin_detach_irq,
-    lpc_pin_irq_enable,    
+    lpc_pin_irq_enable,
+    lpc_pin_get,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/lpc55sxx/Libraries/drivers/drv_pin.c
+++ b/bsp/lpc55sxx/Libraries/drivers/drv_pin.c
@@ -419,6 +419,7 @@ int rt_hw_pin_init(void)
     lpc_pin_ops.pin_attach_irq  = lpc_pin_attach_irq;
     lpc_pin_ops.pin_detach_irq  = lpc_pin_detach_irq;
     lpc_pin_ops.pin_irq_enable  = lpc_pin_irq_enable;
+    lpc_pin_ops.pin_get         = RT_NULL,
 
     ret = rt_device_pin_register("pin", &lpc_pin_ops, RT_NULL);
 

--- a/bsp/ls1cdev/drivers/drv_gpio.c
+++ b/bsp/ls1cdev/drivers/drv_gpio.c
@@ -122,7 +122,8 @@ const static struct rt_pin_ops _ls1c_pin_ops =
 
     ls1c_pin_attach_irq,
     ls1c_pin_detach_irq,
-    ls1c_pin_irq_enable
+    ls1c_pin_irq_enable,
+    RT_NULL,
 };
 
 

--- a/bsp/ls2kdev/drivers/drv_gpio.c
+++ b/bsp/ls2kdev/drivers/drv_gpio.c
@@ -221,6 +221,7 @@ static struct rt_pin_ops loongson_pin_ops = {
     .pin_attach_irq = loongson_pin_attach_irq,
     .pin_detach_irq = loongson_pin_detach_irq,
     .pin_irq_enable = loongson_pin_irq_enable,
+    .pin_get        = RT_NULL,
 };
 
 

--- a/bsp/mm32l3xx/drivers/drv_gpio.c
+++ b/bsp/mm32l3xx/drivers/drv_gpio.c
@@ -409,6 +409,7 @@ const static struct rt_pin_ops _mm32_pin_ops =
     mm32_pin_attach_irq,
     mm32_pin_detach_irq,
     mm32_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/nrf5x/libraries/drivers/drv_gpio.c
+++ b/bsp/nrf5x/libraries/drivers/drv_gpio.c
@@ -351,6 +351,7 @@ const static struct rt_pin_ops _nrf5x_pin_ops =
     nrf5x_pin_attach_irq,
     nrf5x_pin_dettach_irq,
     nrf5x_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/nuclei/libraries/gd32vf103/HAL_Drivers/drv_gpio.c
+++ b/bsp/nuclei/libraries/gd32vf103/HAL_Drivers/drv_gpio.c
@@ -443,6 +443,7 @@ const static struct rt_pin_ops _gd32_pin_ops =
     gd32_pin_attach_irq,
     gd32_pin_dettach_irq,
     gd32_pin_irq_enable,
+    RT_NULL,
 };
 
 rt_inline void pin_irq_hdr(int irqno)

--- a/bsp/nuvoton/libraries/m480/rtt_port/drv_gpio.c
+++ b/bsp/nuvoton/libraries/m480/rtt_port/drv_gpio.c
@@ -44,7 +44,8 @@ static struct rt_pin_ops nu_gpio_ops =
     nu_gpio_read,
     nu_gpio_attach_irq,
     nu_gpio_detach_irq,
-    nu_gpio_irq_enable
+    nu_gpio_irq_enable,
+    RT_NULL,
 };
 
 static IRQn_Type au32GPIRQ[NU_PORT_CNT] = {GPA_IRQn, GPB_IRQn, GPC_IRQn, GPD_IRQn, GPE_IRQn, GPF_IRQn, GPG_IRQn, GPH_IRQn};

--- a/bsp/raspberry-pi/raspi3-32/driver/drv_gpio.c
+++ b/bsp/raspberry-pi/raspi3-32/driver/drv_gpio.c
@@ -294,6 +294,7 @@ static const struct rt_pin_ops ops =
     raspi_pin_attach_irq,
     raspi_pin_detach_irq,
     raspi_pin_irq_enable,
+    RT_NULL,
 };
 #endif
 

--- a/bsp/raspberry-pi/raspi3-64/driver/drv_gpio.c
+++ b/bsp/raspberry-pi/raspi3-64/driver/drv_gpio.c
@@ -295,6 +295,7 @@ static const struct rt_pin_ops ops =
     raspi_pin_attach_irq,
     raspi_pin_detach_irq,
     raspi_pin_irq_enable,
+    RT_NULL,
 };
 #endif
 

--- a/bsp/raspberry-pi/raspi4-32/driver/drv_gpio.c
+++ b/bsp/raspberry-pi/raspi4-32/driver/drv_gpio.c
@@ -344,6 +344,7 @@ static const struct rt_pin_ops ops =
     raspi_pin_attach_irq,
     raspi_pin_detach_irq,
     raspi_pin_irq_enable,
+    RT_NULL,
 };
 
 static void gpio_irq_handler(int irq, void *param)

--- a/bsp/raspberry-pi/raspi4-64/driver/drv_gpio.c
+++ b/bsp/raspberry-pi/raspi4-64/driver/drv_gpio.c
@@ -103,6 +103,7 @@ static const struct rt_pin_ops ops =
     raspi_pin_attach_irq,
     raspi_pin_detach_irq,
     raspi_pin_irq_enable,
+    RT_NULL,
 };
 #endif
 

--- a/bsp/rv32m1_vega/ri5cy/driver/drv_gpio.c
+++ b/bsp/rv32m1_vega/ri5cy/driver/drv_gpio.c
@@ -496,7 +496,8 @@ static const struct rt_pin_ops vega_pin_ops =
 
     vega_pin_attach_irq,
     vega_pin_detach_irq,
-    vega_pin_irq_enable
+    vega_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/stm32/libraries/HAL_Drivers/drv_gpio.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_gpio.c
@@ -313,6 +313,51 @@ static const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
+static rt_base_t stm32_pin_get(const char *name)
+{
+    rt_base_t pin = 0;
+    int hw_port_num, hw_pin_num = 0;
+    int i, name_len = 1;
+    int mul = 1;
+
+    name_len = rt_strlen(name);
+
+    if ((name_len < 4) || (name_len >= 6))
+    {
+        return -RT_EINVAL;
+    }
+    if ((name[0] != 'P') || (name[2] != '.'))
+    {
+        return -RT_EINVAL;
+    }
+
+    if ((name[1] >= 'A') && (name[1] <= 'Z'))
+    {
+        hw_port_num = (int)(name[1] - 'A');
+    }
+    else
+    {
+        return -RT_EINVAL;
+    }
+
+    for (i = name_len - 1; i > 2; i--)
+    {
+        hw_pin_num += ((int)(name[i] - '0') * mul);
+        mul = mul * 10;
+    }
+
+    pin = 16 * hw_port_num + hw_pin_num;
+
+    if (pin < ITEM_NUM(pins))
+    {
+        return pin;
+    }
+    else
+    {
+        return -RT_EINVAL;
+    }
+}
+
 static void stm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
 {
     const struct pin_index *index;
@@ -627,6 +672,7 @@ const static struct rt_pin_ops _stm32_pin_ops =
     stm32_pin_attach_irq,
     stm32_pin_dettach_irq,
     stm32_pin_irq_enable,
+    stm32_pin_get,
 };
 
 rt_inline void pin_irq_hdr(int irqno)

--- a/bsp/swm320-lq100/drivers/drv_gpio.c
+++ b/bsp/swm320-lq100/drivers/drv_gpio.c
@@ -334,7 +334,8 @@ const static struct rt_pin_ops swm320_pin_ops =
     swm320_pin_read,
     swm320_pin_attach_irq,
     swm320_pin_detach_irq,
-    swm320_pin_irq_enable
+    swm320_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/tm4c123bsp/libraries/Drivers/drv_gpio.c
+++ b/bsp/tm4c123bsp/libraries/Drivers/drv_gpio.c
@@ -153,6 +153,7 @@ const static struct rt_pin_ops _tm4c123_pin_ops =
     tm4c123_pin_attach_irq,
     tm4c123_pin_dettach_irq,
     tm4c123_pin_irq_enable,
+    RT_NULL,
 };
 
 int rt_hw_pin_init(void)

--- a/bsp/w60x/drivers/drv_pin.c
+++ b/bsp/w60x/drivers/drv_pin.c
@@ -153,7 +153,8 @@ struct rt_pin_ops _wm_pin_ops =
     wm_pin_read,
     wm_pin_attach_irq,
     wm_pin_detach_irq,
-    wm_pin_irq_enable
+    wm_pin_irq_enable,
+    RT_NULL,
 };
 
 int wm_hw_pin_init(void)

--- a/components/drivers/include/drivers/pin.h
+++ b/components/drivers/include/drivers/pin.h
@@ -74,10 +74,13 @@ struct rt_pin_ops
                       rt_uint32_t mode, void (*hdr)(void *args), void *args);
     rt_err_t (*pin_detach_irq)(struct rt_device *device, rt_int32_t pin);
     rt_err_t (*pin_irq_enable)(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled);
+    rt_base_t (*pin_get)(const char *name);
 };
 
 int rt_device_pin_register(const char *name, const struct rt_pin_ops *ops, void *user_data);
 
+/* Get pin number by name,such as PA.0,P0.12 */
+rt_base_t rt_pin_get(const char *name);
 void rt_pin_mode(rt_base_t pin, rt_base_t mode);
 void rt_pin_write(rt_base_t pin, rt_base_t value);
 int  rt_pin_read(rt_base_t pin);

--- a/components/drivers/misc/pin.c
+++ b/components/drivers/misc/pin.c
@@ -151,3 +151,18 @@ int  rt_pin_read(rt_base_t pin)
     return _hw_pin.ops->pin_read(&_hw_pin.parent, pin);
 }
 FINSH_FUNCTION_EXPORT_ALIAS(rt_pin_read, pinRead, read status from hardware pin);
+
+rt_base_t rt_pin_get(const char *name)
+{
+    RT_ASSERT(_hw_pin.ops != RT_NULL);
+    RT_ASSERT(name[0] == 'P');
+    
+    if(_hw_pin.ops->pin_get == RT_NULL)
+    {
+        return -RT_ENOSYS;
+    }
+
+    return _hw_pin.ops->pin_get(name);
+}
+FINSH_FUNCTION_EXPORT_ALIAS(rt_pin_get, pinGet, get pin number from hardware pin);
+


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
PIN 框架增加 rt_pin_get ，传入字符串后在驱动中进行解析，如 PA.0；
初始化 BSP 中的 rt_pin_ops pin_get；
实现了stm32 pin_get 驱动，实现了 lpc54114-lite pin_get 驱动；
在 pandora上测试通过，在  lpc54114-lite 上测试通过；
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
