### PR TITLE
[drivers/serial]add a line feed to the carriage return character when…

### DIFF
--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -328,6 +328,7 @@ rt_inline int _serial_int_tx(struct rt_serial_device *serial, const rt_uint8_t *
                 rt_completion_wait(&(tx->completion), RT_WAITING_FOREVER);
                 continue;
             }
+        }
 
         if (serial->ops->putc(serial, *(char*)data) == -1)
         {

--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -23,7 +23,7 @@
  *                             add TCFLSH and FIONREAD support.
  * 2018-12-08     Ernest Chen  add DMA choice
  * 2020-09-14     WillianChan  add a line feed to the carriage return character
-                               when using interrupt tx
+ *                             when using interrupt tx
  */
 
 #include <rthw.h>

--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -22,6 +22,8 @@
  * 2017-11-15     JasonJia     fix poll rx issue when data is full.
  *                             add TCFLSH and FIONREAD support.
  * 2018-12-08     Ernest Chen  add DMA choice
+ * 2020-09-14     WillianChan  add a line feed to the carriage return character
+                               when using interrupt tx
  */
 
 #include <rthw.h>
@@ -315,6 +317,18 @@ rt_inline int _serial_int_tx(struct rt_serial_device *serial, const rt_uint8_t *
 
     while (length)
     {
+        /*
+         * to be polite with serial console add a line feed
+         * to the carriage return character
+         */
+        if (*data == '\n' && (serial->parent.open_flag & RT_DEVICE_FLAG_STREAM))
+        {
+            if (serial->ops->putc(serial, '\r') == -1)
+            {
+                rt_completion_wait(&(tx->completion), RT_WAITING_FOREVER);
+                continue;
+            }
+
         if (serial->ops->putc(serial, *(char*)data) == -1)
         {
             rt_completion_wait(&(tx->completion), RT_WAITING_FOREVER);


### PR DESCRIPTION
… using interrupt tx

Signed-off-by: WillianChan <chentingwei@rt-thread.com>

## 拉取/合并请求描述：(PR description)

[
在使用串口中断方式输出时，在回车字符中添加换行符
add a line feed to the carriage return character when using interrupt tx
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [X] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [X] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [X] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [X] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [X] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [X] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [X] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
