### PR TITLE
[bsp] fix mm32 iar icf bugs

### DIFF
--- a/bsp/mm32l07x/drivers/linker_scripts/link.icf
+++ b/bsp/mm32l07x/drivers/linker_scripts/link.icf
@@ -14,8 +14,8 @@ define symbol __ICFEDIT_size_proc_stack__ = 0x0;
 define symbol __ICFEDIT_size_heap__       = 0x0800;
 /**** End of ICF editor section. ###ICF###*/
 define memory mem with size = 4G;
-define region IROM_region   =   mem:[from __ICFEDIT_region_IROM1_start__ to __ICFEDIT_region_IROM_end__];
-define region IRAM_region   =   mem:[from __ICFEDIT_region_IRAM1_start__ to __ICFEDIT_region_IRAM_end__];
+define region IROM_region   =   mem:[from __ICFEDIT_region_IROM_start__ to __ICFEDIT_region_IROM_end__];
+define region IRAM_region   =   mem:[from __ICFEDIT_region_IRAM_start__ to __ICFEDIT_region_IRAM_end__];
 define block CSTACK     with alignment = 8, size = __ICFEDIT_size_cstack__     { };
 define block PROC_STACK with alignment = 8, size = __ICFEDIT_size_proc_stack__ { };
 define block HEAP       with alignment = 8, size = __ICFEDIT_size_heap__       { };
@@ -31,6 +31,4 @@ if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 
 place in IROM_region  { readonly };
-place in EROM_region  { readonly section application_specific_ro };
 place in IRAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
-place in ERAM_region  { readwrite section application_specific_rw };

--- a/bsp/mm32l3xx/drivers/linker_scripts/link.icf
+++ b/bsp/mm32l3xx/drivers/linker_scripts/link.icf
@@ -14,8 +14,8 @@ define symbol __ICFEDIT_size_proc_stack__ = 0x0;
 define symbol __ICFEDIT_size_heap__       = 0x0800;
 /**** End of ICF editor section. ###ICF###*/
 define memory mem with size = 4G;
-define region IROM_region   =   mem:[from __ICFEDIT_region_IROM1_start__ to __ICFEDIT_region_IROM_end__];
-define region IRAM_region   =   mem:[from __ICFEDIT_region_IRAM1_start__ to __ICFEDIT_region_IRAM_end__];
+define region IROM_region   =   mem:[from __ICFEDIT_region_IROM_start__ to __ICFEDIT_region_IROM_end__];
+define region IRAM_region   =   mem:[from __ICFEDIT_region_IRAM_start__ to __ICFEDIT_region_IRAM_end__];
 define block CSTACK     with alignment = 8, size = __ICFEDIT_size_cstack__     { };
 define block PROC_STACK with alignment = 8, size = __ICFEDIT_size_proc_stack__ { };
 define block HEAP       with alignment = 8, size = __ICFEDIT_size_heap__       { };
@@ -31,6 +31,4 @@ if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 
 place in IROM_region  { readonly };
-place in EROM_region  { readonly section application_specific_ro };
 place in IRAM_region  { readwrite, block CSTACK, block PROC_STACK, block HEAP };
-place in ERAM_region  { readwrite section application_specific_rw };


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修复 MM32 在 IAR icf 文件中地址范围名称配置不正确的问题，以及去掉了不存在的 `EROM_region` 地址区间
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other style
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
