### PR TITLE
[fix] after modify rtc datetime, update alarm set when use second,min…

### DIFF
--- a/components/drivers/rtc/alarm.c
+++ b/components/drivers/rtc/alarm.c
@@ -8,6 +8,7 @@
  * 2012-10-27     heyuanjie87       first version.
  * 2013-05-17     aozima            initial alarm event & mutex in system init.
  * 2020-10-15     zhangsz           add alarm flags hour minute second.
+ * 2020-11-09     zhangsz           fix alarm set when modify rtc time.
  */
 
 #include <rtthread.h>
@@ -102,7 +103,7 @@ static void alarm_wakeup(struct rt_alarm *alarm, struct tm *now)
         {
             alarm->wktime.tm_hour = now->tm_hour;
             alarm->wktime.tm_min = now->tm_min;
-            alarm->wktime.tm_sec = alarm->wktime.tm_sec + 1;
+            alarm->wktime.tm_sec = now->tm_sec + 1;
             if (alarm->wktime.tm_sec > 59)
             {
                 alarm->wktime.tm_sec = 0;
@@ -125,7 +126,7 @@ static void alarm_wakeup(struct rt_alarm *alarm, struct tm *now)
             alarm->wktime.tm_hour = now->tm_hour;
             if (alarm->wktime.tm_sec == now->tm_sec)
             {
-                alarm->wktime.tm_min = alarm->wktime.tm_min + 1;
+                alarm->wktime.tm_min = now->tm_min + 1;
                 if (alarm->wktime.tm_min > 59)
                 {
                     alarm->wktime.tm_min = 0;
@@ -144,7 +145,7 @@ static void alarm_wakeup(struct rt_alarm *alarm, struct tm *now)
             if ((alarm->wktime.tm_min == now->tm_min) &&
                 (alarm->wktime.tm_sec == now->tm_sec))
             {
-                alarm->wktime.tm_hour = alarm->wktime.tm_hour + 1;
+                alarm->wktime.tm_hour = now->tm_hour + 1;
                 if (alarm->wktime.tm_hour > 23)
                 {
                     alarm->wktime.tm_hour = 0;


### PR DESCRIPTION
 [fix] after modify rtc datetime, update alarm set when use second,minute,hour period repeat

## 拉取/合并请求描述：(PR description)

[
当用户修改rtc 的时间，并且比当前时间超前，如 2020-11-09 10:10:10 改为：2020-11-09 09:10:10，时间alarm设置，只关心时、分、秒。会造成触发周期基于秒、分、小时的alarm，因为alarm时间晚于rtc时间，无法触发。

每次更新rtc时间，都需要：rt_alarm_update，并更新基于秒、分、小时为周期的alarm。

alarm_set时，基于重新获取的RTC当前时间设置下去，保证alarm中断正常触发。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
