### PR TITLE
fix long call linker error with 'jal', 'j' or conditional branch instruction in .S files for k210

### DIFF
--- a/libcpu/risc-v/common/context_gcc.S
+++ b/libcpu/risc-v/common/context_gcc.S
@@ -47,7 +47,7 @@ rt_hw_context_switch_to:
 
 #ifdef RT_USING_SMP
     mv   a0,   a1
-    jal  rt_cpus_lock_status_restore
+    call  rt_cpus_lock_status_restore
 #endif
     LOAD a0,   2 * REGBYTES(sp)
     csrw mstatus, a0
@@ -123,7 +123,7 @@ save_mpie:
 
 #ifdef RT_USING_SMP
     mv   a0,   a2
-    jal  rt_cpus_lock_status_restore
+    call  rt_cpus_lock_status_restore
 #endif /*RT_USING_SMP*/
 
     j rt_hw_context_switch_exit

--- a/libcpu/risc-v/k210/interrupt_gcc.S
+++ b/libcpu/risc-v/k210/interrupt_gcc.S
@@ -82,7 +82,7 @@ trap_entry:
     mv  sp, s0
     mv  a0, s0
     call rt_scheduler_do_irq_switch
-    j   rt_hw_context_switch_exit
+    tail   rt_hw_context_switch_exit
 
 #else
 
@@ -106,4 +106,4 @@ trap_entry:
 #endif
 
 spurious_interrupt:
-    j rt_hw_context_switch_exit
+    tail rt_hw_context_switch_exit

--- a/libcpu/risc-v/k210/startup_gcc.S
+++ b/libcpu/risc-v/k210/startup_gcc.S
@@ -116,18 +116,21 @@ _start:
 
   /* other cpu core, jump to cpu entry directly */
   bnez a0, secondary_cpu_entry
-  j primary_cpu_entry
+  tail primary_cpu_entry
 
 secondary_cpu_entry:
 #ifdef RT_USING_SMP
   la a0, secondary_boot_flag
   ld a0, 0(a0)
   li a1, 0xa55a
-  beq a0, a1, secondary_cpu_c_start
+  beq a0, a1, 1f
 #endif
   j secondary_cpu_entry
 
 #ifdef RT_USING_SMP
+1:
+  tail secondary_cpu_c_start
+
 .data
 .global secondary_boot_flag
 .align 3


### PR DESCRIPTION
…ruction

## 拉取/合并请求描述：(PR description)

[
**Target**
k210

**Problem**
As code size increases to a point in development, especially in `BUILD='debug'` mode, the following linker errors may occur:
```
xxx/libcpu/risc-v/k210/startup_gcc.o: in function `.L0 ':
xxx/libcpu/risc-v/k210/startup_gcc.S:125:(.start+0x134): relocation truncated to fit: R_RISCV_JAL against symbol `secondary_cpu_c_start' defined in .text.secondary_cpu_c_start section in xxx/libcpu/risc-v/k210/cpuport_smp.o
xxx/libcpu/risc-v/common/context_gcc.o: in function `.L0 ':
xxx/libcpu/risc-v/common/context_gcc.S:50:(.text+0x12): relocation truncated to fit: R_RISCV_JAL against symbol `rt_cpus_lock_status_restore' defined in .text.rt_cpus_lock_status_restore section in xxx/src/cpu.o
xxx/libcpu/risc-v/k210/interrupt_gcc.o: in function `.L0 ':
xxx/libcpu/risc-v/k210/interrupt_gcc.S:77:(.text.entry+0x7c): relocation truncated to fit: R_RISCV_JAL against symbol `rt_hw_context_switch_exit' defined in .text section in xxx/libcpu/risc-v/common/context_gcc.o
collect2: error: ld returned 1 exit status
scons: *** [rtthread.elf] Error 1
scons: building terminated because of errors.
```

**Why**
In the above .S files there are `jal`, `j` or conditional branch instruction whose target offsets are defined in other files. However, these instructions can only access limited address range. For example, `jal` can only access +/-1MB from the current PC. When code size is large enough, the targets offset of these instructions may be beyond the address range they can access. If so, the above linker errors occur.

**How** 
In .S files, use `call` instead of `jal` to make a returnable call, and `tail` instead of `j` to make a non-returnable call. 

*The PR has been tested and confirmed on Kendryte KD233 board.*
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
