### PR TITLE
[rtc.alarm][fix]fix alarm when update datetime

### DIFF
--- a/components/drivers/rtc/alarm.c
+++ b/components/drivers/rtc/alarm.c
@@ -8,6 +8,7 @@
  * 2012-10-27     heyuanjie87       first version.
  * 2013-05-17     aozima            initial alarm event & mutex in system init.
  * 2020-10-15     zhangsz           add alarm flags hour minute second.
+ * 2020-11-09     zhangsz           fix alarm set when modify rtc time.
  */
 
 #include <rtthread.h>
@@ -102,7 +103,7 @@ static void alarm_wakeup(struct rt_alarm *alarm, struct tm *now)
         {
             alarm->wktime.tm_hour = now->tm_hour;
             alarm->wktime.tm_min = now->tm_min;
-            alarm->wktime.tm_sec = alarm->wktime.tm_sec + 1;
+            alarm->wktime.tm_sec = now->tm_sec + 1;
             if (alarm->wktime.tm_sec > 59)
             {
                 alarm->wktime.tm_sec = 0;
@@ -125,7 +126,7 @@ static void alarm_wakeup(struct rt_alarm *alarm, struct tm *now)
             alarm->wktime.tm_hour = now->tm_hour;
             if (alarm->wktime.tm_sec == now->tm_sec)
             {
-                alarm->wktime.tm_min = alarm->wktime.tm_min + 1;
+                alarm->wktime.tm_min = now->tm_min + 1;
                 if (alarm->wktime.tm_min > 59)
                 {
                     alarm->wktime.tm_min = 0;
@@ -144,7 +145,7 @@ static void alarm_wakeup(struct rt_alarm *alarm, struct tm *now)
             if ((alarm->wktime.tm_min == now->tm_min) &&
                 (alarm->wktime.tm_sec == now->tm_sec))
             {
-                alarm->wktime.tm_hour = alarm->wktime.tm_hour + 1;
+                alarm->wktime.tm_hour = now->tm_hour + 1;
                 if (alarm->wktime.tm_hour > 23)
                 {
                     alarm->wktime.tm_hour = 0;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
使用rtc alarm时，若更新rtc 的日期时间，并且日期的日期超前于当前日期。会造成基于hour、minute、second为周期的闹钟，无法正常触发。

造成这个问题的原因为：
* alarm hour：只关心mm:ss，set alarm时，hour需要采用当前时间的hour，因为hour是alarm不关心的项。
* alarm minute：只关心 ss，set alarm时，hour、minute 需要采用当前时间的hour、minute。此时hour minute 是alarm不关心的项。
* alarm second：只要更新，就需要触发！，set alarm时，hour、minute、second 需要采用当前时间的hour、minute、second。此时second、hour 、minute都 是alarm不关心的项。

但是setalarm，需要设置hh:mm:ss，若因为更新rtc时间，设置的alarm时间：hh:mm:ss比当前的rtc时间超前，则当天可能就不再触发alarm，这样 hour 、minute、second 为周期性的alarm，无法触发。

基于hour、minute、second 周期性的alarm，在设置时，不关心的项，需要同步当前时间项。

apollo3、STM32L4等平台验证通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
