### PR TITLE
Fixed an issue with rt_timer_start being broken and destroying the ti…

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -331,7 +331,6 @@ rt_err_t rt_timer_start(rt_timer_t timer)
     _rt_timer_remove(timer);
     /* change status of timer */
     timer->parent.flag &= ~RT_TIMER_FLAG_ACTIVATED;
-    rt_hw_interrupt_enable(level);
 
     RT_OBJECT_HOOK_CALL(rt_object_take_hook, (&(timer->parent)));
 
@@ -341,9 +340,6 @@ rt_err_t rt_timer_start(rt_timer_t timer)
      */
     RT_ASSERT(timer->init_tick < RT_TICK_MAX / 2);
     timer->timeout_tick = rt_tick_get() + timer->init_tick;
-
-    /* disable interrupt */
-    level = rt_hw_interrupt_disable();
 
 #ifdef RT_USING_TIMER_SOFT
     if (timer->parent.flag & RT_TIMER_FLAG_SOFT_TIMER)


### PR DESCRIPTION
…mer list

修复rt_timer_start被打断，破坏定时器链表的问题

## 拉取/合并请求描述：(PR description)

[
还未在真机测试。
关联的issue：https://github.com/RT-Thread/rt-thread/issues/3800

这样修改之后，造成 Hook 的执行环境变为了 关中断的情况。这在其他的几个地方也存在，不知会不会有风险：
https://github.com/RT-Thread/rt-thread/blob/dfa99ad16546c2b1b03187e634201295606f4246/src/ipc.c#L688
https://github.com/RT-Thread/rt-thread/blob/dfa99ad16546c2b1b03187e634201295606f4246/src/ipc.c#L851
https://github.com/RT-Thread/rt-thread/blob/dfa99ad16546c2b1b03187e634201295606f4246/src/ipc.c#L1104
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
