### PR TITLE
为rt_device_control函数增加spi先写再读功能，该写读操作在同一个CS片选内完成

### DIFF
--- a/components/drivers/include/drivers/spi.h
+++ b/components/drivers/include/drivers/spi.h
@@ -56,6 +56,11 @@ extern "C"{
 #define RT_SPI_BUS_MODE_QSPI        (1<<1)
 
 /**
+ * spi device control commands
+ */
+#define RT_DEVICE_CTRL_SPI_WRITE_THEN_READ 0x10            /* spi write then read */
+
+/**
  * SPI message structure
  */
 struct rt_spi_message
@@ -159,6 +164,14 @@ struct rt_qspi_device
     void (*enter_qspi_mode)(struct rt_qspi_device *device);
 
     void (*exit_qspi_mode)(struct rt_qspi_device *device);
+};
+
+struct rt_spi_ctrl_args
+{
+    const void *send_buf;
+    rt_size_t send_length;
+    void *recv_buf;
+    rt_size_t recv_length;
 };
 
 #define SPI_DEVICE(dev) ((struct rt_spi_device *)(dev))

--- a/components/drivers/spi/spi_dev.c
+++ b/components/drivers/spi/spi_dev.c
@@ -125,12 +125,24 @@ static rt_err_t _spidev_device_control(rt_device_t dev,
                                        int         cmd,
                                        void       *args)
 {
+    struct rt_spi_device *device;
+    struct rt_spi_ctrl_args *args_s;
+
+    device = (struct rt_spi_device *)dev;
+    RT_ASSERT(device != RT_NULL);
+    RT_ASSERT(device->bus != RT_NULL);
+
     switch (cmd)
     {
-    case 0: /* set device */
-        break;
-    case 1: 
-        break;
+    case RT_DEVICE_CTRL_SPI_WRITE_THEN_READ:
+        if(args == RT_NULL)
+        {
+            return -RT_EINVAL;
+        }
+
+        args_s = (struct rt_spi_ctrl_args *)args;
+
+        return rt_spi_send_then_recv(device, args_s->send_buf, args_s->send_length, args_s->recv_buf, args_s->recv_length);
     }
 
     return RT_EOK;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
SPI驱动没有在一个CS片选内完成先写后读的操作，在rt_device_control函数内添加该操作。已在产品板子上进行过测试，工作正常。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [X] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [X] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [X] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [X] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [X] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [X] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
