### PR TITLE
[ioctl] ioctl函数实现设置和获取终端窗口大小功能

### DIFF
--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -24,6 +24,7 @@
  * 2018-12-08     Ernest Chen  add DMA choice
  * 2020-09-14     WillianChan  add a line feed to the carriage return character
  *                             when using interrupt tx
+ * 2020-12-05     Meco Man     add function of getting and setting window's size(TIOCGWINSZ TIOCSWINSZ)
  */
 
 #include <rthw.h>
@@ -1113,6 +1114,28 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
                 rt_hw_interrupt_enable(level);
 
                 *(rt_size_t *)args = recved;
+            }
+            break;
+            
+        case TIOCGWINSZ:
+            {
+                struct winsize* p_winsize;
+                
+                p_winsize = (struct winsize*)args;
+                /* TODO: get windows size from console */
+                p_winsize->ws_col = 80; 
+                p_winsize->ws_row = 24;
+                p_winsize->ws_xpixel = 0;/*unused*/
+                p_winsize->ws_ypixel = 0;/*unused*/
+            }
+            break;
+            
+        case TIOCSWINSZ:
+            {
+                struct winsize* p_winsize;
+                
+                p_winsize = (struct winsize*)args;
+                rt_kprintf("\x1b[8;%d;%dt", p_winsize->ws_col, p_winsize->ws_row);
             }
             break;
 #endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
示例代码：
```c
#include <sys/ioctl.h>
#include <unistd.h>

        struct winsize window;
        window.ws_col = 10;
        window.ws_row = 10;
        ioctl(STDOUT_FILENO, TIOCSWINSZ, &window);
```
已经在正点原子潘多拉板子通过测试, 目前可以确保在移植linux涉及到到获取窗口大小的代码时，可以返回窗口大小数据（目前数据固定为长80宽24，因为我没有找到如何让putty自动返回当前的窗口大小，但是不影响正常使用）；在设置窗口大小时，终端窗口会自动调整至设置的大小。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
