### PR TITLE
add error checks of function rt_event_recv()

### DIFF
--- a/bsp/nrf5x/libraries/templates/nrf52x/applications/ble_nus_app.c
+++ b/bsp/nrf5x/libraries/templates/nrf52x/applications/ble_nus_app.c
@@ -603,7 +603,13 @@ static void _stack_thread(void *parameter)
 
         result = rt_event_recv(stack_event, STACK_EV_DISCON | STACK_EV_DISPATCH | STACK_EV_KEY,
                     RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, next_timeout, &event);
-        RT_ASSERT(result == RT_EOK);
+        if (result == -RT_ETIMEOUT) {
+            LOG_E("wait completed timeout");
+            continue;
+        }else if (result == -RT_ERROR) {
+            LOG_E("event received error");
+            continue;
+        }
 
         if (evt_dispatch_worker() != RT_EOK)
         {

--- a/bsp/nrf5x/libraries/templates/nrf52x/applications/ble_nus_app.c
+++ b/bsp/nrf5x/libraries/templates/nrf52x/applications/ble_nus_app.c
@@ -599,9 +599,11 @@ static void _stack_thread(void *parameter)
     {
         rt_uint32_t event = 0;
         rt_tick_t dispatch_timeout = RT_WAITING_NO;
+        rt_err_t result;
 
-        rt_event_recv(stack_event, STACK_EV_DISCON | STACK_EV_DISPATCH | STACK_EV_KEY,
+        result = rt_event_recv(stack_event, STACK_EV_DISCON | STACK_EV_DISPATCH | STACK_EV_KEY,
                     RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, next_timeout, &event);
+        RT_ASSERT(result == RT_EOK);
 
         if (evt_dispatch_worker() != RT_EOK)
         {

--- a/bsp/nrf5x/libraries/templates/nrf52x/applications/ble_nus_app.c
+++ b/bsp/nrf5x/libraries/templates/nrf52x/applications/ble_nus_app.c
@@ -603,10 +603,13 @@ static void _stack_thread(void *parameter)
 
         result = rt_event_recv(stack_event, STACK_EV_DISCON | STACK_EV_DISPATCH | STACK_EV_KEY,
                     RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, next_timeout, &event);
-        if (result == -RT_ETIMEOUT) {
+        if (result == -RT_ETIMEOUT) 
+        {
             LOG_E("wait completed timeout");
             continue;
-        }else if (result == -RT_ERROR) {
+        }
+        else if (result == -RT_ERROR) 
+        {
             LOG_E("event received error");
             continue;
         }

--- a/components/dfs/filesystems/jffs2/src/gcthread.c
+++ b/components/dfs/filesystems/jffs2/src/gcthread.c
@@ -187,7 +187,7 @@ jffs2_stop_garbage_collect_thread(struct jffs2_sb_info *c)
 {
      struct super_block *sb=OFNI_BS_2SFFJ(c);
      cyg_mtab_entry *mte;
-	   rt_uint32_t  e;
+     rt_uint32_t  e;
      rt_err_t result;
 	 
      //RT_ASSERT(sb->s_gc_thread_handle);
@@ -203,13 +203,16 @@ jffs2_stop_garbage_collect_thread(struct jffs2_sb_info *c)
                    GC_THREAD_FLAG_HAS_EXIT,
                    RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR,
 				   RT_WAITING_FOREVER,  &e);
-     if (result == -RT_ETIMEOUT) {
-            LOG_E("wait completed timeout");
-            return;
-        }else if (result == -RT_ERROR) {
-            LOG_E("event received error");
-            return;
-        }
+     if (result == -RT_ETIMEOUT) 
+     {
+       LOG_E("wait completed timeout");
+       return;
+     }
+     else if (result == -RT_ERROR)
+     {
+       LOG_E("event received error");
+       return;
+     }
 
      // Kill and free the resources ...  this is safe due to the flag
      // from the thread.
@@ -236,10 +239,13 @@ jffs2_garbage_collect_thread(unsigned long data)
                         RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR,
 				        cyg_current_time() + CYGNUM_JFFS2_GS_THREAD_TICKS,  
 						&flag);
-          if (result == -RT_ETIMEOUT) {
+          if (result == -RT_ETIMEOUT) 
+          {
             LOG_E("wait completed timeout");
             continue;
-          }else if (result == -RT_ERROR) {
+          }
+          else if (result == -RT_ERROR) 
+          {
             LOG_E("event received error");
             continue;
           }

--- a/components/dfs/filesystems/jffs2/src/gcthread.c
+++ b/components/dfs/filesystems/jffs2/src/gcthread.c
@@ -187,7 +187,8 @@ jffs2_stop_garbage_collect_thread(struct jffs2_sb_info *c)
 {
      struct super_block *sb=OFNI_BS_2SFFJ(c);
      cyg_mtab_entry *mte;
-	 rt_uint32_t  e;
+	   rt_uint32_t  e;
+     rt_err_t result;
 	 
      //RT_ASSERT(sb->s_gc_thread_handle);
 
@@ -198,10 +199,11 @@ jffs2_stop_garbage_collect_thread(struct jffs2_sb_info *c)
 
      D1(printk("jffs2_stop_garbage_collect_thread wait\n"));
 	 
-     rt_event_recv(&sb->s_gc_thread_flags,
+     result = rt_event_recv(&sb->s_gc_thread_flags,
                    GC_THREAD_FLAG_HAS_EXIT,
                    RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR,
 				   RT_WAITING_FOREVER,  &e);
+     RT_ASSERT(result == RT_EOK);
 
      // Kill and free the resources ...  this is safe due to the flag
      // from the thread.
@@ -218,15 +220,17 @@ jffs2_garbage_collect_thread(unsigned long data)
      struct super_block *sb=OFNI_BS_2SFFJ(c);
      cyg_mtab_entry *mte;
      rt_uint32_t flag = 0;
+     rt_err_t result;
 	 
      D1(printk("jffs2_garbage_collect_thread START\n"));
 
      while(1) {
-          rt_event_recv(&sb->s_gc_thread_flags,
+          result = rt_event_recv(&sb->s_gc_thread_flags,
                         GC_THREAD_FLAG_TRIG | GC_THREAD_FLAG_STOP,
                         RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR,
 				        cyg_current_time() + CYGNUM_JFFS2_GS_THREAD_TICKS,  
 						&flag);
+          RT_ASSERT(result == RT_EOK);
 
           if (flag & GC_THREAD_FLAG_STOP)
                break;

--- a/components/dfs/filesystems/jffs2/src/gcthread.c
+++ b/components/dfs/filesystems/jffs2/src/gcthread.c
@@ -203,7 +203,13 @@ jffs2_stop_garbage_collect_thread(struct jffs2_sb_info *c)
                    GC_THREAD_FLAG_HAS_EXIT,
                    RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR,
 				   RT_WAITING_FOREVER,  &e);
-     RT_ASSERT(result == RT_EOK);
+     if (result == -RT_ETIMEOUT) {
+            LOG_E("wait completed timeout");
+            return;
+        }else if (result == -RT_ERROR) {
+            LOG_E("event received error");
+            return;
+        }
 
      // Kill and free the resources ...  this is safe due to the flag
      // from the thread.
@@ -230,7 +236,13 @@ jffs2_garbage_collect_thread(unsigned long data)
                         RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR,
 				        cyg_current_time() + CYGNUM_JFFS2_GS_THREAD_TICKS,  
 						&flag);
-          RT_ASSERT(result == RT_EOK);
+          if (result == -RT_ETIMEOUT) {
+            LOG_E("wait completed timeout");
+            continue;
+          }else if (result == -RT_ERROR) {
+            LOG_E("event received error");
+            continue;
+          }
 
           if (flag & GC_THREAD_FLAG_STOP)
                break;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
bsp/nrf5x/libraries/templates/nrf52x/applications/ble_nus_app.c ，
components/dfs/filesystems/jffs2/src/gcthread.c  ：
add error checks of function rt_event_recv()
添加rt_event_recv()函数的错误检查
修复 #4105
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
