### PR TITLE
add error checks of rt_mutex_take()

### DIFF
--- a/bsp/CME_M7/drivers/emac.c
+++ b/bsp/CME_M7/drivers/emac.c
@@ -312,8 +312,19 @@ struct pbuf *rt_cme_eth_rx(rt_device_t dev)
     ETH_RX_DESC *desc;
     uint32_t framelength;
     struct rt_cme_eth * cme_eth = (struct rt_cme_eth *)dev;
+    rt_err_t result;
 
-    rt_mutex_take(&cme_eth->lock, RT_WAITING_FOREVER);
+    result = rt_mutex_take(&cme_eth->lock, RT_WAITING_FOREVER);
+    if (result == -RT_ETIMEOUT)
+    {
+        rt_kprintf("Take mutex time out.\n");
+        goto _exit;
+    }
+    else if (result == -RT_ERROR)
+    {
+        rt_kprintf("Take mutex error.\n");
+        goto _exit;
+    }
 
     desc = ETH_AcquireFreeRxDesc();
     if(desc == RT_NULL)

--- a/bsp/fh8620/drivers/i2c.c
+++ b/bsp/fh8620/drivers/i2c.c
@@ -87,7 +87,10 @@ static rt_size_t fh_i2c_xfer(struct rt_i2c_bus_device *dev,
 
     rt_completion_init(&i2c_drv->transfer_completion);
 
-	ret = rt_mutex_take(i2c_drv->lock, RT_WAITING_FOREVER );
+    ret = rt_mutex_take(i2c_drv->lock, RT_WAITING_FOREVER);
+	if (ret != RT_EOK) {
+		goto done;
+	}
 
 	i2c_drv->msgs = msgs;
 	i2c_drv->msgs_num = num;

--- a/bsp/lpc55sxx/Libraries/drivers/drv_sd.c
+++ b/bsp/lpc55sxx/Libraries/drivers/drv_sd.c
@@ -52,8 +52,19 @@ static rt_size_t rt_mci_read(rt_device_t dev, rt_off_t pos, void *buffer, rt_siz
 {
     rt_uint8_t status = kStatus_Success;
     struct mci_device *mci = (struct mci_device *)dev;
+    int ret;
 
-    rt_mutex_take(&mci->lock, RT_WAITING_FOREVER);
+    ret = rt_mutex_take(&mci->lock, RT_WAITING_FOREVER);
+    if (ret == -RT_ETIMEOUT)
+    {
+        rt_kprintf("Take mutex time out.\n");
+        return ret;
+    }
+    else if (ret == -RT_ERROR)
+    {
+        rt_kprintf("Take mutex error.\n");
+        return ret;
+    }
 
     {
         /* non-aligned. */
@@ -66,7 +77,7 @@ static rt_size_t rt_mci_read(rt_device_t dev, rt_off_t pos, void *buffer, rt_siz
 
         for(i=0; i<size; i++)
         {
-            status=SD_ReadBlocks(&mci->card, sdio_buffer, sector_adr, 1);
+            status = SD_ReadBlocks(&mci->card, sdio_buffer, sector_adr, 1);
 
             memcpy(copy_buffer, sdio_buffer, mci->card.blockSize);
             sector_adr ++;
@@ -85,8 +96,19 @@ static rt_size_t rt_mci_write(rt_device_t dev, rt_off_t pos, const void *buffer,
 {
     rt_uint8_t status = kStatus_Success;
     struct mci_device *mci = (struct mci_device *)dev;
+    int ret;
 
-    rt_mutex_take(&mci->lock, RT_WAITING_FOREVER);
+    ret = rt_mutex_take(&mci->lock, RT_WAITING_FOREVER);
+    if (ret == -RT_ETIMEOUT)
+    {
+        rt_kprintf("Take mutex time out.\n");
+        return ret;
+    }
+    else if (ret == -RT_ERROR)
+    {
+        rt_kprintf("Take mutex error.\n");
+        return ret;
+    }
 
     {
         /* non-aligned. */

--- a/bsp/simulator/drivers/sst25vfxx_mtd_sim.c
+++ b/bsp/simulator/drivers/sst25vfxx_mtd_sim.c
@@ -58,7 +58,17 @@ static int sst25vfxx_read(struct rt_mtd_nor_device *device, rt_off_t position, r
     sst25 = SST25_MTD(device);
     RT_ASSERT(sst25 != RT_NULL);
 
-    rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    result = rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    if (result == -RT_ETIMEOUT)
+    {
+        rt_kprintf("Take mutex time out.\n");
+        return result;
+    }
+    else if (result == -RT_ERROR)
+    {
+        rt_kprintf("Take mutex error.\n");
+        return result;
+    }
 
     fseek(sst25->file, position, SEEK_SET);
     result = fread(data, size, 1, sst25->file);
@@ -78,7 +88,17 @@ static int sst25vfxx_write(struct rt_mtd_nor_device *device, rt_off_t position,
     sst25 = SST25_MTD(device);
     RT_ASSERT(sst25 != RT_NULL);
 
-    rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    result = rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    if (result == -RT_ETIMEOUT)
+    {
+        rt_kprintf("Take mutex time out.\n");
+        return result;
+    }
+    else if (result == -RT_ERROR)
+    {
+        rt_kprintf("Take mutex error.\n");
+        return result;
+    }
 
     fseek(sst25->file, position, SEEK_SET);
     result = fwrite(data, size, 1, sst25->file);
@@ -99,7 +119,17 @@ static rt_err_t sst25vfxx_erase_block(struct rt_mtd_nor_device *device, rt_off_t
 
     RT_ASSERT(sst25 != RT_NULL);
 
-    rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    result = rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    if (result == -RT_ETIMEOUT)
+    {
+        rt_kprintf("Take mutex time out.\n");
+        return -RT_ETIMEOUT;
+    }
+    else if (result == -RT_ERROR)
+    {
+        rt_kprintf("Take mutex error.\n");
+        return -RT_ERROR;
+    }
 
     memset(block_buffer, 0xFF, BLOCK_SIZE);
     fseek(sst25->file, offset, SEEK_SET);

--- a/bsp/swm320-lq100/drivers/drv_nor_flash.c
+++ b/bsp/swm320-lq100/drivers/drv_nor_flash.c
@@ -32,7 +32,18 @@ static rt_size_t swm320_read(struct rt_mtd_nor_device *device,
                              rt_uint8_t *data,
                              rt_size_t size)
 {
-    rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    int ret = rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    if (ret == -RT_ETIMEOUT)
+    {
+        rt_kprintf("Take mutex time out.\n");
+        return ret;
+    }
+    else if (ret == -RT_ERROR)
+    {
+        rt_kprintf("Take mutex error.\n");
+        return ret;
+    }
+
     memcpy(data, ((const void *)(NORFLM_BASE + position)), size);
     rt_mutex_release(&flash_lock);
     return size;
@@ -45,7 +56,18 @@ static rt_size_t swm320_write(struct rt_mtd_nor_device *device,
 {
     rt_size_t i;
     const rt_uint16_t *hwdata = (const rt_uint16_t *)data;
-    rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    int ret = rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    if (ret == -RT_ETIMEOUT)
+    {
+        rt_kprintf("Take mutex time out.\n");
+        return ret;
+    }
+    else if (ret == -RT_ERROR)
+    {
+        rt_kprintf("Take mutex error.\n");
+        return ret;
+    }
+
     for (i = 0; i < size / 2; i++)
     {
         NORFL_Write(position, hwdata[i]);
@@ -59,7 +81,18 @@ static rt_err_t swm320_erase_block(struct rt_mtd_nor_device *device,
                                    rt_off_t offset,
                                    rt_uint32_t length)
 {
-    rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    rt_err_t ret = rt_mutex_take(&flash_lock, RT_WAITING_FOREVER);
+    if (ret == -RT_ETIMEOUT)
+    {
+        rt_kprintf("Take mutex time out.\n");
+        return ret;
+    }
+    else if (ret == -RT_ERROR)
+    {
+        rt_kprintf("Take mutex error.\n");
+        return ret;
+    }
+    
     NORFL_SectorErase(offset);
     rt_mutex_release(&flash_lock);
     return RT_EOK;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
bsp\stm32f20x\Drivers\i2c.c : add error check of rt_mutex_take()
添加rt_mutex_take()函数的返回值ret的错误检查
修复 #4103 中的部分问题
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
