### PR TITLE
add error checks of rt_mutex_create()

### DIFF
--- a/bsp/nuvoton/libraries/m480/rtt_port/drv_fmc.c
+++ b/bsp/nuvoton/libraries/m480/rtt_port/drv_fmc.c
@@ -315,6 +315,11 @@ static int nu_fmc_init(void)
     SYS_LockReg();
 
     g_mutex_fmc = rt_mutex_create("nu_fmc_lock", RT_IPC_FLAG_FIFO);
+    if (g_mutex_fmc == RT_NULL) 
+    {
+        LOG_E("Create mutex for nu_fmc_lock failed!");
+        return -(int)RT_ERROR;
+    }
 
     return (int)RT_EOK;
 }

--- a/bsp/simulator/drivers/sd_sim.c
+++ b/bsp/simulator/drivers/sd_sim.c
@@ -136,6 +136,11 @@ rt_err_t rt_hw_sdcard_init(const char *spi_device_name)
     device = &(sd->parent);
 
     lock = rt_mutex_create("lock", RT_IPC_FLAG_FIFO);
+    if (lock == RT_NULL) 
+    {
+        LOG_E("Create mutex in rt_hw_sdcard_init failed!");
+        return -RT_ERROR;
+    }
 
     /* open sd card file, if not exist, then create it  */
     sd->file = fopen(SDCARD_SIM, "rb+");

--- a/bsp/simulator/drivers/sdl_fb.c
+++ b/bsp/simulator/drivers/sdl_fb.c
@@ -215,6 +215,10 @@ static void sdlfb_hw_init(void)
     rt_device_register(RT_DEVICE(&_device), "sdl", RT_DEVICE_FLAG_RDWR);
 
     sdllock = rt_mutex_create("fb", RT_IPC_FLAG_FIFO);
+    if (sdllock == RT_NULL) 
+    {
+        LOG_E("Create mutex for sdlfb failed!");
+    }
 }
 
 #ifdef _WIN32

--- a/bsp/stm32f20x/Drivers/i2c.c
+++ b/bsp/stm32f20x/Drivers/i2c.c
@@ -572,6 +572,11 @@ void I2C1_INIT()
 	
 		rt_event_init(&i2c_event, "i2c_event", RT_IPC_FLAG_FIFO );
 		i2c_mux = rt_mutex_create("i2c_mux", RT_IPC_FLAG_FIFO );
+		if (i2c_mux == RT_NULL) 
+		{
+			LOG_E("Create mutex for i2c_mux failed!");
+		}
+
 		i2c1_init_flag = 1;
 	}
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
add error checks of rt_mutex_create()
在4个文件中，添加了关于rt_mutex_create()的错误处理
修复 #4102
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
