### PR TITLE
fix scheduler bug in simulator.

### DIFF
--- a/libcpu/sim/win32/cpu_port.c
+++ b/libcpu/sim/win32/cpu_port.c
@@ -27,6 +27,8 @@
 *  The context switch is managed by the threads.So the task stack does not have to be managed directly,
 *  although the stack stack is still used to hold an WinThreadState structure this is the only thing it
 *  will be ever hold.
+*  YieldEvent used to make sure the thread does not execute before asynchronous SuspendThread() operation
+*  actually being performed.
 *  the structure indirectly maps the task handle to a thread handle
 *********************************************************************************************************
 */
@@ -35,6 +37,7 @@ typedef struct
     void            *Param;                     //Thread param
     void            (*Entry)(void *);           //Thread entry
     void            (*Exit)(void);                      //Thread exit
+    HANDLE          YieldEvent;
     HANDLE          ThreadHandle;
     DWORD           ThreadID;
 }win_thread_t;
@@ -171,6 +174,11 @@ rt_uint8_t* rt_hw_stack_init(void *pEntry,void *pParam,rt_uint8_t *pStackAddr,vo
     pWinThread->ThreadHandle = NULL;
     pWinThread->ThreadID = 0;
 
+    pWinThread->YieldEvent = CreateEvent(NULL,
+                                         FALSE,
+                                         FALSE,
+                                         NULL);
+
     /* Create the winthread */
     pWinThread->ThreadHandle = CreateThread(NULL,
                                             0,
@@ -277,6 +285,19 @@ void rt_hw_context_switch(rt_uint32_t from,
     //trigger YIELD exception(cause contex switch)
     TriggerSimulateInterrupt(CPU_INTERRUPT_YIELD);
 
+    // make sure the event is not already signaled
+    WinThread = (win_thread_t *)rt_interrupt_from_thread;
+    ResetEvent(WinThread->YieldEvent);
+
+    /*
+     * enable interrupt in advance so that scheduler can be executed.please note that interrupt
+     * maybe disable twice before.
+     */
+    rt_hw_interrupt_enable(0);
+    rt_hw_interrupt_enable(0);
+
+    // wait to suspend.
+    WaitForSingleObject(WinThread->YieldEvent, INFINITE);
 } /*** rt_hw_context_switch ***/
 
 /*
@@ -578,6 +599,7 @@ void RegisterSimulateInterrupt(rt_uint32_t IntIndex,rt_uint32_t (*IntHandler)(vo
             if ((WinThreadFrom != NULL) && (WinThreadFrom->ThreadHandle != NULL))
             {
                 SuspendThread(WinThreadFrom->ThreadHandle);
+                SetEvent(WinThreadFrom->YieldEvent);
             }
 
             ResumeThread(WinThreadTo->ThreadHandle);

--- a/libcpu/sim/win32/cpu_port.c
+++ b/libcpu/sim/win32/cpu_port.c
@@ -286,7 +286,7 @@ void rt_hw_context_switch(rt_uint32_t from,
     TriggerSimulateInterrupt(CPU_INTERRUPT_YIELD);
 
     // make sure the event is not already signaled
-    WinThread = (win_thread_t *)rt_interrupt_from_thread;
+    win_thread_t *WinThread = (win_thread_t *)rt_interrupt_from_thread;
     ResetEvent(WinThread->YieldEvent);
 
     /*

--- a/libcpu/sim/win32/cpu_port.h
+++ b/libcpu/sim/win32/cpu_port.h
@@ -17,8 +17,8 @@
 *                                             CPU INTERRUPT PRIORITY
 *********************************************************************************************************
 */
-#define CPU_INTERRUPT_YIELD         0x00
-#define CPU_INTERRUPT_TICK          0x01
+#define CPU_INTERRUPT_YIELD         0x01 // should be set to the lowest priority.
+#define CPU_INTERRUPT_TICK          0x00
 
 
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

这份PR解决了simulator中调度器的2个问题：1.线程Yield时没有及时被挂起；2.Yield中断优先级高于Timer中断，导致调度器挂起了非正在运行的线程。我的解决方案是：1.增加一个YieldEvent事件，用于确保异步挂起动作被执行前，线程不会继续执行；2.修改Yield中断的优先级，确保它是当前所有中断里面最低级的。

更详细的描述可以看这两篇帖子：
https://club.rt-thread.org/ask/question/429478.html
https://club.rt-thread.org/ask/question/3899.html

这个版本在vs2019 simulator中通过了测试。

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
