### PR TITLE
[ST32MP1] add modifier __no_init for IAR

### DIFF
--- a/bsp/stm32/stm32mp157a-st-ev1/board/Kconfig
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/Kconfig
@@ -60,13 +60,13 @@ menu "Onboard Peripheral Drivers"
         select RT_USING_SDIO
         select RT_USING_DFS
         select RT_USING_DFS_ELMFAT
-        select BSP_USING_PMIC
         if BSP_USING_SDMMC
-            menuconfig BSP_USING_SD_CARD
+            menuconfig BSP_USING_SDCARD
                 bool "Enable sd card"
+                select BSP_USING_PMIC
                 default n
-                if BSP_USING_SD_CARD
-                    config SD_USING_DFS
+                if BSP_USING_SDCARD
+                    config BSP_USING_SDCARD_FS
                         bool "sd card fatfs"
                         default y
                 endif
@@ -75,7 +75,7 @@ menu "Onboard Peripheral Drivers"
                 bool "Enable eMMC (32 Gbits)"
                 default n
                 if BSP_USING_EMMC
-                    config EMMC_USING_DFS
+                    config BSP_USING_EMMC_FS
                         bool "emmc card fatfs"
                         default y
                 endif
@@ -86,7 +86,7 @@ menu "Onboard Peripheral Drivers"
         select RT_USING_AUDIO
         select BSP_USING_PMIC
         select BSP_USING_SDMMC
-        select BSP_USING_SD_CARD
+        select BSP_USING_SDCARD
         select SD_USING_DFS
         select BSP_USING_I2C
         select BSP_USING_I2C2
@@ -96,6 +96,8 @@ menu "Onboard Peripheral Drivers"
         bool "Enable CAMERA (ov5640)"
         select BSP_USING_MFX
         select BSP_USING_PMIC
+	select BSP_USING_SDMMC
+        select BSP_USING_SDCARD
         select BSP_USING_I2C
         select BSP_USING_I2C2
         default n

--- a/bsp/stm32/stm32mp157a-st-ev1/board/SConscript
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/SConscript
@@ -25,7 +25,7 @@ if GetDepend(['BSP_USING_NAND']):
 if GetDepend(['BSP_USING_GBE']):
     src += Glob('ports/eth/drv_eth.c')
 
-if GetDepend(['BSP_USING_SD_CARD']):
+if GetDepend(['BSP_USING_SDCARD']):
     src += Glob('ports/drv_sdcard.c')
 
 if GetDepend(['BSP_USING_EMMC']):

--- a/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_dfsdm.c
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_dfsdm.c
@@ -18,34 +18,34 @@
 #define LOG_TAG             "drv.dfsdm"
 #include <drv_log.h>
 
-#define          FILTER_FIFO_SIZE         (1024)
+#define FILTER_FIFO_SIZE    (1024)
 #if defined(__CC_ARM) || defined(__CLANG_ARM)
-__attribute__((at(0x2FFC8000)))
+__attribute__((at(0x2FFC8000))) static rt_int32_t FILTER0_FIFO[FILTER_FIFO_SIZE];
 #elif defined ( __GNUC__ )
-__attribute__((at(0x2FFC8000)))
+static rt_int32_t FILTER0_FIFO[FILTER_FIFO_SIZE] __attribute__((section(".Filter0Section")));
 #elif defined(__ICCARM__)
 #pragma location = 0x2FFC8000
+__no_init static rt_int32_t FILTER0_FIFO[FILTER_FIFO_SIZE];
 #endif
-rt_int32_t FILTER0_FIFO[FILTER_FIFO_SIZE];
+
+#if defined(__CC_ARM) || defined(__CLANG_ARM)
+__attribute__((at(0x2FFC9000))) static rt_int32_t FILTER0_FIFO[FILTER_FIFO_SIZE];
+#elif defined ( __GNUC__ )
+static rt_int32_t FILTER0_FIFO[FILTER_FIFO_SIZE] __attribute__((section(".Filter1Section")));
+#elif defined(__ICCARM__)
+#pragma location = 0x2FFC9000
+__no_init static rt_int32_t FILTER1_FIFO[FILTER_FIFO_SIZE];
+#endif
 
 #define PALY_SIZE 2048
 #if defined(__CC_ARM) || defined(__CLANG_ARM)
-__attribute__((at(0x2FFCA000)))
+__attribute__((at(0x2FFCA000))) static rt_int16_t PLAY_BUF[PALY_SIZE];
 #elif defined ( __GNUC__ )
-__attribute__((at(0x2FFCA000)))
+__attribute__((at(0x2FFCA000))) __attribute__((section(".DfsdmSection")));
 #elif defined(__ICCARM__)
 #pragma location = 0x2FFCA000
+ __no_init static rt_int16_t PLAY_BUF[PALY_SIZE];
 #endif
-static rt_int16_t PLAY_BUF[PALY_SIZE];
-    
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
-__attribute__((at(0x2FFC9000)))
-#elif defined ( __GNUC__ )
-__attribute__((at(0x2FFC9000)))
-#elif defined(__ICCARM__)
-#pragma location = 0x2FFC9000
-#endif
-rt_int32_t FILTER1_FIFO[FILTER_FIFO_SIZE];
 
 static volatile rt_uint8_t DmaLeftRecBuffCplt  = 0;
 static volatile rt_uint8_t DmaRightRecBuffCplt = 0;

--- a/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_emmc.c
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_emmc.c
@@ -49,13 +49,14 @@ struct rthw_sdio
 };
 
 #define EMMC_BUFF_SIZE       4096
+#define EMMC_BUFF_ADDR       0x2FFCB000
 #if defined(__CC_ARM) || defined(__CLANG_ARM)
-rt_uint8_t cache_buf[SDIO_BUFF_SIZE] __attribute__((at(0x2FFCB000)));
-#elif defined(__ICCARM__)
-#pragma location = 0x2FFCB000
-rt_uint8_t cache_buf[EMMC_BUFF_SIZE];
+__attribute__((at(EMMC_BUFF_ADDR))) static rt_uint8_t cache_buf[EMMC_BUFF_SIZE];
 #elif defined ( __GNUC__ )
-rt_uint8_t cache_buf[SDIO_BUFF_SIZE] __attribute__((at(0x2FFCB000)));
+static rt_uint8_t cache_buf[EMMC_BUFF_SIZE] __attribute__((section(".eMMCSection")));
+#elif defined(__ICCARM__)
+#pragma location = EMMC_BUFF_ADDR
+__no_init static rt_uint8_t cache_buf[EMMC_BUFF_SIZE];
 #endif
 
 #if defined(EMMC_RX_DUMP) || defined(EMMC_TX_DUMP)
@@ -558,7 +559,7 @@ int rt_hw_sdio_init(void)
 }
 INIT_DEVICE_EXPORT(rt_hw_sdio_init);
 
-#if defined(EMMC_USING_DFS)
+#if defined(BSP_USING_EMMC_FS)
 int mnt_init(void)
 {
     rt_device_t sd = RT_NULL;

--- a/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_ov5640.c
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_ov5640.c
@@ -28,23 +28,22 @@
 #define JPEG_LINE_SIZE  1 * 1024
 
 #if defined(__CC_ARM) || defined(__CLANG_ARM)
-__attribute__((at(0x2FFCC000)))
+__attribute__((at(0x2FFCC000))) static rt_int32_t JPEG_DATA_BUF[JPEG_BUF_SIZE];
 #elif defined(__GNUC__)
-__attribute__((at(0x2FFCC000)))
+static rt_int32_t JPEG_DATA_BUF[JPEG_BUF_SIZE] __attribute__((section(".Dcmi0Section")));
 #elif defined(__ICCARM__)
 #pragma location = 0x2FFCC000
+__no_init static rt_int32_t JPEG_DATA_BUF[JPEG_BUF_SIZE];
 #endif
-static rt_int32_t JPEG_DATA_BUF[JPEG_BUF_SIZE];
 
 #if defined(__CC_ARM) || defined(__CLANG_ARM)
-__attribute__((at(0x2FFDC000)))
+__attribute__((at(0x2FFDC000))) static rt_int32_t JPEG_LINE_BUF[2][JPEG_LINE_SIZE];
 #elif defined(__GNUC__)
-__attribute__((at(0x2FFDC000)))             
+static rt_int32_t JPEG_LINE_BUF[2][JPEG_LINE_SIZE]  __attribute__((section(".Dcmi1Section")));            
 #elif defined(__ICCARM__)
 #pragma location = 0x2FFDC000
+__no_init static rt_int32_t JPEG_LINE_BUF[2][JPEG_LINE_SIZE]; 
 #endif
-static rt_int32_t JPEG_LINE_BUF[2][JPEG_LINE_SIZE]; 
-
 
 volatile rt_uint32_t jpeg_data_len = 0;
 volatile rt_uint8_t  jpeg_data_ok  = 0;

--- a/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_sdcard.c
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_sdcard.c
@@ -10,7 +10,7 @@
 
 #include "board.h"
 
-#if defined(BSP_USING_SD_CARD)
+#if defined(BSP_USING_SDCARD)
 #include <dfs_fs.h>
 
 #define DRV_DEBUG
@@ -41,14 +41,15 @@ struct rt_completion rx_comp;
 
 /* SYSRAM SDMMC1/2 accesses */
 #define SDIO_BUFF_SIZE       512
+#define SDCARD_ADDR          0x2FFC0000
 #if defined(__CC_ARM) || defined(__CLANG_ARM)
-__attribute__((at(0x2FFC0000)))
+__attribute__((at(SDCARD_ADDR))) static rt_uint32_t cache_buf[SDIO_BUFF_SIZE];
 #elif defined ( __GNUC__ )
-__attribute__((at(0x2FFC0000)))
+static rt_uint32_t cache_buf[SDIO_BUFF_SIZE] __attribute__((section(".SdCardSection")));
 #elif defined(__ICCARM__)
-#pragma location = 0x2FFC0000
+#pragma location = SDCARD_ADDR 
+__no_init static rt_uint32_t cache_buf[SDIO_BUFF_SIZE];
 #endif
-static rt_uint32_t cache_buf[SDIO_BUFF_SIZE];
 
 #if defined(SDMMC_RX_DUMP) || defined(SDMMC_TX_DUMP)
 #define __is_print(ch) ((unsigned int)((ch) - ' ') < 127u - ' ')
@@ -378,7 +379,7 @@ int rt_hw_sdcard_init(void)
 }
 INIT_DEVICE_EXPORT(rt_hw_sdcard_init);
 
-#if defined(SD_USING_DFS)
+#if defined(BSP_USING_SDCARD_FS)
 int mnt_init(void)
 {
     rt_device_t sd_dev = RT_NULL;

--- a/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_sound.c
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_sound.c
@@ -23,13 +23,13 @@
 
 #define TX_FIFO_SIZE         (4096)
 #if defined(__CC_ARM) || defined(__CLANG_ARM)
-__attribute__((at(0x2FFC2000)))
+__attribute__((at(0x2FFC2000))) static rt_uint8_t AUDIO_TX_FIFO[TX_FIFO_SIZE];
 #elif defined ( __GNUC__ )
-__attribute__((at(0x2FFC2000)))
+static rt_uint8_t AUDIO_TX_FIFO[TX_FIFO_SIZE] __attribute__((section(".AudioSection")));
 #elif defined(__ICCARM__)
 #pragma location = 0x2FFC2000
+__no_init static rt_uint8_t AUDIO_TX_FIFO[TX_FIFO_SIZE];
 #endif
-static rt_uint8_t AUDIO_TX_FIFO[TX_FIFO_SIZE];
 
 struct sound_device
 {
@@ -348,7 +348,7 @@ static rt_err_t sound_start(struct rt_audio_device *audio, int stream)
     
     RT_ASSERT(audio != RT_NULL);
     snd_dev = (struct sound_device *)audio->parent.user_data;
-
+    
     if (stream == AUDIO_STREAM_REPLAY)
     {
         LOG_D("open sound device");
@@ -367,15 +367,11 @@ static rt_err_t sound_start(struct rt_audio_device *audio, int stream)
 
 static rt_err_t sound_stop(struct rt_audio_device *audio, int stream)
 {
-    struct sound_device *device;
     RT_ASSERT(audio != RT_NULL);
-    device = (struct sound_device *)audio->parent.user_data;
     
     if (stream == AUDIO_STREAM_REPLAY)
     {
         HAL_SAI_DMAStop(&hsai_BlockA2);
-        
-        rt_device_close(device->decoder);
 
         LOG_D("close sound device");
     }

--- a/bsp/stm32/stm32mp157a-st-ev1/board/ports/eth/drv_eth.c
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/ports/eth/drv_eth.c
@@ -33,22 +33,22 @@ rt_base_t level;
 #if defined(__ICCARM__)
 /* transmit buffer */
 #pragma location = TX_ADD_BASE
-static uint8_t txBuffer[ETH_TXBUFNB][ETH_TX_BUF_SIZE];
+__no_init static rt_uint8_t txBuffer[ETH_TXBUFNB][ETH_TX_BUF_SIZE];
 /* Receive buffer */
 #pragma location = RX_ADD_BASE
-static uint8_t rxBuffer[ETH_RXBUFNB][ETH_RX_BUF_SIZE];
+__no_init static rt_uint8_t rxBuffer[ETH_RXBUFNB][ETH_RX_BUF_SIZE];
 /* Transmit DMA descriptors */
 #pragma location = TX_DMA_ADD_BASE
-static TxDmaDesc txDmaDesc[ETH_TXBUFNB];
+__no_init static TxDmaDesc txDmaDesc[ETH_TXBUFNB];
 /* Receive DMA descriptors */
 #pragma location = RX_DMA_ADD_BASE
-static RxDmaDesc rxDmaDesc[ETH_RXBUFNB];
+__no_init static RxDmaDesc rxDmaDesc[ETH_RXBUFNB];
 
 #elif defined(__CC_ARM) || defined(__CLANG_ARM)
 /* transmit buffer */
-static uint8_t txBuffer[ETH_TXBUFNB][ETH_TX_BUF_SIZE] __attribute__((at(TX_ADD_BASE)));
+static rt_uint8_t txBuffer[ETH_TXBUFNB][ETH_TX_BUF_SIZE] __attribute__((at(TX_ADD_BASE)));
 /* Receive buffer */
-static uint8_t rxBuffer[ETH_RXBUFNB][ETH_RX_BUF_SIZE] __attribute__((at(RX_ADD_BASE)));
+static rt_uint8_t rxBuffer[ETH_RXBUFNB][ETH_RX_BUF_SIZE] __attribute__((at(RX_ADD_BASE)));
 /* Transmit DMA descriptors */
 static TxDmaDesc txDmaDesc[ETH_TXBUFNB] __attribute__((at(TX_DMA_ADD_BASE)));
 /* Receive DMA descriptors */
@@ -56,13 +56,13 @@ static RxDmaDesc rxDmaDesc[ETH_RXBUFNB] __attribute__((at(RX_DMA_ADD_BASE)));
 
 #elif defined ( __GNUC__ )
 /* transmit buffer */
-static uint8_t txBuffer[ETH_TXBUFNB][ETH_TX_BUF_SIZE] __attribute__((at(TX_ADD_BASE)));
+static rt_uint8_t txBuffer[ETH_TXBUFNB][ETH_TX_BUF_SIZE] __attribute__((section(".TxArraySection")));
 /* Receive buffer */
-static uint8_t rxBuffer[ETH_RXBUFNB][ETH_RX_BUF_SIZE] __attribute__((at(RX_ADD_BASE)));
+static rt_uint8_t rxBuffer[ETH_RXBUFNB][ETH_RX_BUF_SIZE] __attribute__((section(".RxArraySection")));
 /* Transmit DMA descriptors */
-static TxDmaDesc txDmaDesc[ETH_TXBUFNB] __attribute__((at(TX_DMA_ADD_BASE)));
+static TxDmaDesc txDmaDesc[ETH_TXBUFNB] __attribute__((section(".TxDecripSection")));
 /* Receive DMA descriptors */
-static RxDmaDesc rxDmaDesc[ETH_RXBUFNB] __attribute__((at(RX_DMA_ADD_BASE)));
+static RxDmaDesc rxDmaDesc[ETH_RXBUFNB] __attribute__((section(".RxDecripSection")));
 #endif
 
 //Current transmit descriptor


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
 to avoid  the not be enabled ram be init by function `__iar_data_init3()` ;
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
