### PR TITLE
cleanup操作改由当前线程退出前执行

### DIFF
--- a/src/idle.c
+++ b/src/idle.c
@@ -150,82 +150,37 @@ void rt_thread_idle_excute(void)
 {
     /* Loop until there is no dead thread. So one call to rt_thread_idle_excute
      * will do all the cleanups. */
-    while (_has_defunct_thread())
+    /* disable interrupt */
+
+    RT_DEBUG_NOT_IN_INTERRUPT;
+
+#ifdef RT_USING_HEAP
+    while (1)
     {
         rt_base_t lock;
         rt_thread_t thread;
-#ifdef RT_USING_MODULE
-        struct rt_dlmodule *module = RT_NULL;
-#endif
-        RT_DEBUG_NOT_IN_INTERRUPT;
 
-        /* disable interrupt */
         lock = rt_hw_interrupt_disable();
 
-        /* re-check whether list is empty */
-        if (_has_defunct_thread())
+        /* check whether list is empty */
+        if (!_has_defunct_thread())
         {
-            /* get defunct thread */
-            thread = rt_list_entry(rt_thread_defunct.next,
-                                   struct rt_thread,
-                                   tlist);
-#ifdef RT_USING_MODULE
-            module = (struct rt_dlmodule*)thread->module_id;
-            if (module)
-            {
-                dlmodule_destroy(module);
-            }
-#endif
-            /* remove defunct thread */
-            rt_list_remove(&(thread->tlist));
-
-            /* lock scheduler to prevent scheduling in cleanup function. */
-            rt_enter_critical();
-
-            /* invoke thread cleanup */
-            if (thread->cleanup != RT_NULL)
-                thread->cleanup(thread);
-
-#ifdef RT_USING_SIGNALS
-            rt_thread_free_sig(thread);
-#endif
-
-            /* if it's a system object, not delete it */
-            if (rt_object_is_systemobject((rt_object_t)thread) == RT_TRUE)
-            {
-                /* detach this object */
-                rt_object_detach((rt_object_t)thread);
-                /* unlock scheduler */
-                rt_exit_critical();
-
-                /* enable interrupt */
-                rt_hw_interrupt_enable(lock);
-
-                return;
-            }
-
-            /* unlock scheduler */
-            rt_exit_critical();
-        }
-        else
-        {
-            /* enable interrupt */
             rt_hw_interrupt_enable(lock);
-
-            /* may the defunct thread list is removed by others, just return */
-            return;
+            break;
         }
-
-        /* enable interrupt */
-        rt_hw_interrupt_enable(lock);
-
-#ifdef RT_USING_HEAP
+        /* get defunct thread */
+        thread = rt_list_entry(rt_thread_defunct.next,
+                struct rt_thread,
+                tlist);
+        /* remove defunct thread */
+        rt_list_remove(&(thread->tlist));
         /* release thread's stack */
         RT_KERNEL_FREE(thread->stack_addr);
         /* delete thread object */
         rt_object_delete((rt_object_t)thread);
-#endif
+        rt_hw_interrupt_enable(lock);
     }
+#endif
 }
 
 extern void rt_system_power_manager(void);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
原来的cleanup时机是在idle中，这会在多核中造成问题；且由于原来cleanup是在disable了调度器的状态下执行的，会造成在cleanup不能释放内存及和别的线程通讯。
此修改方式是把cleanup的时机移到当前线程的退出函数来完成（注意，此修改并不包括释放当前线程的tcb和stack)
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
