### PR TITLE
[fix] 修复使用lwip 2.1.2作为协议栈，并使能dhcp server选项时，编译报错问题。

### DIFF
--- a/components/net/lwip_dhcpd/SConscript
+++ b/components/net/lwip_dhcpd/SConscript
@@ -2,7 +2,7 @@ from building import *
 
 cwd = GetCurrentDir()
 
-if GetDepend('RT_USING_LWIP202') or GetDepend('RT_USING_LWIP210') :
+if GetDepend('RT_USING_LWIP202') or GetDepend('RT_USING_LWIP212') :
     src = ['dhcp_server_raw.c']
 else:
     src = ['dhcp_server.c']

--- a/components/net/lwip_dhcpd/dhcp_server.c
+++ b/components/net/lwip_dhcpd/dhcp_server.c
@@ -80,6 +80,22 @@
 #define LWIP_DHCP   1
 #include <lwip/dhcp.h>
 
+#ifndef DHCP_CLIENT_PORT
+#define DHCP_CLIENT_PORT  68
+#endif
+
+#ifndef DHCP_SERVER_PORT
+#define DHCP_SERVER_PORT  67
+#endif
+
+#ifndef ETHADDR32_COPY
+#define ETHADDR32_COPY(dst, src)  SMEMCPY(dst, src, ETH_HWADDR_LEN)
+#endif
+
+#ifndef ETHADDR16_COPY
+#define ETHADDR16_COPY(dst, src)  SMEMCPY(dst, src, ETH_HWADDR_LEN)
+#endif
+
 /* buffer size for receive DHCP packet */
 #define BUFSZ               1024
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修复了在使用lwip 2.1.2协议栈时，使能dhcp serve服务后，编译报错的问题（lwip2.1.2没有了相关宏定义）。
在stm32f401-st-nucleo上测试通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
