### PR TITLE
[bsp][stm32]fix stm32_hw_pwm_init

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -326,14 +326,28 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
 #if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32L4)
     tim->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
 #endif
-
     if (HAL_TIM_Base_Init(tim) != HAL_OK)
     {
         LOG_E("%s pwm init failed", device->name);
         result = -RT_ERROR;
         goto __exit;
     }
+    tim->State = HAL_TIM_STATE_RESET;
     if (HAL_TIM_PWM_Init(tim) != HAL_OK)
+    {
+        LOG_E("%s pwm init failed", device->name);
+        result = -RT_ERROR;
+        goto __exit;
+    }
+    tim->State = HAL_TIM_STATE_RESET;
+    if (HAL_TIM_OC_Init(tim) != HAL_OK)
+    {
+        LOG_E("%s pwm init failed", device->name);
+        result = -RT_ERROR;
+        goto __exit;
+    }
+    tim->State = HAL_TIM_STATE_RESET;
+    if (HAL_TIM_IC_Init(tim) != HAL_OK)
     {
         LOG_E("%s pwm init failed", device->name);
         result = -RT_ERROR;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

 **当前代码的问题：** 在 drv_pwm.c  的 stm32_hw_pwm_init() 中，通过以下代码进行初始化

```
    if (HAL_TIM_Base_Init(tim) != HAL_OK)
    {
        LOG_E("%s pwm init failed", device->name);
        result = -RT_ERROR;
        goto __exit;
    }
    if (HAL_TIM_PWM_Init(tim) != HAL_OK)
    {
        LOG_E("%s pwm init failed", device->name);
        result = -RT_ERROR;
        goto __exit;
    }
```

由于 HAL_TIM_Base_Init 与 HAL_TIM_PWM_Init 内部都会设置  htim->State = HAL_TIM_STATE_READY ，使得两个 Init 初始化中只有第一个可以执行，如果碰巧进入了正确的 MspInit 函数，则 PWM 功能可以正常使用，但在大多数情况下都会出现问题。



STM32 Cube 的 Timer Mspinit函数生成有一定规律，以**STM32H743 Timer3** 为例

- 仅使用 PWM 功能时会生成相应的 HAL_TIM_PWM_MspInit 函数，HAL_TIM_Base_MspInit 中则不包含对应Timer的初始化
- 在开启PWM功能的基础上，选择了Clock Source，对应的MSP初始化代码转移入HAL_TIM_Base_MspInit 
- 在开启PWM功能的基础上，开启 Input Capture 功能， 对应的初始仍在HAL_TIM_PWM_MspInit 中
- 在开启PWM，Input Capture功能的基础上，开启 Output Compare 功能, 对应初始化代码转入 HAL_TIM_OC_MspInit
- 选择Clock Source，对应的MSP初始化代码转移入HAL_TIM_Base_MspInit 

**总结** ：**MSP初始化函数生成的优先顺序：Clock Source，Slave Mode, Trigger Source > OC  > PWM > IC > Force output**  

相应的msp初始化函数名如下：

| 开启的功能                               | 函数名               | 备注                         |
| ---------------------------------------- | -------------------- | ---------------------------- |
| Clock Source，Slave Mode, Trigger Source | HAL_TIM_Base_MspInit |                              |
| OC                                       | HAL_TIM_OC_MspInit   |                              |
| PWM                                      | HAL_TIM_PWM_MspInit  |                              |
| IC                                       | HAL_TIM_IC_MspInit   | 并会生成相应的GPIO初始化代码 |
| Force output                             | HAL_TIM_OC_MspInit   |                              |

同时该规律在不同的定时器上有不同的表现：(未经充分验证)

Advanced-control timers：**TIM1/TIM8** 会以上述规则生成 MSP 初始化函数

General-purpose timers： **TIM2/TIM3/TIM4/TIM5** 会以上述规则生成 MSP 初始化函数

Basic timers：**TIM6/TIM7** 只会生成在 HAL_TIM_Base_MspInit 中，且本身并无PWM输出功能

General-purpose timers： **TIM12/TIM15** 会以上述规则生成 MSP 初始化函数

General-purpose timers：**TIM13/TIM14，TIM16/TIM17** 仅会生成于 HAL_TIM_Base_MspInit (可能与CubeMx中无Clock Source选项有关)

**解决方法：**

由于cube mx 的 Timer MspInit 函数中会通过 htim_base->Instance==TIMx 判断初始化哪一个定时器，不会重复初始化。可以通过设置 tim->State = HAL_TIM_STATE_RESET ，使drv_pwm.c  中的 stm32_hw_pwm_init() 初始化时，将上述所有可能产生的初始化函数均运行一遍，找到需要初始化的定时器，部分没有产生的 MspInit函数 由于有 weak定义，不会报错。

**目前已验证的开发板：**

​	NUCLEO-H743ZI2：PWM3_CH3(LED0), PWM12_CH1(LED3)

​	ATK 探索者 stm32f407zgt6：PWM14_CH1(LED0/DS0) 
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
