### PR TITLE
Append RT_WEAK for overriding various ECC layout.

### DIFF
--- a/components/dfs/filesystems/uffs/src/inc/uffs/uffs_flash.h
+++ b/components/dfs/filesystems/uffs/src/inc/uffs/uffs_flash.h
@@ -62,7 +62,7 @@ extern "C"{
 #define UFFS_LAYOUT_UFFS	0	//!< do layout by dev->attr information
 #define UFFS_LAYOUT_FLASH	1	//!< flash driver do the layout
 
-#define UFFS_SPARE_LAYOUT_SIZE	6	//!< maximum spare layout array size, 2 segments
+#define UFFS_SPARE_LAYOUT_SIZE	16	//!< maximum spare layout array size, 2 segments
 
 /** flash operation return code */
 #define UFFS_FLASH_NO_ERR		0		//!< no error

--- a/components/dfs/filesystems/uffs/uffs_nandif.c
+++ b/components/dfs/filesystems/uffs/uffs_nandif.c
@@ -324,7 +324,7 @@ static rt_uint8_t hw_flash_ecc_layout[UFFS_SPARE_LAYOUT_SIZE] =
     0x00, 0x04, 0xFF, 0x00
 };
 
-void uffs_setup_storage(struct uffs_StorageAttrSt *attr,
+RT_WEAK void uffs_setup_storage(struct uffs_StorageAttrSt *attr,
                         struct rt_mtd_nand_device *nand)
 {
     rt_memset(attr, 0, sizeof(struct uffs_StorageAttrSt));


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
For overriding various DATA/ECC/SEAL_BYTE layout on NAND flash.
Tested Winbond QSPI NAND on Nuvoton NUC980 platform.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
