### PR TITLE
[libcpu][cm33] 修复不同优化等级，函数行为不一致的问题

### DIFF
--- a/libcpu/arm/cortex-m33/cpuport.c
+++ b/libcpu/arm/cortex-m33/cpuport.c
@@ -473,16 +473,12 @@ exit
 #elif defined(__CLANG_ARM)
 int __rt_ffs(int value)
 {
-    __asm volatile(
-        "CMP     r0, #0x00            \n"
-        "BEQ     1f                   \n"
+    if (value == 0) return value;
 
+    __asm volatile(
         "RBIT    r0, r0               \n"
         "CLZ     r0, r0               \n"
         "ADDS    r0, r0, #0x01        \n"
-
-        "1:                           \n"
-        "BX      lr                   \n"
 
         : "=r"(value)
         : "r"(value)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
O0 优化与 O2 优化函数行为有偏差。导致不同优化等级，调用该函数会宕机

调整实现方式，确保不同优化等级下，函数行为移植。

验证不同优化等级下，编译出的汇编代码行为是否一致。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
