### PR TITLE
[libc][stm32-driver RTC] 修复RTC驱动以及libc time.c库若干问题

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
@@ -6,10 +6,12 @@
  * Change Logs:
  * Date         Author        Notes
  * 2018-12-04   balanceTWK    first version
- * 2020-10-14     Dozingfiretruck   Porting for stm32wbxx
+ * 2020-10-14   Dozingfiretruck Porting for stm32wbxx
+ * 2021-02-05   Meco Man      fix the problem of mixing local time and UTC time
  */
 
 #include "board.h"
+#include <sys/time.h>
 
 #ifdef BSP_USING_ONCHIP_RTC
 
@@ -54,7 +56,7 @@ static time_t get_rtc_timestamp(void)
     tm_new.tm_year = RTC_DateStruct.Year + 100;
 
     LOG_D("get rtc time.");
-    return mktime(&tm_new);
+    return timegm(&tm_new);
 }
 
 static rt_err_t set_rtc_time_stamp(time_t time_stamp)
@@ -63,7 +65,7 @@ static rt_err_t set_rtc_time_stamp(time_t time_stamp)
     RTC_DateTypeDef RTC_DateStruct = {0};
     struct tm *p_tm;
 
-    p_tm = localtime(&time_stamp);
+    p_tm = gmtime(&time_stamp);
     if (p_tm->tm_year < 100)
     {
         return -RT_ERROR;

--- a/components/drivers/rtc/rtc.c
+++ b/components/drivers/rtc/rtc.c
@@ -64,7 +64,7 @@ rt_err_t set_date(rt_uint32_t year, rt_uint32_t month, rt_uint32_t day)
     tm_new.tm_mon  = month - 1; /* tm_mon: 0~11 */
     tm_new.tm_mday = day;
 
-    /* converts the UTC time into the calendar time. */
+    /* converts the local time into the calendar time. */
     now = mktime(&tm_new);
 
     device = rt_device_find("rtc");

--- a/components/drivers/rtc/rtc.c
+++ b/components/drivers/rtc/rtc.c
@@ -11,7 +11,7 @@
  * 2018-02-16     armink       add auto sync time by NTP
  */
 
-#include <time.h>
+#include <sys/time.h>
 #include <string.h>
 #include <rtthread.h>
 
@@ -30,7 +30,7 @@
 #endif /* RTC_SYNC_USING_NTP */
 
 /**
- * Set system date(time not modify).
+ * Set system date(time not modify, local timezone).
  *
  * @param rt_uint32_t year  e.g: 2012.
  * @param rt_uint32_t month e.g: 12 (1~12).
@@ -52,10 +52,10 @@ rt_err_t set_date(rt_uint32_t year, rt_uint32_t month, rt_uint32_t day)
 
     /* lock scheduler. */
     rt_enter_critical();
-    /* converts calendar time time into local time. */
+    /* converts calendar time into local time. */
     p_tm = localtime(&now);
     /* copy the statically located variable */
-    memcpy(&tm_new, p_tm, sizeof(struct tm));
+    rt_memcpy(&tm_new, p_tm, sizeof(struct tm));
     /* unlock scheduler. */
     rt_exit_critical();
 
@@ -64,7 +64,7 @@ rt_err_t set_date(rt_uint32_t year, rt_uint32_t month, rt_uint32_t day)
     tm_new.tm_mon  = month - 1; /* tm_mon: 0~11 */
     tm_new.tm_mday = day;
 
-    /* converts the local time in time to calendar time. */
+    /* converts the UTC time into the calendar time. */
     now = mktime(&tm_new);
 
     device = rt_device_find("rtc");
@@ -80,7 +80,7 @@ rt_err_t set_date(rt_uint32_t year, rt_uint32_t month, rt_uint32_t day)
 }
 
 /**
- * Set system time(date not modify).
+ * Set system time(date not modify, local timezone).
  *
  * @param rt_uint32_t hour   e.g: 0~23.
  * @param rt_uint32_t minute e.g: 0~59.
@@ -102,10 +102,10 @@ rt_err_t set_time(rt_uint32_t hour, rt_uint32_t minute, rt_uint32_t second)
 
     /* lock scheduler. */
     rt_enter_critical();
-    /* converts calendar time time into local time. */
+    /* converts calendar time into local time. */
     p_tm = localtime(&now);
     /* copy the statically located variable */
-    memcpy(&tm_new, p_tm, sizeof(struct tm));
+    rt_memcpy(&tm_new, p_tm, sizeof(struct tm));
     /* unlock scheduler. */
     rt_exit_critical();
 
@@ -114,7 +114,7 @@ rt_err_t set_time(rt_uint32_t hour, rt_uint32_t minute, rt_uint32_t second)
     tm_new.tm_min  = minute;
     tm_new.tm_sec  = second;
 
-    /* converts the local time in time to calendar time. */
+    /* converts the local time into the calendar time. */
     now = mktime(&tm_new);
 
     device = rt_device_find("rtc");
@@ -174,6 +174,9 @@ INIT_COMPONENT_EXPORT(rt_rtc_ntp_sync_init);
 #include <finsh.h>
 #include <rtdevice.h>
 
+/**
+ * show date and time (local timezone)
+ */
 void list_date(void)
 {
     time_t now;
@@ -181,12 +184,15 @@ void list_date(void)
     now = time(RT_NULL);
     rt_kprintf("%.*s\n", 25, ctime(&now));
 }
-FINSH_FUNCTION_EXPORT(list_date, show date and time.)
+FINSH_FUNCTION_EXPORT(list_date, show date and time (local timezone))
+FINSH_FUNCTION_EXPORT(set_date, set date(local timezone) e.g: set_date(2010,2,28))
+FINSH_FUNCTION_EXPORT(set_time, set time(local timezone) e.g: set_time(23,59,59))
 
-FINSH_FUNCTION_EXPORT(set_date, set date. e.g: set_date(2010,2,28))
-FINSH_FUNCTION_EXPORT(set_time, set time. e.g: set_time(23,59,59))
 
 #if defined(RT_USING_FINSH) && defined(FINSH_USING_MSH)
+/**
+ * get date and time or set (local timezone) [year month day hour min sec]
+ */
 static void date(uint8_t argc, char **argv)
 {
     if (argc == 1)
@@ -246,9 +252,9 @@ static void date(uint8_t argc, char **argv)
         rt_kprintf("e.g: date 2018 01 01 23 59 59 or date\n");
     }
 }
-MSH_CMD_EXPORT(date, get date and time or set [year month day hour min sec]);
+MSH_CMD_EXPORT(list_date, show date and time (local timezone))
+MSH_CMD_EXPORT(date, get date and time or set (local timezone) [year month day hour min sec])
+
 #endif /* defined(RT_USING_FINSH) && defined(FINSH_USING_MSH) */
-
 #endif /* RT_USING_FINSH */
-
 #endif /* RT_USING_RTC */

--- a/components/libc/compilers/common/sys/time.h
+++ b/components/libc/compilers/common/sys/time.h
@@ -48,8 +48,8 @@ struct timezone {
   int tz_dsttime;       /* type of dst correction */
 };
 
-int gettimeofday(struct timeval *tp, void *ignore);
-struct tm *gmtime_r(const time_t *timep, struct tm *r);
+int gettimeofday(struct timeval *tp, struct timezone *tz);
+time_t timegm(struct tm * const t);
 
 #ifdef __cplusplus
 }

--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -7,12 +7,20 @@
  * Date           Author       Notes
  * 2019-08-21     zhangjun     copy from minilibc
  * 2020-09-07     Meco Man     combine gcc armcc iccarm
+ * 2021-02-05     Meco Man     add timegm()
  */
 
 #include <sys/time.h>
 #include <rtthread.h>
+#ifdef RT_USING_DEVICE
+#include <rtdevice.h>
+#endif
+
 
 #if !defined (__IAR_SYSTEMS_ICC__)
+
+/* seconds per day */
+#define SPD 24*60*60
 
 /* days per month -- nonleap! */
 const short __spm[13] =
@@ -34,15 +42,18 @@ const short __spm[13] =
 static const char days[] = "Sun Mon Tue Wed Thu Fri Sat ";
 static const char months[] = "Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec ";
 
-/* seconds per day */
-#define SPD 24*60*60
-
-int __isleap(int year)
+static int __isleap(int year)
 {
     /* every fourth year is a leap year except for century years that are
      * not divisible by 400. */
     /*  return (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)); */
     return (!(year % 4) && ((year % 100) || !(year % 400)));
+}
+
+static void num2str(char *c, int i)
+{
+    c[0] = i / 10 + '0';
+    c[1] = i % 10 + '0';
 }
 
 struct tm *gmtime_r(const time_t *timep, struct tm *r)
@@ -87,10 +98,15 @@ struct tm* gmtime(const time_t* t)
     return gmtime_r(t, &tmp);
 }
 
-/*TODO timezone is not supprt now */
+/*TODO: timezone */
 struct tm* localtime_r(const time_t* t, struct tm* r)
 {
-    return gmtime_r(t, r);
+    time_t local_tz;
+    int timezone;
+
+    timezone = 0 * 3600 * 8; /* GTM: UTC+0 */
+    local_tz = *t + timezone;
+    return gmtime_r(&local_tz, r);
 }
 
 struct tm* localtime(const time_t* t)
@@ -99,7 +115,124 @@ struct tm* localtime(const time_t* t)
     return localtime_r(t, &tmp);
 }
 
+/* TODO: timezone */
 time_t mktime(struct tm * const t)
+{
+    return timegm(t);
+}
+
+char* asctime_r(const struct tm *t, char *buf)
+{
+    /* "Wed Jun 30 21:49:08 1993\n" */
+    *(int*) buf = *(int*) (days + (t->tm_wday << 2));
+    *(int*) (buf + 4) = *(int*) (months + (t->tm_mon << 2));
+    num2str(buf + 8, t->tm_mday);
+    if (buf[8] == '0')
+        buf[8] = ' ';
+    buf[10] = ' ';
+    num2str(buf + 11, t->tm_hour);
+    buf[13] = ':';
+    num2str(buf + 14, t->tm_min);
+    buf[16] = ':';
+    num2str(buf + 17, t->tm_sec);
+    buf[19] = ' ';
+    num2str(buf + 20, (t->tm_year + 1900) / 100);
+    num2str(buf + 22, (t->tm_year + 1900) % 100);
+    buf[24] = '\n';
+    return buf;
+}
+
+char* asctime(const struct tm *timeptr)
+{
+    static char buf[25];
+    return asctime_r(timeptr, buf);
+}
+
+char* ctime(const time_t *timep)
+{
+    return asctime(localtime(timep));
+}
+
+#endif /* __IAR_SYSTEMS_ICC__ */
+
+/**
+ * Returns the current time.
+ *
+ * @param time_t * t the timestamp pointer, if not used, keep NULL.
+ *
+ * @return time_t return timestamp current.
+ *
+ */
+#if defined (__IAR_SYSTEMS_ICC__) &&  (__VER__) >= 6020000 /* for IAR 6.2 later Compiler */
+#pragma module_name = "?time"
+#if _DLIB_TIME_USES_64
+time_t __time64(time_t *t) 
+#else
+time_t __time32(time_t *t) 
+#endif
+#else /* Keil & GCC */
+time_t time(time_t *t)
+#endif
+{
+    time_t time_now = 0;
+
+#ifdef RT_USING_RTC
+    static rt_device_t device = RT_NULL;
+
+    /* optimization: find rtc device only first. */
+    if (device == RT_NULL)
+    {
+        device = rt_device_find("rtc");
+    }
+
+    /* read timestamp from RTC device. */
+    if (device != RT_NULL)
+    {
+        if (rt_device_open(device, 0) == RT_EOK)
+        {
+            rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIME, &time_now);
+            rt_device_close(device);
+        }
+    }
+#endif /* RT_USING_RTC */
+
+    /* if t is not NULL, write timestamp to *t */
+    if (t != RT_NULL)
+    {
+        *t = time_now;
+    }
+
+    return time_now;
+}
+
+RT_WEAK clock_t clock(void)
+{
+    return rt_tick_get();
+}
+
+/* TODO: timezone */
+int gettimeofday(struct timeval *tp, struct timezone *tz)
+{
+    time_t time = 0;
+#ifdef RT_USING_DEVICE
+    rt_device_t device;
+    device = rt_device_find("rtc");
+    RT_ASSERT(device != RT_NULL);
+    rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIME, &time);
+    if (tp != RT_NULL)
+    {
+        tp->tv_sec = time;
+        tp->tv_usec = 0;
+    }
+#else
+    tv->tv_sec = 0;
+    tv->tv_usec = 0;
+#endif
+
+    return time;
+}
+
+time_t timegm(struct tm * const t)
 {
     register time_t day;
     register time_t i;
@@ -171,122 +304,4 @@ time_t mktime(struct tm * const t)
     day *= i;
     i = 60;
     return ((day + t->tm_hour) * i + t->tm_min) * i + t->tm_sec;
-}
-
-static void num2str(char *c, int i)
-{
-    c[0] = i / 10 + '0';
-    c[1] = i % 10 + '0';
-}
-
-char* asctime_r(const struct tm *t, char *buf)
-{
-    /* "Wed Jun 30 21:49:08 1993\n" */
-    *(int*) buf = *(int*) (days + (t->tm_wday << 2));
-    *(int*) (buf + 4) = *(int*) (months + (t->tm_mon << 2));
-    num2str(buf + 8, t->tm_mday);
-    if (buf[8] == '0')
-        buf[8] = ' ';
-    buf[10] = ' ';
-    num2str(buf + 11, t->tm_hour);
-    buf[13] = ':';
-    num2str(buf + 14, t->tm_min);
-    buf[16] = ':';
-    num2str(buf + 17, t->tm_sec);
-    buf[19] = ' ';
-    num2str(buf + 20, (t->tm_year + 1900) / 100);
-    num2str(buf + 22, (t->tm_year + 1900) % 100);
-    buf[24] = '\n';
-    return buf;
-}
-
-char* asctime(const struct tm *timeptr)
-{
-    static char buf[25];
-    return asctime_r(timeptr, buf);
-}
-
-char* ctime(const time_t *timep)
-{
-    return asctime(localtime(timep));
-}
-
-#endif /* __IAR_SYSTEMS_ICC__ */
-
-int gettimeofday(struct timeval *tp, void *ignore)
-{
-    time_t time = 0;
-#ifdef RT_USING_DEVICE
-    rt_device_t device;
-    device = rt_device_find("rtc");
-    RT_ASSERT(device != RT_NULL);
-    rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIME, &time);
-    if (tp != RT_NULL)
-    {
-        tp->tv_sec = time;
-        tp->tv_usec = 0;
-    }
-#else
-    tv->tv_sec = 0;
-    tv->tv_usec = 0;
-#endif
-
-    return time;
-}
-
-
-/**
- * Returns the current time.
- *
- * @param time_t * t the timestamp pointer, if not used, keep NULL.
- *
- * @return time_t return timestamp current.
- *
- */
-/* for IAR 6.2 later Compiler */
-#if defined (__IAR_SYSTEMS_ICC__) &&  (__VER__) >= 6020000
-#pragma module_name = "?time"
-#if _DLIB_TIME_USES_64
-time_t __time64(time_t *t) 
-#else
-time_t __time32(time_t *t) 
-#endif
-#else
-time_t time(time_t *t)
-#endif
-{
-    time_t time_now = 0;
-
-#ifdef RT_USING_RTC
-    static rt_device_t device = RT_NULL;
-
-    /* optimization: find rtc device only first. */
-    if (device == RT_NULL)
-    {
-        device = rt_device_find("rtc");
-    }
-
-    /* read timestamp from RTC device. */
-    if (device != RT_NULL)
-    {
-        if (rt_device_open(device, 0) == RT_EOK)
-        {
-            rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIME, &time_now);
-            rt_device_close(device);
-        }
-    }
-#endif /* RT_USING_RTC */
-
-    /* if t is not NULL, write timestamp to *t */
-    if (t != RT_NULL)
-    {
-        *t = time_now;
-    }
-
-    return time_now;
-}
-
-RT_WEAK clock_t clock(void)
-{
-    return rt_tick_get();
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1. libc time.c增加timegm函数（mktime转换是会自动考虑时区，timegm不会考虑时区）
2. 修复STM32 RTC驱动 格林威治时区与当地时区混用的问题
3. 整理了RTC驱动文件，看着改动比较大 实际上只是函数调换了位置 ，增加了注释

本次修改为后续增加时区功能做出铺垫，防止增加时区功能后，由于底层驱动没有区分time库中考虑时区和不考虑时区函数的区别，进而导致RTC时钟出现混乱。
在潘多拉上测试通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
