### PR TITLE
對imxrt的SPI傳輸改用非阻塞API

### DIFF
--- a/bsp/imxrt/libraries/drivers/drv_spi.c
+++ b/bsp/imxrt/libraries/drivers/drv_spi.c
@@ -347,7 +347,11 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
 
     if(RT_FALSE == spi->dma_flag)
     {
+#ifdef(BSP_USING_BLOCKING_SPI)
+        status = LPSPI_MasterTransferBlocking(spi->base, &transfer);
+#else
         status = LPSPI_MasterTransferNonBlocking(spi->base, &spi->spi_normal, &transfer);
+#endif
     }
     else
     {

--- a/bsp/imxrt/libraries/drivers/drv_spi.c
+++ b/bsp/imxrt/libraries/drivers/drv_spi.c
@@ -64,6 +64,8 @@ struct imxrt_spi
     char *bus_name;
     LPSPI_Type *base;
     struct rt_spi_bus spi_bus;
+    rt_sem_t xfer_sem;
+    lpspi_master_handle_t spi_normal;
     struct dma_config *dma;
     rt_uint8_t dma_flag;
 };
@@ -159,9 +161,18 @@ static void spi_get_dma_config(void)
 #endif
 }
 
+void normal_xfer_callback(LPSPI_Type *base, lpspi_master_handle_t *handle, status_t status, void *userData)
+{
+    /* xfer complete callback */
+    struct imxrt_spi *spi = (struct imxrt_spi *)userData;
+    rt_sem_release(spi->xfer_sem);
+}
+
 void edma_xfer_callback(LPSPI_Type *base, lpspi_master_edma_handle_t *handle, status_t status, void *userData)
 {
     /* xfer complete callback */
+    struct imxrt_spi *spi = (struct imxrt_spi *)userData;
+    rt_sem_release(spi->xfer_sem);
 }
 
 rt_err_t rt_hw_spi_device_attach(const char *bus_name, const char *device_name, rt_uint32_t pin)
@@ -215,6 +226,17 @@ static uint32_t imxrt_get_lpspi_freq(void)
     freq /= (CLOCK_GetDiv(kCLOCK_LpspiDiv) + 1U); 
 
     return freq;
+}
+
+static void lpspi_normal_config(struct imxrt_spi *spi)
+{
+    RT_ASSERT(spi != RT_NULL);
+
+    LPSPI_MasterTransferCreateHandle(spi->base,
+                                    &spi->spi_normal,
+                                    normal_xfer_callback,
+                                    spi);
+    LOG_D(LOG_TAG" %s normal config done\n", spi->bus_name);
 }
 
 static void lpspi_dma_config(struct imxrt_spi *spi)
@@ -325,12 +347,13 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
 
     if(RT_FALSE == spi->dma_flag)
     {
-        status = LPSPI_MasterTransferBlocking(spi->base, &transfer);
+        status = LPSPI_MasterTransferNonBlocking(spi->base, &spi->spi_normal, &transfer);
     }
     else
     {
         status = LPSPI_MasterTransferEDMA(spi->base,&spi->dma->spi_edma,&transfer);
     }
+    rt_sem_take(spi->xfer_sem, RT_WAITING_FOREVER);
 
     if(message->cs_release)
     {
@@ -369,6 +392,13 @@ int rt_hw_spi_bus_init(void)
         {
             lpspi_dma_config(&lpspis[i]);
         }
+        else
+        {
+            lpspi_normal_config(&lpspis[i]);
+        }
+        char sem_name[RT_NAME_MAX];
+        rt_sprintf(sem_name, "%s_s", lpspis[i].bus_name);
+        lpspis[i].xfer_sem = rt_sem_create(sem_name, 0, RT_IPC_FLAG_PRIO);
     }
 
     return ret; 

--- a/bsp/imxrt/libraries/drivers/drv_spi.c
+++ b/bsp/imxrt/libraries/drivers/drv_spi.c
@@ -347,7 +347,7 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
 
     if(RT_FALSE == spi->dma_flag)
     {
-#ifdef(BSP_USING_BLOCKING_SPI)
+#ifdef BSP_USING_BLOCKING_SPI
         status = LPSPI_MasterTransferBlocking(spi->base, &transfer);
 #else
         status = LPSPI_MasterTransferNonBlocking(spi->base, &spi->spi_normal, &transfer);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
對imxrt的SPI傳輸改用非阻塞API
對imxrt的SPI傳輸使用信号量，確保傳輸完成后才退出傳輸函數
Use non-blocking api for spi transfer in imxrt driver
Use a semaphore to ensure xfer function return while the transfer is completed

已經在自製的imxrt1052 板子進行了測試
Had tested with a custom made imxrt1052 board
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
