### PR TITLE
[libc][keil] 在sconscript中定义CLOCKS_PER_SEC宏

### DIFF
--- a/components/libc/compilers/common/SConscript
+++ b/components/libc/compilers/common/SConscript
@@ -18,8 +18,6 @@ if GetDepend('RT_USING_POSIX') == False:
 
 if rtconfig.CROSS_TOOL == 'keil':
     CPPDEFINES = ['__CLK_TCK=RT_TICK_PER_SECOND']
-elif rtconfig.CROSS_TOOL == 'gcc':
-    CPPDEFINES = ['_CLOCKS_PER_SEC_=RT_TICK_PER_SECOND']
 else:
     CPPDEFINES = []
 

--- a/components/libc/compilers/common/SConscript
+++ b/components/libc/compilers/common/SConscript
@@ -16,7 +16,14 @@ else:
 if GetDepend('RT_USING_POSIX') == False:
         SrcRemove(src, ['unistd.c'])
 
+if rtconfig.CROSS_TOOL == 'keil':
+    CPPDEFINES = ['__CLK_TCK=RT_TICK_PER_SECOND']
+elif rtconfig.CROSS_TOOL == 'gcc':
+    CPPDEFINES = ['_CLOCKS_PER_SEC_=RT_TICK_PER_SECOND']
+else:
+    CPPDEFINES = []
+
 if not GetDepend('RT_USING_MINILIBC') and (GetDepend('RT_USING_LIBC') or GetDepend('RT_LIBC_USING_TIME')):
-	group = DefineGroup('libc', src, depend = [''], CPPPATH = CPPPATH)
+    group = DefineGroup('libc', src, depend = [''], CPPPATH = CPPPATH, CPPDEFINES = CPPDEFINES)
 
 Return('group')


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
对CLOCKS_PER_SEC宏进行重定义，受限于平台的不同规则，该功能仅能在keil中应用
GCC和IAR依然保持默认100

已经在keil平台潘多拉上验证

#3938
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
