### PR TITLE
[components][workqueue] Fix the bug that tasks in work list are not be excuted

### DIFF
--- a/components/drivers/src/workqueue.c
+++ b/components/drivers/src/workqueue.c
@@ -62,7 +62,14 @@ static void _workqueue_thread_entry(void *parameter)
         {
             /* no software timer exist, suspend self. */
             rt_thread_suspend(rt_thread_self());
-            rt_schedule();
+            if(!rt_list_isempty(&(queue->work_list)))
+            {
+                rt_thread_resume(queue->work_thread);
+            }
+            else
+            {
+                rt_schedule();
+            }
         }
 
         /* we have work to do with. */


### PR DESCRIPTION
…e executed

## 拉取/合并请求描述：(PR description)

[
■为什么提交这份PR: 
    用workqueue 功能时发现 worklist上的任务有不被执行的情况发生
■问题描述：
   概要：在工作队列线程_workqueue_thread_entry判断worklist为空后，此时被_workqueue_submit_work抢占（将工作任务放到worklist上）， 然后工作队列线程进入睡眠，导致任务不被执行。
   详细：https://club.rt-thread.org/ask/question/430076.html
■解决问题：
    尝试修复worlist上的任务有可能不被执行的bug
■解决方案:
    在工作线程判断 worklist为空，并设置为挂起状态后，再一次判断一次工作队列是否为空。
■验证平台
   此修改以在 cortex-a7平台验证
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
