### PR TITLE
[libc] 去除RT_USING_NOLIBC 历史遗留

### DIFF
--- a/bsp/efm32/rtconfig.h
+++ b/bsp/efm32/rtconfig.h
@@ -211,7 +211,6 @@
 #endif
 
 /* SECTION: Runtime library */
-// #define RT_USING_NOLIBC
 // #define RT_USING_NEWLIB
 #define RT_LIBC_USING_TIME
 

--- a/bsp/simulator/rtconfig_project.h
+++ b/bsp/simulator/rtconfig_project.h
@@ -17,9 +17,6 @@
 #pragma warning(disable:4267)   /* to ignore: warning C4267: conversion from 'size_t' to 'rt_size_t', possible loss of data */
 #pragma warning(disable:4244)   /* to ignore: warning C4244: '=' : conversion from '__w64 int' to 'rt_size_t', possible loss of data */
 
-#elif defined(__GNUC__)
-#define RT_USING_NOLIBC
-
 #endif /* end of _MSC_VER */
 
 #endif

--- a/bsp/taihu/rtconfig.h
+++ b/bsp/taihu/rtconfig.h
@@ -53,7 +53,6 @@
 /* Using Small MM*/
 #define RT_USING_SMALL_MEM
 
-// #define RT_USING_NOLIBC
 #define RT_TINY_SIZE
 
 /* SECTION: Device System */

--- a/components/libc/compilers/common/readme.md
+++ b/components/libc/compilers/common/readme.md
@@ -1,8 +1,8 @@
 ## Attentions
 
-1. This folder is "common" for armlibc newlibc and dlib. It's not "common" for minilibc.
+1. This folder is "common" for armlibc newlibc and dlib.
 
-2. If you want to add new .c files, please do not forget to fix SConscript file too. eg:
+2. If you want to add new `.c` files, please do not forget to fix SConscript file too. eg:
 
 ```python
 if GetDepend('RT_USING_POSIX') == False:

--- a/tools/building.py
+++ b/tools/building.py
@@ -276,9 +276,6 @@ def PrepareBuilding(env, root_directory, has_libcpu=False, remove_components = [
         except KeyError:
             print ('Unknow target: '+ tgt_name+'. Avaible targets: ' +', '.join(tgt_dict.keys()))
             sys.exit(1)
-    elif (GetDepend('RT_USING_NEWLIB') == False and GetDepend('RT_USING_NOLIBC') == False) \
-        and rtconfig.PLATFORM == 'gcc':
-        AddDepend('RT_USING_MINILIBC')
 
     # auto change the 'RTT_EXEC_PATH' when 'rtconfig.EXEC_PATH' get failed
     if not os.path.exists(rtconfig.EXEC_PATH):


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
去除在RTT中残留的RT_USING_NOLIBC痕迹
#4337
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
