### PR TITLE
[update][kernel]规范rt_object_t强制转换的使用，消除上次提交的编译警告

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -358,8 +358,6 @@ RTM_EXPORT(rt_thread_startup);
  */
 rt_err_t rt_thread_detach(rt_thread_t thread)
 {
-    rt_base_t lock;
-
     /* thread check */
     RT_ASSERT(thread != RT_NULL);
     RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);

--- a/src/timer.c
+++ b/src/timer.c
@@ -201,7 +201,7 @@ void rt_timer_init(rt_timer_t  timer,
     RT_ASSERT(timer != RT_NULL);
 
     /* timer object initialization */
-    rt_object_init((rt_object_t)timer, RT_Object_Class_Timer, name);
+    rt_object_init(&(timer->parent), RT_Object_Class_Timer, name);
 
     _rt_timer_init(timer, timeout, parameter, time, flag);
 }
@@ -298,7 +298,7 @@ rt_err_t rt_timer_delete(rt_timer_t timer)
     /* enable interrupt */
     rt_hw_interrupt_enable(level);
 
-    rt_object_delete((rt_object_t)timer);
+    rt_object_delete(&(timer->parent));
 
     return RT_EOK;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1、除了rt_thread，统一其他内核对象派生对象，rt_timer的操作。
2、消除上次提交，rt_thread.c 有一处未使用变量未移除，引起的编译报警。

只是代码规范，不影响功能。在模拟器、STM32L4平台验证通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
