### PR TITLE
[sfud] Correct dual_io dummy cycle setting to 4.

### DIFF
--- a/components/drivers/spi/sfud/src/sfud.c
+++ b/components/drivers/spi/sfud/src/sfud.c
@@ -218,7 +218,7 @@ sfud_err sfud_qspi_fast_read_enable(sfud_flash *flash, uint8_t data_line_width) 
         break;
     case 2:
         if (read_mode & DUAL_IO) {
-            qspi_set_read_cmd_format(flash, SFUD_CMD_DUAL_IO_READ_DATA, 1, 2, 8, 2);
+            qspi_set_read_cmd_format(flash, SFUD_CMD_DUAL_IO_READ_DATA, 1, 2, 4, 2);
         } else if (read_mode & DUAL_OUTPUT) {
             qspi_set_read_cmd_format(flash, SFUD_CMD_DUAL_OUTPUT_READ_DATA, 1, 1, 8, 2);
         } else {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
Correct DUAL_IO Fastread dummy cycle to 4.

Checked dummy cycle of supported DUAL_IO flashes in SFUD is 4.

![c5eadca7838d5b9f54b81d5417bc99a](https://user-images.githubusercontent.com/15135795/110654562-3589df80-81f9-11eb-879b-ba136685e68c.png)
 
 
![883b592f07e224d892bcf18a999aaec](https://user-images.githubusercontent.com/15135795/110654837-75e95d80-81f9-11eb-9a90-7cdff33b9c08.png)

![56932baa00fe444b84190d7c8a83361](https://user-images.githubusercontent.com/15135795/110654858-7aae1180-81f9-11eb-84f7-96655edc659c.png)


![8aec8d7e185e233ac1756c5ac26e1e4](https://user-images.githubusercontent.com/15135795/110654887-813c8900-81f9-11eb-9135-1f7c9b7beeb7.png)
![ee063d1fb3df2766ffbc748bc9260c7](https://user-images.githubusercontent.com/15135795/110654900-84377980-81f9-11eb-9b81-ecb5b035a846.png)

![3c111126cc034d922cfed1564a55694](https://user-images.githubusercontent.com/15135795/110654916-87cb0080-81f9-11eb-94eb-909eed55b39e.png)
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
