### PR TITLE
[bsp]fix overwrite issue when using SDRAM on STM32F7XX

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_sdram.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_sdram.c
@@ -212,11 +212,11 @@ int sdram_test(void)
     for (i = 0; i < SDRAM_SIZE / data_width; i++)
     {
 #if SDRAM_DATA_WIDTH == 8
-        *(__IO uint8_t *)(SDRAM_BANK_ADDR + i * data_width) = (uint8_t)0x55;
+        *(__IO uint8_t *)(SDRAM_BANK_ADDR + i * data_width) = (uint8_t)(i % 100);
 #elif SDRAM_DATA_WIDTH == 16
-        *(__IO uint16_t *)(SDRAM_BANK_ADDR + i * data_width) = (uint16_t)0x5555;
+        *(__IO uint16_t *)(SDRAM_BANK_ADDR + i * data_width) = (uint16_t)(i % 1000);
 #else
-        *(__IO uint32_t *)(SDRAM_BANK_ADDR + i * data_width) = (uint32_t)0x55555555;
+        *(__IO uint32_t *)(SDRAM_BANK_ADDR + i * data_width) = (uint32_t)(i % 1000);
 #endif
     }
     time_cast = rt_tick_get() - start_time;
@@ -229,21 +229,21 @@ int sdram_test(void)
     {
 #if SDRAM_DATA_WIDTH == 8
         data = *(__IO uint8_t *)(SDRAM_BANK_ADDR + i * data_width);
-        if (data != 0x55)
+        if (data != i % 100)
         {
             LOG_E("SDRAM test failed!");
             break;
         }
 #elif SDRAM_DATA_WIDTH == 16
         data = *(__IO uint16_t *)(SDRAM_BANK_ADDR + i * data_width);
-        if (data != 0x5555)
+        if (data != i % 1000)
         {
             LOG_E("SDRAM test failed!");
             break;
         }
 #else
         data = *(__IO uint32_t *)(SDRAM_BANK_ADDR + i * data_width);
-        if (data != 0x55555555)
+        if (data != i % 1000)
         {
             LOG_E("SDRAM test failed!");
             break;

--- a/bsp/stm32/stm32f746-st-disco/board/CubeMX_Config/Src/stm32f7xx_hal_msp.c
+++ b/bsp/stm32/stm32f746-st-disco/board/CubeMX_Config/Src/stm32f7xx_hal_msp.c
@@ -671,7 +671,7 @@ static void HAL_FMC_MspInit(void){
   /* USER CODE BEGIN FMC_MspInit 0 */
 
   /* USER CODE END FMC_MspInit 0 */
-  GPIO_InitTypeDef GPIO_InitStruct ={0};
+  GPIO_InitTypeDef GPIO_InitStruct = {0};
   if (FMC_Initialized) {
     return;
   }
@@ -716,53 +716,33 @@ static void HAL_FMC_MspInit(void){
   PE15   ------> FMC_D12
   PE13   ------> FMC_D10
   */
-  GPIO_InitStruct.Pin = GPIO_PIN_15|GPIO_PIN_8|GPIO_PIN_0|GPIO_PIN_5 
-                          |GPIO_PIN_4;
-  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
+  GPIO_InitStruct.Mode      = GPIO_MODE_AF_PP;
+  GPIO_InitStruct.Pull      = GPIO_NOPULL;
+  GPIO_InitStruct.Speed     = GPIO_SPEED_FREQ_VERY_HIGH;
   GPIO_InitStruct.Alternate = GPIO_AF12_FMC;
-  HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
-
-  GPIO_InitStruct.Pin = GPIO_PIN_0|GPIO_PIN_1|GPIO_PIN_15|GPIO_PIN_10 
-                          |GPIO_PIN_14|GPIO_PIN_9|GPIO_PIN_8;
-  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-  GPIO_InitStruct.Alternate = GPIO_AF12_FMC;
-  HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
-
-  GPIO_InitStruct.Pin = GPIO_PIN_0|GPIO_PIN_1|GPIO_PIN_2|GPIO_PIN_3 
-                          |GPIO_PIN_4|GPIO_PIN_5|GPIO_PIN_12|GPIO_PIN_15 
-                          |GPIO_PIN_13|GPIO_PIN_14|GPIO_PIN_11;
-  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-  GPIO_InitStruct.Alternate = GPIO_AF12_FMC;
-  HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
-
-  GPIO_InitStruct.Pin = GPIO_PIN_5|GPIO_PIN_3;
-  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-  GPIO_InitStruct.Alternate = GPIO_AF12_FMC;
-  HAL_GPIO_Init(GPIOH, &GPIO_InitStruct);
 
   GPIO_InitStruct.Pin = GPIO_PIN_3;
-  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-  GPIO_InitStruct.Alternate = GPIO_AF12_FMC;
   HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
 
-  GPIO_InitStruct.Pin = GPIO_PIN_8|GPIO_PIN_9|GPIO_PIN_11|GPIO_PIN_14 
-                          |GPIO_PIN_7|GPIO_PIN_10|GPIO_PIN_12|GPIO_PIN_15 
-                          |GPIO_PIN_13;
-  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
-  GPIO_InitStruct.Alternate = GPIO_AF12_FMC;
+  GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1 | GPIO_PIN_8 | GPIO_PIN_9 |\
+                        GPIO_PIN_10 | GPIO_PIN_14 | GPIO_PIN_15;
+  HAL_GPIO_Init(GPIOD, &GPIO_InitStruct);
+
+  GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1 | GPIO_PIN_7 | GPIO_PIN_8 | GPIO_PIN_9      |\
+                        GPIO_PIN_10 | GPIO_PIN_11 | GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 |\
+                        GPIO_PIN_15;
   HAL_GPIO_Init(GPIOE, &GPIO_InitStruct);
+
+  GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1 | GPIO_PIN_2 | GPIO_PIN_3 | GPIO_PIN_4     |\
+                        GPIO_PIN_5 | GPIO_PIN_11 | GPIO_PIN_12 | GPIO_PIN_13 | GPIO_PIN_14 |\
+                        GPIO_PIN_15;
+  HAL_GPIO_Init(GPIOF, &GPIO_InitStruct);
+
+  GPIO_InitStruct.Pin = GPIO_PIN_0 | GPIO_PIN_1 | GPIO_PIN_4 | GPIO_PIN_5 | GPIO_PIN_8 | GPIO_PIN_15;
+  HAL_GPIO_Init(GPIOG, &GPIO_InitStruct);
+
+  GPIO_InitStruct.Pin = GPIO_PIN_3 | GPIO_PIN_5;
+  HAL_GPIO_Init(GPIOH, &GPIO_InitStruct);
 
   /* USER CODE BEGIN FMC_MspInit 1 */
 

--- a/bsp/stm32/stm32f746-st-disco/board/Kconfig
+++ b/bsp/stm32/stm32f746-st-disco/board/Kconfig
@@ -103,7 +103,7 @@ menu "On-chip Peripheral Drivers"
         default n
         
     config BSP_USING_FMC
-        bool
+        bool "Enable Flash Memory Controller(FMC)"
         default n
 
     config BSP_USING_LTDC


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

STM32F7XX 系列中开启 SDRAM 后，可用的空间只有 1MB，对超过 1MB 的访问将会产生 Overwrite。例如对 0xC0100000 的修改将会引起 0xC0000000 的变化。跟官方 HAL 库提供的 DEMO 对比来看，产生这种错误的原因在于函数`HAL_FMC_MspInit` 中少了几个 GPIO 引脚的初始化，导致实际的寻址空间错误。本 PR 中仿照官方 HAL 库对代码进行了修改。

而且，在 `sdram_test` 中由于写入 SDRAM 的内容都是一样的，无法检测出 Overwrite。本 PR 修改了写入的测试数据。

同时在 KConfig 中，缺少了`BSP_USING_FMC`的说明，导致在 MenuConfig 中无法显示。本 PR 补充了它的说明。

本次修改已在 STM32F746G-DISCO 上测试通过。

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
