### PR TITLE
[bsp][ab32vg1] Fix sizeof(time_t) no match with this chip

### DIFF
--- a/bsp/bluetrum/ab32vg1-ab-prougen/board/Kconfig
+++ b/bsp/bluetrum/ab32vg1-ab-prougen/board/Kconfig
@@ -167,11 +167,16 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    config BSP_USING_ONCHIP_RTC
+    menuconfig BSP_USING_ONCHIP_RTC
         bool "Enable RTC"
         select RT_USING_RTC
         select RT_USING_LIBC
         default n
+        if BSP_USING_ONCHIP_RTC
+            config RTC_USING_INTERNAL_CLK
+            bool "Using internal clock RTC"
+            default y
+        endif
 
     menuconfig BSP_USING_ADC
         bool "Enable ADC"

--- a/bsp/bluetrum/ab32vg1-ab-prougen/rtconfig.py
+++ b/bsp/bluetrum/ab32vg1-ab-prougen/rtconfig.py
@@ -41,7 +41,7 @@ if PLATFORM == 'gcc':
     # DEVICE  = ' -mcmodel=medany -march=rv32imc -mabi=ilp32 -fsingle-precision-constant'
     DEVICE  = ' -mcmodel=medany -march=rv32imc -mabi=ilp32'
     # CFLAGS  = DEVICE + ' -fno-common -ffunction-sections -fdata-sections -fstrict-volatile-bitfields'
-    CFLAGS = DEVICE
+    CFLAGS = DEVICE + ' -D_USE_LONG_TIME_T'
     AFLAGS  = ' -c' + DEVICE + ' -x assembler-with-cpp'
     LFLAGS  = DEVICE + ' -nostartfiles -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,_start -T link.lds'
     CPATH   = ''

--- a/bsp/bluetrum/libraries/hal_drivers/drv_rtc.c
+++ b/bsp/bluetrum/libraries/hal_drivers/drv_rtc.c
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author            Notes
  * 2021-01-28     greedyhao         first version
+ * 2021-03-19     iysheng           modify just set time first power up
  */
 
 #include "board.h"
@@ -108,17 +109,17 @@ void hal_rtc_init(void)
     irtc_sfr_write(RTCCON2_CMD, temp | RTC_CON2_32K_SELECT);
 
     temp = irtc_sfr_read(RTCCON0_CMD);
-    if (temp & BIT(7)) {
-        temp &= ~BIT(7);
+    if (temp & RTC_CON0_PWRUP_FIRST) {
+        temp &= ~RTC_CON0_PWRUP_FIRST;
         irtc_sfr_write(RTCCON0_CMD, temp); /* First power on */
+        tm_new.tm_mday = 29;
+        tm_new.tm_mon  = 1 - 1;
+        tm_new.tm_year = 2021 - 1900;
+        sec = timegm(&tm_new);
+
+        irtc_time_write(RTCCNT_CMD, sec);
     }
 
-    tm_new.tm_mday = 29;
-    tm_new.tm_mon  = 1 - 1;
-    tm_new.tm_year = 2021 - 1900;
-    sec = timegm(&tm_new);
-
-    irtc_time_write(RTCCNT_CMD, sec);
 }
 /************** HAL End *******************/
 

--- a/bsp/bluetrum/libraries/hal_libraries/ab32vg1_hal/include/ab32vg1_hal_rtc.h
+++ b/bsp/bluetrum/libraries/hal_libraries/ab32vg1_hal/include/ab32vg1_hal_rtc.h
@@ -34,7 +34,7 @@ enum
 
 // RTCCON0
 #define RTC_CON0_PWRUP_FIRST                (0x01u << 7)    /*!< RTC first power up flag            */
-#define RTC_CON0_EXTERNAL_32K               (0x01u << 6)    /*!< External 32K select                */
+#define RTC_CON0_INTERNAL_32K               (0x01u << 6)    /*!< Internal 32K select                */
 #define RTC_CON0_VDD_ENABLE                 (0x01u << 5)    /*!< RTC VDD12 enable                   */
 #define RTC_CON0_BG_ENABLE                  (0x01u << 4)    /*!< BG enable                          */
 #define RTC_CON0_LVD_OUTPUT_ENABLE          (0x01u << 3)    /*!< LVD output enable                  */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修复 sizeof(time_t) 和实际 AB32VG1 的寄存器不匹配问题
修复之前，测试 RTC 驱动
```
 \ | /
- RT -     Thread Operating System
 / | \     4.0.3 build Mar 19 2021
 2006 - 2021 Copyright by rt-thread team
Hello, world a
msh >date
found rtc sizeof time_t=8
111111 time_now=0x10
over found rtc
now=-1
xmsh >
```
修复之后，测试 RTC 驱动
```
 \ | /
- RT -     Thread Operating System
 / | \     4.0.3 build Mar 19 2021
 2006 - 2021 Copyright by rt-thread team
Hello, world a
msh >
msh >date
found rtc sizeof time_t=4
111111 time_now=0x60135001
over found rtc
now=1611878401
Fri Jan 29 00:00:01 2021
msh >
```
在 AB32VG1 板子测试通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
