### PR TITLE
[bsp][ab32vg1] Add alarm and 1 second interrupt support

### DIFF
--- a/bsp/bluetrum/ab32vg1-ab-prougen/board/Kconfig
+++ b/bsp/bluetrum/ab32vg1-ab-prougen/board/Kconfig
@@ -176,6 +176,10 @@ menu "On-chip Peripheral Drivers"
             config RTC_USING_INTERNAL_CLK
             bool "Using internal clock RTC"
             default y
+            config RTC_USING_1S_INT
+            bool "Using 1 second interrupt"
+            depends on RT_USING_ALARM
+            default n
         endif
 
     menuconfig BSP_USING_ADC

--- a/bsp/bluetrum/libraries/hal_drivers/drv_rtc.c
+++ b/bsp/bluetrum/libraries/hal_drivers/drv_rtc.c
@@ -7,6 +7,7 @@
  * Date           Author            Notes
  * 2021-01-28     greedyhao         first version
  * 2021-03-19     iysheng           modify just set time first power up
+ * 2021-03-26     iysheng           add alarm and 1s interrupt support
  */
 
 #include "board.h"
@@ -134,15 +135,22 @@ void hal_rtc_init(void)
 
         irtc_time_write(RTCCNT_CMD, sec);
     }
+#ifdef RT_USING_ALARM
+    RTCCON |= RTC_CON_ALM_INTERRUPT;
+#ifdef RTC_USING_1S_INT
+    RTCCON |= RTC_CON_1S_INTERRUPT;
+#endif
+#endif
 }
 /************** HAL End *******************/
 
-static time_t get_rtc_timestamp(void)
+static time_t get_rtc_time_stamp(void)
 {
     time_t sec = 0;
 
     sec = irtc_time_read(RTCCNT_CMD);
     LOG_D("get rtc time.");
+
     return sec;
 }
 
@@ -151,6 +159,22 @@ static rt_err_t set_rtc_time_stamp(time_t time_stamp)
     irtc_time_write(RTCCNT_CMD, time_stamp);
 
     return RT_EOK;
+}
+
+static rt_err_t set_rtc_alarm_stamp(time_t alarm_stamp)
+{
+    irtc_time_write(RTCALM_CMD, alarm_stamp);
+
+    return RT_EOK;
+}
+
+static time_t get_rtc_alarm_stamp(void)
+{
+    time_t sec = 0;
+
+    sec = irtc_time_read(RTCALM_CMD);
+
+    return sec;
 }
 
 static void rt_rtc_init(void)
@@ -165,8 +189,8 @@ static rt_err_t rt_rtc_control(rt_device_t dev, int cmd, void *args)
     switch (cmd)
     {
     case RT_DEVICE_CTRL_RTC_GET_TIME:
-        *(rt_uint32_t *)args = get_rtc_timestamp();
-        LOG_D("RTC: get rtc_time %x\n", *(rt_uint32_t *)args);
+        *(rt_uint32_t *)args = get_rtc_time_stamp();
+        LOG_D("RTC: get rtc_time %x", *(rt_uint32_t *)args);
         break;
 
     case RT_DEVICE_CTRL_RTC_SET_TIME:
@@ -174,7 +198,18 @@ static rt_err_t rt_rtc_control(rt_device_t dev, int cmd, void *args)
         {
             result = -RT_ERROR;
         }
-        LOG_D("RTC: set rtc_time %x\n", *(rt_uint32_t *)args);
+        LOG_D("RTC: set rtc_time %x", *(rt_uint32_t *)args);
+        break;
+    case RT_DEVICE_CTRL_RTC_SET_ALARM:
+        if (set_rtc_alarm_stamp(*(rt_uint32_t *)args))
+        {
+            result = -RT_ERROR;
+        }
+        LOG_D("RTC: set alarm_stamp %x", *(rt_uint32_t *)args);
+        break;
+    case RT_DEVICE_CTRL_RTC_GET_ALARM:
+        *(rt_uint32_t *)args = get_rtc_alarm_stamp();
+        LOG_D("RTC: get alarm_stamp %x", *(rt_uint32_t *)args);
         break;
     }
 
@@ -217,15 +252,41 @@ static rt_err_t rt_hw_rtc_register(rt_device_t device, const char *name, rt_uint
     return rt_device_register(device, name, flag);
 }
 
+#ifdef RT_USING_ALARM
+static void rtc_isr(int vector, void *param)
+{
+    rt_interrupt_enter();
+
+    if (RTCCON & RTC_CON_ALM_PEND)
+    {
+        RTCCPND |= RTC_CPND_ALM;
+    }
+
+#ifdef RTC_USING_1S_INT
+    if (RTCCON & RTC_CON_1S_PEND)
+    {
+        RTCCPND |= RTC_CPND_1S;
+    }
+#endif
+
+    rt_interrupt_leave();
+}
+#endif
+
 int rt_hw_rtc_init(void)
 {
     rt_err_t result;
+
     result = rt_hw_rtc_register(&rtc, "rtc", RT_DEVICE_FLAG_RDWR);
     if (result != RT_EOK)
     {
         LOG_E("rtc register err code: %d", result);
         return result;
     }
+
+#ifdef RT_USING_ALARM
+    rt_hw_interrupt_install(IRQ_RTC_VECTOR, rtc_isr, RT_NULL, "rtc_isr");
+#endif
     LOG_D("rtc init success");
     return RT_EOK;
 }

--- a/bsp/bluetrum/libraries/hal_libraries/ab32vg1_hal/include/ab32vg1_hal_rtc.h
+++ b/bsp/bluetrum/libraries/hal_libraries/ab32vg1_hal/include/ab32vg1_hal_rtc.h
@@ -32,6 +32,10 @@ enum
 #define RTC_CON_BAUD_SELECT                 (0x3u <<  1)    /*!< Increase clock selection           */
 #define RTC_CON_CHIP_SELECT                 (0x1u <<  0)    /*!< RTC chip select                    */
 
+// RTCCPND
+#define RTC_CPND_1S                         (0x1u <<  18)    /*!< Clear RTC 1S pending              */
+#define RTC_CPND_ALM                      (0x1u <<  17)    /*!< Clear RTC alarm pendind           */
+
 // RTCCON0
 #define RTC_CON0_PWRUP_FIRST                (0x01u << 7)    /*!< RTC first power up flag            */
 #define RTC_CON0_INTERNAL_32K               (0x01u << 6)    /*!< Internal 32K select                */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
添加 AB32VG1 的 RTC 驱动 alarm 和 1s 中断支持
在 AB32VG1 板卡测试通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
