### PR TITLE
[UPD]nRF5x 'scons --dist' support

### DIFF
--- a/bsp/nrf5x/nrf52832/rtconfig.py
+++ b/bsp/nrf5x/nrf52832/rtconfig.py
@@ -84,3 +84,11 @@ elif PLATFORM == 'armcc':
         CFLAGS += ' -O2'
 
     POST_ACTION = 'fromelf --bin $TARGET --output rtthread.bin \nfromelf -z $TARGET'
+
+
+def dist_handle(BSP_ROOT, dist_dir):
+    import sys
+    cwd_path = os.getcwd()
+    sys.path.append(os.path.join(os.path.dirname(BSP_ROOT), 'tools'))
+    from sdk_dist import dist_do_building
+    dist_do_building(BSP_ROOT, dist_dir)

--- a/bsp/nrf5x/nrf52840/rtconfig.py
+++ b/bsp/nrf5x/nrf52840/rtconfig.py
@@ -82,3 +82,11 @@ elif PLATFORM == 'armcc':
         CFLAGS += ' -O2'
 
     POST_ACTION = 'fromelf --bin $TARGET --output rtthread.bin \nfromelf -z $TARGET'
+
+
+def dist_handle(BSP_ROOT, dist_dir):
+    import sys
+    cwd_path = os.getcwd()
+    sys.path.append(os.path.join(os.path.dirname(BSP_ROOT), 'tools'))
+    from sdk_dist import dist_do_building
+    dist_do_building(BSP_ROOT, dist_dir)

--- a/bsp/nrf5x/tools/sdk_dist.py
+++ b/bsp/nrf5x/tools/sdk_dist.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import shutil
+cwd_path = os.getcwd()
+sys.path.append(os.path.join(os.path.dirname(cwd_path), 'rt-thread', 'tools'))
+
+# BSP dist function
+def dist_do_building(BSP_ROOT, dist_dir):
+    from mkdist import bsp_copy_files
+    import rtconfig
+
+    library_dir  = os.path.join(dist_dir, 'libraries')
+
+    print("=> copy nrf52 bsp libraries")
+    library_path = os.path.join(os.path.dirname(BSP_ROOT), 'libraries')
+
+    bsp_copy_files(library_path, library_dir)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
完善了nRF52832和nRF52840 bsp的'scons --dist'功能，经过测试导出的dist目录下的项目可以正常编译。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
