### PR TITLE
[object.c]修复 'obj never used'  警告，并减少代码。

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -313,7 +313,9 @@ void rt_object_init(struct rt_object         *object,
                     const char               *name)
 {
     register rt_base_t temp;
+#ifdef RT_DEBUG
     struct rt_list_node *node = RT_NULL;
+#endif
     struct rt_object_information *information;
 #ifdef RT_USING_MODULE
     struct rt_dlmodule *module = dlmodule_self();
@@ -323,6 +325,7 @@ void rt_object_init(struct rt_object         *object,
     information = rt_object_get_information(type);
     RT_ASSERT(information != RT_NULL);
 
+#ifdef RT_DEBUG
     /* check object type to avoid re-initialization */
 
     /* enter critical */
@@ -342,6 +345,7 @@ void rt_object_init(struct rt_object         *object,
     }
     /* leave critical */
     rt_exit_critical();
+#endif
 
     /* initialize object's parameters */
     /* set object type to static */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
src/object.c 中的 rt_object_init( )函数中的一段：
`    /* enter critical */
    rt_enter_critical();
    /* try to find object */
    for (node  = information->object_list.next;
            node != &(information->object_list);
            node  = node->next)
    {
        struct rt_object *obj;

        obj = rt_list_entry(node, struct rt_object, list);
        if (obj) /* skip warning when disable debug */
        {
            RT_ASSERT(obj != object);
        }
    }
    /* leave critical */
    rt_exit_critical();`

当在正式的生产环境时，一般去掉 RT_DEBUG的宏定义，此时RT_ASSERT也变空，就会产生 ` warning: #550-D: variable "obj" was set but never used` 警告，同时 for 循环也变得多余了，增加了代码量，也降低了执行速度。
因此需要在此增加编译开关。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
