### PR TITLE
[add] the function of set [internet up] status, activate the callback.

### DIFF
--- a/components/net/netdev/include/netdev.h
+++ b/components/net/netdev/include/netdev.h
@@ -186,6 +186,7 @@ void netdev_low_level_set_gw(struct netdev *netdev, const ip_addr_t *gw);
 void netdev_low_level_set_dns_server(struct netdev *netdev, uint8_t dns_num, const ip_addr_t *dns_server);
 void netdev_low_level_set_status(struct netdev *netdev, rt_bool_t is_up);
 void netdev_low_level_set_link_status(struct netdev *netdev, rt_bool_t is_up);
+void netdev_low_level_set_internet_status(struct netdev *netdev, rt_bool_t is_up);
 void netdev_low_level_set_dhcp_status(struct netdev *netdev, rt_bool_t is_enable);
 
 #ifdef __cplusplus

--- a/components/net/netdev/src/netdev.c
+++ b/components/net/netdev/src/netdev.c
@@ -829,6 +829,34 @@ void netdev_low_level_set_link_status(struct netdev *netdev, rt_bool_t is_up)
 }
 
 /**
+ * This function will set network interface device active internet status.
+ * @NOTE it can only be called in the network interface device driver.
+ *
+ * @param netdev the network interface device to change
+ * @param is_up the new internet status
+ */
+void netdev_low_level_set_internet_status(struct netdev *netdev, rt_bool_t is_up)
+{
+    if (netdev && netdev_is_internet_up(netdev) != is_up)
+    {
+        if (is_up)
+        {
+            netdev->flags |= NETDEV_FLAG_INTERNET_UP;
+        }
+        else
+        {
+            netdev->flags &= ~NETDEV_FLAG_INTERNET_UP;
+        }
+
+        /* execute  network interface device status change callback function */
+        if (netdev->status_callback)
+        {
+            netdev->status_callback(netdev, is_up ? NETDEV_CB_STATUS_INTERNET_UP : NETDEV_CB_STATUS_INTERNET_DOWN);
+        }
+    }
+}
+
+/**
  * This function will set network interface device DHCP status.
  * @NOTE it can only be called in the network interface device driver.
  *

--- a/components/net/sal_socket/src/sal_socket.c
+++ b/components/net/sal_socket/src/sal_socket.c
@@ -261,12 +261,12 @@ __exit:
     if (result > 0)
     {
         LOG_D("Set network interface device(%s) internet status up.", netdev->name);
-        netdev->flags |= NETDEV_FLAG_INTERNET_UP;
+        netdev_low_level_set_internet_status(netdev, RT_TRUE);
     }
     else
     {
         LOG_D("Set network interface device(%s) internet status down.", netdev->name);
-        netdev->flags &= ~NETDEV_FLAG_INTERNET_UP;
+        netdev_low_level_set_internet_status(netdev, RT_FALSE);
     }
 
     if (sockfd >= 0)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
 * have tested on qemu-a9, stm32f407-atk
 
accord to ```enum netdev_cb_type``` , the ```netdev->callback``` should include UP/DOWN LINK_UP/LINK_DOWN INTERNET_UP/INTERNET_DOWN status. But we haven't INTERNET_UP/INTERNET_DOWN status callback before.

```c
enum netdev_cb_type
{
    NETDEV_CB_ADDR_IP,                 /* IP address */
    NETDEV_CB_ADDR_NETMASK,            /* subnet mask */
    NETDEV_CB_ADDR_GATEWAY,            /* netmask */
    NETDEV_CB_ADDR_DNS_SERVER,         /* dns server */
    NETDEV_CB_STATUS_UP,               /* changed to 'up' */
    NETDEV_CB_STATUS_DOWN,             /* changed to 'down' */
    NETDEV_CB_STATUS_LINK_UP,          /* changed to 'link up' */
    NETDEV_CB_STATUS_LINK_DOWN,        /* changed to 'link down' */
    NETDEV_CB_STATUS_INTERNET_UP,      /* changed to 'internet up' */
    NETDEV_CB_STATUS_INTERNET_DOWN,    /* changed to 'internet down' */
    NETDEV_CB_STATUS_DHCP_ENABLE,      /* enable DHCP capability */
    NETDEV_CB_STATUS_DHCP_DISABLE,     /* disable DHCP capability */
};
```

ISSUE：
https://git.rt-thread.com/community/Teco-Team/-/issues/64

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
