### PR TITLE
Add more trys when switching MMC card data width

### DIFF
--- a/components/drivers/sdio/mmc.c
+++ b/components/drivers/sdio/mmc.c
@@ -300,7 +300,7 @@ static int mmc_select_bus_width(struct rt_mmcsd_card *card, rt_uint8_t *ext_csd)
     MMCSD_BUS_WIDTH_1
   };
   struct rt_mmcsd_host *host = card->host;
-  unsigned idx, bus_width = 0;
+  unsigned idx, trys, bus_width = 0;
   int err = 0;
 
   if (GET_BITS(card->resp_cid, 122, 4) < 4)
@@ -335,10 +335,13 @@ static int mmc_select_bus_width(struct rt_mmcsd_card *card, rt_uint8_t *ext_csd)
     if (err)
       continue;
 
-    bus_width = bus_widths[idx];
-    mmcsd_set_bus_width(host, bus_width);
-    mmcsd_delay_ms(20); //delay 10ms
-    err = mmc_compare_ext_csds(card, ext_csd, bus_width);
+    for(trys = 0; trys < 5; trys++){
+        mmcsd_set_bus_width(host, bus_width);
+        mmcsd_delay_ms(10); 
+        err = mmc_compare_ext_csds(card, ext_csd, bus_width);
+        if(!err)
+            break;
+    }
     if (!err) {
       err = bus_width;
       break;

--- a/components/drivers/sdio/mmc.c
+++ b/components/drivers/sdio/mmc.c
@@ -337,7 +337,7 @@ static int mmc_select_bus_width(struct rt_mmcsd_card *card, rt_uint8_t *ext_csd)
 
     for(trys = 0; trys < 5; trys++){
         mmcsd_set_bus_width(host, bus_width);
-        mmcsd_delay_ms(10); 
+        mmcsd_delay_ms(10);
         err = mmc_compare_ext_csds(card, ext_csd, bus_width);
         if(!err)
             break;


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

现有的MMC 设备在切换数据宽度的时候，会遇到切换失败的情况。以前没问题，现在换了一个emmc之后出现了问题。
溯源发现是发送切换指令后，等待时间不够长。这里我把原来的20ms固定的delay换成多次尝试。成功使新的emmc切换到8bit宽度。

When switching data width in emmc car, try a few times before considering the width is invalid (leave a longer timer for the card to prepared). 
The original strategy (simply wait for 20ms ) failed on STM32H743 with an MTFC4GACAJCN-4M (4GB EMMC) when switching data width. 
(unless the debugging info is enabled, which add more delays)
With this EMMC, the fixed delay was set to 50ms for it to be able to work. 

Instead of increasing the fixed delay, I think we better change the strategy to trying a few more times with smaller delays.

This change was validated on a customized board with STM32H743BI and  MTFC4GACAJCN-4M and THGBMNG5D1LBAIT (Both are 4 GB emmc ). The hardware SDIO connection width on the tested board is 8 wires. 


以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
