### PR TITLE
[add] spi config increases irq_type

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/config/f0/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f0/spi_config.h
@@ -24,6 +24,7 @@ extern "C" {
     {                                               \
         .Instance = SPI1,                           \
         .bus_name = "spi1",                         \
+        .irq_type = SPI1_IRQn,                      \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -56,6 +57,7 @@ extern "C" {
     {                                               \
         .Instance = SPI2,                           \
         .bus_name = "spi2",                         \
+        .irq_type = SPI2_IRQn,                      \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f1/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f1/spi_config.h
@@ -24,6 +24,7 @@ extern "C" {
     {                                               \
         .Instance = SPI1,                           \
         .bus_name = "spi1",                         \
+        .irq_type = SPI1_IRQn,                      \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -56,6 +57,7 @@ extern "C" {
     {                                               \
         .Instance = SPI2,                           \
         .bus_name = "spi2",                         \
+        .irq_type = SPI2_IRQn,                      \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
@@ -88,6 +90,7 @@ extern "C" {
     {                                               \
         .Instance = SPI3,                           \
         .bus_name = "spi3",                         \
+        .irq_type = SPI3_IRQn,                      \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f2/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f2/spi_config.h
@@ -24,6 +24,7 @@ extern "C" {
     {                                               \
         .Instance = SPI1,                           \
         .bus_name = "spi1",                         \
+        .irq_type = SPI1_IRQn,                      \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -58,6 +59,7 @@ extern "C" {
     {                                               \
         .Instance = SPI2,                           \
         .bus_name = "spi2",                         \
+        .irq_type = SPI2_IRQn,                      \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
@@ -92,6 +94,7 @@ extern "C" {
     {                                               \
         .Instance = SPI3,                           \
         .bus_name = "spi3",                         \
+        .irq_type = SPI3_IRQn,                      \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f4/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f4/spi_config.h
@@ -24,6 +24,7 @@ extern "C" {
     {                                               \
         .Instance = SPI1,                           \
         .bus_name = "spi1",                         \
+        .irq_type = SPI1_IRQn,                      \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -58,6 +59,7 @@ extern "C" {
     {                                               \
         .Instance = SPI2,                           \
         .bus_name = "spi2",                         \
+        .irq_type = SPI2_IRQn,                      \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
@@ -92,6 +94,7 @@ extern "C" {
     {                                               \
         .Instance = SPI3,                           \
         .bus_name = "spi3",                         \
+        .irq_type = SPI3_IRQn,                      \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
@@ -126,6 +129,7 @@ extern "C" {
     {                                               \
         .Instance = SPI4,                           \
         .bus_name = "spi4",                         \
+        .irq_type = SPI4_IRQn,                      \
     }
 #endif /* SPI4_BUS_CONFIG */
 #endif /* BSP_USING_SPI4 */
@@ -160,6 +164,7 @@ extern "C" {
     {                                               \
         .Instance = SPI5,                           \
         .bus_name = "spi5",                         \
+        .irq_type = SPI5_IRQn,                      \
     }
 #endif /* SPI5_BUS_CONFIG */
 #endif /* BSP_USING_SPI5 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f7/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f7/spi_config.h
@@ -23,6 +23,7 @@ extern "C" {
     {                                               \
         .Instance = SPI1,                           \
         .bus_name = "spi1",                         \
+        .irq_type = SPI1_IRQn,                      \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -57,6 +58,7 @@ extern "C" {
     {                                               \
         .Instance = SPI2,                           \
         .bus_name = "spi2",                         \
+        .irq_type = SPI2_IRQn,                      \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
@@ -91,6 +93,7 @@ extern "C" {
     {                                               \
         .Instance = SPI3,                           \
         .bus_name = "spi3",                         \
+        .irq_type = SPI3_IRQn,                      \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
@@ -125,6 +128,7 @@ extern "C" {
     {                                               \
         .Instance = SPI4,                           \
         .bus_name = "spi4",                         \
+        .irq_type = SPI4_IRQn,                      \
     }
 #endif /* SPI4_BUS_CONFIG */
 #endif /* BSP_USING_SPI4 */
@@ -159,6 +163,7 @@ extern "C" {
     {                                               \
         .Instance = SPI5,                           \
         .bus_name = "spi5",                         \
+        .irq_type = SPI5_IRQn,                      \
     }
 #endif /* SPI5_BUS_CONFIG */
 #endif /* BSP_USING_SPI5 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/g0/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/g0/spi_config.h
@@ -24,6 +24,7 @@ extern "C" {
     {                                               \
         .Instance = SPI1,                           \
         .bus_name = "spi1",                         \
+        .irq_type = SPI1_IRQn,                      \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -58,6 +59,7 @@ extern "C" {
     {                                               \
         .Instance = SPI2,                           \
         .bus_name = "spi2",                         \
+        .irq_type = SPI2_IRQn,                      \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/g4/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/g4/spi_config.h
@@ -24,6 +24,7 @@ extern "C" {
     {                                               \
         .Instance = SPI1,                           \
         .bus_name = "spi1",                         \
+        .irq_type = SPI1_IRQn,                      \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -58,6 +59,7 @@ extern "C" {
     {                                               \
         .Instance = SPI2,                           \
         .bus_name = "spi2",                         \
+        .irq_type = SPI2_IRQn,                      \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
@@ -92,6 +94,7 @@ extern "C" {
     {                                               \
         .Instance = SPI3,                           \
         .bus_name = "spi3",                         \
+        .irq_type = SPI3_IRQn,                      \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
@@ -126,6 +129,7 @@ extern "C" {
     {                                               \
         .Instance = SPI4,                           \
         .bus_name = "spi4",                         \
+        .irq_type = SPI4_IRQn,                      \
     }
 #endif /* SPI4_BUS_CONFIG */
 #endif /* BSP_USING_SPI4 */
@@ -160,6 +164,7 @@ extern "C" {
     {                                               \
         .Instance = SPI5,                           \
         .bus_name = "spi5",                         \
+        .irq_type = SPI5_IRQn,                      \
     }
 #endif /* SPI5_BUS_CONFIG */
 #endif /* BSP_USING_SPI5 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/h7/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/h7/spi_config.h
@@ -23,6 +23,7 @@ extern "C" {
     {                                               \
         .Instance = SPI1,                           \
         .bus_name = "spi1",                         \
+        .irq_type = SPI1_IRQn,                      \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -57,6 +58,7 @@ extern "C" {
     {                                               \
         .Instance = SPI2,                           \
         .bus_name = "spi2",                         \
+        .irq_type = SPI2_IRQn,                      \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
@@ -91,6 +93,7 @@ extern "C" {
     {                                               \
         .Instance = SPI3,                           \
         .bus_name = "spi3",                         \
+        .irq_type = SPI3_IRQn,                      \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
@@ -125,6 +128,7 @@ extern "C" {
     {                                               \
         .Instance = SPI4,                           \
         .bus_name = "spi4",                         \
+        .irq_type = SPI4_IRQn,                      \
     }
 #endif /* SPI4_BUS_CONFIG */
 #endif /* BSP_USING_SPI4 */
@@ -159,6 +163,7 @@ extern "C" {
     {                                               \
         .Instance = SPI5,                           \
         .bus_name = "spi5",                         \
+        .irq_type = SPI5_IRQn,                      \
     }
 #endif /* SPI5_BUS_CONFIG */
 #endif /* BSP_USING_SPI5 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/l1/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l1/spi_config.h
@@ -24,6 +24,7 @@ extern "C" {
     {                                               \
         .Instance = SPI1,                           \
         .bus_name = "spi1",                         \
+        .irq_type = SPI1_IRQn,                      \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -56,6 +57,7 @@ extern "C" {
     {                                               \
         .Instance = SPI2,                           \
         .bus_name = "spi2",                         \
+        .irq_type = SPI2_IRQn,                      \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
@@ -88,6 +90,7 @@ extern "C" {
     {                                               \
         .Instance = SPI3,                           \
         .bus_name = "spi3",                         \
+        .irq_type = SPI3_IRQn,                      \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/l4/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l4/spi_config.h
@@ -23,6 +23,7 @@ extern "C" {
     {                                                       \
         .Instance = SPI1,                                   \
         .bus_name = "spi1",                                 \
+        .irq_type = SPI1_IRQn,                      \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -57,6 +58,7 @@ extern "C" {
     {                                                       \
         .Instance = SPI2,                                   \
         .bus_name = "spi2",                                 \
+        .irq_type = SPI2_IRQn,                      \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
@@ -91,6 +93,7 @@ extern "C" {
     {                                                       \
         .Instance = SPI3,                                   \
         .bus_name = "spi3",                                 \
+        .irq_type = SPI3_IRQn,                      \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/mp1/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/mp1/spi_config.h
@@ -23,6 +23,7 @@ extern "C" {
     {                                               \
         .Instance = SPI1,                           \
         .bus_name = "spi1",                         \
+        .irq_type = SPI1_IRQn,                      \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -57,6 +58,7 @@ extern "C" {
     {                                               \
         .Instance = SPI2,                           \
         .bus_name = "spi2",                         \
+        .irq_type = SPI2_IRQn,                      \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
@@ -91,6 +93,7 @@ extern "C" {
     {                                               \
         .Instance = SPI3,                           \
         .bus_name = "spi3",                         \
+        .irq_type = SPI3_IRQn,                      \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
@@ -125,6 +128,7 @@ extern "C" {
     {                                               \
         .Instance = SPI4,                           \
         .bus_name = "spi4",                         \
+        .irq_type = SPI4_IRQn,                      \
     }
 #endif /* SPI4_BUS_CONFIG */
 #endif /* BSP_USING_SPI4 */
@@ -159,6 +163,7 @@ extern "C" {
     {                                               \
         .Instance = SPI5,                           \
         .bus_name = "spi5",                         \
+        .irq_type = SPI5_IRQn,                      \
     }
 #endif /* SPI5_BUS_CONFIG */
 #endif /* BSP_USING_SPI5 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/wb/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/wb/spi_config.h
@@ -23,6 +23,7 @@ extern "C" {
     {                                                       \
         .Instance = SPI1,                                   \
         .bus_name = "spi1",                                 \
+        .irq_type = SPI1_IRQn,                              \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -57,6 +58,7 @@ extern "C" {
     {                                                       \
         .Instance = SPI2,                                   \
         .bus_name = "spi2",                                 \
+        .irq_type = SPI2_IRQn,                              \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
@@ -91,6 +93,7 @@ extern "C" {
     {                                                       \
         .Instance = SPI3,                                   \
         .bus_name = "spi3",                                 \
+        .irq_type = SPI3_IRQn,                              \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/wl/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/wl/spi_config.h
@@ -23,6 +23,7 @@ extern "C" {
     {                                                       \
         .Instance = SPI1,                                   \
         .bus_name = "spi1",                                 \
+        .irq_type = SPI1_IRQn,                              \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
@@ -57,6 +58,7 @@ extern "C" {
     {                                                       \
         .Instance = SPI2,                                   \
         .bus_name = "spi2",                                 \
+        .irq_type = SPI2_IRQn,                              \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
@@ -91,6 +93,7 @@ extern "C" {
     {                                                       \
         .Instance = SPI3,                                   \
         .bus_name = "spi3",                                 \
+        .irq_type = SPI3_IRQn,                              \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */

--- a/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
@@ -263,6 +263,12 @@ static rt_err_t stm32_spi_init(struct stm32_spi *spi_drv, struct rt_spi_configur
         HAL_NVIC_SetPriority(spi_drv->config->dma_tx->dma_irq, 0, 1);
         HAL_NVIC_EnableIRQ(spi_drv->config->dma_tx->dma_irq);
     }
+    
+    if(spi_drv->spi_dma_flag & SPI_USING_TX_DMA_FLAG || spi_drv->spi_dma_flag & SPI_USING_RX_DMA_FLAG)
+    {
+        HAL_NVIC_SetPriority(spi_drv->config->irq_type, 2, 0);
+        HAL_NVIC_EnableIRQ(spi_drv->config->irq_type);
+    }
 
     LOG_D("%s init done", spi_drv->config->bus_name);
     return RT_EOK;

--- a/bsp/stm32/libraries/HAL_Drivers/drv_spi.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_spi.h
@@ -37,6 +37,7 @@ struct stm32_spi_config
 {
     SPI_TypeDef *Instance;
     char *bus_name;
+    IRQn_Type irq_type;
     struct dma_config *dma_rx, *dma_tx;
 };
 

--- a/bsp/stm32/stm32f072-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f072-st-nucleo/board/Kconfig
@@ -31,8 +31,8 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART1 RX DMA"
                 depends on BSP_USING_UART1 && RT_SERIAL_USING_DMA
                 default n
-				
-			config BSP_USING_UART2
+
+            config BSP_USING_UART2
                 bool "Enable UART2"
                 default y
 
@@ -40,44 +40,6 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART2 RX DMA"
                 depends on BSP_USING_UART2 && RT_SERIAL_USING_DMA
                 default n
-        endif
-
-    menuconfig BSP_USING_SPI
-        bool "Enable SPI BUS"
-        default n
-        select RT_USING_SPI
-        if BSP_USING_SPI
-            config BSP_USING_SPI1
-                bool "Enable SPI1 BUS"
-                default n
-
-            config BSP_SPI1_TX_USING_DMA
-                bool "Enable SPI1 TX DMA"
-                depends on BSP_USING_SPI1
-                default n
-                
-            config BSP_SPI1_RX_USING_DMA
-                bool "Enable SPI1 RX DMA"
-                depends on BSP_USING_SPI1
-                select BSP_SPI1_TX_USING_DMA
-                default n
-        endif
-
-    menuconfig BSP_USING_I2C1
-        bool "Enable I2C1 BUS (software simulation)"
-        default n
-        select RT_USING_I2C
-        select RT_USING_I2C_BITOPS
-        select RT_USING_PIN
-        if BSP_USING_I2C1
-            config BSP_I2C1_SCL_PIN
-                int "i2c1 scl pin number"
-                range 1 216
-                default 15
-            config BSP_I2C1_SDA_PIN
-                int "I2C1 sda pin number"
-                range 1 216
-                default 16
         endif
     source "../libraries/HAL_Drivers/Kconfig"
     


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
本 PR 是修复 gitee 上的一个 [issuse](https://gitee.com/rtthread/rt-thread/issues/I3NDPA)

在使用 SPI DMA 收发时需要使能外设中断，查看了 `stm32f407-atk`  这个 BSP 在 msp.c 中就打开了外设中断，然后能正常工作，所以就有了 issues 提到的中断未开启导致 DMA 方式接受失败的问题。

这个中断的使能，如果在 cubemx 配置了，就会在 msp.c 文件生成，如果没有配置，就需要在驱动层去配置。这个中断应该在哪个地方使能，目前没有看到有具体的说法。

查看了 uart 和 eth 的驱动，发现中断的使能都是在驱动层，因此有了本次的 PR。

本次提交在 `stm32f407-atk`  和 `ART-Pi` 测试通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
