### PR TITLE
[net][lwip] Fix the compile error when enable RT_LWIP_DEBUG relate config

### DIFF
--- a/components/net/lwip-2.0.2/src/arch/include/arch/cc.h
+++ b/components/net/lwip-2.0.2/src/arch/include/arch/cc.h
@@ -38,12 +38,14 @@
 #include <rthw.h>
 #include <rtthread.h>
 
+#define X8_F  "02x"
 #define U16_F "hu"
 #define S16_F "hd"
 #define X16_F "hx"
 #define U32_F "lu"
 #define S32_F "ld"
 #define X32_F "lx"
+#define SZT_F U32_F
 
 #if defined(RT_USING_LIBC) || defined(RT_LIBC_USING_TIME) || (defined( __GNUC__ ) && !defined(__ARMCC_VERSION))
 #include <sys/time.h>

--- a/components/net/lwip-2.1.2/src/arch/include/arch/cc.h
+++ b/components/net/lwip-2.1.2/src/arch/include/arch/cc.h
@@ -38,12 +38,14 @@
 #include <rthw.h>
 #include <rtthread.h>
 
+#define X8_F  "02x"
 #define U16_F "hu"
 #define S16_F "hd"
 #define X16_F "hx"
 #define U32_F "lu"
 #define S32_F "ld"
 #define X32_F "lx"
+#define SZT_F U32_F
 
 #ifdef RT_USING_LIBC
 #if defined(__CC_ARM) || defined(__CLANG_ARM) || defined(__IAR_SYSTEMS_ICC__)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
解决了在 **lwip-2.0.2** 和 **lwip-2.1.2** 版本上开启 RT_LWIP_DEBUG 等相关的宏之后,编译出错的问题,具体编译时的错误打印是:
![](https://ftp.bmp.ovh/imgs/2021/04/f860195418d81f40.png)
![](https://ftp.bmp.ovh/imgs/2021/04/e0c87305d1c4563a.png)
原因是 lwip 在 2.0.2 和 2.1.2 版本中取消了在 1.4.1 版本对这两个宏的补充定义:
``` C
/** Temporary: define format string for size_t if not defined in cc.h */
#ifndef SZT_F
#define SZT_F U32_F
#endif /* SZT_F */
/** Temporary upgrade helper: define format string for u8_t as hex if not
    defined in cc.h */
#ifndef X8_F
#define X8_F  "02x"
#endif /* X8_F */
```
并确认并列出已经在什么情况或板卡上进行了测试。
STM32F407ZET6 板卡
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
