### PR TITLE
[fix] ignore useless dirty data when AT interactive process is exceptional.

### DIFF
--- a/components/net/at/src/at_client.c
+++ b/components/net/at/src/at_client.c
@@ -437,7 +437,7 @@ rt_size_t at_client_obj_send(at_client_t client, const char *buf, rt_size_t size
     }
 
 #ifdef AT_PRINT_RAW_CMD
-    at_print_raw_cmd("sendline", buf, size);
+    at_print_raw_cmd("senddata", buf, size);
 #endif
 
     return rt_device_write(client->device, 0, buf, size);
@@ -508,7 +508,7 @@ rt_size_t at_client_obj_recv(at_client_t client, char *buf, rt_size_t size, rt_i
     }
 
 #ifdef AT_PRINT_RAW_CMD
-    at_print_raw_cmd("urc_recv", buf, size);
+    at_print_raw_cmd("recvdata", buf, read_idx);
 #endif
 
     return read_idx;
@@ -715,10 +715,6 @@ static int at_recv_readline(at_client_t client)
         last_ch = ch;
     }
 
-#ifdef AT_PRINT_RAW_CMD
-    at_print_raw_cmd("recvline", client->recv_line_buf, read_len);
-#endif
-
     return read_len;
 }
 
@@ -735,13 +731,18 @@ static void client_parser(at_client_t client)
                 /* current receive is request, try to execute related operations */
                 if (urc->func != RT_NULL)
                 {
+#ifdef AT_PRINT_RAW_CMD
+                    at_print_raw_cmd(" urc_cmd", client->recv_line_buf, client->recv_line_len);
+#endif
                     urc->func(client, client->recv_line_buf, client->recv_line_len);
                 }
             }
             else if (client->resp != RT_NULL)
             {
                 at_response_t resp = client->resp;
-
+#ifdef AT_PRINT_RAW_CMD
+                at_print_raw_cmd("recvline", client->recv_line_buf, client->recv_line_len);
+#endif
                 /* current receive is response */
                 client->recv_line_buf[client->recv_line_len - 1] = '\0';
                 if (resp->buf_len + client->recv_line_len < resp->buf_size)
@@ -785,7 +786,9 @@ static void client_parser(at_client_t client)
             }
             else
             {
-//                log_d("unrecognized line: %.*s", client->recv_line_len, client->recv_line_buf);
+#ifdef AT_PRINT_RAW_CMD
+                at_print_raw_cmd("    drop", client->recv_line_buf, client->recv_line_len);
+#endif
             }
         }
     }

--- a/components/net/at/src/at_client.c
+++ b/components/net/at/src/at_client.c
@@ -304,6 +304,13 @@ int at_obj_exec_cmd(at_client_t client, at_response_t resp, const char *cmd_expr
 
     rt_mutex_take(client->lock, RT_WAITING_FOREVER);
 
+    /* clear the needless "rx buffer" data, ignore useless data */
+    if(client->rx_notice != RT_NULL)
+    {
+        char ch;
+        while(rt_device_read(client->device, 0, &ch, 1) != 0);
+    }
+
     client->resp_status = AT_RESP_OK;
     client->resp = resp;
 

--- a/components/net/at/src/at_utils.c
+++ b/components/net/at/src/at_utils.c
@@ -70,7 +70,7 @@ rt_size_t at_vprintf(rt_device_t device, const char *format, va_list args)
     last_cmd_len = vsnprintf(send_buf, sizeof(send_buf), format, args);
 
 #ifdef AT_PRINT_RAW_CMD
-    at_print_raw_cmd("sendline", send_buf, last_cmd_len);
+    at_print_raw_cmd(" sendcmd", send_buf, last_cmd_len);
 #endif
 
     return rt_device_write(device, 0, send_buf, last_cmd_len);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
  Clear the buffer before executing the next  AT command to prevent dirty data to interfere the next instruction.

  have tested on atk-f407 + ESP8266.


   https://github.com/RT-Thread-packages/at_device/issues/155
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
