### PR TITLE
[libc][time] remove _TIMESPEC_DEFINED in common/sys/time.h and complete time.c

### DIFF
--- a/components/libc/compilers/common/sys/time.h
+++ b/components/libc/compilers/common/sys/time.h
@@ -18,14 +18,6 @@
 extern "C" {
 #endif
 
-/*
- * Skip define timespec for IAR version over 8.10.1 where __VER__ is 8010001.
- */
-#if defined ( __ICCARM__ ) && (__VER__ >= 8010001)
-#define _TIMESPEC_DEFINED
-#endif
-
-
 #ifndef _TIMEVAL_DEFINED
 #define _TIMEVAL_DEFINED
 /*
@@ -40,7 +32,7 @@ struct timeval {
 #endif
 #endif /* _TIMEVAL_DEFINED */
 
-#if !(defined(__GNUC__) && !defined(__ARMCC_VERSION)/*GCC*/) && !defined (__ICCARM__) && !defined (_WIN32)
+#if !(defined(__GNUC__) && !defined(__ARMCC_VERSION)/*GCC*/) && !(defined(__ICCARM__) && (__VER__ >= 8010001)) && !defined(_WIN32)
 struct timespec {
     time_t  tv_sec;     /* seconds */
     long    tv_nsec;    /* and nanoseconds */

--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -270,7 +270,7 @@ char* asctime(const struct tm *timeptr)
 }
 RTM_EXPORT(asctime);
 
-char *ctime_r (const time_t * tim_p, char * result)
+char *ctime_r(const time_t * tim_p, char * result)
 {
     struct tm tm;
     return asctime_r(localtime_r(tim_p, &tm), result);

--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -16,7 +16,7 @@
  * 2012-12-08     Bernard      <clock_time.c> fix the issue of _timevalue.tv_usec initialization,
  *                             which found by Rob <rdent@iinet.net.au>
  * 2021-02-12     Meco Man     move all of the functions located in <clock_time.c> to this file
- * 2021-03-15     Meco Man     fixed bug: https://club.rt-thread.org/ask/question/423650.html
+ * 2021-03-15     Meco Man     fixed a bug of leaking memory in asctime()
  */
 
 #include <sys/time.h>
@@ -104,7 +104,7 @@ static int get_timeval(struct timeval *tv)
     }
     else
     {
-        /* LOG_W will cause a recursive printing if ulog timestamp function is turned on */
+        /* LOG_W will cause a recursive printing if ulog timestamp function is enabled */
         rt_kprintf("Cannot find a RTC device to provide time!\r\n");
         return -1;
     }
@@ -112,7 +112,7 @@ static int get_timeval(struct timeval *tv)
     return (rst < 0) ? -1 : 1;
 
 #else
-    /* LOG_W will cause a recursive printing if ulog timestamp function is turned on */
+    /* LOG_W will cause a recursive printing if ulog timestamp function is enabled */
     rt_kprintf("Cannot find a RTC device to provide time!\r\n");
     return -1;
 #endif /* RT_USING_RTC */
@@ -273,13 +273,13 @@ RTM_EXPORT(asctime);
 char *ctime_r (const time_t * tim_p, char * result)
 {
     struct tm tm;
-    return asctime_r (localtime_r (tim_p, &tm), result);
+    return asctime_r(localtime_r(tim_p, &tm), result);
 }
 RTM_EXPORT(ctime_r);
 
 char* ctime(const time_t *tim_p)
 {
-    return asctime (localtime (tim_p));
+    return asctime(localtime(tim_p));
 }
 RTM_EXPORT(ctime);
 

--- a/components/libc/compilers/newlib/SConscript
+++ b/components/libc/compilers/newlib/SConscript
@@ -4,17 +4,18 @@ Import('rtconfig')
 src = []
 cwd = GetCurrentDir()
 group = []
-
+LIBS = []
+CPPDEFINES = []
 CPPPATH = [cwd]
 
 if rtconfig.PLATFORM == 'gcc':
     if GetDepend('RT_USING_LIBC'):
-        CPPDEFINES = ['RT_USING_NEWLIB']
+        CPPDEFINES += ['RT_USING_NEWLIB']
         # link with libc and libm:
         # libm is a frequently used lib. Newlib is compiled with -ffunction-sections in
         # recent GCC tool chains. The linker would just link in the functions that have
         # been referenced. So setting this won't result in bigger text size.
-        LIBS = ['c', 'm']
+        LIBS += ['c', 'm']
 
         src += Glob('*.c')
         SrcRemove(src, ['minilib.c'])
@@ -22,8 +23,6 @@ if rtconfig.PLATFORM == 'gcc':
             SrcRemove(src, ['libc_syms.c'])
     else:
         src += ['minilib.c']
-        CPPDEFINES = []
-        LIBS = []
 
     group = DefineGroup('libc', src, depend = [], CPPPATH = CPPPATH, CPPDEFINES = CPPDEFINES, LIBS = LIBS)
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
去除没有用的宏定义 _TIMESPEC_DEFINED 该定义未在newlib或者musl中出现
细微调整了代码格式
gcc keil iar编译通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
