### PR TITLE
[libc][time]优化gettimeofday/settimeofday; 规范set_timeval/get_timeval函数返回值

### DIFF
--- a/components/libc/compilers/common/sys/mman.h
+++ b/components/libc/compilers/common/sys/mman.h
@@ -16,7 +16,7 @@ extern "C" {
 #endif
 
 #include <sys/types.h>
-    
+
 #define MAP_FAILED     ((void *) -1)
 
 #define MAP_SHARED     0x01

--- a/components/libc/compilers/common/sys/time.h
+++ b/components/libc/compilers/common/sys/time.h
@@ -18,9 +18,6 @@
 extern "C" {
 #endif
 
-#ifndef _TIMEVAL_DEFINED
-#define _TIMEVAL_DEFINED
-
 #define DST_NONE    0   /* not on dst */
 #define DST_USA     1   /* USA style dst */
 #define DST_AUST    2   /* Australian style dst */
@@ -33,6 +30,8 @@ extern "C" {
 #define DST_TUR     9   /* Turkey */
 #define DST_AUSTALT 10  /* Australian style with shift in 1986 */
 
+#ifndef _TIMEVAL_DEFINED
+#define _TIMEVAL_DEFINED
 /*
  * Structure returned by gettimeofday(2) system call,
  * and used in other calls.

--- a/components/libc/compilers/common/sys/time.h
+++ b/components/libc/compilers/common/sys/time.h
@@ -20,6 +20,19 @@ extern "C" {
 
 #ifndef _TIMEVAL_DEFINED
 #define _TIMEVAL_DEFINED
+
+#define DST_NONE    0   /* not on dst */
+#define DST_USA     1   /* USA style dst */
+#define DST_AUST    2   /* Australian style dst */
+#define DST_WET     3   /* Western European dst */
+#define DST_MET     4   /* Middle European dst */
+#define DST_EET     5   /* Eastern European dst */
+#define DST_CAN     6   /* Canada */
+#define DST_GB      7   /* Great Britain and Eire */
+#define DST_RUM     8   /* Rumania */
+#define DST_TUR     9   /* Turkey */
+#define DST_AUSTALT 10  /* Australian style with shift in 1986 */
+
 /*
  * Structure returned by gettimeofday(2) system call,
  * and used in other calls.

--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -424,7 +424,7 @@ int gettimeofday(struct timeval *tv, struct timezone *tz)
      */
     if(tz != RT_NULL)
     {
-        tz->tz_dsttime = 0;
+        tz->tz_dsttime = DST_NONE;
         tz->tz_minuteswest = -(RT_LIBC_FIXED_TIMEZONE * 60);
     }
 

--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -20,7 +20,7 @@
  * 2021-05-01     Meco Man     support fixed timezone
  */
 
-#include <sys/time.h>
+#include "sys/time.h"
 #include <rtthread.h>
 
 #ifdef RT_USING_DEVICE

--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -124,11 +124,11 @@ static rt_err_t get_timeval(struct timeval *tv)
 }
 
 /**
- * Set time to RTC device (without timezone)
+ * Set time to RTC device (without timezone, UTC+0)
  * @param tv: struct timeval
  * @return the operation status, RT_EOK on successful
  */
-static int set_timeval(struct timeval *tv)
+static rt_err_t set_timeval(struct timeval *tv)
 {
 #ifdef RT_USING_RTC
     static rt_device_t device = RT_NULL;

--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -17,6 +17,7 @@
  *                             which found by Rob <rdent@iinet.net.au>
  * 2021-02-12     Meco Man     move all of the functions located in <clock_time.c> to this file
  * 2021-03-15     Meco Man     fixed a bug of leaking memory in asctime()
+ * 2021-05-01     Meco Man     support fixed timezone
  */
 
 #include <sys/time.h>
@@ -73,18 +74,18 @@ static void num2str(char *c, int i)
 }
 
 /**
- * Get time from RTC device (without timezone)
+ * Get time from RTC device (without timezone, UTC+0)
  * @param tv: struct timeval
- * @return -1 failure; 1 success
+ * @return the operation status, RT_EOK on successful
  */
-static int get_timeval(struct timeval *tv)
+static rt_err_t get_timeval(struct timeval *tv)
 {
 #ifdef RT_USING_RTC
     static rt_device_t device = RT_NULL;
     rt_err_t rst = -RT_ERROR;
 
     if (tv == RT_NULL)
-        return -1;
+        return -RT_EINVAL;
 
     /* default is 0 */
     tv->tv_sec = 0;
@@ -110,22 +111,22 @@ static int get_timeval(struct timeval *tv)
     {
         /* LOG_W will cause a recursive printing if ulog timestamp function is enabled */
         rt_kprintf("Cannot find a RTC device to provide time!\r\n");
-        return -1;
+        return -RT_ENOSYS;
     }
 
-    return (rst < 0) ? -1 : 1;
+    return rst;
 
 #else
     /* LOG_W will cause a recursive printing if ulog timestamp function is enabled */
     rt_kprintf("Cannot find a RTC device to provide time!\r\n");
-    return -1;
+    return -RT_ENOSYS;
 #endif /* RT_USING_RTC */
 }
 
 /**
  * Set time to RTC device (without timezone)
  * @param tv: struct timeval
- * @return -1 failure; 1 success
+ * @return the operation status, RT_EOK on successful
  */
 static int set_timeval(struct timeval *tv)
 {
@@ -134,7 +135,7 @@ static int set_timeval(struct timeval *tv)
     rt_err_t rst = -RT_ERROR;
 
     if (tv == RT_NULL)
-        return -1;
+        return -RT_EINVAL;
 
     /* optimization: find rtc device only first */
     if (device == RT_NULL)
@@ -155,14 +156,14 @@ static int set_timeval(struct timeval *tv)
     else
     {
         LOG_W("Cannot find a RTC device to provide time!");
-        return -1;
+        return -RT_ENOSYS;
     }
 
-    return (rst < 0) ? -1 : 1;
+    return rst;
 
 #else
     LOG_W("Cannot find a RTC device to provide time!");
-    return -1;
+    return -RT_ENOSYS;
 #endif /* RT_USING_RTC */
 }
 
@@ -294,7 +295,7 @@ RT_WEAK time_t time(time_t *t)
 {
     struct timeval now;
 
-    if(get_timeval(&now) > 0)
+    if(get_timeval(&now) == RT_EOK)
     {
         if (t)
         {
@@ -304,7 +305,7 @@ RT_WEAK time_t time(time_t *t)
     }
     else
     {
-        errno = EFAULT;
+        rt_set_errno(EFAULT);
         return ((time_t)-1);
     }
 }
@@ -322,18 +323,18 @@ int stime(const time_t *t)
 
     if (!t)
     {
-        errno = EFAULT;
+        rt_set_errno(EFAULT);
         return -1;
     }
 
     tv.tv_sec = *t;
-    if (set_timeval(&tv) > 0)
+    if (set_timeval(&tv) == RT_EOK)
     {
         return 0;
     }
     else
     {
-        errno = EFAULT;
+        rt_set_errno(EFAULT);
         return -1;
     }
 }
@@ -414,47 +415,53 @@ time_t timegm(struct tm * const t)
 }
 RTM_EXPORT(timegm);
 
-/* TODO: timezone */
+/* TODO: Daylight Saving Time */
 int gettimeofday(struct timeval *tv, struct timezone *tz)
 {
-    if (tv != RT_NULL && get_timeval(tv) > 0)
+    if(tz != RT_NULL)
+    {
+        tz->tz_dsttime = 0;
+        tz->tz_minuteswest = -(RT_LIBC_FIXED_TIMEZONE * 60);
+    }
+
+    if (tv != RT_NULL && get_timeval(tv) == RT_EOK)
     {
         return 0;
     }
     else
     {
-        errno = EFAULT;
+        rt_set_errno(EFAULT);
         return -1;
     }
 }
 RTM_EXPORT(gettimeofday);
 
-/* TODO: timezone */
+/* TODO: Daylight Saving Time */
 int settimeofday(const struct timeval *tv, const struct timezone *tz)
 {
     if (tv != RT_NULL)
     {
         if(tv->tv_sec >= 0 && tv->tv_usec >= 0)
         {
-            if(set_timeval((struct timeval *)tv) > 0)
+            if(set_timeval((struct timeval *)tv) == RT_EOK)
             {
                 return 0;
             }
             else
             {
-                errno = EFAULT;
+                rt_set_errno(EFAULT);
                 return -1;
             }
         }
         else
         {
-            errno = EINVAL;
+            rt_set_errno(EINVAL);
             return -1;
         }
     }
     else
     {
-        errno = EFAULT;
+        rt_set_errno(EFAULT);
         return -1;
     }
 }

--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -128,7 +128,7 @@ static rt_err_t get_timeval(struct timeval *tv)
  * @param tv: struct timeval
  * @return the operation status, RT_EOK on successful
  */
-static int set_timeval(const struct timeval *tv)
+static int set_timeval(struct timeval *tv)
 {
 #ifdef RT_USING_RTC
     static rt_device_t device = RT_NULL;
@@ -450,7 +450,7 @@ int settimeofday(const struct timeval *tv, const struct timezone *tz)
     if (tv != RT_NULL
         && tv->tv_sec >= 0
         && tv->tv_usec >= 0
-        && set_timeval(tv) == RT_EOK)
+        && set_timeval((struct timeval *)tv) == RT_EOK)
     {
         return 0;
     }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1.优化gettimeofday/settimeofday
2.规范set_timeval/get_timeval函数返回值
3.考虑到使用time.c时，libc可能没有开启，因此由errno改为rt_set_errno

至此，简易版时区功能支持完毕。所谓简易版即时区为只能手动更改且固定不变。与简易版相对的是完整版即支持夏令时功能的版本。
简易版对中国用户没有影响，因为中国的时区永远是UTC+8。默认即为中国时区。对于中国用户而言，可认为至此RTT已经完全支持时区功能。但是简易版对欧美国家并不友好，因为欧美国家一般采用夏令时的方式，简易版时区无法支持夏令时功能。

夏令时功能将在4.0.4发布之后支持，不作为近期支持计划。夏令时功能支持起来非常麻烦。
https://github.com/RT-Thread/rt-thread/pull/4653
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
