### PR TITLE
[network][lwip][kconfig] 默认LWIP协议栈版本由2.0.2转为2.1.2

### DIFF
--- a/components/net/Kconfig
+++ b/components/net/Kconfig
@@ -114,7 +114,7 @@ config RT_USING_LWIP
     if RT_USING_LWIP
         choice
             prompt "lwIP version"
-            default RT_USING_LWIP202
+            default RT_USING_LWIP212
             help
                 Select the lwIP version
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
LWIP官方表示2.0.2在发布时意外带入了一些bug，建议用户尽快升级到2.0.3，因此默认2.0.2并不合适。默认版本改为最新稳定版2.1.2. 详见：http://savannah.nongnu.org/forum/forum.php?forum_id=8953
顺便建议2.0.2版本也尽快升级到2.0.3吧，2.0.3也是相当不错的稳定版本
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
