### PR TITLE
[ymodem] 修改YMODEM_USING_FILE_TRANSFER功能的开启条件

### DIFF
--- a/components/utilities/Kconfig
+++ b/components/utilities/Kconfig
@@ -11,8 +11,8 @@ config RT_USING_RYM
 
         config YMODEM_USING_FILE_TRANSFER
         bool "Enable file transfer feature"
-        select RT_USING_DFS
-        default n
+        depends on RT_USING_DFS
+        default y
     endif
 
 config RT_USING_ULOG

--- a/components/utilities/ymodem/SConscript
+++ b/components/utilities/ymodem/SConscript
@@ -7,7 +7,7 @@ ymodem.c
  
 CPPPATH = [cwd]
 
-if GetDepend('RT_USING_DFS') and GetDepend('YMODEM_USING_FILE_TRANSFER'):
+if GetDepend('YMODEM_USING_FILE_TRANSFER'):
     src += ['ry_sy.c']
 
 group   = DefineGroup('Utilities', src, depend = ['RT_USING_RYM'], CPPPATH = CPPPATH)


### PR DESCRIPTION
目前开启的逻辑存在问题，ymodem的文件传输功能开启的前提是得有完整的文件系统，
但是目前，这个开启逻辑错了。
用户选择YMODEM_USING_FILE_TRANSFER功能后select DFS没有任何意义，因为除了需要依赖DFS之外还要依赖其他的例如FATFS，需要和SDIO适配等等等
正确的做法应该是用户配置好完整的文件系统后，ymodem文件传输才能有机会开启，
因此是depends on DFS 而非select DFS
更改之后，只要用户开启了文件系统，在选定YMODEM时，会自动开启文件传输功能，这也是用户希望看到的，直接一键搞定，不需要再多点一步
https://club.rt-thread.org/ask/question/431237.html

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
