### PR TITLE
add RT_DEBUG_SCHEDULER_AVAILABLE check.

### DIFF
--- a/components/drivers/ipc/completion.c
+++ b/components/drivers/ipc/completion.c
@@ -58,10 +58,7 @@ rt_err_t rt_completion_wait(struct rt_completion *completion,
     RT_ASSERT(completion != RT_NULL);
 
     /* current context checking */
-    if (timeout != 0)
-    {
-        RT_DEBUG_SCHEDULER_AVAILABLE;
-    }
+    RT_DEBUG_SCHEDULER_AVAILABLE(timeout != 0);
 
     result = RT_EOK;
     thread = rt_thread_self();
@@ -87,9 +84,6 @@ rt_err_t rt_completion_wait(struct rt_completion *completion,
             /* add to suspended list */
             rt_list_insert_before(&(completion->suspended_list),
                                   &(thread->tlist));
-
-            /* current context checking */
-            RT_DEBUG_NOT_IN_INTERRUPT;
 
             /* start timer */
             if (timeout > 0)

--- a/components/drivers/ipc/completion.c
+++ b/components/drivers/ipc/completion.c
@@ -57,6 +57,12 @@ rt_err_t rt_completion_wait(struct rt_completion *completion,
     rt_thread_t thread;
     RT_ASSERT(completion != RT_NULL);
 
+    /* current context checking */
+    if (timeout != 0)
+    {
+        RT_DEBUG_SCHEDULER_AVAILABLE;
+    }
+
     result = RT_EOK;
     thread = rt_thread_self();
 

--- a/components/drivers/ipc/dataqueue.c
+++ b/components/drivers/ipc/dataqueue.c
@@ -99,10 +99,7 @@ rt_err_t rt_data_queue_push(struct rt_data_queue *queue,
     RT_ASSERT(queue->magic == DATAQUEUE_MAGIC);
 
     /* current context checking */
-    if (timeout != 0)
-    {
-        RT_DEBUG_SCHEDULER_AVAILABLE;
-    }
+    RT_DEBUG_SCHEDULER_AVAILABLE(timeout != 0);
 
     result = RT_EOK;
     thread = rt_thread_self();
@@ -221,10 +218,7 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
     RT_ASSERT(size != RT_NULL);
 
     /* current context checking */
-    if (timeout != 0)
-    {
-        RT_DEBUG_SCHEDULER_AVAILABLE;
-    }
+    RT_DEBUG_SCHEDULER_AVAILABLE(timeout != 0);
 
     result = RT_EOK;
     thread = rt_thread_self();

--- a/components/drivers/ipc/dataqueue.c
+++ b/components/drivers/ipc/dataqueue.c
@@ -98,6 +98,12 @@ rt_err_t rt_data_queue_push(struct rt_data_queue *queue,
     RT_ASSERT(queue != RT_NULL);
     RT_ASSERT(queue->magic == DATAQUEUE_MAGIC);
 
+    /* current context checking */
+    if (timeout != 0)
+    {
+        RT_DEBUG_SCHEDULER_AVAILABLE;
+    }
+
     result = RT_EOK;
     thread = rt_thread_self();
 
@@ -111,9 +117,6 @@ rt_err_t rt_data_queue_push(struct rt_data_queue *queue,
 
             goto __exit;
         }
-
-        /* current context checking */
-        RT_DEBUG_NOT_IN_INTERRUPT;
 
         /* reset thread error number */
         thread->error = RT_EOK;
@@ -217,6 +220,12 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
     RT_ASSERT(data_ptr != RT_NULL);
     RT_ASSERT(size != RT_NULL);
 
+    /* current context checking */
+    if (timeout != 0)
+    {
+        RT_DEBUG_SCHEDULER_AVAILABLE;
+    }
+
     result = RT_EOK;
     thread = rt_thread_self();
 
@@ -229,9 +238,6 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
             result = -RT_ETIMEOUT;
             goto __exit;
         }
-
-        /* current context checking */
-        RT_DEBUG_NOT_IN_INTERRUPT;
 
         /* reset thread error number */
         thread->error = RT_EOK;

--- a/components/drivers/ipc/waitqueue.c
+++ b/components/drivers/ipc/waitqueue.c
@@ -129,7 +129,7 @@ int rt_wqueue_wait(rt_wqueue_t *queue, int condition, int msec)
     rt_base_t level;
 
     /* current context checking */
-    RT_DEBUG_SCHEDULER_AVAILABLE;
+    RT_DEBUG_SCHEDULER_AVAILABLE(RT_TRUE);
 
     tick = rt_tick_from_millisecond(msec);
 

--- a/components/drivers/ipc/waitqueue.c
+++ b/components/drivers/ipc/waitqueue.c
@@ -129,7 +129,7 @@ int rt_wqueue_wait(rt_wqueue_t *queue, int condition, int msec)
     rt_base_t level;
 
     /* current context checking */
-    RT_DEBUG_NOT_IN_INTERRUPT;
+    RT_DEBUG_SCHEDULER_AVAILABLE;
 
     tick = rt_tick_from_millisecond(msec);
 

--- a/include/rtdebug.h
+++ b/include/rtdebug.h
@@ -110,9 +110,31 @@ do                                                                            \
     rt_hw_interrupt_enable(level);                                            \
 }                                                                             \
 while (0)
+
+/* "scheduler available" means:
+ *     1) the scheduler has been started.
+ *     2) not in interrupt context.
+ *     3) scheduler is not locked.
+ */
+#define RT_DEBUG_SCHEDULER_AVAILABLE                                          \
+do                                                                            \
+{                                                                             \
+    rt_base_t level;                                                          \
+    level = rt_hw_interrupt_disable();                                        \
+    if (rt_critical_level() != 0)                                             \
+    {                                                                         \
+        rt_kprintf("Function[%s]: scheduler is not available\n",              \
+                   __FUNCTION__);                                             \
+        RT_ASSERT(0)                                                          \
+    }                                                                         \
+    RT_DEBUG_IN_THREAD_CONTEXT;                                               \
+    rt_hw_interrupt_enable(level);                                            \
+}                                                                             \
+while (0)
 #else
 #define RT_DEBUG_NOT_IN_INTERRUPT
 #define RT_DEBUG_IN_THREAD_CONTEXT
+#define RT_DEBUG_SCHEDULER_AVAILABLE
 #endif
 
 #else /* RT_DEBUG */
@@ -121,6 +143,7 @@ while (0)
 #define RT_DEBUG_LOG(type, message)
 #define RT_DEBUG_NOT_IN_INTERRUPT
 #define RT_DEBUG_IN_THREAD_CONTEXT
+#define RT_DEBUG_SCHEDULER_AVAILABLE
 
 #endif /* RT_DEBUG */
 

--- a/include/rtdebug.h
+++ b/include/rtdebug.h
@@ -116,25 +116,28 @@ while (0)
  *     2) not in interrupt context.
  *     3) scheduler is not locked.
  */
-#define RT_DEBUG_SCHEDULER_AVAILABLE                                          \
+#define RT_DEBUG_SCHEDULER_AVAILABLE(need_check)                              \
 do                                                                            \
 {                                                                             \
-    rt_base_t level;                                                          \
-    level = rt_hw_interrupt_disable();                                        \
-    if (rt_critical_level() != 0)                                             \
+    if (need_check)                                                           \
     {                                                                         \
-        rt_kprintf("Function[%s]: scheduler is not available\n",              \
-                   __FUNCTION__);                                             \
-        RT_ASSERT(0)                                                          \
+        rt_base_t level;                                                      \
+        level = rt_hw_interrupt_disable();                                    \
+        if (rt_critical_level() != 0)                                         \
+        {                                                                     \
+            rt_kprintf("Function[%s]: scheduler is not available\n",          \
+                    __FUNCTION__);                                            \
+            RT_ASSERT(0)                                                      \
+        }                                                                     \
+        RT_DEBUG_IN_THREAD_CONTEXT;                                           \
+        rt_hw_interrupt_enable(level);                                        \
     }                                                                         \
-    RT_DEBUG_IN_THREAD_CONTEXT;                                               \
-    rt_hw_interrupt_enable(level);                                            \
 }                                                                             \
 while (0)
 #else
 #define RT_DEBUG_NOT_IN_INTERRUPT
 #define RT_DEBUG_IN_THREAD_CONTEXT
-#define RT_DEBUG_SCHEDULER_AVAILABLE
+#define RT_DEBUG_SCHEDULER_AVAILABLE(need_check)
 #endif
 
 #else /* RT_DEBUG */
@@ -143,7 +146,7 @@ while (0)
 #define RT_DEBUG_LOG(type, message)
 #define RT_DEBUG_NOT_IN_INTERRUPT
 #define RT_DEBUG_IN_THREAD_CONTEXT
-#define RT_DEBUG_SCHEDULER_AVAILABLE
+#define RT_DEBUG_SCHEDULER_AVAILABLE(need_check)
 
 #endif /* RT_DEBUG */
 

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -484,11 +484,9 @@ rt_err_t rt_sem_take(rt_sem_t sem, rt_int32_t time)
     /* parameter check */
     RT_ASSERT(sem != RT_NULL);
     RT_ASSERT(rt_object_get_type(&sem->parent.parent) == RT_Object_Class_Semaphore);
+
     /* current context checking */
-    if (time != 0)
-    {
-        RT_DEBUG_SCHEDULER_AVAILABLE;
-    }
+    RT_DEBUG_SCHEDULER_AVAILABLE(time != 0);
 
     RT_OBJECT_HOOK_CALL(rt_object_trytake_hook, (&(sem->parent.parent)));
 
@@ -914,13 +912,8 @@ rt_err_t rt_mutex_take(rt_mutex_t mutex, rt_int32_t time)
     struct rt_thread *thread;
 
     /* this function must not be used in interrupt even if time = 0 */
-    RT_DEBUG_IN_THREAD_CONTEXT;
-
     /* current context checking */
-    if (time != 0)
-    {
-        RT_DEBUG_SCHEDULER_AVAILABLE;
-    }
+    RT_DEBUG_SCHEDULER_AVAILABLE(RT_TRUE);
 
     /* parameter check */
     RT_ASSERT(mutex != RT_NULL);
@@ -1579,12 +1572,7 @@ rt_err_t rt_event_recv(rt_event_t   event,
     RT_ASSERT(rt_object_get_type(&event->parent.parent) == RT_Object_Class_Event);
 
     /* current context checking */
-    RT_DEBUG_IN_THREAD_CONTEXT;
-
-    if (timeout != 0)
-    {
-        RT_DEBUG_SCHEDULER_AVAILABLE;
-    }
+    RT_DEBUG_SCHEDULER_AVAILABLE(RT_TRUE);
 
     if (set == 0)
         return -RT_ERROR;
@@ -2008,10 +1996,7 @@ rt_err_t rt_mb_send_wait(rt_mailbox_t mb,
     RT_ASSERT(rt_object_get_type(&mb->parent.parent) == RT_Object_Class_MailBox);
 
     /* current context checking */
-    if (timeout != 0)
-    {
-        RT_DEBUG_SCHEDULER_AVAILABLE;
-    }
+    RT_DEBUG_SCHEDULER_AVAILABLE(timeout != 0);
 
     /* initialize delta tick */
     tick_delta = 0;
@@ -2256,10 +2241,7 @@ rt_err_t rt_mb_recv(rt_mailbox_t mb, rt_ubase_t *value, rt_int32_t timeout)
     RT_ASSERT(rt_object_get_type(&mb->parent.parent) == RT_Object_Class_MailBox);
 
     /* current context checking */
-    if (timeout != 0)
-    {
-        RT_DEBUG_SCHEDULER_AVAILABLE;
-    }
+    RT_DEBUG_SCHEDULER_AVAILABLE(timeout != 0);
 
     /* initialize delta tick */
     tick_delta = 0;
@@ -2769,10 +2751,7 @@ rt_err_t rt_mq_send_wait(rt_mq_t     mq,
     RT_ASSERT(size != 0);
 
     /* current context checking */
-    if (timeout != 0)
-    {
-        RT_DEBUG_SCHEDULER_AVAILABLE;
-    }
+    RT_DEBUG_SCHEDULER_AVAILABLE(timeout != 0);
 
     /* greater than one message size */
     if (size > mq->msg_size)
@@ -3084,10 +3063,7 @@ rt_err_t rt_mq_recv(rt_mq_t    mq,
     RT_ASSERT(size != 0);
 
     /* current context checking */
-    if (timeout != 0)
-    {
-        RT_DEBUG_SCHEDULER_AVAILABLE;
-    }
+    RT_DEBUG_SCHEDULER_AVAILABLE(timeout != 0);
 
     /* initialize delta tick */
     tick_delta = 0;

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -484,6 +484,11 @@ rt_err_t rt_sem_take(rt_sem_t sem, rt_int32_t time)
     /* parameter check */
     RT_ASSERT(sem != RT_NULL);
     RT_ASSERT(rt_object_get_type(&sem->parent.parent) == RT_Object_Class_Semaphore);
+    /* current context checking */
+    if (time != 0)
+    {
+        RT_DEBUG_SCHEDULER_AVAILABLE;
+    }
 
     RT_OBJECT_HOOK_CALL(rt_object_trytake_hook, (&(sem->parent.parent)));
 
@@ -514,9 +519,6 @@ rt_err_t rt_sem_take(rt_sem_t sem, rt_int32_t time)
         }
         else
         {
-            /* current context checking */
-            RT_DEBUG_IN_THREAD_CONTEXT;
-
             /* semaphore is unavailable, push to suspend list */
             /* get current thread */
             thread = rt_thread_self();
@@ -913,6 +915,12 @@ rt_err_t rt_mutex_take(rt_mutex_t mutex, rt_int32_t time)
 
     /* this function must not be used in interrupt even if time = 0 */
     RT_DEBUG_IN_THREAD_CONTEXT;
+
+    /* current context checking */
+    if (time != 0)
+    {
+        RT_DEBUG_SCHEDULER_AVAILABLE;
+    }
 
     /* parameter check */
     RT_ASSERT(mutex != RT_NULL);
@@ -1566,11 +1574,17 @@ rt_err_t rt_event_recv(rt_event_t   event,
     register rt_ubase_t level;
     register rt_base_t status;
 
-    RT_DEBUG_IN_THREAD_CONTEXT;
-
     /* parameter check */
     RT_ASSERT(event != RT_NULL);
     RT_ASSERT(rt_object_get_type(&event->parent.parent) == RT_Object_Class_Event);
+
+    /* current context checking */
+    RT_DEBUG_IN_THREAD_CONTEXT;
+
+    if (timeout != 0)
+    {
+        RT_DEBUG_SCHEDULER_AVAILABLE;
+    }
 
     if (set == 0)
         return -RT_ERROR;
@@ -1993,6 +2007,12 @@ rt_err_t rt_mb_send_wait(rt_mailbox_t mb,
     RT_ASSERT(mb != RT_NULL);
     RT_ASSERT(rt_object_get_type(&mb->parent.parent) == RT_Object_Class_MailBox);
 
+    /* current context checking */
+    if (timeout != 0)
+    {
+        RT_DEBUG_SCHEDULER_AVAILABLE;
+    }
+
     /* initialize delta tick */
     tick_delta = 0;
     /* get current thread */
@@ -2025,7 +2045,6 @@ rt_err_t rt_mb_send_wait(rt_mailbox_t mb,
             return -RT_EFULL;
         }
 
-        RT_DEBUG_IN_THREAD_CONTEXT;
         /* suspend current thread */
         _ipc_list_suspend(&(mb->suspend_sender_thread),
                             thread,
@@ -2236,6 +2255,12 @@ rt_err_t rt_mb_recv(rt_mailbox_t mb, rt_ubase_t *value, rt_int32_t timeout)
     RT_ASSERT(mb != RT_NULL);
     RT_ASSERT(rt_object_get_type(&mb->parent.parent) == RT_Object_Class_MailBox);
 
+    /* current context checking */
+    if (timeout != 0)
+    {
+        RT_DEBUG_SCHEDULER_AVAILABLE;
+    }
+
     /* initialize delta tick */
     tick_delta = 0;
     /* get current thread */
@@ -2271,7 +2296,6 @@ rt_err_t rt_mb_recv(rt_mailbox_t mb, rt_ubase_t *value, rt_int32_t timeout)
             return -RT_ETIMEOUT;
         }
 
-        RT_DEBUG_IN_THREAD_CONTEXT;
         /* suspend current thread */
         _ipc_list_suspend(&(mb->parent.suspend_thread),
                             thread,
@@ -2744,6 +2768,12 @@ rt_err_t rt_mq_send_wait(rt_mq_t     mq,
     RT_ASSERT(buffer != RT_NULL);
     RT_ASSERT(size != 0);
 
+    /* current context checking */
+    if (timeout != 0)
+    {
+        RT_DEBUG_SCHEDULER_AVAILABLE;
+    }
+
     /* greater than one message size */
     if (size > mq->msg_size)
         return -RT_ERROR;
@@ -2784,7 +2814,6 @@ rt_err_t rt_mq_send_wait(rt_mq_t     mq,
             return -RT_EFULL;
         }
 
-        RT_DEBUG_IN_THREAD_CONTEXT;
         /* suspend current thread */
         _ipc_list_suspend(&(mq->suspend_sender_thread),
                             thread,
@@ -3054,6 +3083,12 @@ rt_err_t rt_mq_recv(rt_mq_t    mq,
     RT_ASSERT(buffer != RT_NULL);
     RT_ASSERT(size != 0);
 
+    /* current context checking */
+    if (timeout != 0)
+    {
+        RT_DEBUG_SCHEDULER_AVAILABLE;
+    }
+
     /* initialize delta tick */
     tick_delta = 0;
     /* get current thread */
@@ -3074,8 +3109,6 @@ rt_err_t rt_mq_recv(rt_mq_t    mq,
     /* message queue is empty */
     while (mq->entry == 0)
     {
-        RT_DEBUG_IN_THREAD_CONTEXT;
-
         /* reset error number in thread */
         thread->error = RT_EOK;
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
在获取锁的时候，如果调度器不可用，会导致系统异常，而且没有任何提示信息，破坏临界区。用来检查是否存在滥用 rt_enter_critical 的情况。
所以添加了两种情况下的检查：
- 获取锁且不等待时，不论能否获取到都不做任何处理
- 不论能否获取到锁，只要等待，都要检查调度器是否可用（可以被调度走：检查调度器不被锁，且处于线程模式下）。

在ART-Pi上完成了测试。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
