### PR TITLE
[kernel]对rt_tick_increase临界区进行保护

### DIFF
--- a/src/clock.c
+++ b/src/clock.c
@@ -62,6 +62,9 @@ void rt_tick_set(rt_tick_t tick)
 void rt_tick_increase(void)
 {
     struct rt_thread *thread;
+    rt_base_t level;
+
+    level = rt_hw_interrupt_disable();
 
     /* increase the global tick */
 #ifdef RT_USING_SMP
@@ -76,16 +79,16 @@ void rt_tick_increase(void)
     -- thread->remaining_tick;
     if (thread->remaining_tick == 0)
     {
-        rt_base_t level;
-
         /* change to initialized tick */
         thread->remaining_tick = thread->init_tick;
-
-        level = rt_hw_interrupt_disable();
         thread->stat |= RT_THREAD_STAT_YIELD;
-        rt_hw_interrupt_enable(level);
 
+        rt_hw_interrupt_enable(level);
         rt_schedule();
+    }
+    else
+    {
+        rt_hw_interrupt_enable(level);
     }
 
     /* check timer */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
对 #4741 做出补充，由于滴答时钟中断一般位于最低优先级，该函数内的全局变量必须予以保护，以防止用户在高优先级中断中修改对应全局变量时造成意外。
类似：https://github.com/weston-embedded/uC-OS3/blob/develop/Source/os_tick.c#L94-L129
stm32f407探路者测试通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
