### PR TITLE
[stm32][bluepill] fix flash size

### DIFF
--- a/bsp/stm32/stm32f103-blue-pill/board/linker_scripts/link.lds
+++ b/bsp/stm32/stm32f103-blue-pill/board/linker_scripts/link.lds
@@ -5,7 +5,7 @@
 /* Program Entry, set to mark it as "used" and avoid gc */
 MEMORY
 {
-    ROM (rx) : ORIGIN = 0x08000000, LENGTH = 128k /* 128KB flash */
+    ROM (rx) : ORIGIN = 0x08000000, LENGTH =  64k /* 64KB flash */
     RAM (rw) : ORIGIN = 0x20000000, LENGTH =  20k /* 20K sram */
 }
 ENTRY(Reset_Handler)


### PR DESCRIPTION
Signed-off-by: wuhanstudio <wuhanstudio@qq.com>

## 拉取/合并请求描述：(PR description)

[

Even though the stm32F103C8T6 has 128KB flash secretly, the last 64KB is not writeable using the official st-link programmer, which is being used in RT-Thread Studio.

As a result, if the firmware grows larger than 64KB, RT-Thread Studio will fail to flash the firmware, but it gives no error. 

Perhaps it's better to stick with the official documentation that sets the flash size to be 64KB, so that RT-Thread Studio will raise an error to kindly remind users that the firmware exceeds the limit.

https://zhuanlan.zhihu.com/p/72752458

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
