### PR TITLE
fixed bug of lcd_draw_line function when y1 == y2. need to consider u…

### DIFF
--- a/bsp/stm32/stm32l475-atk-pandora/board/ports/drv_lcd.c
+++ b/bsp/stm32/stm32l475-atk-pandora/board/ports/drv_lcd.c
@@ -446,18 +446,33 @@ void lcd_draw_line(rt_uint16_t x1, rt_uint16_t y1, rt_uint16_t x2, rt_uint16_t y
     if (y1 == y2)
     {
         /* fast draw transverse line */
-        lcd_address_set(x1, y1, x2, y2);
+        rt_uint32_t x_offset = 0;
+        if (x1 < x2)
+        {
+            x_offset = x2 - x1;
+            lcd_address_set(x1, y1, x2, y2);
+        }
+        else if (x1 > x2)
+        {
+            x_offset = x1 - x2;
+            lcd_address_set(x2, y2, x1, y1);
+        }
+        else
+        {
+            lcd_draw_point(x1, y1);
+            return;
+        }
 
         rt_uint8_t line_buf[480] = {0};
 
-        for (i = 0; i < x2 - x1; i++)
+        for (i = 0; i < x_offset; i++)
         {
             line_buf[2 * i] = FORE_COLOR >> 8;
             line_buf[2 * i + 1] = FORE_COLOR;
         }
 
         rt_pin_write(LCD_DC_PIN, PIN_HIGH);
-        rt_spi_send(spi_dev_lcd, line_buf, (x2 - x1) * 2);
+        rt_spi_send(spi_dev_lcd, line_buf, x_offset * 2);
 
         return ;
     }


### PR DESCRIPTION
…ser case when x1 >= x2

## 拉取/合并请求描述：(PR description)

[
lcd_draw_line function does not consider x1 >= x2 cases, it will fail when caller want draw a horizontal line from right to left.
add some codes to process x1 > x2 or x1 == x2
verified on Pandora board
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
