### PR TITLE
[bug][kernel][heap] 将内存堆信号量保护机制由FIFO改为PRIO

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -250,7 +250,7 @@ void rt_system_heap_init(void *begin_addr, void *end_addr)
     rt_mem_setname(heap_end, "INIT");
 #endif
 
-    rt_sem_init(&heap_sem, "heap", 1, RT_IPC_FLAG_FIFO);
+    rt_sem_init(&heap_sem, "heap", 1, RT_IPC_FLAG_PRIO);
 
     /* initialize the lowest-free pointer to the start of the heap */
     lfree = (struct heap_mem *)heap_ptr;

--- a/src/memheap.c
+++ b/src/memheap.c
@@ -155,7 +155,7 @@ rt_err_t rt_memheap_init(struct rt_memheap *memheap,
     item->next_free = item->prev_free = RT_NULL;
 
     /* initialize semaphore lock */
-    rt_sem_init(&(memheap->lock), name, 1, RT_IPC_FLAG_FIFO);
+    rt_sem_init(&(memheap->lock), name, 1, RT_IPC_FLAG_PRIO);
 
     RT_DEBUG_LOG(RT_DEBUG_MEMHEAP,
                  ("memory heap: start addr 0x%08x, size %d, free list header 0x%08x\n",

--- a/src/slab.c
+++ b/src/slab.c
@@ -363,7 +363,7 @@ void rt_system_heap_init(void *begin_addr, void *end_addr)
     npages  = limsize / RT_MM_PAGE_SIZE;
 
     /* initialize heap semaphore */
-    rt_sem_init(&heap_sem, "heap", 1, RT_IPC_FLAG_FIFO);
+    rt_sem_init(&heap_sem, "heap", 1, RT_IPC_FLAG_PRIO);
 
     RT_DEBUG_LOG(RT_DEBUG_SLAB, ("heap[0x%x - 0x%x], size 0x%x, 0x%x pages\n",
                                  heap_start, heap_end, limsize, npages));


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
rt_malloc,rt_free函数内部也是调用的以fifo创建的信号量，也就是说凡是调用rt_malloc rt_free的线程都会导致该线程超出用户意料之外的非实时，可能会导致超出deadline。进言之，rt_thread_create rt_thread_delete rt_sem_create等等这些调用rt_malloc函数的动态创建内核对象的api都存在非实时的问题，最可怕的是这些问题用户并不会察觉，用户并不清楚调用上述api会导致自己的线程处于非实时状态。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
