### PR TITLE
[bug][kernel]修复RT_THREAD_CTRL_CHANGE_PRIORITY命令被错误理解，导致优先级被意外恢复的bug

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -556,10 +556,10 @@ typedef siginfo_t rt_siginfo_t;
 #define RT_THREAD_CTRL_STARTUP          0x00                /**< Startup thread. */
 #define RT_THREAD_CTRL_CLOSE            0x01                /**< Close thread. */
 #define RT_THREAD_CTRL_CHANGE_PRIORITY  0x02                /**< Change thread priority. */
-#define RT_THREAD_CTRL_PRIORITY_INHER   0x03                /**< Change thread priority for priority inheritance (internal used). */
-#define RT_THREAD_CTRL_INFO             0x04                /**< Get thread information. */
-#define RT_THREAD_CTRL_BIND_CPU         0x05                /**< Set thread bind cpu. */
-
+#define RT_THREAD_CTRL_INFO             0x03                /**< Get thread information. */
+#define RT_THREAD_CTRL_BIND_CPU         0x04                /**< Set thread bind cpu. */
+#define RT_THREAD_CTRL_PRIORITY_INHER   0x05                /**< Change thread priority for priority inheritance (internal used). */
+  
 #ifdef RT_USING_SMP
 
 #define RT_CPU_DETACHED                 RT_CPUS_NR          /**< The thread not running on cpu. */

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -35,6 +35,7 @@
  * 2020-08-10     Meco Man     add macro for struct rt_device_ops
  * 2020-10-23     Meco Man     define maximum value of ipc type
  * 2021-05-10     armink       change version number to v4.0.4
+ * 2021-06-08     Meco Man     add RT_THREAD_CTRL_PRIORITY_INHER command
  */
 
 #ifndef __RT_DEF_H__
@@ -555,8 +556,9 @@ typedef siginfo_t rt_siginfo_t;
 #define RT_THREAD_CTRL_STARTUP          0x00                /**< Startup thread. */
 #define RT_THREAD_CTRL_CLOSE            0x01                /**< Close thread. */
 #define RT_THREAD_CTRL_CHANGE_PRIORITY  0x02                /**< Change thread priority. */
-#define RT_THREAD_CTRL_INFO             0x03                /**< Get thread information. */
-#define RT_THREAD_CTRL_BIND_CPU         0x04                /**< Set thread bind cpu. */
+#define RT_THREAD_CTRL_PRIORITY_INHER   0x03                /**< Change thread priority for priority inheritance (internal used). */
+#define RT_THREAD_CTRL_INFO             0x04                /**< Get thread information. */
+#define RT_THREAD_CTRL_BIND_CPU         0x05                /**< Set thread bind cpu. */
 
 #ifdef RT_USING_SMP
 

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -559,7 +559,7 @@ typedef siginfo_t rt_siginfo_t;
 #define RT_THREAD_CTRL_INFO             0x03                /**< Get thread information. */
 #define RT_THREAD_CTRL_BIND_CPU         0x04                /**< Set thread bind cpu. */
 #define RT_THREAD_CTRL_PRIORITY_INHER   0x05                /**< Change thread priority for priority inheritance (internal used). */
-  
+
 #ifdef RT_USING_SMP
 
 #define RT_CPU_DETACHED                 RT_CPUS_NR          /**< The thread not running on cpu. */

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -760,7 +760,7 @@ __again:
                 {
                     /* change the owner thread priority */
                     rt_thread_control(mutex->owner,
-                                      RT_THREAD_CTRL_CHANGE_PRIORITY,
+                                      RT_THREAD_CTRL_PRIORITY_INHER,
                                       &thread->current_priority);
                 }
 
@@ -886,7 +886,7 @@ rt_err_t rt_mutex_release(rt_mutex_t mutex)
         if (mutex->original_priority != mutex->owner->current_priority)
         {
             rt_thread_control(mutex->owner,
-                              RT_THREAD_CTRL_CHANGE_PRIORITY,
+                              RT_THREAD_CTRL_PRIORITY_INHER,
                               &(mutex->original_priority));
         }
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
由于文档手册以及rt_thread_control注释头对该命令的解释问题，造成了该问题的bug。
这个命令在设计之初仅用于互斥量优先级继承时使用，因为在这个里边只是临时的改变了current_priority 并没有改变init_priority 以及 互斥量的 original_priority。但是，过去十多年间，由于文档手册的错误宣传，导致用户误以为RT_THREAD_CTRL_CHANGE_PRIORITY命令是用户更改更改线程优先级的。并造成用户在应用级代码中大量使用这个命令企图改变线程优先级。那么，一旦碰到rt_mutex_release函数，该函数会将用户更改的优先级还原回到改变之前，相当于白改了。
因此pr做出了以下改动：
增加RT_THREAD_CTRL_PRIORITY_INHER，该命令专门用于ipc.c内部处理优先级继承算法。原来的RT_THREAD_CTRL_CHANGE_PRIORITY用于更改线程优先级。这样用户调用RT_THREAD_CTRL_CHANGE_PRIORITY是真的更改线程优先级。

https://github.com/RT-Thread/rt-thread/blob/5c8625c8ef6deff6979d990f1638200029978dd2/src/ipc.c#L886-L891
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
