### PR TITLE
将defined(__CC_ARM) || defined(__CLANG_ARM) 改为 ifdef __ARMCC_VERSION

### DIFF
--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -817,7 +817,7 @@ int finsh_system_init(void)
     rt_thread_t tid;
 
 #ifdef FINSH_USING_SYMTAB
-#if defined(__CC_ARM) || defined(__CLANG_ARM)          /* ARM C Compiler */
+#ifdef __ARMCC_VERSION  /* ARM C Compiler */
     extern const int FSymTab$$Base;
     extern const int FSymTab$$Limit;
     extern const int VSymTab$$Base;

--- a/include/libc/libc_signal.h
+++ b/include/libc/libc_signal.h
@@ -71,7 +71,7 @@ typedef unsigned long sigset_t;
 
 #include <signal.h>
 
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
+#ifdef __ARMCC_VERSION
 
 #define SIGHUP       1
 /* #define SIGINT       2 */

--- a/include/rtlibc.h
+++ b/include/rtlibc.h
@@ -22,7 +22,7 @@
 #include "libc/libc_stdio.h"
 
 #ifndef RT_USING_LIBC
-#if defined(__CC_ARM) || defined(__CLANG_ARM) || defined(__IAR_SYSTEMS_ICC__)
+#if defined(__ARMCC_VERSION) || defined(__IAR_SYSTEMS_ICC__)
 typedef signed long off_t;
 typedef int mode_t;
 #endif

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -567,7 +567,7 @@ rt_size_t rt_strlen(const char *src);
 #endif /*RT_KSERVICE_USING_STDLIB*/
 
 char *rt_strdup(const char *s);
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
+#ifdef __ARMCC_VERSION
 /* lack strdup interface */
 char* strdup(const char* str);
 #endif

--- a/src/components.c
+++ b/src/components.c
@@ -134,7 +134,7 @@ void rt_application_init(void);
 void rt_hw_board_init(void);
 int rtthread_startup(void);
 
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
+#ifdef __ARMCC_VERSION
 extern int $Super$$main(void);
 /* re-define main function */
 int $Sub$$main(void)
@@ -183,7 +183,7 @@ void main_thread_entry(void *parameter)
     rt_hw_secondary_cpu_up();
 #endif /* RT_USING_SMP */
     /* invoke system main function */
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
+#ifdef __ARMCC_VERSION
     {
         extern int $Super$$main(void);
         $Super$$main(); /* for ARMCC. */

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -532,7 +532,7 @@ char *rt_strdup(const char *s)
     return tmp;
 }
 RTM_EXPORT(rt_strdup);
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
+#ifdef __ARMCC_VERSION
 char *strdup(const char *s) __attribute__((alias("rt_strdup")));
 #endif
 #endif /* RT_USING_HEAP */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[
__CC_ARM 是 arm的内置宏定义 只适用于AC5
__CLANG_ARM 是rtt的宏定义 由于arm内部并没有直接表示armclang AC6的宏，因此rtt内部创造了一个

在rtt代码中判断编译器是否为keil（不区分AC5 还是AC6）时，可以使用__ARMCC_VERSION来代替(__CC_ARM) || (__CLANG_ARM) 这种写法，因为这种写法必须包含rtthread.h，有可能引发类似于 https://github.com/RT-Thread/rt-thread/issues/3720 所述的问题。

keil官方手册中给出的定义是，凡是使用keil编译器的话，__ARMCC_VERSION 即会被定义。
![image](https://user-images.githubusercontent.com/34888354/122378000-2785f080-cf98-11eb-9635-03a27c859c79.png)

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
