### PR TITLE
[testcase] 增加serial_v2的测试用例

### DIFF
--- a/examples/utest/testcases/Kconfig
+++ b/examples/utest/testcases/Kconfig
@@ -9,6 +9,7 @@ if RT_USING_UTESTCASES
 
 source "$RTT_DIR/examples/utest/testcases/utest/Kconfig"
 source "$RTT_DIR/examples/utest/testcases/kernel/Kconfig"
+source "$RTT_DIR/examples/utest/testcases/drivers/serial_v2/Kconfig"
 
 endif
 

--- a/examples/utest/testcases/drivers/SConscript
+++ b/examples/utest/testcases/drivers/SConscript
@@ -1,0 +1,15 @@
+# RT-Thread building script for bridge
+
+import os
+from building import *
+
+cwd = GetCurrentDir()
+objs = []
+list = os.listdir(cwd)
+
+for d in list:
+    path = os.path.join(cwd, d)
+    if os.path.isfile(os.path.join(path, 'SConscript')):
+        objs = objs + SConscript(os.path.join(d, 'SConscript'))
+
+Return('objs')

--- a/examples/utest/testcases/drivers/serial_v2/Kconfig
+++ b/examples/utest/testcases/drivers/serial_v2/Kconfig
@@ -1,0 +1,7 @@
+menu "Utest Serial Testcase"
+
+config UTEST_SERIAL_TC
+    bool "Serial testcase"
+    default n
+
+endmenu

--- a/examples/utest/testcases/drivers/serial_v2/README.md
+++ b/examples/utest/testcases/drivers/serial_v2/README.md
@@ -1,0 +1,120 @@
+## 1、介绍
+
+该目录下 c 文件是新版本串口的测试用例，在 `examples/utest/testcases/drivers/serial_v2` 目录结构里，该测试用例用来测试串口的各个操作模式是否正常工作。
+
+## 2、 文件说明
+
+| 文件             | 描述                                      |
+| ---------------- | ----------------------------------------- |
+| uart_rxb_txb.c   | 串口接收阻塞和发送阻塞模式 的测试用例     |
+| uart_rxb_txnb.c  | 串口接收阻塞和发送非阻塞模式 的测试用例   |
+| uart_rxnb_txb.c  | 串口接收非阻塞和发送阻塞模式 的测试用例   |
+| uart_rxnb_txnb.c | 串口接收非阻塞和发送非阻塞模式 的测试用例 |
+
+## 3、软硬件环境
+
+硬件上需要支持 RT-Thread 的完整版操作系统，版本为4.0.4及以上，且硬件有串口硬件外设，软件上需要支持 内核接口、IPC 、Device 框架。
+
+## 4、测试项
+
+### 4.1 测试说明
+
+上文所提及的模式是指串口使用时的操作模式，不涉及硬件的工作模式的配置情况（硬件工作模式一般有轮询POLL、中断INT、DMA），因此使用时需要结合具体的硬件工作模式去配置使用。例如 发送阻塞和接收非阻塞模式 ，这个测试有很多种硬件配置，配置情况例如：DMA发送阻塞和DMA接收非阻塞，INT发送阻塞和DMA接收非阻塞，POLL发送阻塞和DMA接收非阻塞等等。因此通过排列组合后的测试场景有4*9=36种，有意义的组合方式为20种。如下表：
+
+
+| 接收非阻塞 | 发送阻塞 | 组合              | 有意义的组合方式 |
+| ---------- | -------- | ----------------- | ---------------- |
+| POLL       | POLL     | RX_POLL + TX_POLL |                  |
+|            | INT      | RX_POLL + TX_INT  |                  |
+|            | DMA      | RX_POLL + TX_DMA  |                  |
+| INT        | POLL     | RX_INT + TX_POLL  | ✔                |
+|            | INT      | RX_INT + TX_INT   | ✔                |
+|            | DMA      | RX_INT + TX_DMA   | ✔                |
+| DMA        | POLL     | RX_DMA + TX_POLL  | ✔                |
+|            | INT      | RX_DMA + TX_INT   | ✔                |
+|            | DMA      | RX_DMA + TX_DMA   | ✔                |
+
+| 接收非阻塞 | 发送非阻塞 | 组合              | 有意义的组合方式 |
+| ---------- | ---------- | ----------------- | ---------------- |
+| POLL       | POLL       | RX_POLL + TX_POLL |                  |
+|            | INT        | RX_POLL + TX_INT  |                  |
+|            | DMA        | RX_POLL + TX_DMA  |                  |
+| INT        | POLL       | RX_INT + TX_POLL  |                  |
+|            | INT        | RX_INT + TX_INT   | ✔                |
+|            | DMA        | RX_INT + TX_DMA   | ✔                |
+| DMA        | POLL       | RX_DMA + TX_POLL  |                  |
+|            | INT        | RX_DMA + TX_INT   | ✔                |
+|            | DMA        | RX_DMA + TX_DMA   | ✔                |
+
+| 接收阻塞 | 发送阻塞 | 组合              | 有意义的组合方式 |
+| -------- | -------- | ----------------- | ---------------- |
+| POLL     | POLL     | RX_POLL + TX_POLL |                  |
+|          | INT      | RX_POLL + TX_INT  |                  |
+|          | DMA      | RX_POLL + TX_DMA  |                  |
+| INT      | POLL     | RX_INT + TX_POLL  | ✔                |
+|          | INT      | RX_INT + TX_INT   | ✔                |
+|          | DMA      | RX_INT + TX_DMA   | ✔                |
+| DMA      | POLL     | RX_DMA + TX_POLL  | ✔                |
+|          | INT      | RX_DMA + TX_INT   | ✔                |
+|          | DMA      | RX_DMA + TX_DMA   | ✔                |
+
+| 接收阻塞 | 发送非阻塞 | 组合              | 有意义的组合方式 |
+| -------- | ---------- | ----------------- | ---------------- |
+| POLL     | POLL       | RX_POLL + TX_POLL |                  |
+|          | INT        | RX_POLL + TX_INT  |                  |
+|          | DMA        | RX_POLL + TX_DMA  |                  |
+| INT      | POLL       | RX_INT + TX_POLL  |                  |
+|          | INT        | RX_INT + TX_INT   | ✔                |
+|          | DMA        | RX_INT + TX_DMA   | ✔                |
+| DMA      | POLL       | RX_DMA + TX_POLL  |                  |
+|          | INT        | RX_DMA + TX_INT   | ✔                |
+|          | DMA        | RX_DMA + TX_DMA   | ✔                |
+
+需要解释的是，为什么会存在无意义的组合模式，举个例子，非阻塞模式下，肯定是不会出现POLL（轮询）方式的，因为POLL方式已经表明是阻塞方式了。
+该测试用例在测试多种组合时，需要通过更改`rtconfig.h`文件对硬件模式进行静态配置。
+
+### 4.2 测试思路
+
+这四个测试用例的测试思路基本一致。
+
+硬件上：**短接串口的发送TX引脚和接收RX引脚，完成自发自收的回路**。
+
+软件上：创建两个线程A和B，A为接收线程，B为发送线程，设置A线程优先级比B线程优先级高。发送线程发送随机长度（长度范围是 0 到 1000）的数据，接收线程接收到数据进行校验，数据正确则测试通过，默认测试100次。
+
+## 5、配置
+
+使用该测试用例需要在 `env` 工具的 `menuconfig` 中做相关配置，配置如下所示（使用 RT-Thread-Studio 的配置路径一致 ）：
+
+```
+RT-Thread Utestcases  --->
+    [*] RT-Thread Utestcases  --->
+           Utest Serial Testcase --->
+                [*] Serial testcase
+```
+
+## 6、使用
+
+\- 编译下载。
+
+\- 在 MSH 中输入 `utest_run testcases.drivers.uart_rxb_txb` 运行串口接收阻塞和发送阻塞测试用例。
+
+\- 在 MSH 中输入 `utest_run testcases.drivers.uart_rxb_txb` 运行串口接收阻塞和发送阻塞测试用例。
+
+\- 在 MSH 中输入 `utest_run testcases.drivers.uart_rxb_txb` 运行串口接收阻塞和发送阻塞测试用例。
+
+\- 在 MSH 中输入 `utest_run testcases.drivers.uart_rxb_txb` 运行串口接收阻塞和发送阻塞测试用例。
+
+如果仅仅配置了 `Serial testcase` 相关的测试用例，则直接输入 `utest_run` 运行即可将上述测试用例按序测试。
+
+## 7、注意事项
+
+\- 需配置正确的测试用例。
+
+\- 如有需要，可开启 ULOG 查看测试用例日志信息。
+
+\- 需在 MSH 中输入正确的命令行。
+
+\- 测试用例默认的测试数据长度范围最大为1000字节，如果接收端的缓冲区大小配置为小于1000字节时，那么在测试接收阻塞模式时，将会由于获取不了1000字节长度导致线程持续阻塞（因为测试用例是按 `recv_len` 长度去接收的，而不是按照单字节去接收的），因此建议接收端的缓冲区大小 （对应宏例如为 `BSP_UART2_RX_BUFSIZE`）设置为1024即可；当然也可按需减小测试的最大数据长度。
+
+\- 该测试用例需要结合硬件具体的工作模式（POLL 、INT、DMA）进行测试，而硬件工作模式只能选择一种，因此需要在 `rtconfig.h` 中对串口相应的宏进行配置，来选择不同的工作模式去进行测试。
+

--- a/examples/utest/testcases/drivers/serial_v2/SConscript
+++ b/examples/utest/testcases/drivers/serial_v2/SConscript
@@ -1,0 +1,16 @@
+Import('rtconfig')
+from building import *
+
+cwd     = GetCurrentDir()
+src     = Split('''
+uart_rxb_txnb.c
+uart_rxb_txb.c
+uart_rxnb_txb.c
+uart_rxnb_txnb.c
+''')
+
+CPPPATH = [cwd]
+
+group = DefineGroup('utestcases', src, depend = ['UTEST_SERIAL_TC'], CPPPATH = CPPPATH)
+
+Return('group')

--- a/examples/utest/testcases/drivers/serial_v2/uart_rxb_txb.c
+++ b/examples/utest/testcases/drivers/serial_v2/uart_rxb_txb.c
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2006-2019, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2021-06-16     KyleChan     the first version
+ */
+
+#include <rtthread.h>
+#include "utest.h"
+#include <rtdevice.h>
+#include <stdlib.h>
+
+#define TC_UART_DEVICE_NAME "uart2"
+#define TC_UART_SEND_TIMES 100
+
+
+#ifdef UTEST_SERIAL_TC
+
+#define TEST_UART_NAME            TC_UART_DEVICE_NAME
+
+static struct rt_serial_device *serial;
+static rt_uint8_t uart_over_flag;
+static rt_bool_t uart_result = RT_TRUE;
+
+static rt_err_t uart_find(void)
+{
+    serial = (struct rt_serial_device *)rt_device_find(TEST_UART_NAME);
+
+    if (serial == RT_NULL)
+    {
+        LOG_E("find %s device failed!\n", TEST_UART_NAME);
+        return -RT_ERROR;
+    }
+
+    return RT_EOK;
+}
+
+static void uart_send_entry(void *parameter)
+{
+    rt_uint8_t *uart_write_buffer;
+    rt_uint16_t send_len;
+
+    rt_uint32_t i = 0;
+    send_len = *(rt_uint16_t *)parameter;
+    /* assign send buffer */
+    uart_write_buffer = (rt_uint8_t *)rt_malloc(send_len);
+    if (uart_write_buffer == RT_NULL)
+    {
+        LOG_E("Without spare memory for uart dma!");
+        uart_result = RT_FALSE;
+        return;
+    }
+
+    rt_memset(uart_write_buffer, 0, send_len);
+
+    for (i = 0; i < send_len; i++)
+    {
+        uart_write_buffer[i] = (rt_uint8_t)i;
+    }
+    /* send buffer */
+    if (rt_device_write(&serial->parent, 0, uart_write_buffer, send_len) != send_len)
+    {
+        LOG_E("device write failed\r\n");
+    }
+    rt_free(uart_write_buffer);
+
+}
+
+static void uart_rec_entry(void *parameter)
+{
+    rt_uint16_t rev_len;
+
+    rev_len = *(rt_uint16_t *)parameter;
+    rt_uint8_t *ch;
+    ch = (rt_uint8_t *)rt_calloc(1, sizeof(rt_uint8_t) * (rev_len + 1));
+    rt_int32_t cnt, i;
+    rt_uint8_t last_old_data;
+    rt_bool_t fisrt_flag = RT_TRUE;
+    rt_uint32_t all_receive_length = 0;
+
+
+    while (1)
+    {
+        cnt = rt_device_read(&serial->parent, 0, (void *)ch, rev_len);
+        if (cnt == 0)
+        {
+            continue;
+        }
+
+        if (fisrt_flag != RT_TRUE)
+        {
+            if ((rt_uint8_t)(last_old_data + 1) != ch[0])
+            {
+                LOG_E("_Read Different data -> former data: %x, current data: %x.", last_old_data, ch[0]);
+                uart_result = RT_FALSE;
+                rt_free(ch);
+                return;
+            }
+        }
+        else
+        {
+            fisrt_flag = RT_FALSE;
+        }
+
+        for (i = 0; i < cnt - 1; i++)
+        {
+            if ((rt_uint8_t)(ch[i] + 1) != ch[i + 1])
+            {
+                LOG_E("Read Different data -> former data: %x, current data: %x.", ch[i], ch[i + 1]);
+
+                uart_result = RT_FALSE;
+                rt_free(ch);
+                return;
+            }
+        }
+        all_receive_length += cnt;
+        if (all_receive_length >= rev_len)
+            break;
+        else
+            last_old_data = ch[cnt - 1];
+    }
+    rt_free(ch);
+    uart_over_flag = RT_TRUE;
+}
+
+static rt_err_t uart_api(rt_uint16_t length)
+{
+    rt_thread_t thread_send = RT_NULL;
+    rt_thread_t thread_recv = RT_NULL;
+    rt_err_t result = RT_EOK;
+    uart_over_flag = RT_FALSE;
+
+    result = uart_find();
+    if (result != RT_EOK)
+    {
+        return -RT_ERROR;
+    }
+
+    /* Reinitialize */
+    struct serial_configure config = RT_SERIAL_CONFIG_DEFAULT;
+    config.baud_rate = BAUD_RATE_115200;
+    config.rx_bufsz = BSP_UART2_RX_BUFSIZE;
+    config.tx_bufsz = BSP_UART2_TX_BUFSIZE;
+    rt_device_control(&serial->parent, RT_DEVICE_CTRL_CONFIG, &config);
+
+    result = rt_device_open(&serial->parent, RT_DEVICE_FLAG_RX_BLOCKING | RT_DEVICE_FLAG_TX_BLOCKING);
+
+    if (result != RT_EOK)
+    {
+        LOG_E("Open uart device failed.");
+        uart_result = RT_FALSE;
+        return -RT_ERROR;
+    }
+
+    thread_send = rt_thread_create("uart_send", uart_send_entry, &length, 1024, RT_THREAD_PRIORITY_MAX - 4, 10);
+    thread_recv = rt_thread_create("uart_recv", uart_rec_entry, &length, 1024, RT_THREAD_PRIORITY_MAX - 5, 10);
+    if ((thread_send != RT_NULL) && (thread_recv != RT_NULL))
+    {
+        rt_thread_startup(thread_send);
+        rt_thread_startup(thread_recv);
+    }
+    else
+    {
+        result = -RT_ERROR;
+        goto __exit;
+    }
+
+    while (1)
+    {
+        if (uart_result != RT_TRUE)
+        {
+            LOG_E("The test for uart dma is failure.");
+            result = -RT_ERROR;
+            goto __exit;
+        }
+        if (uart_over_flag == RT_TRUE)
+        {
+            goto __exit;
+        }
+        /* waiting for test over */
+        rt_thread_mdelay(5);
+    }
+__exit:
+    rt_device_close(&serial->parent);
+    return result;
+}
+
+static void tc_uart_api(void)
+{
+    rt_uint32_t times = 0;
+    rt_uint16_t num = 0;
+    while (TC_UART_SEND_TIMES - times)
+    {
+        num = (rand() % 1000) + 1;
+        if(uart_api(num) == RT_EOK)
+           LOG_I("data_lens [%3d], it is correct to read and write data. [%d] times testing.", num, ++times);
+        else
+        {
+            LOG_E("uart test error");
+            break;
+        }
+    }
+    uassert_true(uart_over_flag == RT_TRUE);
+}
+
+static rt_err_t utest_tc_init(void)
+{
+    LOG_I("UART TEST: Please connect Tx and Rx directly for self testing.");
+    return RT_EOK;
+}
+
+static rt_err_t utest_tc_cleanup(void)
+{
+    uart_result = RT_TRUE;
+    uart_over_flag = RT_FALSE;
+
+    return RT_EOK;
+}
+
+static void testcase(void)
+{
+    UTEST_UNIT_RUN(tc_uart_api);
+}
+
+UTEST_TC_EXPORT(testcase, "testcases.drivers.uart_rxb_txb", utest_tc_init, utest_tc_cleanup, 30);
+
+#endif /* TC_UART_USING_TC */

--- a/examples/utest/testcases/drivers/serial_v2/uart_rxb_txnb.c
+++ b/examples/utest/testcases/drivers/serial_v2/uart_rxb_txnb.c
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2006-2019, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2021-06-16     KyleChan     the first version
+ */
+
+#include <rtthread.h>
+#include "utest.h"
+#include <rtdevice.h>
+#include <stdlib.h>
+
+#define TC_UART_DEVICE_NAME "uart2"
+#define TC_UART_SEND_TIMES 100
+
+
+#ifdef UTEST_SERIAL_TC
+
+#define TEST_UART_NAME            TC_UART_DEVICE_NAME
+
+static struct rt_serial_device *serial;
+static rt_sem_t tx_sem;
+static rt_uint8_t uart_over_flag;
+static rt_bool_t uart_result = RT_TRUE;
+
+static rt_err_t uart_find(void)
+{
+    serial = (struct rt_serial_device *)rt_device_find(TEST_UART_NAME);
+
+    if (serial == RT_NULL)
+    {
+        LOG_E("find %s device failed!\n", TEST_UART_NAME);
+        return -RT_ERROR;
+    }
+
+    return RT_EOK;
+}
+
+static rt_err_t uart_tx_completion(rt_device_t device, void *buffer)
+{
+    rt_sem_release(tx_sem);
+
+    return RT_EOK;
+}
+
+static void uart_send_entry(void *parameter)
+{
+    rt_uint8_t *uart_write_buffer;
+    rt_uint16_t send_len, len = 0;
+    rt_err_t result;
+
+    rt_uint32_t i = 0;
+    send_len = *(rt_uint16_t *)parameter;
+    /* assign send buffer */
+    uart_write_buffer = (rt_uint8_t *)rt_malloc(send_len);
+    if (uart_write_buffer == RT_NULL)
+    {
+        LOG_E("Without spare memory for uart dma!");
+        uart_result = RT_FALSE;
+        return;
+    }
+
+    rt_memset(uart_write_buffer, 0, send_len);
+
+    for (i = 0; i < send_len; i++)
+    {
+        uart_write_buffer[i] = (rt_uint8_t)i;
+    }
+    /* send buffer */
+    while (send_len - len)
+    {
+        len += rt_device_write(&serial->parent, 0, uart_write_buffer + len, send_len - len);
+        result = rt_sem_take(tx_sem, RT_WAITING_FOREVER);
+        if (result != RT_EOK)
+        {
+            LOG_E("take sem err in send.");
+        }
+    }
+    rt_free(uart_write_buffer);
+
+}
+
+static void uart_rec_entry(void *parameter)
+{
+    rt_uint16_t rev_len;
+
+    rev_len = *(rt_uint16_t *)parameter;
+    rt_uint8_t *ch;
+    ch = (rt_uint8_t *)rt_calloc(1, sizeof(rt_uint8_t) * (rev_len + 1));
+    rt_int32_t cnt, i;
+    rt_uint8_t last_old_data;
+    rt_bool_t fisrt_flag = RT_TRUE;
+    rt_uint32_t all_receive_length = 0;
+
+    while (1)
+    {
+        cnt = rt_device_read(&serial->parent, 0, (void *)ch, rev_len);
+        if (cnt != rev_len)
+        {
+            continue;
+        }
+
+        if (fisrt_flag != RT_TRUE)
+        {
+            if ((rt_uint8_t)(last_old_data + 1) != ch[0])
+            {
+                LOG_E("_Read Different data -> former data: %x, current data: %x.", last_old_data, ch[0]);
+                uart_result = RT_FALSE;
+                rt_free(ch);
+                return;
+            }
+        }
+        else
+        {
+            fisrt_flag = RT_FALSE;
+        }
+
+        for (i = 0; i < cnt - 1; i++)
+        {
+            if ((rt_uint8_t)(ch[i] + 1) != ch[i + 1])
+            {
+                LOG_E("Read Different data -> former data: %x, current data: %x.", ch[i], ch[i + 1]);
+
+                uart_result = RT_FALSE;
+                rt_free(ch);
+                return;
+            }
+        }
+        all_receive_length += cnt;
+        if (all_receive_length >= rev_len)
+            break;
+        else
+            last_old_data = ch[cnt - 1];
+    }
+    rt_free(ch);
+    uart_over_flag = RT_TRUE;
+}
+
+static rt_err_t uart_api(rt_uint16_t test_buf)
+{
+    rt_thread_t thread_send = RT_NULL;
+    rt_thread_t thread_recv = RT_NULL;
+    rt_err_t result = RT_EOK;
+    uart_over_flag = RT_FALSE;
+
+    result = uart_find();
+    if (result != RT_EOK)
+    {
+        return -RT_ERROR;
+    }
+
+    tx_sem = rt_sem_create("tx_sem", 0, RT_IPC_FLAG_PRIO);
+    if (tx_sem == RT_NULL)
+    {
+        LOG_E("Init sem failed.");
+        uart_result = RT_FALSE;
+        return -RT_ERROR;
+    }
+
+    /* Reinitialize */
+    struct serial_configure config = RT_SERIAL_CONFIG_DEFAULT;
+    config.baud_rate = BAUD_RATE_115200;
+    config.rx_bufsz = BSP_UART2_RX_BUFSIZE;
+    config.tx_bufsz = BSP_UART2_TX_BUFSIZE;
+    rt_device_control(&serial->parent, RT_DEVICE_CTRL_CONFIG, &config);
+
+    result = rt_device_open(&serial->parent, RT_DEVICE_FLAG_RX_BLOCKING | RT_DEVICE_FLAG_TX_NON_BLOCKING);
+
+    if (result != RT_EOK)
+    {
+        LOG_E("Open uart device failed.");
+        uart_result = RT_FALSE;
+        return -RT_ERROR;
+    }
+
+    /* set receive callback function */
+    result = rt_device_set_tx_complete(&serial->parent, uart_tx_completion);
+    if (result != RT_EOK)
+    {
+        goto __exit;
+    }
+
+    thread_recv = rt_thread_create("uart_recv", uart_rec_entry, &test_buf, 1024, RT_THREAD_PRIORITY_MAX - 5, 10);
+    thread_send = rt_thread_create("uart_send", uart_send_entry, &test_buf, 1024, RT_THREAD_PRIORITY_MAX - 4, 10);
+
+    if (thread_send != RT_NULL && thread_recv != RT_NULL)
+    {
+        rt_thread_startup(thread_recv);
+        rt_thread_startup(thread_send);
+    }
+    else
+    {
+        result = -RT_ERROR;
+        goto __exit;
+    }
+
+    while (1)
+    {
+        if (uart_result != RT_TRUE)
+        {
+            LOG_E("The test for uart dma is failure.");
+            result = -RT_ERROR;
+            goto __exit;
+        }
+        if (uart_over_flag == RT_TRUE)
+        {
+            goto __exit;
+        }
+        /* waiting for test over */
+        rt_thread_mdelay(5);
+    }
+__exit:
+    if (tx_sem)
+        rt_sem_delete(tx_sem);
+
+    rt_device_close(&serial->parent);
+    return result;
+}
+
+static void tc_uart_api(void)
+{
+    rt_uint32_t times = 0;
+    rt_uint16_t num = 0;
+    while (TC_UART_SEND_TIMES - times)
+    {
+        num = (rand() % 1000) + 1;
+        if(uart_api(num) == RT_EOK)
+           LOG_I("data_lens [%3d], it is correct to read and write data. [%d] times testing.", num, ++times);
+        else
+        {
+            LOG_E("uart test error");
+            break;
+        }
+    }
+    uassert_true(uart_over_flag == RT_TRUE);
+}
+
+static rt_err_t utest_tc_init(void)
+{
+    LOG_I("UART TEST: Please connect Tx and Rx directly for self testing.");
+    return RT_EOK;
+}
+
+static rt_err_t utest_tc_cleanup(void)
+{
+    tx_sem = RT_NULL;
+    uart_result = RT_TRUE;
+    uart_over_flag = RT_FALSE;
+
+    return RT_EOK;
+}
+
+static void testcase(void)
+{
+    UTEST_UNIT_RUN(tc_uart_api);
+}
+
+UTEST_TC_EXPORT(testcase, "testcases.drivers.uart_rxb_txnb", utest_tc_init, utest_tc_cleanup, 30);
+
+#endif

--- a/examples/utest/testcases/drivers/serial_v2/uart_rxnb_txb.c
+++ b/examples/utest/testcases/drivers/serial_v2/uart_rxnb_txb.c
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2006-2019, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2021-06-16     KyleChan     the first version
+ */
+
+#include <rtthread.h>
+#include "utest.h"
+#include <rtdevice.h>
+#include <stdlib.h>
+
+#define TC_UART_DEVICE_NAME "uart2"
+#define TC_UART_SEND_TIMES 100
+
+
+#ifdef UTEST_SERIAL_TC
+
+#define TEST_UART_NAME            TC_UART_DEVICE_NAME
+
+static struct rt_serial_device *serial;
+static rt_sem_t rx_sem;
+static rt_uint8_t uart_over_flag;
+static rt_bool_t uart_result = RT_TRUE;
+
+static rt_err_t uart_find(void)
+{
+    serial = (struct rt_serial_device *)rt_device_find(TEST_UART_NAME);
+
+    if (serial == RT_NULL)
+    {
+        LOG_E("find %s device failed!\n", TEST_UART_NAME);
+        return -RT_ERROR;
+    }
+
+    return RT_EOK;
+}
+
+static rt_err_t uart_rx_indicate(rt_device_t device, rt_size_t size)
+{
+    rt_sem_release(rx_sem);
+
+    return RT_EOK;
+}
+
+static void uart_send_entry(void *parameter)
+{
+    rt_uint8_t *uart_write_buffer;
+    rt_uint16_t send_len;
+
+    rt_uint32_t i = 0;
+    send_len = *(rt_uint16_t *)parameter;
+
+    /* assign send buffer */
+    uart_write_buffer = (rt_uint8_t *)rt_malloc(send_len);
+    if (uart_write_buffer == RT_NULL)
+    {
+        LOG_E("Without spare memory for uart dma!");
+        uart_result = RT_FALSE;
+        return;
+    }
+
+    rt_memset(uart_write_buffer, 0, send_len);
+
+    for (i = 0; i < send_len; i++)
+    {
+        uart_write_buffer[i] = (rt_uint8_t)i;
+    }
+
+    /* send buffer */
+    if (rt_device_write(&serial->parent, 0, uart_write_buffer, send_len) != send_len)
+    {
+        LOG_E("device write failed\r\n");
+    }
+    rt_free(uart_write_buffer);
+}
+
+static void uart_rec_entry(void *parameter)
+{
+    rt_uint16_t rev_len;
+
+    rev_len = *(rt_uint16_t *)parameter;
+    rt_uint8_t *ch;
+    ch = (rt_uint8_t *)rt_calloc(1, sizeof(rt_uint8_t) * (rev_len + 1));
+    rt_int32_t cnt, i;
+    rt_uint8_t last_old_data;
+    rt_bool_t fisrt_flag = RT_TRUE;
+    rt_uint32_t all_receive_length = 0;
+
+    while (1)
+    {
+        rt_err_t result;
+
+        result = rt_sem_take(rx_sem, RT_WAITING_FOREVER);
+        if (result != RT_EOK)
+        {
+            LOG_E("take sem err in recv.");
+        }
+
+        cnt = rt_device_read(&serial->parent, 0, (void *)ch, rev_len);
+        if (cnt == 0)
+        {
+            continue;
+        }
+
+        if (fisrt_flag != RT_TRUE)
+        {
+            if ((rt_uint8_t)(last_old_data + 1) != ch[0])
+            {
+                LOG_E("_Read Different data -> former data: %x, current data: %x.", last_old_data, ch[0]);
+                uart_result = RT_FALSE;
+                rt_free(ch);
+                return;
+            }
+        }
+        else
+        {
+            fisrt_flag = RT_FALSE;
+        }
+
+        for (i = 0; i < cnt - 1; i++)
+        {
+            if ((rt_uint8_t)(ch[i] + 1) != ch[i + 1])
+            {
+                LOG_E("Read Different data -> former data: %x, current data: %x.", ch[i], ch[i + 1]);
+
+                uart_result = RT_FALSE;
+                rt_free(ch);
+                return;
+            }
+        }
+        all_receive_length += cnt;
+        if (all_receive_length >= rev_len)
+            break;
+        else
+            last_old_data = ch[cnt - 1];
+    }
+    rt_free(ch);
+    uart_over_flag = RT_TRUE;
+}
+
+static rt_err_t uart_api(rt_uint16_t test_buf)
+{
+    rt_thread_t thread_send = RT_NULL;
+    rt_thread_t thread_recv = RT_NULL;
+    rt_err_t result = RT_EOK;
+
+    result = uart_find();
+    if (result != RT_EOK)
+    {
+        return -RT_ERROR;
+    }
+
+    rx_sem = rt_sem_create("rx_sem", 0, RT_IPC_FLAG_PRIO);
+    if (rx_sem == RT_NULL)
+    {
+        LOG_E("Init sem failed.");
+        uart_result = RT_FALSE;
+        return -RT_ERROR;
+    }
+
+    /* reinitialize */
+    struct serial_configure config = RT_SERIAL_CONFIG_DEFAULT;
+    config.baud_rate = BAUD_RATE_115200;
+    config.rx_bufsz = BSP_UART2_RX_BUFSIZE;
+    config.tx_bufsz = BSP_UART2_TX_BUFSIZE;
+    rt_device_control(&serial->parent, RT_DEVICE_CTRL_CONFIG, &config);
+
+    result = rt_device_open(&serial->parent, RT_DEVICE_FLAG_RX_NON_BLOCKING | RT_DEVICE_FLAG_TX_BLOCKING);
+
+    if (result != RT_EOK)
+    {
+        LOG_E("Open uart device failed.");
+        uart_result = RT_FALSE;
+        rt_sem_delete(rx_sem);
+        return -RT_ERROR;
+    }
+
+    /* set receive callback function */
+    result = rt_device_set_rx_indicate(&serial->parent, uart_rx_indicate);
+    if (result != RT_EOK)
+    {
+        goto __exit;
+    }
+
+    thread_recv = rt_thread_create("uart_recv", uart_rec_entry, &test_buf, 1024, RT_THREAD_PRIORITY_MAX - 5, 10);
+    thread_send = rt_thread_create("uart_send", uart_send_entry, &test_buf, 1024, RT_THREAD_PRIORITY_MAX - 4, 10);
+
+    if (thread_send != RT_NULL && thread_recv != RT_NULL)
+    {
+        rt_thread_startup(thread_recv);
+        rt_thread_startup(thread_send);
+    }
+    else
+    {
+        result = -RT_ERROR;
+        goto __exit;
+    }
+
+    while (1)
+    {
+        if (uart_result != RT_TRUE)
+        {
+            LOG_E("The test for uart dma is failure.");
+            result = -RT_ERROR;
+            goto __exit;
+        }
+        if (uart_over_flag == RT_TRUE)
+        {
+            goto __exit;
+        }
+        /* waiting for test over */
+        rt_thread_mdelay(5);
+    }
+__exit:
+    if (rx_sem)
+        rt_sem_delete(rx_sem);
+    rt_device_close(&serial->parent);
+    uart_over_flag = RT_FALSE;
+    return result;
+}
+
+static void tc_uart_api(void)
+{
+    rt_uint32_t times = 0;
+    rt_uint16_t num = 0;
+    while (TC_UART_SEND_TIMES - times)
+    {
+        num = (rand() % 1000) + 1;
+        if(uart_api(num) == RT_EOK)
+           LOG_I("data_lens [%3d], it is correct to read and write data. [%d] times testing.", num, ++times);
+        else
+        {
+            LOG_E("uart test error");
+            break;
+        }
+    }
+    uassert_true(uart_result == RT_TRUE);
+}
+
+static rt_err_t utest_tc_init(void)
+{
+    LOG_I("UART TEST: Please connect Tx and Rx directly for self testing.");
+    return RT_EOK;
+}
+
+static rt_err_t utest_tc_cleanup(void)
+{
+    rx_sem = RT_NULL;
+    uart_result = RT_TRUE;
+    uart_over_flag = RT_FALSE;
+
+    return RT_EOK;
+}
+
+static void testcase(void)
+{
+    UTEST_UNIT_RUN(tc_uart_api);
+}
+
+UTEST_TC_EXPORT(testcase, "testcases.drivers.uart_rxnb_txb", utest_tc_init, utest_tc_cleanup, 30);
+
+#endif /* TC_UART_USING_TC */

--- a/examples/utest/testcases/drivers/serial_v2/uart_rxnb_txnb.c
+++ b/examples/utest/testcases/drivers/serial_v2/uart_rxnb_txnb.c
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2006-2019, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2021-06-16     KyleChan     the first version
+ */
+
+#include <rtthread.h>
+#include "utest.h"
+#include <rtdevice.h>
+#include <stdlib.h>
+
+#define TC_UART_DEVICE_NAME "uart2"
+#define TC_UART_SEND_TIMES 100
+
+
+#ifdef UTEST_SERIAL_TC
+
+#define TEST_UART_NAME            TC_UART_DEVICE_NAME
+
+static struct rt_serial_device *serial;
+static rt_sem_t tx_sem;
+static rt_sem_t rx_sem;
+static rt_uint8_t uart_over_flag;
+static rt_bool_t uart_result = RT_TRUE;
+
+static rt_err_t uart_find(void)
+{
+    serial = (struct rt_serial_device *)rt_device_find(TEST_UART_NAME);
+
+    if (serial == RT_NULL)
+    {
+        LOG_E("find %s device failed!\n", TEST_UART_NAME);
+        return -RT_ERROR;
+    }
+
+    return RT_EOK;
+}
+
+static rt_err_t uart_tx_completion(rt_device_t device, void *buffer)
+{
+    rt_sem_release(tx_sem);
+    return RT_EOK;
+}
+
+static rt_err_t uart_rx_indicate(rt_device_t device, rt_size_t size)
+{
+    rt_sem_release(rx_sem);
+    return RT_EOK;
+}
+
+static void uart_send_entry(void *parameter)
+{
+    rt_uint8_t *uart_write_buffer;
+    rt_uint16_t send_len, len = 0;
+    rt_err_t result;
+
+    rt_uint32_t i = 0;
+    send_len = *(rt_uint16_t *)parameter;
+    /* assign send buffer */
+    uart_write_buffer = (rt_uint8_t *)rt_malloc(send_len);
+    if (uart_write_buffer == RT_NULL)
+    {
+        LOG_E("Without spare memory for uart dma!");
+        uart_result = RT_FALSE;
+        return;
+    }
+
+    rt_memset(uart_write_buffer, 0, send_len);
+
+    for (i = 0; i < send_len; i++)
+    {
+        uart_write_buffer[i] = (rt_uint8_t)i;
+    }
+    /* send buffer */
+    while (send_len - len)
+    {
+        len += rt_device_write(&serial->parent, 0, uart_write_buffer + len, send_len - len);
+        result = rt_sem_take(tx_sem, RT_WAITING_FOREVER);
+        if (result != RT_EOK)
+        {
+            LOG_E("take sem err in send.");
+        }
+    }
+    rt_free(uart_write_buffer);
+
+}
+
+static void uart_rec_entry(void *parameter)
+{
+    rt_uint16_t rev_len;
+
+    rev_len = *(rt_uint16_t *)parameter;
+    rt_uint8_t *ch;
+    ch = (rt_uint8_t *)rt_calloc(1, sizeof(rt_uint8_t) * (rev_len + 1));
+    rt_int32_t cnt, i;
+    rt_uint8_t last_old_data;
+    rt_bool_t fisrt_flag = RT_TRUE;
+    rt_uint32_t all_receive_length = 0;
+
+    while (1)
+    {
+        rt_err_t result;
+
+        result = rt_sem_take(rx_sem, RT_WAITING_FOREVER);
+        if (result != RT_EOK)
+        {
+            LOG_E("take sem err in recv.");
+        }
+
+        cnt = rt_device_read(&serial->parent, 0, (void *)ch, rev_len);
+        if (cnt == 0)
+        {
+            continue;
+        }
+
+        if (fisrt_flag != RT_TRUE)
+        {
+            if ((rt_uint8_t)(last_old_data + 1) != ch[0])
+            {
+                LOG_E("_Read Different data -> former data: %x, current data: %x.", last_old_data, ch[0]);
+                uart_result = RT_FALSE;
+                rt_free(ch);
+                return;
+            }
+        }
+        else
+        {
+            fisrt_flag = RT_FALSE;
+        }
+
+        for (i = 0; i < cnt - 1; i++)
+        {
+            if ((rt_uint8_t)(ch[i] + 1) != ch[i + 1])
+            {
+                LOG_E("Read Different data -> former data: %x, current data: %x.", ch[i], ch[i + 1]);
+
+                uart_result = RT_FALSE;
+                rt_free(ch);
+                return;
+            }
+        }
+        all_receive_length += cnt;
+        if (all_receive_length >= rev_len)
+            break;
+        else
+            last_old_data = ch[cnt - 1];
+    }
+    rt_free(ch);
+    uart_over_flag = RT_TRUE;
+}
+
+static rt_err_t uart_api(rt_uint16_t test_buf)
+{
+    rt_thread_t thread_send = RT_NULL;
+    rt_thread_t thread_recv = RT_NULL;
+    rt_err_t result = RT_EOK;
+    uart_over_flag = RT_FALSE;
+
+    result = uart_find();
+    if (result != RT_EOK)
+    {
+        return -RT_ERROR;
+    }
+
+    rx_sem = rt_sem_create("rx_sem", 0, RT_IPC_FLAG_PRIO);
+    if (rx_sem == RT_NULL)
+    {
+        LOG_E("Init rx_sem failed.");
+        uart_result = RT_FALSE;
+        return -RT_ERROR;
+    }
+
+    tx_sem = rt_sem_create("tx_sem", 0, RT_IPC_FLAG_PRIO);
+    if (tx_sem == RT_NULL)
+    {
+        LOG_E("Init tx_sem failed.");
+        uart_result = RT_FALSE;
+        return -RT_ERROR;
+    }
+
+    /* reinitialize */
+    struct serial_configure config = RT_SERIAL_CONFIG_DEFAULT;
+    config.baud_rate = BAUD_RATE_115200;
+    config.rx_bufsz = BSP_UART2_RX_BUFSIZE;
+    config.tx_bufsz = BSP_UART2_TX_BUFSIZE;
+    rt_device_control(&serial->parent, RT_DEVICE_CTRL_CONFIG, &config);
+
+    result = rt_device_open(&serial->parent, RT_DEVICE_FLAG_RX_NON_BLOCKING | RT_DEVICE_FLAG_TX_NON_BLOCKING);
+
+    if (result != RT_EOK)
+    {
+        LOG_E("Open uart device failed.");
+        uart_result = RT_FALSE;
+        return -RT_ERROR;
+    }
+
+    /* set receive callback function */
+    result = rt_device_set_tx_complete(&serial->parent, uart_tx_completion);
+    if (result != RT_EOK)
+    {
+        goto __exit;
+    }
+
+    result = rt_device_set_rx_indicate(&serial->parent, uart_rx_indicate);
+    if (result != RT_EOK)
+    {
+        goto __exit;
+    }
+
+    thread_recv = rt_thread_create("uart_recv", uart_rec_entry, &test_buf, 1024, RT_THREAD_PRIORITY_MAX - 5, 10);
+    thread_send = rt_thread_create("uart_send", uart_send_entry, &test_buf, 1024, RT_THREAD_PRIORITY_MAX - 4, 10);
+
+    if (thread_send != RT_NULL && thread_recv != RT_NULL)
+    {
+        rt_thread_startup(thread_recv);
+        rt_thread_startup(thread_send);
+    }
+    else
+    {
+        result = -RT_ERROR;
+        goto __exit;
+    }
+
+    while (1)
+    {
+        if (uart_result != RT_TRUE)
+        {
+            LOG_E("The test for uart dma is failure.");
+            result = -RT_ERROR;
+            goto __exit;
+        }
+        if (uart_over_flag == RT_TRUE)
+        {
+            goto __exit;
+        }
+        /* waiting for test over */
+        rt_thread_mdelay(5);
+    }
+__exit:
+    if (tx_sem)
+        rt_sem_delete(tx_sem);
+
+    if (rx_sem)
+        rt_sem_delete(rx_sem);
+
+    rt_device_close(&serial->parent);
+    return result;
+}
+
+static void tc_uart_api(void)
+{
+    rt_uint32_t times = 0;
+    rt_uint16_t num = 0;
+    while (TC_UART_SEND_TIMES - times)
+    {
+        num = (rand() % 1000) + 1;
+        if(uart_api(num) == RT_EOK)
+           LOG_I("data_lens [%3d], it is correct to read and write data. [%d] times testing.", num, ++times);
+        else
+        {
+            LOG_E("uart test error");
+            break;
+        }
+    }
+    uassert_true(uart_over_flag == RT_TRUE);
+}
+
+static rt_err_t utest_tc_init(void)
+{
+    LOG_I("UART TEST: Please connect Tx and Rx directly for self testing.");
+    return RT_EOK;
+}
+
+static rt_err_t utest_tc_cleanup(void)
+{
+    tx_sem = RT_NULL;
+    uart_result = RT_TRUE;
+    uart_over_flag = RT_FALSE;
+
+    return RT_EOK;
+}
+
+static void testcase(void)
+{
+    UTEST_UNIT_RUN(tc_uart_api);
+}
+
+UTEST_TC_EXPORT(testcase, "testcases.drivers.uart_rxnb_txnb", utest_tc_init, utest_tc_cleanup, 30);
+
+#endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
该测试用例配合这个PR[[serial] 增加serial_v2版本的框架和基于stm32的串口驱动](https://github.com/RT-Thread/rt-thread/pull/4764#partial-pull-merging)验证新版本的串口框架。

测试用例包含四个文件，分别为串口 发送阻塞接收非阻塞、发送阻塞接收阻塞、发送非阻塞接收非阻塞、发送非阻塞接收阻塞这种操作模式进行测试。

以上四种操作模式，需要结合硬件的配置模式一起工作。例如 发送阻塞接收非阻塞 ，这个测试有很多种硬件配置，配置情况例如：DMA发送阻塞DMA接收非阻塞，INT发送阻塞DMA接收非阻塞，POLL发送阻塞DMA接收非阻塞等等。因此通过排列组合后的测试场景有4*9=36种，有意义的组合方式为20种。如下表：



| 接收非阻塞 | 发送阻塞 | 组合              | 有意义的组合方式 |
| ---------- | -------- | ----------------- | ---------------- |
| POLL       | POLL     | RX_POLL + TX_POLL |                  |
|            | INT      | RX_POLL + TX_INT  |                  |
|            | DMA      | RX_POLL + TX_DMA  |                  |
| INT        | POLL     | RX_INT + TX_POLL  | ✔                |
|            | INT      | RX_INT + TX_INT   | ✔                |
|            | DMA      | RX_INT + TX_DMA   | ✔                |
| DMA        | POLL     | RX_DMA + TX_POLL  | ✔                |
|            | INT      | RX_DMA + TX_INT   | ✔                |
|            | DMA      | RX_DMA + TX_DMA   | ✔                |



| 接收非阻塞 | 发送非阻塞 | 组合              | 有意义的组合方式 |
| ---------- | ---------- | ----------------- | ---------------- |
| POLL       | POLL       | RX_POLL + TX_POLL |                  |
|            | INT        | RX_POLL + TX_INT  |                  |
|            | DMA        | RX_POLL + TX_DMA  |                  |
| INT        | POLL       | RX_INT + TX_POLL  |                  |
|            | INT        | RX_INT + TX_INT   | ✔                |
|            | DMA        | RX_INT + TX_DMA   | ✔                |
| DMA        | POLL       | RX_DMA + TX_POLL  |                  |
|            | INT        | RX_DMA + TX_INT   | ✔                |
|            | DMA        | RX_DMA + TX_DMA   | ✔                |



| 接收阻塞 | 发送阻塞 | 组合              | 有意义的组合方式 |
| -------- | -------- | ----------------- | ---------------- |
| POLL     | POLL     | RX_POLL + TX_POLL |                  |
|          | INT      | RX_POLL + TX_INT  |                  |
|          | DMA      | RX_POLL + TX_DMA  |                  |
| INT      | POLL     | RX_INT + TX_POLL  | ✔                |
|          | INT      | RX_INT + TX_INT   | ✔                |
|          | DMA      | RX_INT + TX_DMA   | ✔                |
| DMA      | POLL     | RX_DMA + TX_POLL  | ✔                |
|          | INT      | RX_DMA + TX_INT   | ✔                |
|          | DMA      | RX_DMA + TX_DMA   | ✔                |



| 接收阻塞 | 发送非阻塞 | 组合              | 有意义的组合方式 |
| -------- | ---------- | ----------------- | ---------------- |
| POLL     | POLL       | RX_POLL + TX_POLL |                  |
|          | INT        | RX_POLL + TX_INT  |                  |
|          | DMA        | RX_POLL + TX_DMA  |                  |
| INT      | POLL       | RX_INT + TX_POLL  |                  |
|          | INT        | RX_INT + TX_INT   | ✔                |
|          | DMA        | RX_INT + TX_DMA   | ✔                |
| DMA      | POLL       | RX_DMA + TX_POLL  |                  |
|          | INT        | RX_DMA + TX_INT   | ✔                |
|          | DMA        | RX_DMA + TX_DMA   | ✔                |

需要解释的是，为什么会存在无意义的组合模式，举个例子，非阻塞模式下，肯定是不会出现POLL（轮询）方式的，因为POLL方式已经表明是阻塞方式了。另外是由于接收线程的优先级高于发送线程的优先级，因此，当接收模式为阻塞POLL时，其组合的测试也是无意义的，但在脱离自发自收的测试时，这些模式组合是可以正常工作的。
该测试用例在测试多种组合时，需要通过更改`rtconfig.h`文件对硬件模式进行静态配置。目前已经在STM32L475-pandora平台上对以上20种模式进行了测试且测试通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
