### PR TITLE
[pm] index should be less than PM_MODLUE_MAX_ID

### DIFF
--- a/components/drivers/pm/pm.c
+++ b/components/drivers/pm/pm.c
@@ -836,12 +836,10 @@ rt_uint32_t rt_pm_module_get_status(void)
     rt_uint32_t req_status = 0x00;
     pm = &_pm;
 
-    for (index = 0; index < 32; index ++)
+    for (index = 0; index < PM_MODULE_MAX_ID; index ++)
     {
         if (pm->module_status[index].req_status == 0x01)
             req_status |= 1<<index;
-        if (index >= PM_MODULE_MAX_ID)
-            break;
     }
 
     return req_status;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
https://github.com/RT-Thread/rt-thread/blob/a1a656fbe776c40e8ad31298f1bfd2deec11b122/components/drivers/pm/pm.c#L839

这里作者的意图是通过遍历的方法去寻找到当前模块是否处于已请求低功耗模式的状态。
但是作者这里直接写了 ` index < 32` 在目前的版本来看，有如下两个问题：
1. 低功耗的模块数量没有超过32，如果超过了这里就没办法正确的去遍历了
2. 作者这里为了防止数组写穿的问题，当检查到 `index > PM_MODLUE_MAX_ID` 的时候直接 `break`  ,如果直接检查 `index`  不超过 `PM_MODLUE_MAX_ID`，这里就没必要在检查一次 `index` 的值。

本次提交已经在 `stm32l475-atk-pandora` 测试通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
