### PR TITLE
[bsp][tm4c129x] Fix the buffer free error in eth driver receive func.

### DIFF
--- a/bsp/tm4c129x/libraries/driverlib/adc.c
+++ b/bsp/tm4c129x/libraries/driverlib/adc.c
@@ -2,25 +2,25 @@
 //
 // adc.c - Driver for the ADC.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -554,7 +554,7 @@ ADCSequenceConfigure(uint32_t ui32Base, uint32_t ui32SequenceNum,
         // Set the shift for the module and generator
         //
         ui32Gen = (ui32Gen - ADC_TRIGGER_PWM0) * 8;
-        
+
         HWREG(ui32Base + ADC_O_TSSEL) = ((HWREG(ui32Base + ADC_O_TSSEL) &
                                          ~(0x30 << ui32Gen)) |
                                          ((ui32Trigger & 0x30) << ui32Gen));
@@ -568,10 +568,15 @@ ADCSequenceConfigure(uint32_t ui32Base, uint32_t ui32SequenceNum,
 //! \param ui32Base is the base address of the ADC module.
 //! \param ui32SequenceNum is the sample sequence number.
 //! \param ui32Step is the step to be configured.
-//! \param ui32Config is the configuration of this step; must be a logical OR
+//! \param ui32Config is the configuration of this step; is a logical OR
 //! of \b ADC_CTL_TS, \b ADC_CTL_IE, \b ADC_CTL_END, \b ADC_CTL_D, one of the
 //! input channel selects (\b ADC_CTL_CH0 through \b ADC_CTL_CH23), and one of
 //! the digital comparator selects (\b ADC_CTL_CMP0 through \b ADC_CTL_CMP7).
+//! On some parts the sample and hold time can be increased by including a
+//! logical OR of one of \b ADC_CTL_SHOLD_4, \b ADC_CTL_SHOLD_8,
+//! \b ADC_CTL_SHOLD_16, \b ADC_CTL_SHOLD_32, \b ADC_CTL_SHOLD_64,
+//! \b ADC_CTL_SHOLD_128 or \b ADC_CTL_SHOLD_256. The default sample time is 4
+//! ADC clocks.
 //!
 //! This function configures the ADC for one step of a sample sequence.  The
 //! ADC can be configured for single-ended or differential operation (the
@@ -1010,9 +1015,9 @@ ADCSoftwareOversampleStepConfigure(uint32_t ui32Base, uint32_t ui32SequenceNum,
     ASSERT((ui32Base == ADC0_BASE) || (ui32Base == ADC1_BASE));
     ASSERT(ui32SequenceNum < 3);
     ASSERT(((ui32SequenceNum == 0) &&
-            (ui32Step < 
+            (ui32Step <
             (8 >> g_pui8OversampleFactor[ui32ADCInst][ui32SequenceNum]))) ||
-           (ui32Step < 
+           (ui32Step <
            (4 >> g_pui8OversampleFactor[ui32ADCInst][ui32SequenceNum])));
 
     //
@@ -1029,7 +1034,7 @@ ADCSoftwareOversampleStepConfigure(uint32_t ui32Base, uint32_t ui32SequenceNum,
     // Loop through the hardware steps that make up this step of the software
     // oversampled sequence.
     //
-    for(ui32SequenceNum = 
+    for(ui32SequenceNum =
         (1 << g_pui8OversampleFactor[ui32ADCInst][ui32SequenceNum]);
         ui32SequenceNum; ui32SequenceNum--)
     {
@@ -1114,9 +1119,9 @@ ADCSoftwareOversampleDataGet(uint32_t ui32Base, uint32_t ui32SequenceNum,
     ASSERT((ui32Base == ADC0_BASE) || (ui32Base == ADC1_BASE));
     ASSERT(ui32SequenceNum < 3);
     ASSERT(((ui32SequenceNum == 0) &&
-            (ui32Count < 
+            (ui32Count <
             (8 >> g_pui8OversampleFactor[ui32ADCInst][ui32SequenceNum]))) ||
-            (ui32Count < 
+            (ui32Count <
             (4 >> g_pui8OversampleFactor[ui32ADCInst][ui32SequenceNum])));
 
     //
@@ -1145,7 +1150,7 @@ ADCSoftwareOversampleDataGet(uint32_t ui32Base, uint32_t ui32SequenceNum,
         //
         // Write the averaged sample to the output buffer.
         //
-        *pui32Buffer++ = 
+        *pui32Buffer++ =
             ui32Accum >> g_pui8OversampleFactor[ui32ADCInst][ui32SequenceNum];
     }
 }
@@ -1678,7 +1683,7 @@ ADCIntClearEx(uint32_t ui32Base, uint32_t ui32IntFlags)
 //!
 //! The ADC reference is set as specified by \e ui32Ref.  It must be one of
 //! \b ADC_REF_INT, or \b ADC_REF_EXT_3V for internal or external reference
-//! If \b ADC_REF_INT is chosen, then an internal 3V reference is used and 
+//! If \b ADC_REF_INT is chosen, then an internal 3V reference is used and
 //! no external reference is needed.  If \b ADC_REF_EXT_3V is chosen, then
 //! a 3V reference must be supplied to the AVREF pin.
 //!
@@ -1977,7 +1982,7 @@ ADCClockConfigSet(uint32_t ui32Base, uint32_t ui32Config,
     //
     // Check the argument.
     //
-    ASSERT((ui32Base == ADC0_BASE) || (ui32Base == ADC1_BASE));
+    ASSERT(ui32Base == ADC0_BASE);
     ASSERT((ui32ClockDiv - 1) <= (ADC_CC_CLKDIV_M >> ADC_CC_CLKDIV_S));
 
     //
@@ -2036,12 +2041,12 @@ ADCClockConfigGet(uint32_t ui32Base, uint32_t *pui32ClockDiv)
     //
     // Check the argument.
     //
-    ASSERT((ui32Base == ADC0_BASE) || (ui32Base == ADC1_BASE));
+    ASSERT(ui32Base == ADC0_BASE);
 
     //
     // Read the current configuration.
     //
-    ui32Config = HWREG(ui32Base + ADC_O_CC);
+    ui32Config = HWREG(ADC0_BASE + ADC_O_CC);
 
     //
     // If the clock divider was requested provide the current value.
@@ -2060,7 +2065,7 @@ ADCClockConfigGet(uint32_t ui32Base, uint32_t *pui32ClockDiv)
     //
     // Add in the sample interval to the configuration.
     //
-    ui32Config |= (HWREG(ui32Base + ADC_O_PC) & ADC_PC_SR_M) << 4;
+    ui32Config |= (HWREG(ADC0_BASE + ADC_O_PC) & ADC_PC_SR_M) << 4;
 
     return(ui32Config);
 }

--- a/bsp/tm4c129x/libraries/driverlib/adc.h
+++ b/bsp/tm4c129x/libraries/driverlib/adc.h
@@ -2,25 +2,25 @@
 //
 // adc.h - ADC headers for using the ADC driver functions.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/aes.c
+++ b/bsp/tm4c129x/libraries/driverlib/aes.c
@@ -2,25 +2,25 @@
 //
 // aes.c - Driver for the AES module.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/aes.h
+++ b/bsp/tm4c129x/libraries/driverlib/aes.h
@@ -2,25 +2,25 @@
 //
 // aes.h - Defines and Macros for the AES module.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/can.c
+++ b/bsp/tm4c129x/libraries/driverlib/can.c
@@ -2,25 +2,25 @@
 //
 // can.c - Driver for the CAN module.
 //
-// Copyright (c) 2006-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2006-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -831,7 +831,7 @@ CANIntRegister(uint32_t ui32Base, void (*pfnHandler)(void))
     IntRegister(ui8IntNumber, pfnHandler);
 
     //
-    // Enable the Ethernet interrupt.
+    // Enable the CAN interrupt.
     //
     IntEnable(ui8IntNumber);
 }
@@ -1076,6 +1076,13 @@ CANIntStatus(uint32_t ui32Base, tCANIntStsReg eIntStsReg)
 //! actually cleared.  Failure to do so may result in the interrupt handler
 //! being immediately reentered (because the interrupt controller still sees
 //! the interrupt source asserted).
+//!
+//! \note The functions CANIntClear(), CANMessageSet(), and CANMessageClear()
+//! are not re-entrant.  If any of these functions are used in the main
+//! application code and if any of them are also used within an interrupt
+//! routine, then the corresponding interrupt for that interrupt routine should
+//! be disabled prior to the call for any of these functions.  The interrupt
+//! can be re-enabled immediately after the function call has returned.
 //!
 //! \return None.
 //
@@ -1470,6 +1477,13 @@ CANErrCntrGet(uint32_t ui32Base, uint32_t *pui32RxCount,
 //! If you specify a message object buffer that already contains a message
 //! definition, it is overwritten.
 //!
+//! \note The functions CANIntClear(), CANMessageSet(), and CANMessageClear()
+//! are not re-entrant.  If any of these functions are used in the main
+//! application code and if any of them are also used within an interrupt
+//! routine, then the corresponding interrupt for that interrupt routine should
+//! be disabled prior to the call for any of these functions.  The interrupt
+//! can be re-enabled immediately after the function call has returned.
+//!
 //! \return None.
 //
 //*****************************************************************************
@@ -1831,6 +1845,12 @@ CANMessageSet(uint32_t ui32Base, uint32_t ui32ObjID,
 //! - \b MSG_OBJ_DATA_LOST indicates that at least one message was received on
 //!   this message object and not read by the host before being overwritten.
 //!
+//! \note This function is not re-entrant.  If it is used in both main
+//! application code and in an interrupt routine, then the corresponding
+//! interrupt should be disabled prior to the call for CANMessageGet().
+//! The interrupt can be re-enabled immediately after the function call has
+//! returned.
+//!
 //! \return None.
 //
 //*****************************************************************************
@@ -2075,6 +2095,13 @@ CANMessageGet(uint32_t ui32Base, uint32_t ui32ObjID,
 //! This function frees the specified message object from use.  Once a message
 //! object has been ``cleared,'' it no longer automatically sends or receives
 //! messages, nor does it generate interrupts.
+//!
+//! \note The functions CANIntClear(), CANMessageSet(), and CANMessageClear()
+//! are not re-entrant.  If any of these functions are used in the main
+//! application code and if any of them are also used within an interrupt
+//! routine, then the corresponding interrupt for that interrupt routine should
+//! be disabled prior to the call for any of these functions.  The interrupt
+//! can be re-enabled immediately after the function call has returned.
 //!
 //! \return None.
 //

--- a/bsp/tm4c129x/libraries/driverlib/can.h
+++ b/bsp/tm4c129x/libraries/driverlib/can.h
@@ -2,25 +2,25 @@
 //
 // can.h - Defines and Macros for the CAN controller.
 //
-// Copyright (c) 2006-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2006-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/comp.c
+++ b/bsp/tm4c129x/libraries/driverlib/comp.c
@@ -2,25 +2,25 @@
 //
 // comp.c - Driver for the analog comparator.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/comp.h
+++ b/bsp/tm4c129x/libraries/driverlib/comp.h
@@ -2,25 +2,25 @@
 //
 // comp.h - Prototypes for the analog comparator driver.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/cpu.c
+++ b/bsp/tm4c129x/libraries/driverlib/cpu.c
@@ -3,25 +3,25 @@
 // cpu.c - Instruction wrappers for special CPU instructions needed by the
 //         drivers.
 //
-// Copyright (c) 2006-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2006-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -33,8 +33,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/cpu.h
+++ b/bsp/tm4c129x/libraries/driverlib/cpu.h
@@ -2,25 +2,25 @@
 //
 // cpu.h - Prototypes for the CPU instruction wrapper functions.
 //
-// Copyright (c) 2006-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2006-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/crc.c
+++ b/bsp/tm4c129x/libraries/driverlib/crc.c
@@ -2,25 +2,25 @@
 //
 // crc.c - Driver for the CRC module.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/crc.h
+++ b/bsp/tm4c129x/libraries/driverlib/crc.h
@@ -2,25 +2,25 @@
 //
 // crc.h - Defines and Macros for CRC module.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/debug.h
+++ b/bsp/tm4c129x/libraries/driverlib/debug.h
@@ -2,25 +2,25 @@
 //
 // debug.h - Macros for assisting debug of the driver library.
 //
-// Copyright (c) 2006-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2006-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/des.c
+++ b/bsp/tm4c129x/libraries/driverlib/des.c
@@ -2,25 +2,25 @@
 //
 // des.c - Driver for the DES data transformation.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/des.h
+++ b/bsp/tm4c129x/libraries/driverlib/des.h
@@ -2,25 +2,25 @@
 //
 // des.h - Defines and Macros for the DES module.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/eeprom.c
+++ b/bsp/tm4c129x/libraries/driverlib/eeprom.c
@@ -2,25 +2,25 @@
 //
 // eeprom.c - Driver for programming the on-chip EEPROM.
 //
-// Copyright (c) 2010-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2010-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/eeprom.h
+++ b/bsp/tm4c129x/libraries/driverlib/eeprom.h
@@ -2,25 +2,25 @@
 //
 // eeprom.h - Prototypes for the EEPROM driver.
 //
-// Copyright (c) 2010-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2010-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/emac.c
+++ b/bsp/tm4c129x/libraries/driverlib/emac.c
@@ -3,25 +3,25 @@
 // emac.c - Driver for the Integrated Ethernet Controller on Snowflake-class
 //          Tiva devices.
 //
-// Copyright (c) 2013-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2013-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -33,8 +33,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -297,12 +297,12 @@ g_pi16MIIClockDiv[] =
 //! (where each descriptor includes a field that points to the next descriptor
 //! in the list).  In ring mode, the hardware uses the \e ui32DescSkipSize to
 //! skip past any application-defined fields after the end of the hardware-
-//! defined descriptor fields.  The parameter value indicates the number of 
-//! 32-bit words to skip after the last field of the hardware-defined 
-//! descriptor to get to the first field of the next descriptor.  When using 
-//! arrays of either the \b tEMACDMADescriptor or \b tEMACAltDMADescriptor 
+//! defined descriptor fields.  The parameter value indicates the number of
+//! 32-bit words to skip after the last field of the hardware-defined
+//! descriptor to get to the first field of the next descriptor.  When using
+//! arrays of either the \b tEMACDMADescriptor or \b tEMACAltDMADescriptor
 //! types defined for this driver, \e ui32DescSkipSize must be set to 1 to skip
-//!  the \e pvNext pointer added to the end of each of these structures.  
+//!  the \e pvNext pointer added to the end of each of these structures.
 //! Applications may modify these structure definitions to include their own
 //! application-specific data and modify \e ui32DescSkipSize appropriately if
 //! desired.
@@ -419,8 +419,8 @@ EMACInit(uint32_t ui32Base, uint32_t ui32SysClk, uint32_t ui32BusConfig,
 //!
 //! \param ui32Base is the base address of the Ethernet controller.
 //!
-//! This function performs a reset of the Ethernet MAC by resetting all logic 
-//! and returning all registers to their default values.  The function returns 
+//! This function performs a reset of the Ethernet MAC by resetting all logic
+//! and returning all registers to their default values.  The function returns
 //! only after the hardware indicates that the reset has completed.
 //!
 //! \note To ensure that the reset completes, the selected PHY clock must be
@@ -495,7 +495,7 @@ EMACReset(uint32_t ui32Base)
 //! RMII interface.
 //!
 //! If \b EMAC_PHY_TYPE_INTERNAL is selected, the following flags may be ORed
-//! into \e ui32Config to control various PHY features and modes.  These flags 
+//! into \e ui32Config to control various PHY features and modes.  These flags
 //! are ignored if an external PHY is selected.
 //!
 //! - \b EMAC_PHY_INT_NIB_TXERR_DET_DIS disables odd nibble transmit error
@@ -682,7 +682,7 @@ EMACPHYConfigSet(uint32_t ui32Base, uint32_t ui32Config)
 //! The back-off limit determines the range of the random time that the MAC
 //! delays after a collision and before attempting to retransmit a frame.  One
 //! of the following values must be used to select this limit.  In each case,
-//! the retransmission delay in terms of 512 bit time slots, is the lower of 
+//! the retransmission delay in terms of 512 bit time slots, is the lower of
 //! (2 ** N) and a random number between 0 and the selected backoff-limit.
 //!
 //! - \b EMAC_CONFIG_BO_LIMIT_1024
@@ -727,10 +727,10 @@ EMACPHYConfigSet(uint32_t ui32Base, uint32_t ui32Config)
 //! up to 9018 (or 9022 if using VLAN tagging) to be handled without reporting
 //! giant frame errors.
 //! - \b EMAC_CONFIG_100MBPS forces the MAC to communicate with the PHY using
-//! 100Mbps signaling.  If this option is not specified, the MAC uses 10Mbps 
-//! signaling.  This speed setting is important when using an external RMII 
-//! PHY where the selected rate must match the PHY's setting which may have 
-//! been made as a result of auto-negotiation.  When using the internal PHY 
+//! 100Mbps signaling.  If this option is not specified, the MAC uses 10Mbps
+//! signaling.  This speed setting is important when using an external RMII
+//! PHY where the selected rate must match the PHY's setting which may have
+//! been made as a result of auto-negotiation.  When using the internal PHY
 //! or an external MII PHY, the signaling rate is controlled by the PHY-
 //! provided transmit and receive clocks.
 //! - \b EMAC_CONFIG_CS_DISABLE disables Carrier Sense during transmission
@@ -743,15 +743,15 @@ EMACPHYConfigSet(uint32_t ui32Base, uint32_t ui32Config)
 //! of the checksum calculations are reported via status fields in the DMA
 //! receive descriptors.
 //! - \b EMAC_CONFIG_RETRY_DISABLE disables retransmission in cases where
-//! half-duplex mode is in use and a collision occurs.  This condition causes 
-//! the current frame to be ignored and a frame abort to be reported in the 
+//! half-duplex mode is in use and a collision occurs.  This condition causes
+//! the current frame to be ignored and a frame abort to be reported in the
 //! transmit frame status.
 //! - \b EMAC_CONFIG_AUTO_CRC_STRIPPING strips the last 4 bytes (frame check
 //! sequence) from all Ether type frames before forwarding the frames to the
 //! application.
 //! - \b EMAC_CONFIG_DEFERRAL_CHK_ENABLE enables transmit deferral checking
-//! in half-duplex mode.  When enabled, the transmitter reports an error if it 
-//! is unable to transmit a frame for more than 24288 bit times (or 155680 
+//! in half-duplex mode.  When enabled, the transmitter reports an error if it
+//! is unable to transmit a frame for more than 24288 bit times (or 155680
 //! bit times in Jumbo frame mode) due to an active carrier sense signal on
 //! the MII.
 //!
@@ -971,14 +971,14 @@ EMACConfigSet(uint32_t ui32Base, uint32_t ui32Config, uint32_t ui32ModeFlags,
 //! fields in the DMA receive descriptors.
 //! - \b EMAC_CONFIG_RETRY_DISABLE indicates that retransmission is disabled
 //! in cases where half-duplex mode is in use and a collision occurs.  This
-//! condition causes the current frame to be ignored and a frame abort to be 
+//! condition causes the current frame to be ignored and a frame abort to be
 //! reported in the transmit frame status.
 //! - \b EMAC_CONFIG_AUTO_CRC_STRIPPING indicates that the last 4 bytes
 //! (frame check sequence) from all Ether type frames are being stripped before
 //! frames are forwarded to the application.
 //! - \b EMAC_CONFIG_DEFERRAL_CHK_ENABLE indicates that transmit deferral
 //! checking is disabled in half-duplex mode.  When enabled, the transmitter
-//! reports an error if it is unable to transmit a frame for more than 24288 
+//! reports an error if it is unable to transmit a frame for more than 24288
 //! bit times (or 155680 bit times in Jumbo frame mode) due to an active
 //! carrier sense signal on the MII.
 //! - \b EMAC_CONFIG_TX_ENABLED indicates that the MAC transmitter is
@@ -1225,7 +1225,7 @@ EMACAddrSet(uint32_t ui32Base, uint32_t ui32Index, const uint8_t *pui8MACAddr)
 //!
 //! AC-DE-48-00-00-80
 //!
-//! the data is returned with 0xAC in the first byte of the array, 0xDE in 
+//! the data is returned with 0xAC in the first byte of the array, 0xDE in
 //! the second, 0x48 in the third and so on.
 //!
 //! \return None.
@@ -1287,7 +1287,7 @@ EMACNumAddrGet(uint32_t ui32Base)
 //! addresses.
 //!
 //! \param ui32Base is the base address of the controller.
-//! \param ui32Index is the index of the MAC address slot for which the filter 
+//! \param ui32Index is the index of the MAC address slot for which the filter
 //!        is to be set.
 //! \param ui32Config sets the filter parameters for the given MAC address.
 //!
@@ -1295,9 +1295,9 @@ EMACNumAddrGet(uint32_t ui32Base)
 //! address slots that the controller supports.  This configuration is used
 //! when perfect filtering (rather than hash table filtering) is selected.
 //!
-//! Valid values for \e ui32Index are from 1 to (number of MAC address 
-//! slots - 1). The number of supported MAC address slots may be found by 
-//! calling EMACNumAddrGet().  MAC index 0 is the local MAC address and does 
+//! Valid values for \e ui32Index are from 1 to (number of MAC address
+//! slots - 1). The number of supported MAC address slots may be found by
+//! calling EMACNumAddrGet().  MAC index 0 is the local MAC address and does
 //! not have filtering parameters associated with it.
 //!
 //! The \e ui32Config parameter determines how the given MAC address is used
@@ -1362,16 +1362,16 @@ EMACAddrFilterSet(uint32_t ui32Base, uint32_t ui32Index, uint32_t ui32Config)
 //! addresses.
 //!
 //! \param ui32Base is the base address of the controller.
-//! \param ui32Index is the index of the MAC address slot for which the filter 
+//! \param ui32Index is the index of the MAC address slot for which the filter
 //!        is to be queried.
 //!
 //! This function returns filtering parameters associated with one of the MAC
 //! address slots that the controller supports.  This configuration is used
 //! when perfect filtering (rather than hash table filtering) is selected.
 //!
-//! Valid values for \e ui32Index are from 1 to (number of MAC address 
-//! slots - 1). The number of supported MAC address slots may be found by 
-//! calling EMACNumAddrGet().  MAC index 0 is the local MAC address and does 
+//! Valid values for \e ui32Index are from 1 to (number of MAC address
+//! slots - 1). The number of supported MAC address slots may be found by
+//! calling EMACNumAddrGet().  MAC index 0 is the local MAC address and does
 //! not have filtering parameters associated with it.
 //!
 //! \return Returns the filter configuration as the logical OR of the
@@ -1450,7 +1450,7 @@ EMACAddrFilterGet(uint32_t ui32Base, uint32_t ui32Index)
 //! when the source address field in the frame does not match the values
 //! programmed into the enabled SA registers.
 //! - \b EMAC_FRMFILTER_INV_SADDR enables inverse source address filtering.
-//! When this option is specified, frames for which the SA does not match the 
+//! When this option is specified, frames for which the SA does not match the
 //! SA registers are marked as passing the source address filter.
 //! - \b EMAC_FRMFILTER_BROADCAST configures the MAC to discard all incoming
 //! broadcast frames.
@@ -1530,7 +1530,7 @@ EMACFrameFilterSet(uint32_t ui32Base, uint32_t ui32FilterOpts)
 //! received frames when the source address field in the frame does not match
 //! the values programmed into the enabled SA registers.
 //! - \b EMAC_FRMFILTER_INV_SADDR enables inverse source address filtering.
-//! When this option is specified, frames for which the SA does not match the 
+//! When this option is specified, frames for which the SA does not match the
 //! SA registers are marked as passing the source address filter.
 //! - \b EMAC_FRMFILTER_BROADCAST indicates that the MAC is configured to
 //! discard all incoming broadcast frames.
@@ -1621,9 +1621,9 @@ EMACHashFilterSet(uint32_t ui32Base, uint32_t ui32HashHi, uint32_t ui32HashLo)
 //! Returns the current MAC address hash filter table.
 //!
 //! \param ui32Base is the base address of the controller.
-//! \param pui32HashHi points to storage to be written with the upper 32 bits 
+//! \param pui32HashHi points to storage to be written with the upper 32 bits
 //! of the current 64-bit hash filter table.
-//! \param pui32HashLo points to storage to be written with the lower 32 bits 
+//! \param pui32HashLo points to storage to be written with the lower 32 bits
 //! of the current 64-bit hash filter table.
 //!
 //! This function may be used to retrieve the current 64-bit hash filter table
@@ -1766,8 +1766,8 @@ EMACRxWatchdogTimerSet(uint32_t ui32Base, uint8_t ui8Timeout)
 //! - \b EMAC_STATUS_RWC_ACTIVE
 //! - \b EMAC_STATUS_RPE_ACTIVE
 //!
-//! The transmit frame controller status can be extracted from the returned 
-//! value by ANDing with \b EMAC_STATUS_TFC_STATE_MASK and is one of the 
+//! The transmit frame controller status can be extracted from the returned
+//! value by ANDing with \b EMAC_STATUS_TFC_STATE_MASK and is one of the
 //! following:
 //!
 //! - \b EMAC_STATUS_TFC_STATE_IDLE
@@ -1775,8 +1775,8 @@ EMACRxWatchdogTimerSet(uint32_t ui32Base, uint8_t ui8Timeout)
 //! - \b EMAC_STATUS_TFC_STATE_PAUSING
 //! - \b EMAC_STATUS_TFC_STATE_WRITING
 //!
-//! The transmit FIFO read controller status can be extracted from the returned 
-//! value by ANDing with \b EMAC_STATUS_TRC_STATE_MASK and is one of the 
+//! The transmit FIFO read controller status can be extracted from the returned
+//! value by ANDing with \b EMAC_STATUS_TRC_STATE_MASK and is one of the
 //! following:
 //!
 //! - \b EMAC_STATUS_TRC_STATE_IDLE
@@ -1785,7 +1785,7 @@ EMACRxWatchdogTimerSet(uint32_t ui32Base, uint8_t ui8Timeout)
 //! - \b EMAC_STATUS_TRC_STATE_STATUS
 //!
 //! The current receive FIFO levels can be extracted from the returned value
-//! by ANDing with \b EMAC_STATUS_RX_FIFO_LEVEL_MASK and is one of the 
+//! by ANDing with \b EMAC_STATUS_RX_FIFO_LEVEL_MASK and is one of the
 //! following:
 //!
 //! - \b EMAC_STATUS_RX_FIFO_EMPTY indicating that the FIFO is empty.
@@ -1796,7 +1796,7 @@ EMACRxWatchdogTimerSet(uint32_t ui32Base, uint8_t ui8Timeout)
 //! - \b EMAC_STATUS_RX_FIFO_FULL indicating that the FIFO is full.
 //!
 //! The current receive FIFO state can be extracted from the returned value
-//! by ANDing with \b EMAC_STATUS_RX_FIFO_STATE_MASK and is one of the 
+//! by ANDing with \b EMAC_STATUS_RX_FIFO_STATE_MASK and is one of the
 //! following:
 //!
 //! - \b EMAC_STATUS_RX_FIFO_IDLE
@@ -2049,7 +2049,7 @@ EMACTxDMADescriptorListSet(uint32_t ui32Base, tEMACDMADescriptor *pDescriptor)
 //! \param ui32Base is the base address of the controller.
 //!
 //! This function returns a pointer to the head of the Ethernet MAC's transmit
-//! DMA descriptor list.  This value corresponds to the pointer originally set 
+//! DMA descriptor list.  This value corresponds to the pointer originally set
 //! using a call to EMACTxDMADescriptorListSet().
 //!
 //! \return Returns a pointer to the start of the DMA transmit descriptor list.
@@ -2438,8 +2438,8 @@ EMACIntUnregister(uint32_t ui32Base)
 //! - \b EMAC_INT_RX_OVERFLOW indicates that an overflow was experienced
 //! during reception.
 //! - \b EMAC_INT_TX_JABBER indicates that the transmit jabber timer expired.
-//! This condition occurs when the frame size exceeds 2048 bytes (or 10240 
-//! bytes in Jumbo Frame mode) and causes the transmit process to abort and 
+//! This condition occurs when the frame size exceeds 2048 bytes (or 10240
+//! bytes in Jumbo Frame mode) and causes the transmit process to abort and
 //! enter the Stopped state.
 //! - \b EMAC_INT_TX_NO_BUFFER indicates that the host owns the next buffer
 //! in the DMA's transmit descriptor list and that the DMA cannot, therefore,
@@ -2540,8 +2540,8 @@ EMACIntEnable(uint32_t ui32Base, uint32_t ui32IntFlags)
 //! - \b EMAC_INT_RX_OVERFLOW indicates that an overflow was experienced
 //! during reception.
 //! - \b EMAC_INT_TX_JABBER indicates that the transmit jabber timer expired.
-//! This condition occurs when the frame size exceeds 2048 bytes (or 10240 
-//! bytes in Jumbo Frame mode) and causes the transmit process to abort and 
+//! This condition occurs when the frame size exceeds 2048 bytes (or 10240
+//! bytes in Jumbo Frame mode) and causes the transmit process to abort and
 //! enter the Stopped state.
 //! - \b EMAC_INT_TX_NO_BUFFER indicates that the host owns the next buffer
 //! in the DMA's transmit descriptor list and that the DMA cannot, therefore,
@@ -2660,8 +2660,8 @@ EMACIntDisable(uint32_t ui32Base, uint32_t ui32IntFlags)
 //! - \b EMAC_INT_RX_OVERFLOW indicates that an overflow was experienced
 //! during reception.
 //! - \b EMAC_INT_TX_JABBER indicates that the transmit jabber timer expired.
-//! This condition occurs when the frame size exceeds 2048 bytes (or 10240 
-//! bytes in Jumbo Frame mode) and causes the transmit process to abort and 
+//! This condition occurs when the frame size exceeds 2048 bytes (or 10240
+//! bytes in Jumbo Frame mode) and causes the transmit process to abort and
 //! enter the Stopped state.
 //! - \b EMAC_INT_TX_NO_BUFFER indicates that the host owns the next buffer
 //! in the DMA's transmit descriptor list and that the DMA cannot, therefore,
@@ -2767,8 +2767,8 @@ EMACIntStatus(uint32_t ui32Base, bool bMasked)
 //! - \b EMAC_INT_RX_OVERFLOW indicates that an overflow was experienced
 //! during reception.
 //! - \b EMAC_INT_TX_JABBER indicates that the transmit jabber timer expired.
-//! This condition occurs when the frame size exceeds 2048 bytes (or 10240 
-//! bytes in Jumbo Frame mode) and causes the transmit process to abort and 
+//! This condition occurs when the frame size exceeds 2048 bytes (or 10240
+//! bytes in Jumbo Frame mode) and causes the transmit process to abort and
 //! enter the Stopped state.
 //! - \b EMAC_INT_TX_NO_BUFFER indicates that the host owns the next buffer
 //! in the DMA's transmit descriptor list and that the DMA cannot, therefore,
@@ -3160,7 +3160,7 @@ EMACPHYPowerOn(uint32_t ui32Base, uint8_t ui8PhyAddr)
 //! simple 31-bit counter, rolling over to 0 after reaching 0x7FFFFFFF.  In
 //! this case, each lsb of the subsecond counter represents 0.465 ns (assuming
 //! the definition of 1 second resolution for the seconds counter).  When
-//! binary rollover mode is selected, the subsecond counter acts as a 
+//! binary rollover mode is selected, the subsecond counter acts as a
 //! nanosecond counter and rolls over to 0 after reaching 999,999,999 making
 //! each lsb represent 1 nanosecond.
 //!
@@ -3250,7 +3250,7 @@ EMACTimestampConfigSet(uint32_t ui32Base, uint32_t ui32Config,
 //! are filtered using any of the configured MAC addresses.  Messages with a
 //! destination address programmed into the MAC address filter are passed,
 //! others are discarded.  If this flag is absent, the MAC address is ignored.
-//! - \b EMAC_TS_UPDATE_FINE implements the fine update method that causes the 
+//! - \b EMAC_TS_UPDATE_FINE implements the fine update method that causes the
 //! IEEE 1588 clock to advance by the the value returned in the
 //! \e *pui32SubSecondInc parameter each time a carry is generated from the
 //! addend accumulator register.  If this flag is absent, the coarse update
@@ -3689,7 +3689,7 @@ EMACTimestampTargetIntDisable(uint32_t ui32Base)
     ASSERT(ui32Base == EMAC0_BASE);
 
     //
-    // Clear the bit to disable the timestamp target interrupt.  This bit 
+    // Clear the bit to disable the timestamp target interrupt.  This bit
     // clears automatically when the interrupt fires, so it only must be
     // disabled if you want to cancel a previously-set interrupt.
     //
@@ -4022,7 +4022,7 @@ EMACTimestampPPSPeriodSet(uint32_t ui32Base, uint32_t ui32Period,
 //! (Type = 0x88A8) frames as valid VLAN-tagged frames.  If absent, only
 //! frames with type 0x8100 are considered valid VLAN frames.
 //! - \b EMAC_VLAN_RX_INVERSE_MATCH causes the receiver to pass all VLAN
-//! frames for which the tags do not match the supplied \e ui16Tag value.  If 
+//! frames for which the tags do not match the supplied \e ui16Tag value.  If
 //! this flag is absent, only tagged frames matching \e ui16Tag are passed.
 //! - \b EMAC_VLAN_RX_12BIT_TAG causes the receiver to compare only the
 //! bottom 12 bits of \e ui16Tag when performing either perfect or hash
@@ -4082,7 +4082,7 @@ EMACVLANRxConfigSet(uint32_t ui32Base, uint16_t ui16Tag, uint32_t ui32Config)
 //! S-VLAN (Type = 0x88A8) frames as valid VLAN-tagged frames.  If absent, only
 //! frames with type 0x8100 are considered valid VLAN frames.
 //! - \b EMAC_VLAN_RX_INVERSE_MATCH indicates that the receiver passes all
-//! VLAN frames for which the tags do not match the \e *pui16Tag value.  If 
+//! VLAN frames for which the tags do not match the \e *pui16Tag value.  If
 //! this flag is absent, only tagged frames matching \e *pui16Tag are passed.
 //! - \b EMAC_VLAN_RX_12BIT_TAG indicates that the receiver is comparing only
 //! the bottom 12 bits of \e *pui16Tag when performing either perfect or hash
@@ -4254,7 +4254,7 @@ EMACVLANTxConfigGet(uint32_t ui32Base, uint16_t *pui16Tag)
 //! Returns the bit number to set in the VLAN hash filter corresponding to a
 //! given tag.
 //!
-//! \param ui16Tag is the VLAN tag for which the hash filter bit number is to 
+//! \param ui16Tag is the VLAN tag for which the hash filter bit number is to
 //! be determined.
 //!
 //! This function may be used to determine which bit in the VLAN hash filter
@@ -4379,8 +4379,8 @@ EMACVLANHashFilterGet(uint32_t ui32Base)
 //! calculated on up to 31 payload bytes in the frame.  The actual bytes used
 //! in the CRC calculation are defined by means of a bit mask where a ``1''
 //! indicates that a byte in the frame should contribute to the CRC
-//! calculation and a ``0'' indicates that the byte should be skipped, as well 
-//! as an offset from the start of the frame to the payload byte that represents 
+//! calculation and a ``0'' indicates that the byte should be skipped, as well
+//! as an offset from the start of the frame to the payload byte that represents
 //! the first byte in the 31-byte CRC-checked sequence.
 //!
 //! The \e pFilter parameter points to a structure containing the information
@@ -4400,7 +4400,7 @@ EMACVLANHashFilterGet(uint32_t ui32Base)
 //! - \b pui8Offset defines the zero-based index of the byte within the frame
 //! at which CRC checking defined by \b pui32ByteMask begins.
 //! Alternatively, this value can be thought of as the number of bytes in the
-//! frame that the MAC skips before accumulating the CRC based on the pattern  
+//! frame that the MAC skips before accumulating the CRC based on the pattern
 //! in \b pui32ByteMask.
 //! - \b pui16CRC provides the value of the calculated CRC for a valid remote
 //! wake-up frame.  If the incoming frame is processed according to the filter
@@ -4466,7 +4466,7 @@ EMACRemoteWakeUpFrameFilterSet(uint32_t ui32Base,
 //! actual bytes used in the CRC calculation are defined by means of a bit mask
 //! where a ``1'' indicates that a byte in the frame should contribute to the
 //! CRC calculation and a ``0'' indicates that the byte should be skipped, and
-//! an offset from the start of the frame to the payload byte that represents 
+//! an offset from the start of the frame to the payload byte that represents
 //! the first byte in the 31-byte CRC-checked sequence.
 //!
 //! The \e pFilter parameter points to storage that is written with a
@@ -4756,7 +4756,7 @@ EMACWoLEnter(uint32_t ui32Base)
 //! This function is used to configure the LPI timer and control registers when
 //! the link is established as EEE mode or when the link is lost. When the link
 //! is established as EEE, then \e ui16LPILSTimer is programmed as the link
-//! status timer value and \e ui16LPITWTimer is programmed as the transmit wait 
+//! status timer value and \e ui16LPITWTimer is programmed as the transmit wait
 //! timer value. The parameter \e bLPIConfig is used to decide if the transmit
 //! path must be automated or should be under user control.
 //!
@@ -4773,7 +4773,7 @@ EMACLPIConfig(uint32_t ui32Base, bool bLPIConfig, uint16_t ui16LPILSTimer,
     // Parameter sanity check.
     //
     ASSERT(ui32Base == EMAC0_BASE);
-    
+
     ui32TimerValue = ((ui16LPILSTimer << EMAC_LPITIMERCTL_LST_S) &
                        EMAC_LPITIMERCTL_LST_M);
     ui32TimerValue |= ui16LPITWTimer & EMAC_LPITIMERCTL_TWT_M;
@@ -4932,7 +4932,7 @@ EMACPHYMMDWrite(uint32_t ui32Base, uint8_t ui8PhyAddr, uint16_t ui16RegAddr,
     //
     // Write the extended register value.
     //
-    EMACPHYWrite(ui32Base, ui8PhyAddr, EPHY_REGCTL, 
+    EMACPHYWrite(ui32Base, ui8PhyAddr, EPHY_REGCTL,
                  (0x4000 | DEV_ADDR(ui16RegAddr)));
     EMACPHYWrite(ui32Base, ui8PhyAddr, EPHY_REGCTL, ui16Data);
 }
@@ -4970,7 +4970,7 @@ EMACPHYMMDRead(uint32_t ui32Base, uint8_t ui8PhyAddr, uint16_t ui16RegAddr)
     //
     // Read the extended register value.
     //
-    EMACPHYWrite(ui32Base, ui8PhyAddr, EPHY_REGCTL, 
+    EMACPHYWrite(ui32Base, ui8PhyAddr, EPHY_REGCTL,
                  (0x4000 | DEV_ADDR(ui16RegAddr)));
     return(EMACPHYRead(ui32Base, ui8PhyAddr, EPHY_ADDAR));
 }

--- a/bsp/tm4c129x/libraries/driverlib/emac.h
+++ b/bsp/tm4c129x/libraries/driverlib/emac.h
@@ -3,25 +3,25 @@
 // emac.h - Defines and Macros for the Ethernet module on Snowflake-class
 //          devices.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -33,8 +33,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/epi.c
+++ b/bsp/tm4c129x/libraries/driverlib/epi.c
@@ -2,25 +2,25 @@
 //
 // epi.c - Driver for the EPI module.
 //
-// Copyright (c) 2008-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2008-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/epi.h
+++ b/bsp/tm4c129x/libraries/driverlib/epi.h
@@ -2,25 +2,25 @@
 //
 // epi.h - Prototypes and macros for the EPI module.
 //
-// Copyright (c) 2008-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2008-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -338,7 +338,7 @@ EPIWorkaroundWordWrite(uint32_t *pui32Addr, uint32_t ui32Value)
     __asm
     {
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         NOP
@@ -364,7 +364,7 @@ EPIWorkaroundWordRead(uint32_t *pui32Addr)
     __asm
     {
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         NOP
@@ -392,7 +392,7 @@ EPIWorkaroundHWordWrite(uint16_t *pui16Addr, uint16_t ui16Value)
     __asm
     {
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         NOP
@@ -419,7 +419,7 @@ EPIWorkaroundHWordRead(uint16_t *pui16Addr)
     __asm
     {
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         NOP
@@ -447,7 +447,7 @@ EPIWorkaroundByteWrite(uint8_t *pui8Addr, uint8_t ui8Value)
     __asm
     {
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         NOP
@@ -474,7 +474,7 @@ EPIWorkaroundByteRead(uint8_t *pui8Addr)
     __asm
     {
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         NOP
@@ -525,7 +525,7 @@ EPIWorkaroundWordWrite(uint32_t *pui32Addr, uint32_t ui32Value)
 
     __asm volatile (
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         "    NOP\n"
@@ -553,7 +553,7 @@ EPIWorkaroundWordRead(uint32_t *pui32Addr)
 
     __asm volatile(
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         "    NOP\n"
@@ -580,7 +580,7 @@ EPIWorkaroundHWordWrite(uint16_t *pui16Addr, uint16_t ui16Value)
 
     __asm volatile (
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         "    NOP\n"
@@ -610,7 +610,7 @@ EPIWorkaroundHWordRead(uint16_t *pui16Addr)
 
     __asm volatile(
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         "    NOP\n"
@@ -636,7 +636,7 @@ EPIWorkaroundByteWrite(uint8_t *pui8Addr, uint8_t ui8Value)
 
     __asm volatile (
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         "    NOP\n"
@@ -665,7 +665,7 @@ EPIWorkaroundByteRead(uint8_t *pui8Addr)
 
     __asm volatile(
         //
-        // Add a NOP to ensure we don’t have a flash read immediately before
+        // Add a NOP to ensure we donæŠ° have a flash read immediately before
         // the EPI read.
         //
         "    NOP\n"

--- a/bsp/tm4c129x/libraries/driverlib/flash.c
+++ b/bsp/tm4c129x/libraries/driverlib/flash.c
@@ -2,25 +2,25 @@
 //
 // flash.c - Driver for programming the on-chip flash.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/flash.h
+++ b/bsp/tm4c129x/libraries/driverlib/flash.h
@@ -2,25 +2,25 @@
 //
 // flash.h - Prototypes for the flash driver.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/fpu.c
+++ b/bsp/tm4c129x/libraries/driverlib/fpu.c
@@ -3,25 +3,25 @@
 // fpu.c - Routines for manipulating the floating-point unit in the Cortex-M
 //         processor.
 //
-// Copyright (c) 2011-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2011-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -33,8 +33,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/fpu.h
+++ b/bsp/tm4c129x/libraries/driverlib/fpu.h
@@ -2,25 +2,25 @@
 //
 // fpu.h - Prototypes for the floatint point manipulation routines.
 //
-// Copyright (c) 2011-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2011-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/gpio.h
+++ b/bsp/tm4c129x/libraries/driverlib/gpio.h
@@ -2,25 +2,25 @@
 //
 // gpio.h - Defines and Macros for GPIO API.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -191,6 +191,7 @@ extern void GPIODMATriggerEnable(uint32_t ui32Port, uint8_t ui8Pins);
 extern void GPIODMATriggerDisable(uint32_t ui32Port, uint8_t ui8Pins);
 extern void GPIOADCTriggerEnable(uint32_t ui32Port, uint8_t ui8Pins);
 extern void GPIOADCTriggerDisable(uint32_t ui32Port, uint8_t ui8Pins);
+extern void GPIOUnlockPin(uint32_t ui32Port, uint8_t ui8Pins);
 
 //*****************************************************************************
 //

--- a/bsp/tm4c129x/libraries/driverlib/hibernate.c
+++ b/bsp/tm4c129x/libraries/driverlib/hibernate.c
@@ -2,25 +2,25 @@
 //
 // hibernate.c - Driver for the Hibernation module
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -128,7 +128,7 @@ _HibernateWriteComplete(void)
 //! the system clock is the value returned by SysCtlClockGet() for TM4C123x
 //! devices or the value returned by SysCtlClockFreqSet() for TM4C129x devices,
 //! or it can be explicitly hard coded if it is constant and known (to save the
-//! code/execution overhead of a call to SysCtlClockGet() or fetch of the 
+//! code/execution overhead of a call to SysCtlClockGet() or fetch of the
 //! variable call holding the return value of SysCtlClockFreqSet()).
 //!
 //! \return None.
@@ -272,8 +272,7 @@ HibernateClockConfig(uint32_t ui32Config)
     //
     if(HIBERNATE_CLOCK_OUTPUT)
     {
-        HWREG(HIB_CC) = ui32Config & (HIBERNATE_OUT_SYSCLK |
-                                      HIBERNATE_OUT_ALT1CLK);
+            HWREG(HIB_CC) = ui32Config & (HIBERNATE_OUT_SYSCLK);
     }
 }
 
@@ -1614,6 +1613,12 @@ _HibernateCalendarSet(uint32_t ui32Reg, struct tm *psTime)
 //! 24-hour representation of the time.  This function can only be called when
 //! the hibernate counter is configured in calendar mode using the
 //! HibernateCounterMode() function with one of the calendar modes.
+//!
+//! The hibernate module contains a 7-bit register field to store the year with
+//! valid values ranges from 0 to 99. In order to maximize the calendar
+//! year up to 2099, the HibernateCalendarSet() will accept calendar year
+//! after the year 2000 only. Calendar years before 2000 (i.e. 1987) will
+//! produce unexpected results.
 //!
 //! \note The hibernate calendar mode is not available on all Tiva
 //! devices.  Please consult the data sheet to determine if the device you are

--- a/bsp/tm4c129x/libraries/driverlib/hibernate.h
+++ b/bsp/tm4c129x/libraries/driverlib/hibernate.h
@@ -2,25 +2,25 @@
 //
 // hibernate.h - API definition for the Hibernation module.
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -104,7 +104,6 @@ extern "C"
 #define HIBERNATE_OSC_DISABLE   0x00010000
 #define HIBERNATE_OUT_WRSTALL   0x20000000
 #define HIBERNATE_OUT_SYSCLK    0x00000001
-#define HIBERNATE_OUT_ALT1CLK   0x00000002
 
 //*****************************************************************************
 //

--- a/bsp/tm4c129x/libraries/driverlib/i2c.c
+++ b/bsp/tm4c129x/libraries/driverlib/i2c.c
@@ -2,25 +2,25 @@
 //
 // i2c.c - Driver for Inter-IC (I2C) bus block.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -194,7 +194,7 @@ _I2CIntNumberGet(uint32_t ui32Base)
 //! the system clock is the value returned by SysCtlClockGet() for TM4C123x
 //! devices or the value returned by SysCtlClockFreqSet() for TM4C129x devices,
 //! or it can be explicitly hard coded if it is constant and known (to save the
-//! code/execution overhead of a call to SysCtlClockGet() or fetch of the 
+//! code/execution overhead of a call to SysCtlClockGet() or fetch of the
 //! variable call holding the return value of SysCtlClockFreqSet()).
 //!
 //! \return None.
@@ -1782,7 +1782,7 @@ I2CRxFIFOFlush(uint32_t ui32Base)
 //!
 //! This function retrieves the status for both the transmit (TX) and receive
 //! (RX) FIFOs.  The trigger level for the transmit FIFO is set using
-//! I2CTxFIFOConfigSet() and for the receive FIFO using I2CTxFIFOConfigSet().
+//! I2CTxFIFOConfigSet() and for the receive FIFO using I2CRxFIFOConfigSet().
 //!
 //! \note Not all Tiva devices have an I2C FIFO.  Please consult the
 //! device data sheet to determine if this feature is supported.

--- a/bsp/tm4c129x/libraries/driverlib/i2c.h
+++ b/bsp/tm4c129x/libraries/driverlib/i2c.h
@@ -2,25 +2,25 @@
 //
 // i2c.h - Prototypes for the I2C Driver.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/interrupt.c
+++ b/bsp/tm4c129x/libraries/driverlib/interrupt.c
@@ -2,25 +2,25 @@
 //
 // interrupt.c - Driver for the NVIC Interrupt Controller.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/interrupt.h
+++ b/bsp/tm4c129x/libraries/driverlib/interrupt.h
@@ -2,25 +2,25 @@
 //
 // interrupt.h - Prototypes for the NVIC Interrupt Controller Driver.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/lcd.c
+++ b/bsp/tm4c129x/libraries/driverlib/lcd.c
@@ -2,25 +2,25 @@
 //
 // lcd.c - Defines and Macros for the LCD Controller module.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/lcd.h
+++ b/bsp/tm4c129x/libraries/driverlib/lcd.h
@@ -2,25 +2,25 @@
 //
 // lcd.h - Defines and Macros for the LCD Controller module.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/mpu.c
+++ b/bsp/tm4c129x/libraries/driverlib/mpu.c
@@ -2,25 +2,25 @@
 //
 // mpu.c - Driver for the Cortex-M3 memory protection unit (MPU).
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/mpu.h
+++ b/bsp/tm4c129x/libraries/driverlib/mpu.h
@@ -2,25 +2,25 @@
 //
 // mpu.h - Defines and Macros for the memory protection unit.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/onewire.c
+++ b/bsp/tm4c129x/libraries/driverlib/onewire.c
@@ -2,25 +2,25 @@
 //
 // onewire.c - Driver for OneWire master module.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/onewire.h
+++ b/bsp/tm4c129x/libraries/driverlib/onewire.h
@@ -2,25 +2,25 @@
 //
 // onewire.h - Prototypes for the OneWire Driver.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/pin_map.h
+++ b/bsp/tm4c129x/libraries/driverlib/pin_map.h
@@ -2,25 +2,25 @@
 //
 // pin_map.h - Mapping of peripherals to pins for all parts.
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/pwm.c
+++ b/bsp/tm4c129x/libraries/driverlib/pwm.c
@@ -2,25 +2,25 @@
 //
 // pwm.c - API for the PWM modules
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -1624,11 +1624,11 @@ PWMIntStatus(uint32_t ui32Base, bool bMasked)
 //! \e ui32FaultInts must be the logical OR of any of \b PWM_INT_FAULT0,
 //! \b PWM_INT_FAULT1, \b PWM_INT_FAULT2, or \b PWM_INT_FAULT3.
 //!
-//! The fault interrupts are derived by performing a logical OR of each of the 
+//! The fault interrupts are derived by performing a logical OR of each of the
 //! configured fault trigger signals for a given generator.  Therefore, these
-//! interrupts are not directly related to the four possible FAULTn inputs to 
-//! the device but indicate that a fault has been signaled to one of the four 
-//! possible PWM generators. 
+//! interrupts are not directly related to the four possible FAULTn inputs to
+//! the device but indicate that a fault has been signaled to one of the four
+//! possible PWM generators.
 //!
 //! \note Because there is a write buffer in the Cortex-M processor, it may
 //! take several clock cycles before the interrupt source is actually cleared.
@@ -1993,7 +1993,8 @@ PWMClockSet(uint32_t ui32Base, uint32_t ui32Config)
     // Check the arguments.
     //
     ASSERT((ui32Base == PWM0_BASE) || (ui32Base == PWM1_BASE));
-    ASSERT((ui32Config == PWM_SYSCLK_DIV_2) ||
+    ASSERT((ui32Config == PWM_SYSCLK_DIV_1) ||
+           (ui32Config == PWM_SYSCLK_DIV_2) ||
            (ui32Config == PWM_SYSCLK_DIV_4) ||
            (ui32Config == PWM_SYSCLK_DIV_8) ||
            (ui32Config == PWM_SYSCLK_DIV_16) ||

--- a/bsp/tm4c129x/libraries/driverlib/pwm.h
+++ b/bsp/tm4c129x/libraries/driverlib/pwm.h
@@ -2,25 +2,25 @@
 //
 // pwm.h - API function protoypes for Pulse Width Modulation (PWM) ports
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/qei.c
+++ b/bsp/tm4c129x/libraries/driverlib/qei.c
@@ -2,25 +2,25 @@
 //
 // qei.c - Driver for the Quadrature Encoder with Index.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/qei.h
+++ b/bsp/tm4c129x/libraries/driverlib/qei.h
@@ -2,25 +2,25 @@
 //
 // qei.h - Prototypes for the Quadrature Encoder Driver.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/readme.txt
+++ b/bsp/tm4c129x/libraries/driverlib/readme.txt
@@ -2,7 +2,7 @@ This project will build the TivaWare Peripheral Driver Library.
 
 -------------------------------------------------------------------------------
 
-Copyright (c) 2006-2017 Texas Instruments Incorporated.  All rights reserved.
+Copyright (c) 2006-2020 Texas Instruments Incorporated.  All rights reserved.
 Software License Agreement
 
   Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@ Software License Agreement
 
   Redistributions in binary form must reproduce the above copyright
   notice, this list of conditions and the following disclaimer in the
-  documentation and/or other materials provided with the  
+  documentation and/or other materials provided with the
   distribution.
 
   Neither the name of Texas Instruments Incorporated nor the names of
@@ -33,4 +33,4 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.

--- a/bsp/tm4c129x/libraries/driverlib/rom.h
+++ b/bsp/tm4c129x/libraries/driverlib/rom.h
@@ -2,25 +2,25 @@
 //
 // rom.h - Macros to facilitate calling functions in the ROM.
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/rom_map.h
+++ b/bsp/tm4c129x/libraries/driverlib/rom_map.h
@@ -3,25 +3,25 @@
 // rom_map.h - Macros to facilitate calling functions in the ROM when they are
 //             available and in flash otherwise.
 //
-// Copyright (c) 2008-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2008-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -33,8 +33,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -1703,12 +1703,33 @@
 #define MAP_FlashUserSet                                                      \
         FlashUserSet
 #endif
+#ifdef ROM_FlashAllUserRegisterGet
+#define MAP_FlashAllUserRegisterGet                                           \
+        ROM_FlashAllUserRegisterGet
+#else
+#define MAP_FlashAllUserRegisterGet                                           \
+        FlashAllUserRegisterGet
+#endif
+#ifdef ROM_FlashAllUserRegisterSet
+#define MAP_FlashAllUserRegisterSet                                           \
+        ROM_FlashAllUserRegisterSet
+#else
+#define MAP_FlashAllUserRegisterSet                                           \
+        FlashAllUserRegisterSet
+#endif
 #ifdef ROM_FlashUserSave
 #define MAP_FlashUserSave                                                     \
         ROM_FlashUserSave
 #else
 #define MAP_FlashUserSave                                                     \
         FlashUserSave
+#endif
+#ifdef ROM_FlashAllUserRegisterSave
+#define MAP_FlashAllUserRegisterSave                                          \
+        ROM_FlashAllUserRegisterSave
+#else
+#define MAP_FlashAllUserRegisterSave                                          \
+        FlashAllUserRegisterSave
 #endif
 #ifdef ROM_FlashIntEnable
 #define MAP_FlashIntEnable                                                    \
@@ -1883,6 +1904,41 @@
 #define MAP_GPIOPinTypeComparator                                             \
         GPIOPinTypeComparator
 #endif
+#ifdef ROM_GPIOPinTypeComparatorOutput
+#define MAP_GPIOPinTypeComparatorOutput                                       \
+        ROM_GPIOPinTypeComparatorOutput
+#else
+#define MAP_GPIOPinTypeComparatorOutput                                       \
+        GPIOPinTypeComparatorOutput
+#endif
+#ifdef ROM_GPIOPinTypeDIVSCLK
+#define MAP_GPIOPinTypeDIVSCLK                                                \
+        ROM_GPIOPinTypeDIVSCLK
+#else
+#define MAP_GPIOPinTypeDIVSCLK                                                \
+        GPIOPinTypeDIVSCLK
+#endif
+#ifdef ROM_GPIOPinTypeEPI
+#define MAP_GPIOPinTypeEPI                                                    \
+        ROM_GPIOPinTypeEPI
+#else
+#define MAP_GPIOPinTypeEPI                                                    \
+        GPIOPinTypeEPI
+#endif
+#ifdef ROM_GPIOPinTypeEthernetLED
+#define MAP_GPIOPinTypeEthernetLED                                            \
+        ROM_GPIOPinTypeEthernetLED
+#else
+#define MAP_GPIOPinTypeEthernetLED                                            \
+        GPIOPinTypeEthernetLED
+#endif
+#ifdef ROM_GPIOPinTypeEthernetMII
+#define MAP_GPIOPinTypeEthernetMII                                            \
+        ROM_GPIOPinTypeEthernetMII
+#else
+#define MAP_GPIOPinTypeEthernetMII                                            \
+        GPIOPinTypeEthernetMII
+#endif
 #ifdef ROM_GPIOPinTypeGPIOInput
 #define MAP_GPIOPinTypeGPIOInput                                              \
         ROM_GPIOPinTypeGPIOInput
@@ -1896,6 +1952,13 @@
 #else
 #define MAP_GPIOPinTypeGPIOOutput                                             \
         GPIOPinTypeGPIOOutput
+#endif
+#ifdef ROM_GPIOPinTypeHibernateRTCCLK
+#define MAP_GPIOPinTypeHibernateRTCCLK                                        \
+        ROM_GPIOPinTypeHibernateRTCCLK
+#else
+#define MAP_GPIOPinTypeHibernateRTCCLK                                        \
+        GPIOPinTypeHibernateRTCCLK
 #endif
 #ifdef ROM_GPIOPinTypeI2C
 #define MAP_GPIOPinTypeI2C                                                    \
@@ -1931,6 +1994,13 @@
 #else
 #define MAP_GPIOPinTypeTimer                                                  \
         GPIOPinTypeTimer
+#endif
+#ifdef ROM_GPIOPinTypeTrace
+#define MAP_GPIOPinTypeTrace                                                  \
+        ROM_GPIOPinTypeTrace
+#else
+#define MAP_GPIOPinTypeTrace                                                  \
+        GPIOPinTypeTrace
 #endif
 #ifdef ROM_GPIOPinTypeUART
 #define MAP_GPIOPinTypeUART                                                   \
@@ -2058,12 +2128,47 @@
 #define MAP_GPIOIntStatus                                                     \
         GPIOIntStatus
 #endif
+#ifdef ROM_GPIOIntRegister
+#define MAP_GPIOIntRegiste                                                    \
+        ROM_GPIOIntRegister
+#else
+#define MAP_GPIOIntRegister                                                   \
+        GPIOIntRegister
+#endif
+#ifdef ROM_GPIOIntUnregister
+#define MAP_GPIOIntUnregister                                                 \
+        ROM_GPIOIntUnregister
+#else
+#define MAP_GPIOIntUnregister                                                 \
+        GPIOIntUnregister
+#endif
+#ifdef ROM_GPIOIntRegisterPin
+#define MAP_GPIOIntRegisterPin                                                \
+        ROM_GPIOIntRegisterPin
+#else
+#define MAP_GPIOIntRegisterPin                                                \
+        GPIOIntRegisterPin
+#endif
+#ifdef ROM_GPIOIntUnregisterPin
+#define MAP_GPIOIntUnregisterPin                                              \
+        ROM_GPIOIntUnregisterPin
+#else
+#define MAP_GPIOIntUnregisterPin                                              \
+        GPIOIntUnregisterPin
+#endif
 #ifdef ROM_GPIOPinWakeStatus
 #define MAP_GPIOPinWakeStatus                                                 \
         ROM_GPIOPinWakeStatus
 #else
 #define MAP_GPIOPinWakeStatus                                                 \
         GPIOPinWakeStatus
+#endif
+#ifdef ROM_GPIOUnlockPin
+#define MAP_GPIOUnlockPin                                                     \
+        ROM_GPIOUnlockPin
+#else
+#define MAP_GPIOUnlockPin                                                     \
+        GPIOUnlockPin
 #endif
 
 //*****************************************************************************
@@ -2755,6 +2860,13 @@
 #else
 #define MAP_I2CMasterGlitchFilterConfigSet                                    \
         I2CMasterGlitchFilterConfigSet
+#endif
+#ifdef ROM_I2CLoopbackEnable
+#define MAP_I2CLoopbackEnable                                                 \
+        ROM_I2CLoopbackEnable
+#else
+#define MAP_I2CLoopbackEnable                                                 \
+        I2CLoopbackEnable
 #endif
 
 //*****************************************************************************
@@ -3491,6 +3603,27 @@
 #else
 #define MAP_QEIErrorGet                                                       \
         QEIErrorGet
+#endif
+#ifdef ROM_QEIFilterEnable
+#define MAP_QEIFilterEnable                                                   \
+        ROM_QEIFilterEnable
+#else
+#define MAP_QEIFilterEnable                                                   \
+        QEIFilterEnable
+#endif
+#ifdef ROM_QEIFilterDisable
+#define MAP_QEIFilterDisable                                                  \
+        ROM_QEIFilterDisable
+#else
+#define MAP_QEIFilterDisable                                                  \
+        QEIFilterDisable
+#endif
+#ifdef ROM_QEIFilterConfigure
+#define MAP_QEIFilterConfigure                                                \
+        ROM_QEIFilterConfigure
+#else
+#define MAP_QEIFilterConfigure                                                \
+        QEIFilterConfigure
 #endif
 #ifdef ROM_QEIVelocityEnable
 #define MAP_QEIVelocityEnable                                                 \
@@ -4405,6 +4538,20 @@
 #define MAP_SSIAdvFrameHoldDisable                                            \
         SSIAdvFrameHoldDisable
 #endif
+#ifdef ROM_SSILoopbackEnable
+#define MAP_SSILoopbackEnable                                                 \
+        ROM_SSILoopbackEnable
+#else
+#define MAP_SSILoopbackEnable                                                 \
+        SSILoopbackEnable
+#endif
+#ifdef ROM_SSILoopbackDisable
+#define MAP_SSILoopbackDisable                                                \
+        ROM_SSILoopbackDisable
+#else
+#define MAP_SSILoopbackDisable                                                \
+        SSILoopbackDisable
+#endif
 
 //*****************************************************************************
 //
@@ -4725,6 +4872,13 @@
 #else
 #define MAP_SysCtlAltClkConfig                                                \
         SysCtlAltClkConfig
+#endif
+#ifdef ROM_SysCtlVCOGet
+#define MAP_SysCtlVCOGet                                                      \
+        ROM_SysCtlVCOGet
+#else
+#define MAP_SysCtlVCOGet                                                      \
+        SysCtlVCOGet
 #endif
 
 //*****************************************************************************
@@ -5066,6 +5220,13 @@
 #define MAP_TimerSynchronize                                                  \
         TimerSynchronize
 #endif
+#ifdef ROM_TimerUpdateMode
+#define MAP_TimerUpdateMode                                                   \
+        ROM_TimerUpdateMode
+#else
+#define MAP_TimerUpdateMode                                                   \
+        TimerUpdateMode
+#endif
 
 //*****************************************************************************
 //
@@ -5379,6 +5540,13 @@
 #else
 #define MAP_UARTFlowControlSet                                                \
         UARTFlowControlSet
+#endif
+#ifdef ROM_UARTLoopbackEnable
+#define MAP_UARTLoopbackEnable                                                \
+        ROM_UARTLoopbackEnable
+#else
+#define MAP_UARTLoopbackEnable                                                \
+        UARTLoopbackEnable
 #endif
 
 //*****************************************************************************

--- a/bsp/tm4c129x/libraries/driverlib/rtos_bindings.h
+++ b/bsp/tm4c129x/libraries/driverlib/rtos_bindings.h
@@ -3,25 +3,25 @@
 // rtos_bindings.h - Macros intended to aid porting of TivaWare modules
 //                   for use with an RTOS.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -33,8 +33,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/shamd5.c
+++ b/bsp/tm4c129x/libraries/driverlib/shamd5.c
@@ -2,25 +2,25 @@
 //
 // shamd5.c - Driver for the SHA/MD5 module.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/shamd5.h
+++ b/bsp/tm4c129x/libraries/driverlib/shamd5.h
@@ -2,25 +2,25 @@
 //
 // shamd5.h - Defines and Macros for the SHA/MD5.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/ssi.h
+++ b/bsp/tm4c129x/libraries/driverlib/ssi.h
@@ -2,25 +2,25 @@
 //
 // ssi.h - Prototypes for the Synchronous Serial Interface Driver.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -144,6 +144,8 @@ extern int32_t SSIAdvDataPutFrameEndNonBlocking(uint32_t ui32Base,
                                              uint32_t ui32Data);
 extern void SSIAdvFrameHoldEnable(uint32_t ui32Base);
 extern void SSIAdvFrameHoldDisable(uint32_t ui32Base);
+extern void SSILoopbackEnable(uint32_t ui32Base);
+extern void SSILoopbackDisable(uint32_t ui32Base);
 
 //*****************************************************************************
 //

--- a/bsp/tm4c129x/libraries/driverlib/sw_crc.c
+++ b/bsp/tm4c129x/libraries/driverlib/sw_crc.c
@@ -2,25 +2,25 @@
 //
 // sw_crc.c - Software CRC functions.
 //
-// Copyright (c) 2010-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2010-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/sw_crc.h
+++ b/bsp/tm4c129x/libraries/driverlib/sw_crc.h
@@ -2,25 +2,25 @@
 //
 // sw_crc.h - Prototypes for the software CRC functions.
 //
-// Copyright (c) 2010-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2010-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/sysctl.c
+++ b/bsp/tm4c129x/libraries/driverlib/sysctl.c
@@ -2,25 +2,25 @@
 //
 // sysctl.c - Driver for the system controller.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -2216,7 +2216,7 @@ SysCtlClockFreqSet(uint32_t ui32Config, uint32_t ui32SysClock)
         }
 
         HWREG(SYSCTL_MOSCCTL) = ui32MOSCCTL;
-        
+
         //
         // Timeout using the legacy delay value.
         //
@@ -2241,7 +2241,7 @@ SysCtlClockFreqSet(uint32_t ui32Config, uint32_t ui32SysClock)
             return(0);
         }
 
-        
+
     }
     else
     {
@@ -2495,8 +2495,8 @@ SysCtlClockFreqSet(uint32_t ui32Config, uint32_t ui32SysClock)
 //! many of which are grouped into sets where only one can be chosen.
 //!
 //! The system clock divider is chosen with one of the following values:
-//! \b SYSCTL_SYSDIV_1, \b SYSCTL_SYSDIV_2, \b SYSCTL_SYSDIV_3, ...
-//! \b SYSCTL_SYSDIV_64.
+//! \b SYSCTL_SYSDIV_1, \b SYSCTL_SYSDIV_2, \b SYSCTL_SYSDIV_2_5,
+//! \b SYSCTL_SYSDIV_3, ... \b SYSCTL_SYSDIV_63_5, \b SYSCTL_SYSDIV_64.
 //!
 //! The use of the PLL is chosen with either \b SYSCTL_USE_PLL or
 //! \b SYSCTL_USE_OSC.
@@ -3522,8 +3522,9 @@ SysCtlVoltageEventClear(uint32_t ui32Status)
 //
 //! Gets the effective VCO frequency.
 //!
-//! \param ui32Crystal holds the crystal value used for the PLL.
-//! \param pui32VCOFrequency is a pointer to the storage location which holds 
+//! \param ui32Crystal holds the crystal value definition from \b sysctl.h
+//! such as \b SYSCTL_XTAL_25MHZ.
+//! \param pui32VCOFrequency is a pointer to the storage location which holds
 //! value of the VCO computed.
 //!
 //! This function calculates the VCO of the PLL before the system divider is
@@ -3566,9 +3567,9 @@ SysCtlVCOGet(uint32_t ui32Crystal, uint32_t *pui32VCOFrequency)
         // Return error if PLL is not used.
         //
         *pui32VCOFrequency = 0;
-        return(false);  
+        return(false);
     }
-    
+
     //
     // Get the index of the crystal from the ui32Config parameter.
     //
@@ -3586,13 +3587,13 @@ SysCtlVCOGet(uint32_t ui32Crystal, uint32_t *pui32VCOFrequency)
     ui32PLLFreq0 = HWREG(SYSCTL_PLLFREQ0);
     ui32PLLFreq1 = HWREG(SYSCTL_PLLFREQ1);
 
-    ui32MInt = (ui32PLLFreq0 & SYSCTL_PLLFREQ0_MINT_M) >> 
+    ui32MInt = (ui32PLLFreq0 & SYSCTL_PLLFREQ0_MINT_M) >>
                SYSCTL_PLLFREQ0_MINT_S;
-    ui32MFrac = (ui32PLLFreq0 & SYSCTL_PLLFREQ0_MFRAC_M) >> 
+    ui32MFrac = (ui32PLLFreq0 & SYSCTL_PLLFREQ0_MFRAC_M) >>
                 SYSCTL_PLLFREQ0_MFRAC_S;
-    ui32NDiv = (ui32PLLFreq1 & SYSCTL_PLLFREQ1_N_M) >> 
+    ui32NDiv = (ui32PLLFreq1 & SYSCTL_PLLFREQ1_N_M) >>
                SYSCTL_PLLFREQ1_N_S;
-    ui32QDiv = (ui32PLLFreq1 & SYSCTL_PLLFREQ1_Q_M) >> 
+    ui32QDiv = (ui32PLLFreq1 & SYSCTL_PLLFREQ1_Q_M) >>
                SYSCTL_PLLFREQ1_Q_S;
 
     //
@@ -3600,7 +3601,7 @@ SysCtlVCOGet(uint32_t ui32Crystal, uint32_t *pui32VCOFrequency)
     //
     ui32TempVCO = (ui32Osc * ui32MInt) + ((ui32Osc * ui32MFrac) / 1024);
     ui32TempVCO /= ((ui32NDiv + 1) * (ui32QDiv + 1));
-    
+
     *pui32VCOFrequency = ui32TempVCO;
     return(true);
 }

--- a/bsp/tm4c129x/libraries/driverlib/sysctl.h
+++ b/bsp/tm4c129x/libraries/driverlib/sysctl.h
@@ -2,25 +2,25 @@
 //
 // sysctl.h - Prototypes for the system control driver.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -344,8 +344,23 @@ extern "C"
 #define SYSCTL_SYSDIV_61_5      0xDE800000  // Processor clock is pll / 61.5
 #define SYSCTL_SYSDIV_62_5      0xDF000000  // Processor clock is pll / 62.5
 #define SYSCTL_SYSDIV_63_5      0xDF800000  // Processor clock is pll / 63.5
-#define SYSCTL_CFG_VCO_480      0xF1000000  // VCO is 480 MHz
-#define SYSCTL_CFG_VCO_320      0xF0000000  // VCO is 320 MHz
+//
+// TivaWare 2.2.0.xxx Update
+// Due to TM4C129x Errata Item SYSCTL#22, the SYSCTL_CFG_VCO_xxx configurations
+// have misleading *names* as currently defined as the VCO does not run at the
+// stated frequencies. To amend this, new *name* defintions are being used,
+// however the register configuration remains the same.
+// The old definitions will remain for compatibility with code ported from
+// older versions of TivaWare.
+//
+#define SYSCTL_CFG_VCO_480      0xF1000000  // VCO is 480 MHz - Legacy
+                                            // Does not work @ 480, use
+                                            // SYSCTL_CFG_VCO_240 instead
+#define SYSCTL_CFG_VCO_320      0xF0000000  // VCO is 320 MHz - Legacy
+                                            // Does not work @ 320, use
+                                            // SYSCTL_CFG_VCO_160 instead
+#define SYSCTL_CFG_VCO_240      0xF1000000  // VCO is 240 MHz
+#define SYSCTL_CFG_VCO_160      0xF0000000  // VCO is 160 MHz
 #define SYSCTL_USE_PLL          0x00000000  // System clock is the PLL clock
 #define SYSCTL_USE_OSC          0x00003800  // System clock is the osc clock
 #define SYSCTL_XTAL_1MHZ        0x00000000  // External crystal is 1MHz

--- a/bsp/tm4c129x/libraries/driverlib/sysexc.c
+++ b/bsp/tm4c129x/libraries/driverlib/sysexc.c
@@ -2,25 +2,25 @@
 //
 // sysexc.c - Routines for the System Exception Module.
 //
-// Copyright (c) 2011-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2011-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/sysexc.h
+++ b/bsp/tm4c129x/libraries/driverlib/sysexc.h
@@ -2,25 +2,25 @@
 //
 // sysexc.h - Prototypes for the System Exception Module routines.
 //
-// Copyright (c) 2011-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2011-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/systick.c
+++ b/bsp/tm4c129x/libraries/driverlib/systick.c
@@ -2,25 +2,25 @@
 //
 // systick.c - Driver for the SysTick timer in NVIC.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/systick.h
+++ b/bsp/tm4c129x/libraries/driverlib/systick.h
@@ -2,25 +2,25 @@
 //
 // systick.h - Prototypes for the SysTick driver.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/tiva_timer.c
+++ b/bsp/tm4c129x/libraries/driverlib/tiva_timer.c
@@ -2,25 +2,25 @@
 //
 // timer.c - Driver for the timer module.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -297,6 +297,7 @@ TimerDisable(uint32_t ui32Base, uint32_t ui32Timer)
 //! - \b TIMER_CFG_A_CAP_TIME - Half-width edge time capture
 //! - \b TIMER_CFG_A_CAP_TIME_UP - Half-width edge time capture that counts up
 //!   instead of down (not available on all parts)
+//! - \b TIMER_CFG_A_ONE_SHOT_PWM - Half-width one shot PWM output
 //! - \b TIMER_CFG_A_PWM - Half-width PWM output
 //!
 //! Some Tiva devices also allow configuring an action when the timers
@@ -351,11 +352,11 @@ TimerConfigure(uint32_t ui32Base, uint32_t ui32Config)
     // Check the arguments.
     //
     ASSERT(_TimerBaseValid(ui32Base));
-    ASSERT((ui32Config == TIMER_CFG_ONE_SHOT) ||
-           (ui32Config == TIMER_CFG_ONE_SHOT_UP) ||
-           (ui32Config == TIMER_CFG_PERIODIC) ||
-           (ui32Config == TIMER_CFG_PERIODIC_UP) ||
-           (ui32Config == TIMER_CFG_RTC) ||
+    ASSERT(((ui32Config & 0xfff0ffff) == TIMER_CFG_ONE_SHOT) ||
+           ((ui32Config & 0xfff0ffff) == TIMER_CFG_ONE_SHOT_UP) ||
+           ((ui32Config & 0xfff0ffff) == TIMER_CFG_PERIODIC) ||
+           ((ui32Config & 0xfff0ffff) == TIMER_CFG_PERIODIC_UP) ||
+           ((ui32Config & 0xfff0ffff) == TIMER_CFG_RTC) ||
            ((ui32Config & 0xff000000) == TIMER_CFG_SPLIT_PAIR));
     ASSERT(((ui32Config & 0xff000000) != TIMER_CFG_SPLIT_PAIR) ||
            ((((ui32Config & 0x000000ff) == TIMER_CFG_A_ONE_SHOT) ||
@@ -366,6 +367,7 @@ TimerConfigure(uint32_t ui32Base, uint32_t ui32Config)
              ((ui32Config & 0x000000ff) == TIMER_CFG_A_CAP_COUNT_UP) ||
              ((ui32Config & 0x000000ff) == TIMER_CFG_A_CAP_TIME) ||
              ((ui32Config & 0x000000ff) == TIMER_CFG_A_CAP_TIME_UP) ||
+             ((ui32Config & 0x000000ff) == TIMER_CFG_A_ONE_SHOT_PWM) ||
              ((ui32Config & 0x000000ff) == TIMER_CFG_A_PWM)) &&
             (((ui32Config & 0x0000ff00) == TIMER_CFG_B_ONE_SHOT) ||
              ((ui32Config & 0x0000ff00) == TIMER_CFG_B_ONE_SHOT_UP) ||
@@ -375,6 +377,7 @@ TimerConfigure(uint32_t ui32Base, uint32_t ui32Config)
              ((ui32Config & 0x0000ff00) == TIMER_CFG_B_CAP_COUNT_UP) ||
              ((ui32Config & 0x0000ff00) == TIMER_CFG_B_CAP_TIME) ||
              ((ui32Config & 0x0000ff00) == TIMER_CFG_B_CAP_TIME_UP) ||
+             ((ui32Config & 0x0000ff00) == TIMER_CFG_B_ONE_SHOT_PWM) ||
              ((ui32Config & 0x0000ff00) == TIMER_CFG_B_PWM))));
 
     //
@@ -1454,10 +1457,12 @@ TimerIntUnregister(uint32_t ui32Base, uint32_t ui32Timer)
 //! - \b TIMER_TIMA_DMA - Timer A uDMA complete
 //! - \b TIMER_CAPB_EVENT  - Capture B event interrupt
 //! - \b TIMER_CAPB_MATCH  - Capture B match interrupt
+//! - \b TIMER_TIMB_MATCH  - Timer B match interrupt
 //! - \b TIMER_TIMB_TIMEOUT  - Timer B timeout interrupt
 //! - \b TIMER_RTC_MATCH  - RTC interrupt mask
 //! - \b TIMER_CAPA_EVENT  - Capture A event interrupt
 //! - \b TIMER_CAPA_MATCH  - Capture A match interrupt
+//! - \b TIMER_TIMA_MATCH  - Timer A match interrupt
 //! - \b TIMER_TIMA_TIMEOUT  - Timer A timeout interrupt
 //!
 //! \return None.

--- a/bsp/tm4c129x/libraries/driverlib/tiva_timer.h
+++ b/bsp/tm4c129x/libraries/driverlib/tiva_timer.h
@@ -2,25 +2,25 @@
 //
 // timer.h - Prototypes for the timer module
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -72,6 +72,7 @@ extern "C"
 #define TIMER_CFG_A_CAP_COUNT_UP 0x00000013  // Timer A event up-counter
 #define TIMER_CFG_A_CAP_TIME     0x00000007  // Timer A event timer
 #define TIMER_CFG_A_CAP_TIME_UP  0x00000017  // Timer A event up-count timer
+#define TIMER_CFG_A_ONE_SHOT_PWM 0x00000009  // Timer A one-shot PWM output
 #define TIMER_CFG_A_PWM          0x0000000A  // Timer A PWM output
 #define TIMER_CFG_B_ONE_SHOT     0x00002100  // Timer B one-shot timer
 #define TIMER_CFG_B_ONE_SHOT_UP  0x00003100  // Timer B one-shot up-count timer
@@ -81,6 +82,7 @@ extern "C"
 #define TIMER_CFG_B_CAP_COUNT_UP 0x00001300  // Timer B event up-counter
 #define TIMER_CFG_B_CAP_TIME     0x00000700  // Timer B event timer
 #define TIMER_CFG_B_CAP_TIME_UP  0x00001700  // Timer B event up-count timer
+#define TIMER_CFG_B_ONE_SHOT_PWM 0x00000900  // Timer B one-shot PWM output
 #define TIMER_CFG_B_PWM          0x00000A00  // Timer B PWM output
 #define TIMER_CFG_A_ACT_TOINTD   0x00010000  // Timer A compare action disable
                                              // time-out interrupt.

--- a/bsp/tm4c129x/libraries/driverlib/uart.c
+++ b/bsp/tm4c129x/libraries/driverlib/uart.c
@@ -2,25 +2,25 @@
 //
 // uart.c - Driver for the UART.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -355,7 +355,7 @@ UARTFIFOLevelGet(uint32_t ui32Base, uint32_t *pui32TxLevel,
 //! the system clock is the value returned by SysCtlClockGet() for TM4C123x
 //! devices or the value returned by SysCtlClockFreqSet() for TM4C129x devices,
 //! or it can be explicitly hard coded if it is constant and known (to save the
-//! code/execution overhead of a call to SysCtlClockGet() or fetch of the 
+//! code/execution overhead of a call to SysCtlClockGet() or fetch of the
 //! variable call holding the return value of SysCtlClockFreqSet()).
 //!
 //! The function disables the UART by calling UARTDisable() before changing the
@@ -459,7 +459,7 @@ UARTConfigSetExpClk(uint32_t ui32Base, uint32_t ui32UARTClk,
 //! the system clock is the value returned by SysCtlClockGet() for TM4C123x
 //! devices or the value returned by SysCtlClockFreqSet() for TM4C129x devices,
 //! or it can be explicitly hard coded if it is constant and known (to save the
-//! code/execution overhead of a call to SysCtlClockGet() or fetch of the 
+//! code/execution overhead of a call to SysCtlClockGet() or fetch of the
 //! variable call holding the return value of SysCtlClockFreqSet()).
 //!
 //! For Tiva parts that have the ability to specify the UART baud clock
@@ -811,7 +811,17 @@ UARTModemControlSet(uint32_t ui32Base, uint32_t ui32Control)
     //
     // Check the arguments.
     //
+#if defined(TARGET_IS_TM4C123_RA1) || defined(TARGET_IS_TM4C123_RA2) || \
+    defined(TARGET_IS_TM4C123_RA3) || defined(TARGET_IS_TM4C123_RB0) || \
+    defined(TARGET_IS_TM4C123_RB1)
     ASSERT(ui32Base == UART1_BASE);
+#else
+    ASSERT((ui32Base == UART0_BASE) ||
+           (ui32Base == UART1_BASE) ||
+           (ui32Base == UART2_BASE) ||
+           (ui32Base == UART3_BASE) ||
+           (ui32Base == UART4_BASE));
+#endif
     ASSERT((ui32Control & ~(UART_OUTPUT_RTS | UART_OUTPUT_DTR)) == 0);
 
     //
@@ -853,7 +863,17 @@ UARTModemControlClear(uint32_t ui32Base, uint32_t ui32Control)
     //
     // Check the arguments.
     //
+#if defined(TARGET_IS_TM4C123_RA1) || defined(TARGET_IS_TM4C123_RA2) || \
+    defined(TARGET_IS_TM4C123_RA3) || defined(TARGET_IS_TM4C123_RB0) || \
+    defined(TARGET_IS_TM4C123_RB1)
     ASSERT(ui32Base == UART1_BASE);
+#else
+    ASSERT((ui32Base == UART0_BASE) ||
+           (ui32Base == UART1_BASE) ||
+           (ui32Base == UART2_BASE) ||
+           (ui32Base == UART3_BASE) ||
+           (ui32Base == UART4_BASE));
+#endif
     ASSERT((ui32Control & ~(UART_OUTPUT_RTS | UART_OUTPUT_DTR)) == 0);
 
     //
@@ -889,7 +909,17 @@ UARTModemControlGet(uint32_t ui32Base)
     //
     // Check the arguments.
     //
+#if defined(TARGET_IS_TM4C123_RA1) || defined(TARGET_IS_TM4C123_RA2) || \
+    defined(TARGET_IS_TM4C123_RA3) || defined(TARGET_IS_TM4C123_RB0) || \
+    defined(TARGET_IS_TM4C123_RB1)
     ASSERT(ui32Base == UART1_BASE);
+#else
+    ASSERT((ui32Base == UART0_BASE) ||
+           (ui32Base == UART1_BASE) ||
+           (ui32Base == UART2_BASE) ||
+           (ui32Base == UART3_BASE) ||
+           (ui32Base == UART4_BASE));
+#endif
 
     return(HWREG(ui32Base + UART_O_CTL) & (UART_OUTPUT_RTS | UART_OUTPUT_DTR));
 }
@@ -919,7 +949,17 @@ UARTModemStatusGet(uint32_t ui32Base)
     //
     // Check the arguments.
     //
+#if defined(TARGET_IS_TM4C123_RA1) || defined(TARGET_IS_TM4C123_RA2) || \
+    defined(TARGET_IS_TM4C123_RA3) || defined(TARGET_IS_TM4C123_RB0) || \
+    defined(TARGET_IS_TM4C123_RB1)
     ASSERT(ui32Base == UART1_BASE);
+#else
+    ASSERT((ui32Base == UART0_BASE) ||
+           (ui32Base == UART1_BASE) ||
+           (ui32Base == UART2_BASE) ||
+           (ui32Base == UART3_BASE) ||
+           (ui32Base == UART4_BASE));
+#endif
 
     return(HWREG(ui32Base + UART_O_FR) & (UART_INPUT_RI | UART_INPUT_DCD |
                                           UART_INPUT_CTS | UART_INPUT_DSR));
@@ -1967,7 +2007,7 @@ UART9BitAddrSend(uint32_t ui32Base, uint8_t ui8Addr)
 //! diagnostics and debug.  In this mode, the transmit and receive terminals of
 //! the same UART port are internally connected.  Hence, the data transmitted
 //! on the UnTx output is received on the UxRx input, without having to go
-//! through I/O's.  UARTCharPut(), UARTCharGet() functions can be used along 
+//! through I/O's.  UARTCharPut(), UARTCharGet() functions can be used along
 //! with this function.
 //!
 //! \return None.

--- a/bsp/tm4c129x/libraries/driverlib/uart.h
+++ b/bsp/tm4c129x/libraries/driverlib/uart.h
@@ -2,25 +2,25 @@
 //
 // uart.h - Defines and Macros for the UART.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/udma.c
+++ b/bsp/tm4c129x/libraries/driverlib/udma.c
@@ -2,25 +2,25 @@
 //
 // udma.c - Driver for the micro-DMA controller.
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/udma.h
+++ b/bsp/tm4c129x/libraries/driverlib/udma.h
@@ -2,25 +2,25 @@
 //
 // udma.h - Prototypes and macros for the uDMA controller.
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/usb.c
+++ b/bsp/tm4c129x/libraries/driverlib/usb.c
@@ -2,25 +2,25 @@
 //
 // usb.c - Driver for the USB Interface.
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/usb.h
+++ b/bsp/tm4c129x/libraries/driverlib/usb.h
@@ -2,25 +2,25 @@
 //
 // usb.h - Prototypes for the USB Interface Driver.
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/driverlib/watchdog.c
+++ b/bsp/tm4c129x/libraries/driverlib/watchdog.c
@@ -2,25 +2,25 @@
 //
 // watchdog.c - Driver for the Watchdog Timer Module.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 
@@ -492,7 +492,7 @@ WatchdogIntStatus(uint32_t ui32Base, bool bMasked)
 //! actually cleared.  Failure to do so may result in the interrupt handler
 //! being immediately reentered (because the interrupt controller still sees
 //! the interrupt source asserted). This function has no effect if the watchdog
-//! timer has been locked. 
+//! timer has been locked.
 //!
 //! \return None.
 //

--- a/bsp/tm4c129x/libraries/driverlib/watchdog.h
+++ b/bsp/tm4c129x/libraries/driverlib/watchdog.h
@@ -2,25 +2,25 @@
 //
 // watchdog.h - Prototypes for the Watchdog Timer API
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Peripheral Driver Library.
+//
+// This is part of revision 2.2.0.295 of the Tiva Peripheral Driver Library.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/asmdefs.h
+++ b/bsp/tm4c129x/libraries/inc/asmdefs.h
@@ -2,25 +2,25 @@
 //
 // asmdefs.h - Macros to allow assembly code be portable among toolchains.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_adc.h
+++ b/bsp/tm4c129x/libraries/inc/hw_adc.h
@@ -2,25 +2,25 @@
 //
 // hw_adc.h - Macros used when accessing the ADC hardware.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_aes.h
+++ b/bsp/tm4c129x/libraries/inc/hw_aes.h
@@ -2,25 +2,25 @@
 //
 // hw_aes.h - Macros used when accessing the AES hardware.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_can.h
+++ b/bsp/tm4c129x/libraries/inc/hw_can.h
@@ -2,25 +2,25 @@
 //
 // hw_can.h - Defines and macros used when accessing the CAN controllers.
 //
-// Copyright (c) 2006-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2006-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_ccm.h
+++ b/bsp/tm4c129x/libraries/inc/hw_ccm.h
@@ -2,25 +2,25 @@
 //
 // hw_ccm.h - Macros used when accessing the CCM hardware.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_comp.h
+++ b/bsp/tm4c129x/libraries/inc/hw_comp.h
@@ -2,25 +2,25 @@
 //
 // hw_comp.h - Macros used when accessing the comparator hardware.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_des.h
+++ b/bsp/tm4c129x/libraries/inc/hw_des.h
@@ -2,25 +2,25 @@
 //
 // hw_des.h - Macros used when accessing the DES hardware.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_eeprom.h
+++ b/bsp/tm4c129x/libraries/inc/hw_eeprom.h
@@ -2,25 +2,25 @@
 //
 // hw_eeprom.h - Macros used when accessing the EEPROM controller.
 //
-// Copyright (c) 2011-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2011-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_emac.h
+++ b/bsp/tm4c129x/libraries/inc/hw_emac.h
@@ -2,25 +2,25 @@
 //
 // hw_emac.h - Macros used when accessing the EMAC hardware.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_epi.h
+++ b/bsp/tm4c129x/libraries/inc/hw_epi.h
@@ -2,25 +2,25 @@
 //
 // hw_epi.h - Macros for use in accessing the EPI registers.
 //
-// Copyright (c) 2008-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2008-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_fan.h
+++ b/bsp/tm4c129x/libraries/inc/hw_fan.h
@@ -2,25 +2,25 @@
 //
 // hw_fan.h - Macros used when accessing the fan control hardware.
 //
-// Copyright (c) 2010-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2010-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_flash.h
+++ b/bsp/tm4c129x/libraries/inc/hw_flash.h
@@ -2,25 +2,25 @@
 //
 // hw_flash.h - Macros used when accessing the flash controller.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_gpio.h
+++ b/bsp/tm4c129x/libraries/inc/hw_gpio.h
@@ -2,25 +2,25 @@
 //
 // hw_gpio.h - Defines and Macros for GPIO hardware.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_hibernate.h
+++ b/bsp/tm4c129x/libraries/inc/hw_hibernate.h
@@ -2,25 +2,25 @@
 //
 // hw_hibernate.h - Defines and Macros for the Hibernation module.
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_i2c.h
+++ b/bsp/tm4c129x/libraries/inc/hw_i2c.h
@@ -2,25 +2,25 @@
 //
 // hw_i2c.h - Macros used when accessing the I2C master and slave hardware.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_ints.h
+++ b/bsp/tm4c129x/libraries/inc/hw_ints.h
@@ -3,25 +3,25 @@
 // hw_ints.h - Macros that define the interrupt assignment on Tiva C Series
 // MCUs.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -33,8 +33,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_lcd.h
+++ b/bsp/tm4c129x/libraries/inc/hw_lcd.h
@@ -2,25 +2,25 @@
 //
 // hw_lcd.h - Defines and macros used when accessing the LCD controller.
 //
-// Copyright (c) 2011-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2011-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_memmap.h
+++ b/bsp/tm4c129x/libraries/inc/hw_memmap.h
@@ -2,25 +2,25 @@
 //
 // hw_memmap.h - Macros defining the memory map of the device.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_nvic.h
+++ b/bsp/tm4c129x/libraries/inc/hw_nvic.h
@@ -2,25 +2,25 @@
 //
 // hw_nvic.h - Macros used when accessing the NVIC hardware.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_onewire.h
+++ b/bsp/tm4c129x/libraries/inc/hw_onewire.h
@@ -2,25 +2,25 @@
 //
 // hw_onewire.h - Macros used when accessing the One wire hardware.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_pwm.h
+++ b/bsp/tm4c129x/libraries/inc/hw_pwm.h
@@ -2,25 +2,25 @@
 //
 // hw_pwm.h - Defines and Macros for Pulse Width Modulation (PWM) ports.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_qei.h
+++ b/bsp/tm4c129x/libraries/inc/hw_qei.h
@@ -2,25 +2,25 @@
 //
 // hw_qei.h - Macros used when accessing the QEI hardware.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_shamd5.h
+++ b/bsp/tm4c129x/libraries/inc/hw_shamd5.h
@@ -2,25 +2,25 @@
 //
 // hw_shamd5.h - Macros used when accessing the SHA/MD5 hardware.
 //
-// Copyright (c) 2012-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2012-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_ssi.h
+++ b/bsp/tm4c129x/libraries/inc/hw_ssi.h
@@ -2,25 +2,25 @@
 //
 // hw_ssi.h - Macros used when accessing the SSI hardware.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_sysctl.h
+++ b/bsp/tm4c129x/libraries/inc/hw_sysctl.h
@@ -2,25 +2,25 @@
 //
 // hw_sysctl.h - Macros used when accessing the system control hardware.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_sysexc.h
+++ b/bsp/tm4c129x/libraries/inc/hw_sysexc.h
@@ -2,25 +2,25 @@
 //
 // hw_sysexc.h - Macros used when accessing the system exception module.
 //
-// Copyright (c) 2011-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2011-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_timer.h
+++ b/bsp/tm4c129x/libraries/inc/hw_timer.h
@@ -2,25 +2,25 @@
 //
 // hw_timer.h - Defines and macros used when accessing the timer.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_types.h
+++ b/bsp/tm4c129x/libraries/inc/hw_types.h
@@ -2,25 +2,25 @@
 //
 // hw_types.h - Common types and macros.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 
@@ -110,7 +110,7 @@
 #ifndef REVISION_IS_A1
 #define REVISION_IS_A1                                                     \
         ((HWREG(SYSCTL_DID0) & (SYSCTL_DID0_MAJ_M | SYSCTL_DID0_MIN_M)) == \
-         (SYSCTL_DID0_MAJ_REVA | SYSCTL_DID0_MIN_0))
+         (SYSCTL_DID0_MAJ_REVA | SYSCTL_DID0_MIN_1))
 #endif
 
 #ifndef REVISION_IS_A2

--- a/bsp/tm4c129x/libraries/inc/hw_uart.h
+++ b/bsp/tm4c129x/libraries/inc/hw_uart.h
@@ -2,25 +2,25 @@
 //
 // hw_uart.h - Macros and defines used when accessing the UART hardware.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_udma.h
+++ b/bsp/tm4c129x/libraries/inc/hw_udma.h
@@ -2,25 +2,25 @@
 //
 // hw_udma.h - Macros for use in accessing the UDMA registers.
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_usb.h
+++ b/bsp/tm4c129x/libraries/inc/hw_usb.h
@@ -2,25 +2,25 @@
 //
 // hw_usb.h - Macros for use in accessing the USB registers.
 //
-// Copyright (c) 2007-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2007-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/hw_watchdog.h
+++ b/bsp/tm4c129x/libraries/inc/hw_watchdog.h
@@ -2,25 +2,25 @@
 //
 // hw_watchdog.h - Macros used when accessing the Watchdog Timer hardware.
 //
-// Copyright (c) 2005-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2005-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/inc/tm4c1294ncpdt.h
+++ b/bsp/tm4c129x/libraries/inc/tm4c1294ncpdt.h
@@ -2,25 +2,25 @@
 //
 // tm4c1294ncpdt.h - TM4C1294NCPDT Register Definitions
 //
-// Copyright (c) 2013-2017 Texas Instruments Incorporated.  All rights reserved.
+// Copyright (c) 2013-2020 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 //   Redistribution and use in source and binary forms, with or without
 //   modification, are permitted provided that the following conditions
 //   are met:
-// 
+//
 //   Redistributions of source code must retain the above copyright
 //   notice, this list of conditions and the following disclaimer.
-// 
+//
 //   Redistributions in binary form must reproduce the above copyright
 //   notice, this list of conditions and the following disclaimer in the
-//   documentation and/or other materials provided with the  
+//   documentation and/or other materials provided with the
 //   distribution.
-// 
+//
 //   Neither the name of Texas Instruments Incorporated nor the names of
 //   its contributors may be used to endorse or promote products derived
 //   from this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -32,8 +32,8 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-// This is part of revision 2.1.4.178 of the Tiva Firmware Development Package.
+//
+// This is part of revision 2.2.0.295 of the Tiva Firmware Development Package.
 //
 //*****************************************************************************
 

--- a/bsp/tm4c129x/libraries/startup/startup_ewarm.c
+++ b/bsp/tm4c129x/libraries/startup/startup_ewarm.c
@@ -5,20 +5,20 @@
 //
 // Copyright (c) 2013-2017 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 // Texas Instruments (TI) is supplying this software for use solely and
 // exclusively on TI's microcontroller products. The software is owned by
 // TI and/or its suppliers, and is protected under applicable copyright
 // laws. You may not combine this software with "viral" open-source
 // software in order to form a larger program.
-// 
+//
 // THIS SOFTWARE IS PROVIDED "AS IS" AND WITH ALL FAULTS.
 // NO WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT
 // NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 // A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE. TI SHALL NOT, UNDER ANY
 // CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR CONSEQUENTIAL
 // DAMAGES, FOR ANY REASON WHATSOEVER.
-// 
+//
 // This is part of revision 2.1.4.178 of the DK-TM4C129X Firmware Package.
 //
 //*****************************************************************************

--- a/bsp/tm4c129x/libraries/startup/startup_gcc.c
+++ b/bsp/tm4c129x/libraries/startup/startup_gcc.c
@@ -4,20 +4,20 @@
 //
 // Copyright (c) 2013-2017 Texas Instruments Incorporated.  All rights reserved.
 // Software License Agreement
-// 
+//
 // Texas Instruments (TI) is supplying this software for use solely and
 // exclusively on TI's microcontroller products. The software is owned by
 // TI and/or its suppliers, and is protected under applicable copyright
 // laws. You may not combine this software with "viral" open-source
 // software in order to form a larger program.
-// 
+//
 // THIS SOFTWARE IS PROVIDED "AS IS" AND WITH ALL FAULTS.
 // NO WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT
 // NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 // A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE. TI SHALL NOT, UNDER ANY
 // CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR CONSEQUENTIAL
 // DAMAGES, FOR ANY REASON WHATSOEVER.
-// 
+//
 // This is part of revision 2.1.4.178 of the DK-TM4C129X Firmware Package.
 //
 //*****************************************************************************

--- a/bsp/tm4c129x/libraries/startup/startup_rvmdk.S
+++ b/bsp/tm4c129x/libraries/startup/startup_rvmdk.S
@@ -5,20 +5,20 @@
 ;
 ; Copyright (c) 2013-2017 Texas Instruments Incorporated.  All rights reserved.
 ; Software License Agreement
-; 
+;
 ; Texas Instruments (TI) is supplying this software for use solely and
 ; exclusively on TI's microcontroller products. The software is owned by
 ; TI and/or its suppliers, and is protected under applicable copyright
 ; laws. You may not combine this software with "viral" open-source
 ; software in order to form a larger program.
-; 
+;
 ; THIS SOFTWARE IS PROVIDED "AS IS" AND WITH ALL FAULTS.
 ; NO WARRANTIES, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING, BUT
 ; NOT LIMITED TO, IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 ; A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE. TI SHALL NOT, UNDER ANY
 ; CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR CONSEQUENTIAL
 ; DAMAGES, FOR ANY REASON WHATSOEVER.
-; 
+;
 ; This is part of revision 2.1.4.178 of the DK-TM4C129X Firmware Package.
 ;
 ;******************************************************************************


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[solve #4625,
1. Do not check device ready status when copy data from mb to pBuf. 
2. Force assign pBuf to null after free to avoid using freed pBuf ptr.
3. Update vender library to TivaWare_C_Series-2.2.0.295.
4. Test on TM4C1294XL evaluation board.]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
