### PR TITLE
[kernel][ipc] 移除mutex RT_IPC_FLAG_FIFO 功能

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -548,6 +548,8 @@ RTM_EXPORT(rt_sem_control);
  */
 rt_err_t rt_mutex_init(rt_mutex_t mutex, const char *name, rt_uint8_t flag)
 {
+    (void)flag;
+
     /* parameter check */
     RT_ASSERT(mutex != RT_NULL);
 
@@ -562,8 +564,8 @@ rt_err_t rt_mutex_init(rt_mutex_t mutex, const char *name, rt_uint8_t flag)
     mutex->original_priority = 0xFF;
     mutex->hold  = 0;
 
-    /* set flag */
-    mutex->parent.parent.flag = flag;
+    /* set flag and it can only be RT_IPC_FLAG_PRIO */
+    mutex->parent.parent.flag = RT_IPC_FLAG_PRIO;
 
     return RT_EOK;
 }
@@ -609,6 +611,7 @@ RTM_EXPORT(rt_mutex_detach);
 rt_mutex_t rt_mutex_create(const char *name, rt_uint8_t flag)
 {
     struct rt_mutex *mutex;
+    (void)flag;
 
     RT_DEBUG_NOT_IN_INTERRUPT;
 
@@ -625,8 +628,8 @@ rt_mutex_t rt_mutex_create(const char *name, rt_uint8_t flag)
     mutex->original_priority  = 0xFF;
     mutex->hold               = 0;
 
-    /* set flag */
-    mutex->parent.parent.flag = flag;
+    /* set flag and it can only be RT_IPC_FLAG_PRIO */
+    mutex->parent.parent.flag = RT_IPC_FLAG_PRIO;
 
     return mutex;
 }

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -564,7 +564,7 @@ rt_err_t rt_mutex_init(rt_mutex_t mutex, const char *name, rt_uint8_t flag)
     mutex->original_priority = 0xFF;
     mutex->hold  = 0;
 
-    /* set flag and it can only be RT_IPC_FLAG_PRIO */
+    /* flag can only be RT_IPC_FLAG_PRIO. RT_IPC_FLAG_FIFO cannot solve the unbounded priority inversion problem */
     mutex->parent.parent.flag = RT_IPC_FLAG_PRIO;
 
     return RT_EOK;
@@ -628,7 +628,7 @@ rt_mutex_t rt_mutex_create(const char *name, rt_uint8_t flag)
     mutex->original_priority  = 0xFF;
     mutex->hold               = 0;
 
-    /* set flag and it can only be RT_IPC_FLAG_PRIO */
+    /* flag can only be RT_IPC_FLAG_PRIO. RT_IPC_FLAG_FIFO cannot solve the unbounded priority inversion problem */
     mutex->parent.parent.flag = RT_IPC_FLAG_PRIO;
 
     return mutex;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
信号量、消息队列、消息邮箱其FIFO功能，还有保留的意义。但是互斥量的FIFO没有任何存在的意义。
互斥量诞生之初就是为了解决信号量带来的无界优先级反转问题(Sha, 1990)，而FIFO flag却恰恰人为引入了无界优先级反转的问题，这与互斥量的出现目的背道而驰。

再想一个问题，请问互斥量的FIFO和信号量的FIFO 有什么区别呢，答案是没有任何区别，那么直接用信号量的FIFO好不好呢？

因此解决方法为直接移除FIFO flag，无论用户选择FIFO 还是PRIO 一律按照PRIO处理。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
