### PR TITLE
fix at_vprintf and at_vprintfln and end_sign response

### DIFF
--- a/components/net/at/src/at_client.c
+++ b/components/net/at/src/at_client.c
@@ -8,7 +8,7 @@
  * 2018-03-30     chenyong     first version
  * 2018-04-12     chenyong     add client implement
  * 2018-08-17     chenyong     multiple client support
- * 2021-03-17     Meco Man     fix a buf of leaking memory 
+ * 2021-03-17     Meco Man     fix a buf of leaking memory
  */
 
 #include <at.h>
@@ -28,6 +28,10 @@
 
 static struct at_client at_client_table[AT_CLIENT_NUM_MAX] = { 0 };
 
+extern rt_size_t at_utils_send(rt_device_t dev,
+                               rt_off_t    pos,
+                               const void *buffer,
+                               rt_size_t   size);
 extern rt_size_t at_vprintfln(rt_device_t device, const char *format, va_list args);
 extern void at_print_raw_cmd(const char *type, const char *cmd, rt_size_t size);
 extern const char *at_get_last_cmd(rt_size_t *cmd_size);
@@ -392,7 +396,7 @@ int at_client_obj_wait_connect(at_client_t client, rt_uint32_t timeout)
         /* Check whether it is already connected */
         resp->buf_len = 0;
         resp->line_counts = 0;
-        rt_device_write(client->device, 0, "AT\r\n", 4);
+        at_utils_send(client->device, 0, "AT\r\n", 4);
 
         if (rt_sem_take(client->resp_notice, resp->timeout) != RT_EOK)
             continue;
@@ -433,7 +437,13 @@ rt_size_t at_client_obj_send(at_client_t client, const char *buf, rt_size_t size
     at_print_raw_cmd("sendline", buf, size);
 #endif
 
-    return rt_device_write(client->device, 0, buf, size);
+    rt_mutex_take(client->lock, RT_WAITING_FOREVER);
+
+    rt_size_t len = at_utils_send(client->device, 0, buf, size);
+
+    rt_mutex_release(client->lock);
+
+    return len;
 }
 
 static rt_err_t at_client_getchar(at_client_t client, char *ch, rt_int32_t timeout)

--- a/components/net/at/src/at_client.c
+++ b/components/net/at/src/at_client.c
@@ -735,6 +735,8 @@ static void client_parser(at_client_t client)
             {
                 at_response_t resp = client->resp;
 
+                char end_ch = client->recv_line_buf[client->recv_line_len - 1];
+
                 /* current receive is response */
                 client->recv_line_buf[client->recv_line_len - 1] = '\0';
                 if (resp->buf_len + client->recv_line_len < resp->buf_size)
@@ -752,7 +754,12 @@ static void client_parser(at_client_t client)
                     LOG_E("Read response buffer failed. The Response buffer size is out of buffer size(%d)!", resp->buf_size);
                 }
                 /* check response result */
-                if (rt_memcmp(client->recv_line_buf, AT_RESP_END_OK, rt_strlen(AT_RESP_END_OK)) == 0
+                if ((client->end_sign != 0) && (end_ch == client->end_sign) && (resp->line_num == 0))
+                {
+                    /* get the end sign, return response state END_OK.*/
+                    client->resp_status = AT_RESP_OK;
+                }
+                else if (rt_memcmp(client->recv_line_buf, AT_RESP_END_OK, rt_strlen(AT_RESP_END_OK)) == 0
                         && resp->line_num == 0)
                 {
                     /* get the end data by response result, return response state END_OK. */

--- a/components/net/at/src/at_server.c
+++ b/components/net/at/src/at_server.c
@@ -38,6 +38,10 @@ static at_server_t at_server_local = RT_NULL;
 static at_cmd_t cmd_table = RT_NULL;
 static rt_size_t cmd_num;
 
+extern rt_size_t at_utils_send(rt_device_t dev,
+                               rt_off_t    pos,
+                               const void *buffer,
+                               rt_size_t   size);
 extern void at_vprintf(rt_device_t device, const char *format, va_list args);
 extern void at_vprintfln(rt_device_t device, const char *format, va_list args);
 
@@ -187,7 +191,7 @@ rt_size_t at_server_send(at_server_t server, const char *buf, rt_size_t size)
         return 0;
     }
 
-    return rt_device_write(server->device, 0, buf, size);
+    return at_utils_send(server->device, 0, buf, size);
 }
 
 /**

--- a/components/net/at/src/at_utils.c
+++ b/components/net/at/src/at_utils.c
@@ -68,21 +68,30 @@ const char *at_get_last_cmd(rt_size_t *cmd_size)
 rt_size_t at_vprintf(rt_device_t device, const char *format, va_list args)
 {
     last_cmd_len = vsnprintf(send_buf, sizeof(send_buf), format, args);
+    if(last_cmd_len > sizeof(send_buf))
+        last_cmd_len = sizeof(send_buf);
 
 #ifdef AT_PRINT_RAW_CMD
     at_print_raw_cmd("sendline", send_buf, last_cmd_len);
 #endif
 
-    return rt_device_write(device, 0, send_buf, last_cmd_len);
+    return at_device_send(device, 0, send_buf, last_cmd_len);
 }
 
 rt_size_t at_vprintfln(rt_device_t device, const char *format, va_list args)
 {
     rt_size_t len;
 
-    len = at_vprintf(device, format, args);
+    last_cmd_len = vsnprintf(send_buf, sizeof(send_buf) - 2, format, args);
+    if(last_cmd_len > sizeof(send_buf) - 2)
+        last_cmd_len = sizeof(send_buf) - 2;
+    rt_memcpy(send_buf + last_cmd_len, "\r\n", 2);
 
-    rt_device_write(device, 0, "\r\n", 2);
+    len = last_cmd_len + 2;
 
-    return len + 2;
+#ifdef AT_PRINT_RAW_CMD
+    at_print_raw_cmd("sendline", send_buf, len);
+#endif
+
+    return at_device_send(device, 0, send_buf, len);
 }

--- a/components/net/at/src/at_utils.c
+++ b/components/net/at/src/at_utils.c
@@ -65,6 +65,14 @@ const char *at_get_last_cmd(rt_size_t *cmd_size)
     return send_buf;
 }
 
+RT_WEAK rt_size_t at_utils_send(rt_device_t dev,
+                                rt_off_t    pos,
+                                const void *buffer,
+                                rt_size_t   size)
+{
+    return rt_device_write(dev, pos, buffer, size);
+}
+
 rt_size_t at_vprintf(rt_device_t device, const char *format, va_list args)
 {
     last_cmd_len = vsnprintf(send_buf, sizeof(send_buf), format, args);
@@ -75,7 +83,7 @@ rt_size_t at_vprintf(rt_device_t device, const char *format, va_list args)
     at_print_raw_cmd("sendline", send_buf, last_cmd_len);
 #endif
 
-    return at_device_send(device, 0, send_buf, last_cmd_len);
+    return at_utils_send(device, 0, send_buf, last_cmd_len);
 }
 
 rt_size_t at_vprintfln(rt_device_t device, const char *format, va_list args)
@@ -93,5 +101,5 @@ rt_size_t at_vprintfln(rt_device_t device, const char *format, va_list args)
     at_print_raw_cmd("sendline", send_buf, len);
 #endif
 
-    return at_device_send(device, 0, send_buf, len);
+    return at_utils_send(device, 0, send_buf, len);
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修改 at_vprintf 可能导致的指针溢出
更改 at_vprintfln 使命令和新行一起发送
完善 end_sign 的响应机制

在项目中验证过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
