### PR TITLE
[components][kernel] 解决多核下 finsh 不能响应串口输入问题

### DIFF
--- a/src/kservice.c
+++ b/src/kservice.c
@@ -1176,11 +1176,7 @@ void rt_kputs(const char *str)
     }
     else
     {
-        rt_uint16_t old_flag = _console_device->open_flag;
-
-        _console_device->open_flag |= RT_DEVICE_FLAG_STREAM;
         rt_device_write(_console_device, 0, str, rt_strlen(str));
-        _console_device->open_flag = old_flag;
     }
 #else
     rt_hw_console_output(str);
@@ -1214,11 +1210,7 @@ RT_WEAK void rt_kprintf(const char *fmt, ...)
     }
     else
     {
-        rt_uint16_t old_flag = _console_device->open_flag;
-
-        _console_device->open_flag |= RT_DEVICE_FLAG_STREAM;
         rt_device_write(_console_device, 0, rt_log_buf, length);
-        _console_device->open_flag = old_flag;
     }
 #else
     rt_hw_console_output(rt_log_buf);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
## 问题原因
在`kservice.c`中，`_console_device`设备在系统启动时打开了两次。
1. 第一次是调用`rt_device_t rt_console_set_device(const char *name)`。打开的`oflag`为`RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_STREAM`
2. 第二次是在finsh线程`void finsh_thread_entry(void *parameter)`中。打开的`oflag`为`RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_INT_RX |  RT_DEVICE_FLAG_STREAM`

基于以上情况，在多核环境下，`rt_kprintf`中的以下逻辑可能会覆盖掉`finsh`线程设置的`RT_DEVICE_FLAG_INT_RX` `oflag`

```c
        rt_uint16_t old_flag = _console_device->open_flag;

        _console_device->open_flag |= RT_DEVICE_FLAG_STREAM;
        rt_device_write(_console_device, 0, rt_log_buf, length);
        _console_device->open_flag = old_flag;
```
覆盖逻辑如下：
1. CORE0 调用`rt_kprintf`，执行完`rt_uint16_t old_flag = _console_device->open_flag;`
2. CORE1 执行`finsh`线程打开`_console_device`并设置oflag为`RT_DEVICE_OFLAG_RDWR | RT_DEVICE_FLAG_INT_RX |  RT_DEVICE_FLAG_STREAM`
3. CORE0 执行 `_console_device->open_flag = old_flag;`，覆盖`finsh`设置的`oflag`

`RT_DEVICE_FLAG_INT_RX`标志被覆盖掉后，`finsh`会一直读不到数据。

从现有代码逻辑来看，两次打开`_console_device`设备的oflag都有`RT_DEVICE_FLAG_STREAM`了。不需要每次调用`rt_kprintf`都加上`RT_DEVICE_FLAG_STREAM`

## 解决办法

去掉调用`rt_kprintf`时加`RT_DEVICE_FLAG_STREAM`标志的逻辑。

## 其他

目前RT的设备驱动框架，打开一个设备后，用户能直接通过设备句柄修改设备属性。这种方式在多核情况下，可能存在一个核对一个设备属性的修改会被另外一个核覆盖的情况。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x]  所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
