### PR TITLE
解决at_socket内存泄漏问题

### DIFF
--- a/components/net/at/at_socket/at_socket.c
+++ b/components/net/at/at_socket/at_socket.c
@@ -79,7 +79,7 @@ struct at_socket *at_get_socket(int socket)
 }
 
 /* get a block to the AT socket receive list*/
-static size_t at_recvpkt_put(rt_slist_t *rlist, const char *ptr, size_t length)
+static rt_err_t at_recvpkt_put(rt_slist_t *rlist, const char *ptr, size_t length)
 {
     at_recv_pkt_t pkt = RT_NULL;
 
@@ -87,7 +87,7 @@ static size_t at_recvpkt_put(rt_slist_t *rlist, const char *ptr, size_t length)
     if (pkt == RT_NULL)
     {
         LOG_E("No memory for receive packet table!");
-        return 0;
+        return -RT_ENOMEM;
     }
 
     pkt->bfsz_totle = length;
@@ -96,7 +96,7 @@ static size_t at_recvpkt_put(rt_slist_t *rlist, const char *ptr, size_t length)
 
     rt_slist_append(rlist, &pkt->list);
 
-    return length;
+    return RT_EOK;
 }
 
 /* delete and free all receive buffer list */
@@ -652,7 +652,7 @@ static void at_recv_notice_cb(struct at_socket *sock, at_socket_evt_t event, con
     RT_ASSERT(event == AT_SOCKET_EVT_RECV);
 
     /* check the socket object status */
-    if (sock->magic != AT_SOCKET_MAGIC || sock->state != AT_SOCKET_CONNECT)
+    if (sock->magic != AT_SOCKET_MAGIC || sock->state == AT_SOCKET_CLOSED)
     {
         rt_free((void *)buff);
         return;
@@ -660,7 +660,7 @@ static void at_recv_notice_cb(struct at_socket *sock, at_socket_evt_t event, con
 
     /* put receive buffer to receiver packet list */
     rt_mutex_take(sock->recv_lock, RT_WAITING_FOREVER);
-    if (!at_recvpkt_put(&(sock->recvpkt_list), buff, bfsz))
+    if (at_recvpkt_put(&(sock->recvpkt_list), buff, bfsz) != RT_EOK)
     {
         rt_free((void *)buff);
         rt_mutex_release(sock->recv_lock);

--- a/components/net/at/at_socket/at_socket.c
+++ b/components/net/at/at_socket/at_socket.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <sys/time.h>
+#include <sys/errno.h>
 
 #include <at_socket.h>
 #include <at_device.h>


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
解决at_socket在极限情况下内存泄漏问题，分2点：
1. AT模块在执行AT+CLOSE并返回OK后，在实际关闭前（上报URC前）仍然有可能接收到数据。所以接收数据时需要判断状态是否为AT_SOCKET_CONNECT。
2. at_recv_notice_cb在拒绝数据包时，没有释放数据包内存，从而导致内在泄漏。

另，在拉取最新代码编译时，at_socket.c编译不过。这是由libc改动所导致。这次顺便把这编译问题也解决掉。

在基于stm32芯片自建的bsp中验证通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
