### PR TITLE
[kernel][bug] 修复内核函数全局变量非原子性的问题

### DIFF
--- a/src/clock.c
+++ b/src/clock.c
@@ -39,8 +39,14 @@ static volatile rt_tick_t rt_tick = 0;
  */
 rt_tick_t rt_tick_get(void)
 {
-    /* return the global tick */
-    return rt_tick;
+    rt_tick_t tick;
+    register rt_base_t level;
+
+    level = rt_hw_interrupt_disable();
+    tick = rt_tick;
+    rt_hw_interrupt_enable(level);
+
+    return tick;
 }
 RTM_EXPORT(rt_tick_get);
 
@@ -49,7 +55,7 @@ RTM_EXPORT(rt_tick_get);
  */
 void rt_tick_set(rt_tick_t tick)
 {
-    rt_base_t level;
+    register rt_base_t level;
 
     level = rt_hw_interrupt_disable();
     rt_tick = tick;
@@ -63,7 +69,7 @@ void rt_tick_set(rt_tick_t tick)
 void rt_tick_increase(void)
 {
     struct rt_thread *thread;
-    rt_base_t level;
+    register rt_base_t level;
 
     level = rt_hw_interrupt_disable();
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -301,9 +301,15 @@ rt_thread_t rt_thread_self(void)
     rt_hw_local_irq_enable(lock);
     return self;
 #else
-    extern rt_thread_t rt_current_thread;
+    register rt_base_t level;
+    rt_thread_t current_thread;
+    extern volatile rt_thread_t rt_current_thread;
 
-    return rt_current_thread;
+    level = rt_hw_interrupt_disable();
+    current_thread = rt_current_thread;
+    rt_hw_interrupt_enable(level);
+
+    return current_thread;
 #endif /* RT_USING_SMP */
 }
 RTM_EXPORT(rt_thread_self);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
全局变量不可以直接返回，因为无法确保在任何硬件架构下都能在一个指令周期内完成返回动作。
同时修复了部分全局变量没有加volatile可能导致潜在的数据错乱的问题。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
