### PR TITLE
[Fix bug] fix thread init bug

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -151,6 +151,12 @@ static rt_err_t _rt_thread_init(struct rt_thread *thread,
     thread->current_priority = priority;
 
     thread->number_mask = 0;
+
+#ifdef RT_USING_EVENT
+    thread->event_set = 0;
+    thread->event_info = 0;
+#endif
+
 #if RT_THREAD_PRIORITY_MAX > 32
     thread->number = 0;
     thread->high_mask = 0;
@@ -202,6 +208,13 @@ static rt_err_t _rt_thread_init(struct rt_thread *thread,
 #ifdef RT_USING_LWP
     thread->lwp = RT_NULL;
 #endif
+
+
+#ifdef RT_USING_MODULE
+    thread->module_id = 0;
+#endif
+
+    thread->user_data = 0;
 
     RT_OBJECT_HOOK_CALL(rt_thread_inited_hook, (thread));
 


### PR DESCRIPTION
    When we create thread A by rt_thread_init but do
    not init the thread object,and then create thread
    B in the thread A,it maybe crash.

## 拉取/合并请求描述：(PR description)

[
#  一、问题描述  

在RT_USING_MODULE特性开启的情况下，利用rt_thread_init去创建线程A，再在A线程中去创建线程B，会出现data abort的问题。


# 二、问题分析  

1.在利用rt_thread_init去创建线程A的时候，由于第一个参数（struct rt_thread *）是由用户创建，这个rt_thread中的数据可能是随机的，也就导致其中的成员module_id的值也可能是随机的，而在创建线程B的时候，无论是利用rt_thread_init还是rt_thread_create都会调用rt_object_init函数，我现在看一下这个函数的实现。

``` c
void rt_object_init(struct rt_object         *object,
                    enum rt_object_class_type type,
                    const char               *name)
{
    register rt_base_t temp;
    struct rt_object_information *information;
#ifdef RT_USING_MODULE
    struct rt_dlmodule *module = dlmodule_self();
#endif

    /* get object information */
    information = rt_object_get_information(type);
    RT_ASSERT(information != RT_NULL);

    /* initialize object's parameters */

    /* set object type to static */
    object->type = type | RT_Object_Class_Static;

    /* copy name */
    rt_strncpy(object->name, name, RT_NAME_MAX);

    RT_OBJECT_HOOK_CALL(rt_object_attach_hook, (object));

    /* lock interrupt */
    temp = rt_hw_interrupt_disable();

#ifdef RT_USING_MODULE
    if (module)
    {
        rt_list_insert_after(&(module->object_list), &(object->list));
        object->module_id = (void *)module;
    }
    else
#endif
    {
        /* insert object into information object list */
        rt_list_insert_after(&(information->object_list), &(object->list));
    }

    /* unlock interrupt */
    rt_hw_interrupt_enable(temp);
}
```

2. 从上面代码可以看到，如果线程A的module_id未被初始化0的情况下会进入到if module分支，会引用此时的module，此时module是随机，就会出现data abort的情况。



# 三、解决方法

从上面的分析可知，导致此问题的原因主要是用户创建的struct rt_thread不可预测，所以应该在rt_thread_init处进行memset。如下图所示:  

![image](https://user-images.githubusercontent.com/23095389/127093416-a7d4ffa5-fe89-4c30-83ce-8c667d3b6b0d.png)

此种解决方法已在柿饼M3上验证。

# 四、疑问

1.为何用rt_thread_create时未出现？

因为在用此函数时，会进行memset。

2.如果用rt_thread_init不进行初始化atruct rt_thread结构体，是否会引起其它问题？

存在这种可能，但是如果全部memset则应该会避免。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
