### PR TITLE
Update sockets.c

### DIFF
--- a/components/net/lwip-2.1.2/src/api/sockets.c
+++ b/components/net/lwip-2.1.2/src/api/sockets.c
@@ -710,7 +710,7 @@ lwip_accept(int s, struct sockaddr *addr, socklen_t *addrlen)
     err = netconn_peer(newconn, &naddr, &port);
     if (err != ERR_OK) {
       LWIP_DEBUGF(SOCKETS_DEBUG, ("lwip_accept(%d): netconn_peer failed, err=%d\n", s, err));
-      netconn_delete(newconn);
+      //netconn_delete(newconn);
       free_socket(nsock, 1);
       sock_set_errno(sock, err_to_errno(err));
       done_socket(sock);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1、更正lwip_accept()中调用netconn_peer()失败时，netconn_delete()会被调用两次，从而导致进入rt_assert_handler()死机故障。
详细原因介绍参考LWIP官网(https://savannah.nongnu.org/bugs/?55536) bug #55536: lwIP 2.1.2: netconn_delete() called twice from lwip_accept()。
2、该死机故障复现方法：在基于rtthread+lwip2.1.2的MCU程序中创建TCP服务端监听连接，然后在PC端用一个测试软件创建TCP客户端，在连接时马上关闭掉测试程序，则TCP服务端会lwip_accept()失败，从而导致MCU死机。
3、已在STM32H743上实测过，确认故障已经封闭。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
