### PR TITLE
[workqueue] remove rt_delayed_work_init()

### DIFF
--- a/components/drivers/include/ipc/workqueue.h
+++ b/components/drivers/include/ipc/workqueue.h
@@ -5,6 +5,7 @@
  *
  * Change Logs:
  * Date           Author       Notes
+ * 2021-08-01     Meco Man     remove rt_delayed_work_init() and rt_delayed_work structure
  */
 #ifndef WORKQUEUE_H__
 #define WORKQUEUE_H__
@@ -48,11 +49,6 @@ struct rt_work
     struct rt_workqueue *workqueue;
 };
 
-struct rt_delayed_work
-{
-    struct rt_work work;
-};
-
 #ifdef RT_USING_HEAP
 /**
  * WorkQueue for DeviceDriver
@@ -81,9 +77,6 @@ rt_inline void rt_work_init(struct rt_work *work, void (*work_func)(struct rt_wo
     work->flags = 0;
     work->type = 0;
 }
-
-void rt_delayed_work_init(struct rt_delayed_work *work, void (*work_func)(struct rt_work *work,
-                          void *work_data), void *work_data);
 
 #endif /* RT_USING_HEAP */
 

--- a/components/drivers/src/workqueue.c
+++ b/components/drivers/src/workqueue.c
@@ -5,7 +5,8 @@
  *
  * Change Logs:
  * Date           Author       Notes
- * 2017-02-27     bernard      fix the re-work issue.
+ * 2017-02-27     Bernard      fix the re-work issue.
+ * 2021-08-01     Meco Man     remove rt_delayed_work_init()
  */
 
 #include <rthw.h>
@@ -337,12 +338,6 @@ rt_err_t rt_workqueue_cancel_all_work(struct rt_workqueue *queue)
     rt_exit_critical();
 
     return RT_EOK;
-}
-
-void rt_delayed_work_init(struct rt_delayed_work *work, void (*work_func)(struct rt_work *work,
-                          void *work_data), void *work_data)
-{
-    rt_work_init(&work->work, work_func, work_data);
 }
 
 #ifdef RT_USING_SYSTEM_WORKQUEUE

--- a/components/net/sal_socket/src/sal_socket.c
+++ b/components/net/sal_socket/src/sal_socket.c
@@ -165,7 +165,6 @@ static void check_netdev_internet_up_work(struct rt_work *work, void *work_data)
     struct netdev *netdev = (struct netdev *)work_data;
     socklen_t addr_len = sizeof(struct sockaddr_in);
     char send_data[SAL_INTERNET_BUFF_LEN], recv_data = 0;
-    struct rt_delayed_work *delay_work = (struct rt_delayed_work *)work;
 
     const char month[][SAL_INTERNET_MONTH_LEN] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
     char date[SAL_INTERNET_DATE_LEN];
@@ -176,7 +175,7 @@ static void check_netdev_internet_up_work(struct rt_work *work, void *work_data)
 
     if (work)
     {
-        rt_free(delay_work);
+        rt_free(work);
     }
 
     /* get network interface socket operations */
@@ -287,18 +286,18 @@ int sal_check_netdev_internet_up(struct netdev *netdev)
 
 #ifdef SAL_INTERNET_CHECK
     /* workqueue for network connect */
-    struct rt_delayed_work *net_work = RT_NULL;
+    struct rt_work *net_work = RT_NULL;
 
 
-    net_work = (struct rt_delayed_work *)rt_calloc(1, sizeof(struct rt_delayed_work));
+    net_work = (struct rt_work *)rt_calloc(1, sizeof(struct rt_work));
     if (net_work == RT_NULL)
     {
         LOG_W("No memory for network interface device(%s) delay work.", netdev->name);
         return -1;
     }
 
-    rt_delayed_work_init(net_work, check_netdev_internet_up_work, (void *)netdev);
-    rt_work_submit(&(net_work->work), RT_TICK_PER_SECOND);
+    rt_work_init(net_work, check_netdev_internet_up_work, (void *)netdev);
+    rt_work_submit(net_work, RT_TICK_PER_SECOND);
 #endif /* SAL_INTERNET_CHECK */
     return 0;
 }
@@ -619,7 +618,7 @@ int sal_accept(int socket, struct sockaddr *addr, socklen_t *addrlen)
             LOG_E("New socket registered failed, return error %d.", retval);
             return -1;
         }
-		
+
         /* new socket create by accept should have the same netdev with server*/
         new_sock->netdev = sock->netdev;
         /* socket structure user_data used to store the acquired new socket */
@@ -1176,4 +1175,3 @@ void sal_freeaddrinfo(struct addrinfo *ai)
         pf->netdb_ops->freeaddrinfo(ai);
     }
 }
-


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
The first time that the function `rt_delayed_work_init` was implemented and submitted was on #2463 in 2019.
However, after several contributions, this function has been meaningless but another version of `rt_work_init`.
Thus, this function should be removed.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
