### PR TITLE
[finsh] 将finsh_getchar函数暴露出来

### DIFF
--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -164,7 +164,7 @@ void finsh_set_prompt_mode(rt_uint32_t prompt_mode)
     shell->prompt_mode = prompt_mode;
 }
 
-static int finsh_getchar(void)
+char finsh_getchar(void)
 {
 #ifdef RT_USING_DEVICE
 #ifdef RT_USING_POSIX
@@ -176,7 +176,7 @@ static int finsh_getchar(void)
     while (rt_device_read(shell->device, -1, &ch, 1) != 1)
         rt_sem_take(&shell->rx_sem, RT_WAITING_FOREVER);
 
-    return (int)ch;
+    return ch;
 #endif
 #else
     extern char rt_hw_console_getchar(void);
@@ -329,7 +329,7 @@ static void finsh_wait_auth(void)
             while (1)
             {
                 /* read one character from device */
-                ch = finsh_getchar();
+                ch = (int)finsh_getchar();
                 if (ch < 0)
                 {
                     continue;
@@ -541,7 +541,7 @@ void finsh_thread_entry(void *parameter)
 
     while (1)
     {
-        ch = finsh_getchar();
+        ch = (int)finsh_getchar();
         if (ch < 0)
         {
             continue;

--- a/components/finsh/shell.h
+++ b/components/finsh/shell.h
@@ -97,6 +97,7 @@ rt_uint32_t finsh_get_echo(void);
 int finsh_system_init(void);
 void finsh_set_device(const char* device_name);
 const char* finsh_get_device(void);
+char finsh_getchar(void);
 
 rt_uint32_t finsh_get_prompt_mode(void);
 void finsh_set_prompt_mode(rt_uint32_t prompt_mode);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
目前在finsh线程中如果使用getchar函数，必须开启DFS，ROM一下子飙升40KB，但是完全可以通过finsh_getchar函数替代libc的getchar函数，因此需要将finsh_getchar函数暴露出来。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
