### PR TITLE
修复 ringblk_buf 在不使用动态内存时报错的问题以及 AT 组件优化

### DIFF
--- a/components/drivers/include/ipc/ringblk_buf.h
+++ b/components/drivers/include/ipc/ringblk_buf.h
@@ -76,9 +76,12 @@ typedef struct rt_rbb *rt_rbb_t;
 
 /* rbb (ring block buffer) API */
 void rt_rbb_init(rt_rbb_t rbb, rt_uint8_t *buf, rt_size_t buf_size, rt_rbb_blk_t block_set, rt_size_t blk_max_num);
+rt_size_t rt_rbb_get_buf_size(rt_rbb_t rbb);
+
+#ifdef RT_USING_HEAP
 rt_rbb_t rt_rbb_create(rt_size_t buf_size, rt_size_t blk_max_num);
 void rt_rbb_destroy(rt_rbb_t rbb);
-rt_size_t rt_rbb_get_buf_size(rt_rbb_t rbb);
+#endif
 
 /* rbb block API */
 rt_rbb_blk_t rt_rbb_blk_alloc(rt_rbb_t rbb, rt_size_t blk_size);

--- a/components/drivers/src/ringblk_buf.c
+++ b/components/drivers/src/ringblk_buf.c
@@ -44,6 +44,8 @@ void rt_rbb_init(rt_rbb_t rbb, rt_uint8_t *buf, rt_size_t buf_size, rt_rbb_blk_t
 }
 RTM_EXPORT(rt_rbb_init);
 
+#ifdef RT_USING_HEAP
+
 /**
  * ring block buffer object create
  *
@@ -101,6 +103,8 @@ void rt_rbb_destroy(rt_rbb_t rbb)
 
 }
 RTM_EXPORT(rt_rbb_destroy);
+
+#endif
 
 static rt_rbb_blk_t find_empty_blk_in_set(rt_rbb_t rbb)
 {

--- a/components/net/at/src/at_client.c
+++ b/components/net/at/src/at_client.c
@@ -429,6 +429,8 @@ int at_client_obj_wait_connect(at_client_t client, rt_uint32_t timeout)
  */
 rt_size_t at_client_obj_send(at_client_t client, const char *buf, rt_size_t size)
 {
+    rt_size_t len;
+
     RT_ASSERT(buf);
 
     if (client == RT_NULL)
@@ -443,7 +445,7 @@ rt_size_t at_client_obj_send(at_client_t client, const char *buf, rt_size_t size
 
     rt_mutex_take(client->lock, RT_WAITING_FOREVER);
 
-    rt_size_t len = at_utils_send(client->device, 0, buf, size);
+    len = at_utils_send(client->device, 0, buf, size);
 
     rt_mutex_release(client->lock);
 
@@ -495,9 +497,11 @@ rt_size_t at_client_obj_recv(at_client_t client, char *buf, rt_size_t size, rt_i
 
     while (1)
     {
+        rt_size_t read_len;
+
         rt_sem_control(client->rx_notice, RT_IPC_CMD_RESET, RT_NULL);
 
-        rt_size_t read_len = rt_device_read(client->device, 0, buf + len, size);
+        read_len = rt_device_read(client->device, 0, buf + len, size);
         if(read_len > 0)
         {
             len += read_len;

--- a/components/net/at/src/at_client.c
+++ b/components/net/at/src/at_client.c
@@ -310,13 +310,15 @@ int at_obj_exec_cmd(at_client_t client, at_response_t resp, const char *cmd_expr
     rt_mutex_take(client->lock, RT_WAITING_FOREVER);
 
     client->resp_status = AT_RESP_OK;
-    client->resp = resp;
 
     if (resp != RT_NULL)
     {
         resp->buf_len = 0;
         resp->line_counts = 0;
     }
+
+    client->resp = resp;
+    rt_sem_control(client->resp_notice, RT_IPC_CMD_RESET, RT_NULL);
 
     va_start(args, cmd_expr);
     at_vprintfln(client->device, cmd_expr, args);
@@ -327,7 +329,7 @@ int at_obj_exec_cmd(at_client_t client, at_response_t resp, const char *cmd_expr
         if (rt_sem_take(client->resp_notice, resp->timeout) != RT_EOK)
         {
             cmd = at_get_last_cmd(&cmd_size);
-            LOG_D("execute command (%.*s) timeout (%d ticks)!", cmd_size, cmd, resp->timeout);
+            LOG_W("execute command (%.*s) timeout (%d ticks)!", cmd_size, cmd, resp->timeout);
             client->resp_status = AT_RESP_TIMEOUT;
             result = -RT_ETIMEOUT;
             goto __exit;
@@ -381,6 +383,7 @@ int at_client_obj_wait_connect(at_client_t client, rt_uint32_t timeout)
 
     rt_mutex_take(client->lock, RT_WAITING_FOREVER);
     client->resp = resp;
+    rt_sem_control(client->resp_notice, RT_IPC_CMD_RESET, RT_NULL);
 
     start_time = rt_tick_get();
 
@@ -480,9 +483,7 @@ static rt_err_t at_client_getchar(at_client_t client, char *ch, rt_int32_t timeo
  */
 rt_size_t at_client_obj_recv(at_client_t client, char *buf, rt_size_t size, rt_int32_t timeout)
 {
-    rt_size_t read_idx = 0;
-    rt_err_t result = RT_EOK;
-    char ch;
+    rt_size_t len = 0;
 
     RT_ASSERT(buf);
 
@@ -494,28 +495,28 @@ rt_size_t at_client_obj_recv(at_client_t client, char *buf, rt_size_t size, rt_i
 
     while (1)
     {
-        if (read_idx < size)
-        {
-            result = at_client_getchar(client, &ch, timeout);
-            if (result != RT_EOK)
-            {
-                LOG_E("AT Client receive failed, uart device get data error(%d)", result);
-                return 0;
-            }
+        rt_sem_control(client->rx_notice, RT_IPC_CMD_RESET, RT_NULL);
 
-            buf[read_idx++] = ch;
-        }
-        else
+        rt_size_t read_len = rt_device_read(client->device, 0, buf + len, size);
+        if(read_len > 0)
         {
-            break;
+            len += read_len;
+            size -= read_len;
+            if(size == 0)
+                break;
+
+            continue;
         }
+
+        if(rt_sem_take(client->rx_notice, rt_tick_from_millisecond(timeout)) != RT_EOK)
+            break;
     }
 
 #ifdef AT_PRINT_RAW_CMD
-    at_print_raw_cmd("urc_recv", buf, size);
+    at_print_raw_cmd("urc_recv", buf, len);
 #endif
 
-    return read_idx;
+    return len;
 }
 
 /**


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1. 在不使用动态内存分配的时候 ringblk_buf 会报错，使用 RT_USING_HEAP 宏定义来隔离
2. 更改 at_client_obj_recv，从原来的长度不对就返回 0 变更为返回收到的字节数
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
