### PR TITLE
[netdev] ping cmd with specified netif in lwip-2.1.2

### DIFF
--- a/components/net/lwip-2.1.2/src/arch/sys_arch.c
+++ b/components/net/lwip-2.1.2/src/arch/sys_arch.c
@@ -779,6 +779,30 @@ void ppp_trace(int level, const char *format, ...)
 }
 #endif
 
+struct netif *lwip_ip4_route_src(const ip4_addr_t *dest, const ip4_addr_t *src)
+{
+    struct netif *netif;
+
+    /* iterate through netifs */
+    for (netif = netif_list; netif != NULL; netif = netif->next)
+    {
+    /* is the netif up, does it have a link and a valid address? */
+    if (netif_is_up(netif) && netif_is_link_up(netif) && !ip4_addr_isany_val(*netif_ip4_addr(netif)))
+    {
+    /* gateway matches on a non broadcast interface? (i.e. peer in a point to point interface) */
+    if (src != NULL)
+    {
+        if (ip4_addr_cmp(src, netif_ip4_addr(netif)))
+        {
+            return netif;
+        }
+    }
+    }
+  }
+  netif = netif_default;
+  return netif;
+}
+
 /*
  * export bsd socket symbol for RT-Thread Application Module
  */

--- a/components/net/lwip-2.1.2/src/arch/sys_arch.c
+++ b/components/net/lwip-2.1.2/src/arch/sys_arch.c
@@ -786,21 +786,21 @@ struct netif *lwip_ip4_route_src(const ip4_addr_t *dest, const ip4_addr_t *src)
     /* iterate through netifs */
     for (netif = netif_list; netif != NULL; netif = netif->next)
     {
-    /* is the netif up, does it have a link and a valid address? */
-    if (netif_is_up(netif) && netif_is_link_up(netif) && !ip4_addr_isany_val(*netif_ip4_addr(netif)))
-    {
-    /* gateway matches on a non broadcast interface? (i.e. peer in a point to point interface) */
-    if (src != NULL)
-    {
-        if (ip4_addr_cmp(src, netif_ip4_addr(netif)))
+        /* is the netif up, does it have a link and a valid address? */
+        if (netif_is_up(netif) && netif_is_link_up(netif) && !ip4_addr_isany_val(*netif_ip4_addr(netif)))
         {
-            return netif;
+            /* gateway matches on a non broadcast interface? (i.e. peer in a point to point interface) */
+            if (src != NULL)
+            {
+                if (ip4_addr_cmp(src, netif_ip4_addr(netif)))
+                {
+                    return netif;
+                }
+            }
         }
     }
-    }
-  }
-  netif = netif_default;
-  return netif;
+    netif = netif_default;
+    return netif;
 }
 
 /*

--- a/components/net/lwip-2.1.2/src/lwipopts.h
+++ b/components/net/lwip-2.1.2/src/lwipopts.h
@@ -647,4 +647,5 @@
 #endif
 
 
+#define LWIP_HOOK_IP4_ROUTE_SRC(dest, src)  lwip_ip4_route_src(dest, src)
 #endif /* __LWIPOPTS_H__ */

--- a/components/net/lwip-2.1.2/src/netif/ethernetif.c
+++ b/components/net/lwip-2.1.2/src/netif/ethernetif.c
@@ -197,6 +197,7 @@ int lwip_netdev_ping(struct netdev *netif, const char *host, size_t data_len,
     struct addrinfo hint, *res = RT_NULL;
     struct sockaddr_in *h = RT_NULL;
     struct in_addr ina;
+    struct sockaddr_in local;
     
     RT_ASSERT(netif);
     RT_ASSERT(host);
@@ -222,6 +223,12 @@ int lwip_netdev_ping(struct netdev *netif, const char *host, size_t data_len,
     {
         return -RT_ERROR;
     }
+
+    local.sin_len = sizeof(local);
+    local.sin_family = AF_INET;
+    local.sin_port = 0;
+    local.sin_addr.s_addr = (netif->ip_addr.addr);
+    lwip_bind(s, (struct sockaddr *)&local, sizeof(struct sockaddr_in));
 
     lwip_setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, sizeof(recv_timeout));
 

--- a/components/net/netdev/src/netdev.c
+++ b/components/net/netdev/src/netdev.c
@@ -1051,7 +1051,7 @@ MSH_CMD_EXPORT_ALIAS(netdev_ifconfig, ifconfig, list the information of all netw
 #endif /* NETDEV_USING_IFCONFIG */
 
 #ifdef NETDEV_USING_PING
-int netdev_cmd_ping(char* target_name, rt_uint32_t times, rt_size_t size)
+int netdev_cmd_ping(char* target_name, char *netdev_name, rt_uint32_t times, rt_size_t size)
 {
 #define NETDEV_PING_DATA_SIZE       32
 /** ping receive timeout - in milliseconds */
@@ -1070,6 +1070,16 @@ int netdev_cmd_ping(char* target_name, rt_uint32_t times, rt_size_t size)
     if (size == 0)
     {
         size = NETDEV_PING_DATA_SIZE;
+    }
+
+    if (netdev_name != RT_NULL)
+    {
+        netdev = netdev_get_by_name(netdev_name);
+        if (netdev == RT_NULL)
+        {
+            netdev = netdev_default;
+            rt_kprintf("ping: not found specified netif, using default netdev %s.\n", netdev->name);
+        }
     }
 
     if (NETDEV_PING_IS_COMMONICABLE(netdev_default))
@@ -1145,9 +1155,13 @@ int netdev_ping(int argc, char **argv)
     {
         rt_kprintf("Please input: ping <host address>\n");
     }
-    else
+    else if (argc == 2)
     {
-        netdev_cmd_ping(argv[1], 4, 0);
+        netdev_cmd_ping(argv[1], RT_NULL, 4, 0);
+    }
+    else if (argc == 3)
+    {
+        netdev_cmd_ping(argv[1], argv[2], 4, 0);
     }
 
     return 0;


### PR DESCRIPTION
using LWIP_HOOK_IP4_ROUTE_SRC hook find specified netif route, using
cmd `ping 192.168.xx.xx e0`, ping dest using e0 netif. if not found
netif, using default netif, the effect is same as the cmd `ping 192.168.xx.xx` that only ping with default netif.

## 拉取/合并请求描述：(PR description)

[
解决 netdev 无法通过指定网卡进行ping 操作。

通过增加 lwip 2.1.2 下的 钩子函数 LWIP_HOOK_IP4_ROUTE_SRC  区分指定的网卡。

已经测试
在 art-pi 下多网卡 （wifi，eth）过协议栈 lwip2.1.2，进行测试；
在 qemu-vexpress-a9 单网卡下通过指定 网卡，进行测试；
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
