### PR TITLE
Fix build issue in x86

### DIFF
--- a/bsp/x86/drivers/floppy.c
+++ b/bsp/x86/drivers/floppy.c
@@ -357,7 +357,7 @@ void rt_floppy_init(void)
     device->read = rt_floppy_read;
     device->write = rt_floppy_write;
     device->control = rt_floppy_control;
-    device->user_data = NULL;
+    device->user_data = RT_NULL;
 
     rt_device_register(device, "floppy",
                        RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_REMOVABLE | RT_DEVICE_FLAG_STANDALONE);

--- a/components/dfs/include/dfs_posix.h
+++ b/components/dfs/include/dfs_posix.h
@@ -16,7 +16,6 @@
 #define __DFS_POSIX_H__
 
 #include <dfs_file.h>
-#include <unistd.h>
 #include <stdio.h> /* rename() */
 #include <sys/stat.h>
 #include <sys/statfs.h> /* statfs() */


### PR DESCRIPTION
Got:
scons: Reading SConscript files ...
scons: done reading SConscript files.
scons: Building targets ...
scons: building associated VariantDir targets: build
CC build/drivers/floppy.o
drivers/floppy.c: In function 'rt_floppy_init':
drivers/floppy.c:360:25: error: 'NULL' undeclared (first use in this function); did you mean 'RT_NULL'?
     device->user_data = NULL;
                         ^~~~
                         RT_NULL
drivers/floppy.c:360:25: note: each undeclared identifier is reported only once for each function it appears in
scons: *** [build/drivers/floppy.o] Error 1
scons: building terminated because of errors.

This PR can fix the build issue.