### PR TITLE
[libc] fix the conflict warning of read and write functions

### DIFF
--- a/bsp/x86/drivers/floppy.c
+++ b/bsp/x86/drivers/floppy.c
@@ -357,7 +357,7 @@ void rt_floppy_init(void)
     device->read = rt_floppy_read;
     device->write = rt_floppy_write;
     device->control = rt_floppy_control;
-    device->user_data = NULL;
+    device->user_data = RT_NULL;
 
     rt_device_register(device, "floppy",
                        RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_REMOVABLE | RT_DEVICE_FLAG_STANDALONE);

--- a/components/dfs/src/dfs_posix.c
+++ b/components/dfs/src/dfs_posix.c
@@ -110,7 +110,11 @@ RTM_EXPORT(close);
  * @return the actual read data buffer length. If the returned value is 0, it
  * may be reach the end of file, please check errno.
  */
+#ifdef _READ_WRITE_RETURN_TYPE
+_READ_WRITE_RETURN_TYPE read(int fd, void *buf, size_t len) /* some gcc tool chains will use different data structure */
+#else
 ssize_t read(int fd, void *buf, size_t len)
+#endif
 {
     int result;
     struct dfs_fd *d;
@@ -150,7 +154,11 @@ RTM_EXPORT(read);
  *
  * @return the actual written data buffer length.
  */
+#ifdef _READ_WRITE_RETURN_TYPE
+_READ_WRITE_RETURN_TYPE write(int fd, const void *buf, size_t len) /* some gcc tool chains will use different data structure */
+#else
 ssize_t write(int fd, const void *buf, size_t len)
+#endif
 {
     int result;
     struct dfs_fd *d;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
problem description: https://github.com/RT-Thread/rt-thread/pull/5056
related pr: https://github.com/RT-Thread/rt-thread/pull/5053
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
