### PR TITLE
更改ch32f1_hwtimer_clock_init和ch32f1_hwtimer_clock_get函数名，并修复硬件定时器获取的clock.

### DIFF
--- a/bsp/wch/arm/Libraries/ch32_drivers/drv_hwtimer_ch32f10x.c
+++ b/bsp/wch/arm/Libraries/ch32_drivers/drv_hwtimer_ch32f10x.c
@@ -73,17 +73,16 @@ static void ch32f1_hwtimer_init(struct rt_hwtimer_device *device, rt_uint32_t st
 
     if (state)
     {
-        ch32f1_hwtimer_clock_init(hwtimer_dev->periph);
+        ch32f1_tim_clock_init(hwtimer_dev->periph);
 
         hwtimer_info = ch32f1_hwtimer_info_config_get(hwtimer_dev->periph);
 
-        clk = ch32f1_hwtimer_clock_get(hwtimer_dev->periph);
+        clk = ch32f1_tim_clock_get(hwtimer_dev->periph);
 
         prescaler_value = (rt_uint16_t)(clk / hwtimer_info->minfreq) - 1;
 
         /*
-        * set interrupt callback one or each time need total time =
-        *  (cnt + 1) * (1 / (clk/(prescaler_value + 1) ) )
+        * (1 / freq) = (cnt + 1) * (1 / (clk/(prescaler_value + 1) ) )
         */
 
         TIM_TimeBaseInitType.TIM_Period = hwtimer_info->maxcnt - 1;
@@ -132,8 +131,7 @@ static rt_err_t ch32f1_hwtimer_start(struct rt_hwtimer_device *device, rt_uint32
     hwtimer_dev = (struct hwtimer_device *)device;
 
     /*
-    * interrupt callback one or each time need total time =
-    *  (cnt + 1) * (1 / (clk/(prescaler_value + 1) ) )
+    * (1 / freq) = (cnt + 1) * (1 / (clk/(prescaler_value + 1) ) )
     */
 
     TIM_SetCounter(hwtimer_dev->periph, 0);
@@ -197,15 +195,14 @@ static rt_err_t ch32f1_hwtimer_control(struct rt_hwtimer_device *device, rt_uint
         rt_uint16_t prescaler_value = 0;
 
         /*
-        *set interrupt callback one or each time need total time =
-        *  (cnt + 1) * (1 / (clk/(prescaler_value + 1) ) )
+        * (1 / freq) = (cnt + 1) * (1 / (clk/(prescaler_value + 1) ) )
         */
         if (arg != RT_NULL)
         {
 
             freq = *((rt_uint32_t *)arg);
 
-            clk = ch32f1_hwtimer_clock_get(hwtimer_dev->periph);
+            clk = ch32f1_tim_clock_get(hwtimer_dev->periph);
 
             prescaler_value = (rt_uint16_t)(clk / freq) - 1;
 
@@ -369,4 +366,3 @@ void TIM4_IRQHandler(void)
 #endif
 
 #endif /* BSP_USING_HWTIMER */
-

--- a/bsp/wch/arm/ch32f103c8-core/board/board.c
+++ b/bsp/wch/arm/ch32f103c8-core/board/board.c
@@ -226,10 +226,36 @@ void ch32f1_tim_clock_init(TIM_TypeDef *timx)
 rt_uint32_t ch32f1_tim_clock_get(TIM_TypeDef *timx)
 {
     RCC_ClocksTypeDef RCC_Clocks;
+    rt_uint32_t ppre1;//APB1 DIV
+    rt_uint32_t ppre2;//APB2 DIV
 
     RCC_GetClocksFreq(&RCC_Clocks);
 
-    /*tim1~4 all in HCLK*/
+    //[10:8]:PPRE1
+    ppre1 = (RCC->CFGR0 >> 8) & 0x7;
+    //[13:11]:PPRE2
+    ppre2 = (RCC->CFGR0 >> 11) & 0x7;
+
+    if(timx == TIM1)
+    {
+        //TIM1:APB2_DIV
+        //PPRE2: 0xx, DIV = 1; 100, DIV = 2...; when DIV > 1,  hardware auto complete: HCLK * 2
+        if(ppre2 >= 4 )
+        {
+            return RCC_Clocks.HCLK_Frequency * 2;
+        }
+    }
+    else
+    {
+        //TIM2~4 APB1_DIV
+        //PPRE1: 0xx, DIV = 1; 100, DIV = 2...; when DIV > 1,  hardware auto complete: HCLK * 2
+        if(ppre1 >= 4 )
+        {
+            return RCC_Clocks.HCLK_Frequency * 2;
+        }
+    }
+
+
     return RCC_Clocks.HCLK_Frequency;
 }
 

--- a/bsp/wch/arm/ch32f103c8-core/board/board.c
+++ b/bsp/wch/arm/ch32f103c8-core/board/board.c
@@ -200,7 +200,7 @@ void ch32f1_i2c_config(I2C_TypeDef *i2cx)
     }
 }
 
-void ch32f1_hwtimer_clock_init(TIM_TypeDef *timx)
+void ch32f1_tim_clock_init(TIM_TypeDef *timx)
 {
     if (timx == TIM1)
     {
@@ -223,7 +223,7 @@ void ch32f1_hwtimer_clock_init(TIM_TypeDef *timx)
     }
 }
 
-rt_uint32_t ch32f1_hwtimer_clock_get(TIM_TypeDef *timx)
+rt_uint32_t ch32f1_tim_clock_get(TIM_TypeDef *timx)
 {
     RCC_ClocksTypeDef RCC_Clocks;
 

--- a/bsp/wch/arm/ch32f103c8-core/board/board.h
+++ b/bsp/wch/arm/ch32f103c8-core/board/board.h
@@ -50,8 +50,8 @@ void ch32f1_spi_clock_and_io_init(SPI_TypeDef* spix);
 rt_uint32_t ch32f1_spi_clock_get(SPI_TypeDef* spix);
 void ch32f1_i2c_clock_and_io_init(I2C_TypeDef* i2cx);
 void ch32f1_i2c_config(I2C_TypeDef* i2cx);
-void ch32f1_hwtimer_clock_init(TIM_TypeDef *timx);
-rt_uint32_t ch32f1_hwtimer_clock_get(TIM_TypeDef *timx);
+void ch32f1_tim_clock_init(TIM_TypeDef *timx);
+rt_uint32_t ch32f1_tim_clock_get(TIM_TypeDef *timx);
 struct rt_hwtimer_info* ch32f1_hwtimer_info_config_get(TIM_TypeDef *timx);
 
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
更改函数名：ch32f1_hwtimer_clock_init, ch32f1_hwtimer_clock_get为ch32f1_tim_clock_init，ch32f1_tim_clock_get.
修复ch32f1_tim_clock_get: 当APB1 DIV > 1 或 APB2 DIV > 1时， clock需要乘以2，以上在ch32f103c8测试通过。]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ X] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ X] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ X] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ X] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ X] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ X] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ X] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ X] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
