### PR TITLE
关于rtlink中_long_handle_second函数开启长帧接收超时定时器的逻辑的修改建议

### DIFF
--- a/components/utilities/rt-link/src/rtlink.c
+++ b/components/utilities/rt-link/src/rtlink.c
@@ -447,6 +447,7 @@ static void _long_handle_second(struct rt_link_frame *receive_frame, rt_uint8_t 
             ack_mask |= ack_mask << rt_link_utils_num1(RT_LINK_ACK_MAX);
         }
 
+
         /* receive a complete package */
         if (rt_link_utils_num1(rt_link_scb->rx_record.long_count) == rt_link_scb->rx_record.total)
         {
@@ -474,13 +475,27 @@ static void _long_handle_second(struct rt_link_frame *receive_frame, rt_uint8_t 
             {
                 rt_link_scb->channel[serve].upload_callback(data, size);
             }
+
         }
-        else if (rt_link_hw_recv_len(rt_link_scb->rx_buffer) < (receive_frame->data_len % RT_LINK_MAX_DATA_LENGTH))
+        else 
         {
-            rt_int32_t timeout = RT_LINK_LONG_FRAME_TIMEOUT;
-            rt_timer_control(&rt_link_scb->longframetimer, RT_TIMER_CTRL_SET_TIME, &timeout);
-            rt_timer_start(&rt_link_scb->longframetimer);
+            rt_uint32_t next_frame_data_len = (receive_frame->extend.parameter - (receive_frame->data_len + offset));
+            if(next_frame_data_len % RT_LINK_MAX_DATA_LENGTH )
+            {
+                next_frame_data_len += RT_LINK_HEAD_LENGTH + RT_LINK_MAX_EXTEND_LENGTH + RT_LINK_CRC_LENGTH;
+            }
+            else
+            {
+                next_frame_data_len = RT_LINK_HEAD_LENGTH + RT_LINK_MAX_EXTEND_LENGTH + RT_LINK_MAX_DATA_LENGTH + RT_LINK_CRC_LENGTH;
+            }
+            if (rt_link_hw_recv_len(rt_link_scb->rx_buffer) < next_frame_data_len)
+            {
+                rt_int32_t timeout = RT_LINK_LONG_FRAME_TIMEOUT;
+                rt_timer_control(&rt_link_scb->longframetimer, RT_TIMER_CTRL_SET_TIME, &timeout);
+                rt_timer_start(&rt_link_scb->longframetimer);
+            }
         }
+
     }
 }
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
在_long_handle_second函数中原本使用rt_link_hw_recv_len(rt_link_scb->rx_buffer) < (receive_frame->data_len % RT_LINK_MAX_DATA_LENGTH)来判断是否开启定时器 我一直没有看懂
根据协议我觉得应该的是判断下一帧的数据在接收缓存例有没有接收到如果没有就开启定时器。
我的修改是先获取该长帧还有多少数据，在判断下一帧是不是长帧的最后一条数据，如果是最后一条数据就看一下接收缓存里有没有剩下的数据，如果没有就打开定时器，如果不是最后一条数据就看一下接收缓存里有没有最长一帧的数据，如果没有就打开定时器
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
