### PR TITLE
[kservice] 调整kservice选项的不当位置

### DIFF
--- a/src/Kconfig
+++ b/src/Kconfig
@@ -131,9 +131,19 @@ config RT_KSERVICE_USING_TINY_SIZE
     bool "Enable kservice to use tiny size"
     default n
 
-config RT_USING_ASM_MEMCPY
+config RT_KSERVICE_USING_ASM_MEMCPY
     bool
     default n
+    help
+        only can be selected by asm software packages
+
+config RT_KSERVICE_USING_PRINTF_LONGLONG
+    bool "Enable kservice print format to support long long"
+    default y
+
+config RT_KSERVICE_USING_PRINTF_PRECISION
+    bool "Enable kservice print format to support precision"
+    default y
 
 endmenu
 
@@ -356,10 +366,6 @@ menu "Kernel Device Object"
         config RT_CONSOLE_DEVICE_NAME
             string "the device name for console"
             default "uart"
-
-        config RT_PRINTF_LONGLONG
-            bool "rt_kprintf support long long"
-            default n
     endif
 
 endmenu

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -28,7 +28,9 @@
 #endif /* RT_USING_MODULE */
 
 /* use precision */
-#define RT_PRINTF_PRECISION
+#ifndef RT_KSERVICE_USING_PRINTF_PRECISION
+#define RT_KSERVICE_USING_PRINTF_PRECISION
+#endif
 
 /**
  * @addtogroup KernelService
@@ -201,7 +203,7 @@ RT_WEAK void *rt_memset(void *s, int c, rt_ubase_t count)
 }
 RTM_EXPORT(rt_memset);
 
-#ifndef RT_USING_ASM_MEMCPY
+#ifndef RT_KSERVICE_USING_ASM_MEMCPY
 /**
  * This function will copy memory content from source address to destination address.
  *
@@ -285,7 +287,7 @@ void *rt_memcpy(void *dst, const void *src, rt_ubase_t count)
 #endif /* RT_KSERVICE_USING_TINY_SIZE */
 }
 RTM_EXPORT(rt_memcpy);
-#endif /* RT_USING_ASM_MEMCPY */
+#endif /* RT_KSERVICE_USING_ASM_MEMCPY */
 
 #ifndef RT_KSERVICE_USING_STDLIB
 
@@ -586,7 +588,7 @@ RTM_EXPORT(rt_show_version);
 /* private function */
 #define _ISDIGIT(c)  ((unsigned)((c) - '0') < 10)
 
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KSERVICE_USING_PRINTF_LONGLONG
 /**
  * This function will duplicate a string.
  *
@@ -633,7 +635,7 @@ rt_inline int divide(long *n, int base)
 
     return res;
 }
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KSERVICE_USING_PRINTF_LONGLONG */
 
 rt_inline int skip_atoi(const char **s)
 {
@@ -652,14 +654,14 @@ rt_inline int skip_atoi(const char **s)
 #define SPECIAL     (1 << 5)    /* 0x */
 #define LARGE       (1 << 6)    /* use 'ABCDEF' instead of 'abcdef' */
 
-#ifdef RT_PRINTF_PRECISION
+#ifdef RT_KSERVICE_USING_PRINTF_PRECISION
 static char *print_number(char *buf,
                           char *end,
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KSERVICE_USING_PRINTF_LONGLONG
                           long long  num,
 #else
                           long  num,
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KSERVICE_USING_PRINTF_LONGLONG */
                           int   base,
                           int   s,
                           int   precision,
@@ -667,22 +669,22 @@ static char *print_number(char *buf,
 #else
 static char *print_number(char *buf,
                           char *end,
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KSERVICE_USING_PRINTF_LONGLONG
                           long long  num,
 #else
                           long  num,
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KSERVICE_USING_PRINTF_LONGLONG */
                           int   base,
                           int   s,
                           int   type)
-#endif /* RT_PRINTF_PRECISION */
+#endif /* RT_KSERVICE_USING_PRINTF_PRECISION */
 {
     char c, sign;
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KSERVICE_USING_PRINTF_LONGLONG
     char tmp[32];
 #else
     char tmp[16];
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KSERVICE_USING_PRINTF_LONGLONG */
     int precision_bak = precision;
     const char *digits;
     static const char small_digits[] = "0123456789abcdef";
@@ -732,13 +734,13 @@ static char *print_number(char *buf,
             tmp[i++] = digits[divide(&num, base)];
     }
 
-#ifdef RT_PRINTF_PRECISION
+#ifdef RT_KSERVICE_USING_PRINTF_PRECISION
     if (i > precision)
         precision = i;
     size -= precision;
 #else
     size -= i;
-#endif /* RT_PRINTF_PRECISION */
+#endif /* RT_KSERVICE_USING_PRINTF_PRECISION */
 
     if (!(type & (ZEROPAD | LEFT)))
     {
@@ -797,14 +799,14 @@ static char *print_number(char *buf,
         }
     }
 
-#ifdef RT_PRINTF_PRECISION
+#ifdef RT_KSERVICE_USING_PRINTF_PRECISION
     while (i < precision--)
     {
         if (buf < end)
             *buf = '0';
         ++ buf;
     }
-#endif /* RT_PRINTF_PRECISION */
+#endif /* RT_KSERVICE_USING_PRINTF_PRECISION */
 
     /* put number in the temporary buffer */
     while (i-- > 0 && (precision_bak != 0))
@@ -842,11 +844,11 @@ rt_int32_t rt_vsnprintf(char       *buf,
                         const char *fmt,
                         va_list     args)
 {
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KSERVICE_USING_PRINTF_LONGLONG
     unsigned long long num;
 #else
     rt_uint32_t num;
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KSERVICE_USING_PRINTF_LONGLONG */
     int i, len;
     char *str, *end, c;
     const char *s;
@@ -856,9 +858,9 @@ rt_int32_t rt_vsnprintf(char       *buf,
     rt_uint8_t qualifier;       /* 'h', 'l', or 'L' for integer fields */
     rt_int32_t field_width;     /* width of output field */
 
-#ifdef RT_PRINTF_PRECISION
+#ifdef RT_KSERVICE_USING_PRINTF_PRECISION
     int precision;      /* min. # of digits for integers and max for a string */
-#endif /* RT_PRINTF_PRECISION */
+#endif /* RT_KSERVICE_USING_PRINTF_PRECISION */
 
     str = buf;
     end = buf + size;
@@ -910,7 +912,7 @@ rt_int32_t rt_vsnprintf(char       *buf,
             }
         }
 
-#ifdef RT_PRINTF_PRECISION
+#ifdef RT_KSERVICE_USING_PRINTF_PRECISION
         /* get the precision */
         precision = -1;
         if (*fmt == '.')
@@ -925,24 +927,24 @@ rt_int32_t rt_vsnprintf(char       *buf,
             }
             if (precision < 0) precision = 0;
         }
-#endif /* RT_PRINTF_PRECISION */
+#endif /* RT_KSERVICE_USING_PRINTF_PRECISION */
         /* get the conversion qualifier */
         qualifier = 0;
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KSERVICE_USING_PRINTF_LONGLONG
         if (*fmt == 'h' || *fmt == 'l' || *fmt == 'L')
 #else
         if (*fmt == 'h' || *fmt == 'l')
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KSERVICE_USING_PRINTF_LONGLONG */
         {
             qualifier = *fmt;
             ++ fmt;
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KSERVICE_USING_PRINTF_LONGLONG
             if (qualifier == 'l' && *fmt == 'l')
             {
                 qualifier = 'L';
                 ++ fmt;
             }
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KSERVICE_USING_PRINTF_LONGLONG */
         }
 
         /* the default base */
@@ -978,9 +980,9 @@ rt_int32_t rt_vsnprintf(char       *buf,
             if (!s) s = "(NULL)";
 
             for (len = 0; (len != field_width) && (s[len] != '\0'); len++);
-#ifdef RT_PRINTF_PRECISION
+#ifdef RT_KSERVICE_USING_PRINTF_PRECISION
             if (precision > 0 && len > precision) len = precision;
-#endif /* RT_PRINTF_PRECISION */
+#endif /* RT_KSERVICE_USING_PRINTF_PRECISION */
 
             if (!(flags & LEFT))
             {
@@ -1011,7 +1013,7 @@ rt_int32_t rt_vsnprintf(char       *buf,
                 field_width = sizeof(void *) << 1;
                 flags |= ZEROPAD;
             }
-#ifdef RT_PRINTF_PRECISION
+#ifdef RT_KSERVICE_USING_PRINTF_PRECISION
             str = print_number(str, end,
                                (long)va_arg(args, void *),
                                16, field_width, precision, flags);
@@ -1019,7 +1021,7 @@ rt_int32_t rt_vsnprintf(char       *buf,
             str = print_number(str, end,
                                (long)va_arg(args, void *),
                                16, field_width, flags);
-#endif /* RT_PRINTF_PRECISION */
+#endif /* RT_KSERVICE_USING_PRINTF_PRECISION */
             continue;
 
         case '%':
@@ -1060,12 +1062,12 @@ rt_int32_t rt_vsnprintf(char       *buf,
             continue;
         }
 
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KSERVICE_USING_PRINTF_LONGLONG
         if (qualifier == 'L') num = va_arg(args, long long);
         else if (qualifier == 'l')
 #else
         if (qualifier == 'l')
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KSERVICE_USING_PRINTF_LONGLONG */
         {
             num = va_arg(args, rt_uint32_t);
             if (flags & SIGN) num = (rt_int32_t)num;
@@ -1080,11 +1082,11 @@ rt_int32_t rt_vsnprintf(char       *buf,
             num = va_arg(args, rt_uint32_t);
             if (flags & SIGN) num = (rt_int32_t)num;
         }
-#ifdef RT_PRINTF_PRECISION
+#ifdef RT_KSERVICE_USING_PRINTF_PRECISION
         str = print_number(str, end, num, base, field_width, precision, flags);
 #else
         str = print_number(str, end, num, base, field_width, flags);
-#endif /* RT_PRINTF_PRECISION */
+#endif /* RT_KSERVICE_USING_PRINTF_PRECISION */
     }
 
     if (size > 0)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
规范宏定义RT_PRINTF_LONGLONG和RT_PRINTF_PRECISION的命名
将longlong选项放置于kservice优化选项内
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
