### PR TITLE
Fix rtc

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
@@ -38,7 +38,7 @@ RT_WEAK void HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegiste
     return;
 }
 
-static time_t get_rtc_timestamp(void)
+static void get_rtc_timeval(struct timeval *tv)
 {
     RTC_TimeTypeDef RTC_TimeStruct = {0};
     RTC_DateTypeDef RTC_DateStruct = {0};
@@ -54,8 +54,11 @@ static time_t get_rtc_timestamp(void)
     tm_new.tm_mon  = RTC_DateStruct.Month - 1;
     tm_new.tm_year = RTC_DateStruct.Year + 100;
 
-    LOG_D("get rtc time.");
-    return timegm(&tm_new);
+    tv->tv_sec = timegm(&tm_new);
+
+#if defined(SOC_SERIES_STM32H7)
+    tv->tv_usec = (255.0 - RTC_TimeStruct.SubSeconds * 1.0) / 256.0 * 1000.0 * 1000.0;
+#endif
 }
 
 static rt_err_t set_rtc_time_stamp(time_t time_stamp)
@@ -243,7 +246,9 @@ RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI1;
 
 static rt_err_t stm32_rtc_get_secs(void *args)
 {
-    *(rt_uint32_t *)args = get_rtc_timestamp();
+    struct timeval tv;
+    get_rtc_timeval(&tv);
+    *(rt_uint32_t *) args = tv.tv_sec;
     LOG_D("RTC: get rtc_time %x\n", *(rt_uint32_t *)args);
 
     return RT_EOK;
@@ -262,6 +267,13 @@ static rt_err_t stm32_rtc_set_secs(void *args)
     return result;
 }
 
+static rt_err_t stm32_rtc_get_timeval(void *args)
+{
+    get_rtc_timeval((struct timeval *) args);
+
+    return RT_EOK;
+}
+
 static const struct rt_rtc_ops stm32_rtc_ops =
 {
     stm32_rtc_init,
@@ -269,7 +281,7 @@ static const struct rt_rtc_ops stm32_rtc_ops =
     stm32_rtc_set_secs,
     RT_NULL,
     RT_NULL,
-    RT_NULL,
+    stm32_rtc_get_timeval,
     RT_NULL,
 };
 

--- a/components/drivers/include/drivers/rtc.h
+++ b/components/drivers/include/drivers/rtc.h
@@ -29,8 +29,8 @@ struct rt_rtc_ops
     rt_err_t (*set_secs)(void *arg);
     rt_err_t (*get_alarm)(void *arg);
     rt_err_t (*set_alarm)(void *arg);
-    rt_err_t (*get_usecs)(void *arg);
-    rt_err_t (*set_usecs)(void *arg);
+    rt_err_t (*get_timeval)(void *arg);
+    rt_err_t (*set_timeval)(void *arg);
 };
 
 typedef struct rt_rtc_device

--- a/components/drivers/include/drivers/rtc.h
+++ b/components/drivers/include/drivers/rtc.h
@@ -15,12 +15,12 @@
 
 #include <rtdef.h>
 
-#define RT_DEVICE_CTRL_RTC_GET_TIME     0x10            /**< get second time */
-#define RT_DEVICE_CTRL_RTC_SET_TIME     0x11            /**< set second time */
-#define RT_DEVICE_CTRL_RTC_GET_TIME_US  0x12            /**< get microsecond time */
-#define RT_DEVICE_CTRL_RTC_SET_TIME_US  0x13            /**< set microsecond time */
-#define RT_DEVICE_CTRL_RTC_GET_ALARM    0x14            /**< get alarm */
-#define RT_DEVICE_CTRL_RTC_SET_ALARM    0x15            /**< set alarm */
+#define RT_DEVICE_CTRL_RTC_GET_TIME     0x20            /**< get second time */
+#define RT_DEVICE_CTRL_RTC_SET_TIME     0x21            /**< set second time */
+#define RT_DEVICE_CTRL_RTC_GET_TIMEVAL  0x22            /**< get timeval for gettimeofday */
+#define RT_DEVICE_CTRL_RTC_SET_TIMEVAL  0x23            /**< set timeval for gettimeofday */
+#define RT_DEVICE_CTRL_RTC_GET_ALARM    0x24            /**< get alarm */
+#define RT_DEVICE_CTRL_RTC_SET_ALARM    0x25            /**< set alarm */
 
 struct rt_rtc_ops
 {

--- a/components/drivers/rtc/rtc.c
+++ b/components/drivers/rtc/rtc.c
@@ -71,11 +71,11 @@ static rt_err_t rt_rtc_control(struct rt_device *dev, int cmd, void *args)
         case RT_DEVICE_CTRL_RTC_SET_TIME:
             ret = TRY_DO_RTC_FUNC(rtc_device, set_secs, args);
             break;
-        case RT_DEVICE_CTRL_RTC_GET_TIME_US:
-            ret = TRY_DO_RTC_FUNC(rtc_device, get_usecs, args);
+        case RT_DEVICE_CTRL_RTC_GET_TIMEVAL:
+            ret = TRY_DO_RTC_FUNC(rtc_device, get_timeval, args);
             break;
-        case RT_DEVICE_CTRL_RTC_SET_TIME_US:
-            ret = TRY_DO_RTC_FUNC(rtc_device, set_usecs, args);
+        case RT_DEVICE_CTRL_RTC_SET_TIMEVAL:
+            ret = TRY_DO_RTC_FUNC(rtc_device, set_timeval, args);
             break;
         case RT_DEVICE_CTRL_RTC_GET_ALARM:
             ret = TRY_DO_RTC_FUNC(rtc_device, get_alarm, args);

--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -18,22 +18,20 @@
  * 2021-02-12     Meco Man     move all of the functions located in <clock_time.c> to this file
  * 2021-03-15     Meco Man     fixed a bug of leaking memory in asctime()
  * 2021-05-01     Meco Man     support fixed timezone
+ * 2021-07-21     Meco Man     implement that change/set timezone APIs
  */
 
 #include "sys/time.h"
+#include <sys/errno.h>
 #include <rtthread.h>
-
+#include <rthw.h>
 #ifdef RT_USING_DEVICE
 #include <rtdevice.h>
 #endif
 
-#define DBG_TAG    "TIME"
+#define DBG_TAG    "time"
 #define DBG_LVL    DBG_INFO
 #include <rtdbg.h>
-
-#ifndef RT_LIBC_FIXED_TIMEZONE
-#define RT_LIBC_FIXED_TIMEZONE 8 /* UTC+8 */
-#endif
 
 /* seconds per day */
 #define SPD 24*60*60
@@ -201,7 +199,7 @@ struct tm *gmtime_r(const time_t *timep, struct tm *r)
     r->tm_mon = i;
     r->tm_mday += work - __spm[i];
 
-    r->tm_isdst = 0;
+    r->tm_isdst = tz_is_dst();
     return r;
 }
 RTM_EXPORT(gmtime_r);
@@ -217,7 +215,7 @@ struct tm* localtime_r(const time_t* t, struct tm* r)
 {
     time_t local_tz;
 
-    local_tz = *t + RT_LIBC_FIXED_TIMEZONE * 3600;
+    local_tz = *t + tz_get() * 3600;
     return gmtime_r(&local_tz, r);
 }
 RTM_EXPORT(localtime_r);
@@ -234,13 +232,36 @@ time_t mktime(struct tm * const t)
     time_t timestamp;
 
     timestamp = timegm(t);
-    timestamp = timestamp - 3600 * RT_LIBC_FIXED_TIMEZONE;
+    timestamp = timestamp - 3600 * tz_get();
     return timestamp;
 }
 RTM_EXPORT(mktime);
 
 char* asctime_r(const struct tm *t, char *buf)
 {
+    /* Checking input validity */
+    if (rt_strlen(days) <= (t->tm_wday << 2) || rt_strlen(months) <= (t->tm_mon << 2))
+    {
+        LOG_W("asctime_r: the input parameters exceeded the limit, please check it.");
+        *(int*) buf = *(int*) days;
+        *(int*) (buf + 4) = *(int*) months;
+        num2str(buf + 8, t->tm_mday);
+        if (buf[8] == '0')
+            buf[8] = ' ';
+        buf[10] = ' ';
+        num2str(buf + 11, t->tm_hour);
+        buf[13] = ':';
+        num2str(buf + 14, t->tm_min);
+        buf[16] = ':';
+        num2str(buf + 17, t->tm_sec);
+        buf[19] = ' ';
+        num2str(buf + 20, 2000 / 100);
+        num2str(buf + 22, 2000 % 100);
+        buf[24] = '\n';
+        buf[25] = '\0';
+        return buf;
+    }
+
     /* "Wed Jun 30 21:49:08 1993\n" */
     *(int*) buf = *(int*) (days + (t->tm_wday << 2));
     *(int*) (buf + 4) = *(int*) (months + (t->tm_mon << 2));
@@ -425,7 +446,7 @@ int gettimeofday(struct timeval *tv, struct timezone *tz)
     if(tz != RT_NULL)
     {
         tz->tz_dsttime = DST_NONE;
-        tz->tz_minuteswest = -(RT_LIBC_FIXED_TIMEZONE * 60);
+        tz->tz_minuteswest = -(tz_get() * 60);
     }
 
     if (tv != RT_NULL && get_timeval(tv) == RT_EOK)
@@ -448,7 +469,6 @@ int settimeofday(const struct timeval *tv, const struct timezone *tz)
      * Thus, the following is purely of historic interest.
      */
     if (tv != RT_NULL
-        && tv->tv_sec >= 0
         && tv->tv_usec >= 0
         && set_timeval((struct timeval *)tv) == RT_EOK)
     {
@@ -467,33 +487,47 @@ RTM_EXPORT(difftime);
 RTM_EXPORT(strftime);
 
 #ifdef RT_USING_POSIX
-static struct timeval _timevalue;
-static int clock_time_system_init()
+
+#ifdef RT_USING_RTC
+static volatile struct timeval _timevalue;
+static int _rt_clock_time_system_init()
 {
-    time_t time;
+    register rt_base_t level;
+    time_t time = 0;
     rt_tick_t tick;
     rt_device_t device;
 
-    time = 0;
     device = rt_device_find("rtc");
     if (device != RT_NULL)
     {
         /* get realtime seconds */
-        rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIME, &time);
+        if(rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIME, &time) == RT_EOK)
+        {
+            level = rt_hw_interrupt_disable();
+            tick = rt_tick_get(); /* get tick */
+            _timevalue.tv_usec = (tick%RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK;
+            _timevalue.tv_sec = time - tick/RT_TICK_PER_SECOND - 1;
+            rt_hw_interrupt_enable(level);
+            return 0;
+        }
     }
 
-    /* get tick */
-    tick = rt_tick_get();
+    level = rt_hw_interrupt_disable();
+    _timevalue.tv_usec = 0;
+    _timevalue.tv_sec = 0;
+    rt_hw_interrupt_enable(level);
 
-    _timevalue.tv_usec = (tick%RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK;
-    _timevalue.tv_sec = time - tick/RT_TICK_PER_SECOND - 1;
-
-    return 0;
+    return -1;
 }
-INIT_COMPONENT_EXPORT(clock_time_system_init);
+INIT_COMPONENT_EXPORT(_rt_clock_time_system_init);
+#endif /* RT_USING_RTC */
 
 int clock_getres(clockid_t clockid, struct timespec *res)
 {
+#ifndef RT_USING_RTC
+    LOG_W("Cannot find a RTC device to save time!");
+    return -1;
+#else
     int ret = 0;
 
     if (res == RT_NULL)
@@ -523,11 +557,16 @@ int clock_getres(clockid_t clockid, struct timespec *res)
     }
 
     return ret;
+#endif /* RT_USING_RTC */
 }
 RTM_EXPORT(clock_getres);
 
 int clock_gettime(clockid_t clockid, struct timespec *tp)
 {
+#ifndef RT_USING_RTC
+    LOG_W("Cannot find a RTC device to save time!");
+    return -1;
+#else
     int ret = 0;
 
     if (tp == RT_NULL)
@@ -540,11 +579,14 @@ int clock_gettime(clockid_t clockid, struct timespec *tp)
     {
     case CLOCK_REALTIME:
         {
-            /* get tick */
-            int tick = rt_tick_get();
+            int tick;
+            register rt_base_t level;
 
+            level = rt_hw_interrupt_disable();
+            tick = rt_tick_get(); /* get tick */
             tp->tv_sec  = _timevalue.tv_sec + tick / RT_TICK_PER_SECOND;
             tp->tv_nsec = (_timevalue.tv_usec + (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK) * 1000;
+            rt_hw_interrupt_enable(level);
         }
         break;
 
@@ -568,11 +610,17 @@ int clock_gettime(clockid_t clockid, struct timespec *tp)
     }
 
     return ret;
+#endif /* RT_USING_RTC */
 }
 RTM_EXPORT(clock_gettime);
 
 int clock_settime(clockid_t clockid, const struct timespec *tp)
 {
+#ifndef RT_USING_RTC
+    LOG_W("Cannot find a RTC device to save time!");
+    return -1;
+#else
+    register rt_base_t level;
     int second;
     rt_tick_t tick;
     rt_device_t device;
@@ -580,34 +628,36 @@ int clock_settime(clockid_t clockid, const struct timespec *tp)
     if ((clockid != CLOCK_REALTIME) || (tp == RT_NULL))
     {
         rt_set_errno(EINVAL);
-
         return -1;
     }
 
     /* get second */
     second = tp->tv_sec;
-    /* get tick */
-    tick = rt_tick_get();
 
+    level = rt_hw_interrupt_disable();
+    tick = rt_tick_get(); /* get tick */
     /* update timevalue */
     _timevalue.tv_usec = MICROSECOND_PER_SECOND - (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK;
     _timevalue.tv_sec = second - tick/RT_TICK_PER_SECOND - 1;
+    rt_hw_interrupt_enable(level);
 
     /* update for RTC device */
     device = rt_device_find("rtc");
     if (device != RT_NULL)
     {
         /* set realtime seconds */
-        rt_device_control(device, RT_DEVICE_CTRL_RTC_SET_TIME, &second);
+        if(rt_device_control(device, RT_DEVICE_CTRL_RTC_SET_TIME, &second) == RT_EOK)
+        {
+            return 0;
+        }
     }
-    else
-        return -1;
 
-    return 0;
+    return -1;
+#endif /* RT_USING_RTC */
 }
 RTM_EXPORT(clock_settime);
 
-int clock_time_to_tick(const struct timespec *time)
+int rt_timespec_to_tick(const struct timespec *time)
 {
     int tick;
     int nsecond, second;
@@ -638,6 +688,32 @@ int clock_time_to_tick(const struct timespec *time)
 
     return tick;
 }
-RTM_EXPORT(clock_time_to_tick);
+RTM_EXPORT(rt_timespec_to_tick);
 
 #endif /* RT_USING_POSIX */
+
+
+/* timezone */
+#ifndef RT_LIBC_DEFAULT_TIMEZONE
+#define RT_LIBC_DEFAULT_TIMEZONE    8
+#endif
+
+static volatile int8_t _current_timezone = RT_LIBC_DEFAULT_TIMEZONE;
+
+void tz_set(int8_t tz)
+{
+    register rt_base_t level;
+    level = rt_hw_interrupt_disable();
+    _current_timezone = tz;
+    rt_hw_interrupt_enable(level);
+}
+
+int8_t tz_get(void)
+{
+    return _current_timezone;
+}
+
+int8_t tz_is_dst(void)
+{
+    return 0;
+}

--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -18,20 +18,22 @@
  * 2021-02-12     Meco Man     move all of the functions located in <clock_time.c> to this file
  * 2021-03-15     Meco Man     fixed a bug of leaking memory in asctime()
  * 2021-05-01     Meco Man     support fixed timezone
- * 2021-07-21     Meco Man     implement that change/set timezone APIs
  */
 
 #include "sys/time.h"
-#include <sys/errno.h>
 #include <rtthread.h>
-#include <rthw.h>
+
 #ifdef RT_USING_DEVICE
 #include <rtdevice.h>
 #endif
 
-#define DBG_TAG    "time"
+#define DBG_TAG    "TIME"
 #define DBG_LVL    DBG_INFO
 #include <rtdbg.h>
+
+#ifndef RT_LIBC_FIXED_TIMEZONE
+#define RT_LIBC_FIXED_TIMEZONE 8 /* UTC+8 */
+#endif
 
 /* seconds per day */
 #define SPD 24*60*60
@@ -101,7 +103,7 @@ static rt_err_t get_timeval(struct timeval *tv)
         if (rt_device_open(device, 0) == RT_EOK)
         {
             rst = rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIME, &tv->tv_sec);
-            rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIME_US, &tv->tv_usec);
+            rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIMEVAL, tv);
             rt_device_close(device);
         }
     }
@@ -147,7 +149,7 @@ static int set_timeval(struct timeval *tv)
         if (rt_device_open(device, 0) == RT_EOK)
         {
             rst = rt_device_control(device, RT_DEVICE_CTRL_RTC_SET_TIME, &tv->tv_sec);
-            rt_device_control(device, RT_DEVICE_CTRL_RTC_SET_TIME_US, &tv->tv_usec);
+            rt_device_control(device, RT_DEVICE_CTRL_RTC_SET_TIMEVAL, tv);
             rt_device_close(device);
         }
     }
@@ -199,7 +201,7 @@ struct tm *gmtime_r(const time_t *timep, struct tm *r)
     r->tm_mon = i;
     r->tm_mday += work - __spm[i];
 
-    r->tm_isdst = tz_is_dst();
+    r->tm_isdst = 0;
     return r;
 }
 RTM_EXPORT(gmtime_r);
@@ -215,7 +217,7 @@ struct tm* localtime_r(const time_t* t, struct tm* r)
 {
     time_t local_tz;
 
-    local_tz = *t + tz_get() * 3600;
+    local_tz = *t + RT_LIBC_FIXED_TIMEZONE * 3600;
     return gmtime_r(&local_tz, r);
 }
 RTM_EXPORT(localtime_r);
@@ -232,36 +234,13 @@ time_t mktime(struct tm * const t)
     time_t timestamp;
 
     timestamp = timegm(t);
-    timestamp = timestamp - 3600 * tz_get();
+    timestamp = timestamp - 3600 * RT_LIBC_FIXED_TIMEZONE;
     return timestamp;
 }
 RTM_EXPORT(mktime);
 
 char* asctime_r(const struct tm *t, char *buf)
 {
-    /* Checking input validity */
-    if (rt_strlen(days) <= (t->tm_wday << 2) || rt_strlen(months) <= (t->tm_mon << 2))
-    {
-        LOG_W("asctime_r: the input parameters exceeded the limit, please check it.");
-        *(int*) buf = *(int*) days;
-        *(int*) (buf + 4) = *(int*) months;
-        num2str(buf + 8, t->tm_mday);
-        if (buf[8] == '0')
-            buf[8] = ' ';
-        buf[10] = ' ';
-        num2str(buf + 11, t->tm_hour);
-        buf[13] = ':';
-        num2str(buf + 14, t->tm_min);
-        buf[16] = ':';
-        num2str(buf + 17, t->tm_sec);
-        buf[19] = ' ';
-        num2str(buf + 20, 2000 / 100);
-        num2str(buf + 22, 2000 % 100);
-        buf[24] = '\n';
-        buf[25] = '\0';
-        return buf;
-    }
-
     /* "Wed Jun 30 21:49:08 1993\n" */
     *(int*) buf = *(int*) (days + (t->tm_wday << 2));
     *(int*) (buf + 4) = *(int*) (months + (t->tm_mon << 2));
@@ -446,7 +425,7 @@ int gettimeofday(struct timeval *tv, struct timezone *tz)
     if(tz != RT_NULL)
     {
         tz->tz_dsttime = DST_NONE;
-        tz->tz_minuteswest = -(tz_get() * 60);
+        tz->tz_minuteswest = -(RT_LIBC_FIXED_TIMEZONE * 60);
     }
 
     if (tv != RT_NULL && get_timeval(tv) == RT_EOK)
@@ -469,6 +448,7 @@ int settimeofday(const struct timeval *tv, const struct timezone *tz)
      * Thus, the following is purely of historic interest.
      */
     if (tv != RT_NULL
+        && tv->tv_sec >= 0
         && tv->tv_usec >= 0
         && set_timeval((struct timeval *)tv) == RT_EOK)
     {
@@ -487,47 +467,33 @@ RTM_EXPORT(difftime);
 RTM_EXPORT(strftime);
 
 #ifdef RT_USING_POSIX
-
-#ifdef RT_USING_RTC
-static volatile struct timeval _timevalue;
-static int _rt_clock_time_system_init()
+static struct timeval _timevalue;
+static int clock_time_system_init()
 {
-    register rt_base_t level;
-    time_t time = 0;
+    time_t time;
     rt_tick_t tick;
     rt_device_t device;
 
+    time = 0;
     device = rt_device_find("rtc");
     if (device != RT_NULL)
     {
         /* get realtime seconds */
-        if(rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIME, &time) == RT_EOK)
-        {
-            level = rt_hw_interrupt_disable();
-            tick = rt_tick_get(); /* get tick */
-            _timevalue.tv_usec = (tick%RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK;
-            _timevalue.tv_sec = time - tick/RT_TICK_PER_SECOND - 1;
-            rt_hw_interrupt_enable(level);
-            return 0;
-        }
+        rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIME, &time);
     }
 
-    level = rt_hw_interrupt_disable();
-    _timevalue.tv_usec = 0;
-    _timevalue.tv_sec = 0;
-    rt_hw_interrupt_enable(level);
+    /* get tick */
+    tick = rt_tick_get();
 
-    return -1;
+    _timevalue.tv_usec = (tick%RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK;
+    _timevalue.tv_sec = time - tick/RT_TICK_PER_SECOND - 1;
+
+    return 0;
 }
-INIT_COMPONENT_EXPORT(_rt_clock_time_system_init);
-#endif /* RT_USING_RTC */
+INIT_COMPONENT_EXPORT(clock_time_system_init);
 
 int clock_getres(clockid_t clockid, struct timespec *res)
 {
-#ifndef RT_USING_RTC
-    LOG_W("Cannot find a RTC device to save time!");
-    return -1;
-#else
     int ret = 0;
 
     if (res == RT_NULL)
@@ -557,16 +523,11 @@ int clock_getres(clockid_t clockid, struct timespec *res)
     }
 
     return ret;
-#endif /* RT_USING_RTC */
 }
 RTM_EXPORT(clock_getres);
 
 int clock_gettime(clockid_t clockid, struct timespec *tp)
 {
-#ifndef RT_USING_RTC
-    LOG_W("Cannot find a RTC device to save time!");
-    return -1;
-#else
     int ret = 0;
 
     if (tp == RT_NULL)
@@ -579,14 +540,11 @@ int clock_gettime(clockid_t clockid, struct timespec *tp)
     {
     case CLOCK_REALTIME:
         {
-            int tick;
-            register rt_base_t level;
+            /* get tick */
+            int tick = rt_tick_get();
 
-            level = rt_hw_interrupt_disable();
-            tick = rt_tick_get(); /* get tick */
             tp->tv_sec  = _timevalue.tv_sec + tick / RT_TICK_PER_SECOND;
             tp->tv_nsec = (_timevalue.tv_usec + (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK) * 1000;
-            rt_hw_interrupt_enable(level);
         }
         break;
 
@@ -610,17 +568,11 @@ int clock_gettime(clockid_t clockid, struct timespec *tp)
     }
 
     return ret;
-#endif /* RT_USING_RTC */
 }
 RTM_EXPORT(clock_gettime);
 
 int clock_settime(clockid_t clockid, const struct timespec *tp)
 {
-#ifndef RT_USING_RTC
-    LOG_W("Cannot find a RTC device to save time!");
-    return -1;
-#else
-    register rt_base_t level;
     int second;
     rt_tick_t tick;
     rt_device_t device;
@@ -628,36 +580,34 @@ int clock_settime(clockid_t clockid, const struct timespec *tp)
     if ((clockid != CLOCK_REALTIME) || (tp == RT_NULL))
     {
         rt_set_errno(EINVAL);
+
         return -1;
     }
 
     /* get second */
     second = tp->tv_sec;
+    /* get tick */
+    tick = rt_tick_get();
 
-    level = rt_hw_interrupt_disable();
-    tick = rt_tick_get(); /* get tick */
     /* update timevalue */
     _timevalue.tv_usec = MICROSECOND_PER_SECOND - (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK;
     _timevalue.tv_sec = second - tick/RT_TICK_PER_SECOND - 1;
-    rt_hw_interrupt_enable(level);
 
     /* update for RTC device */
     device = rt_device_find("rtc");
     if (device != RT_NULL)
     {
         /* set realtime seconds */
-        if(rt_device_control(device, RT_DEVICE_CTRL_RTC_SET_TIME, &second) == RT_EOK)
-        {
-            return 0;
-        }
+        rt_device_control(device, RT_DEVICE_CTRL_RTC_SET_TIME, &second);
     }
+    else
+        return -1;
 
-    return -1;
-#endif /* RT_USING_RTC */
+    return 0;
 }
 RTM_EXPORT(clock_settime);
 
-int rt_timespec_to_tick(const struct timespec *time)
+int clock_time_to_tick(const struct timespec *time)
 {
     int tick;
     int nsecond, second;
@@ -688,32 +638,6 @@ int rt_timespec_to_tick(const struct timespec *time)
 
     return tick;
 }
-RTM_EXPORT(rt_timespec_to_tick);
+RTM_EXPORT(clock_time_to_tick);
 
 #endif /* RT_USING_POSIX */
-
-
-/* timezone */
-#ifndef RT_LIBC_DEFAULT_TIMEZONE
-#define RT_LIBC_DEFAULT_TIMEZONE    8
-#endif
-
-static volatile int8_t _current_timezone = RT_LIBC_DEFAULT_TIMEZONE;
-
-void tz_set(int8_t tz)
-{
-    register rt_base_t level;
-    level = rt_hw_interrupt_disable();
-    _current_timezone = tz;
-    rt_hw_interrupt_enable(level);
-}
-
-int8_t tz_get(void)
-{
-    return _current_timezone;
-}
-
-int8_t tz_is_dst(void)
-{
-    return 0;
-}

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -966,13 +966,13 @@ enum rt_device_class_type
 /**
  * special device commands
  */
-#define RT_DEVICE_CTRL_CHAR_STREAM      0x10            /**< stream mode on char device */
-#define RT_DEVICE_CTRL_BLK_GETGEOME     0x10            /**< get geometry information   */
-#define RT_DEVICE_CTRL_BLK_SYNC         0x11            /**< flush data to block device */
-#define RT_DEVICE_CTRL_BLK_ERASE        0x12            /**< erase block on block device */
-#define RT_DEVICE_CTRL_BLK_AUTOREFRESH  0x13            /**< block device : enter/exit auto refresh mode */
-#define RT_DEVICE_CTRL_NETIF_GETMAC     0x10            /**< get mac address */
-#define RT_DEVICE_CTRL_MTD_FORMAT       0x10            /**< format a MTD device */
+#define RT_DEVICE_CTRL_CHAR_STREAM      0x20            /**< stream mode on char device */
+#define RT_DEVICE_CTRL_BLK_GETGEOME     0x20            /**< get geometry information   */
+#define RT_DEVICE_CTRL_BLK_SYNC         0x21            /**< flush data to block device */
+#define RT_DEVICE_CTRL_BLK_ERASE        0x22            /**< erase block on block device */
+#define RT_DEVICE_CTRL_BLK_AUTOREFRESH  0x23            /**< block device : enter/exit auto refresh mode */
+#define RT_DEVICE_CTRL_NETIF_GETMAC     0x20            /**< get mac address */
+#define RT_DEVICE_CTRL_MTD_FORMAT       0x20            /**< format a MTD device */
 
 typedef struct rt_device *rt_device_t;
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

- 增加 timeval RTC ops ，取消原有的 us RTC ops。
  - 原因是在使用 gettimeofday 时，既要获取秒级时间戳，又要获取微秒时间戳。目前上游代码是分两次，分别获取秒及微秒，这会导致先获取的秒级时间会晚于后获取的微秒时间，组合在一起时，时间戳反正倒退的问题
- 增加 stm32 平台亚秒精度的时间戳，并对接至 timeval RTC ops
- 修改 设备特殊命令范围，目前和通用命令有冲突

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
