### PR TITLE
fix the tick of drv_common.c in stm32 bsp

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_common.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_common.c
@@ -29,7 +29,7 @@ MSH_CMD_EXPORT(reboot, Reboot System);
 #endif /* RT_USING_FINSH */
 
 extern __IO uint32_t uwTick;
-static uint32_t sysTickMillisecond = 1;
+static uint32_t _systick_ms = 1;
 
 /* SysTick configuration */
 void rt_hw_systick_init(void)
@@ -38,9 +38,9 @@ void rt_hw_systick_init(void)
 
     NVIC_SetPriority(SysTick_IRQn, 0xFF);
 
-    sysTickMillisecond = 1000u / RT_TICK_PER_SECOND;
-    if(sysTickMillisecond == 0)
-        sysTickMillisecond = 1;
+    _systick_ms = 1000u / RT_TICK_PER_SECOND;
+    if(_systick_ms == 0)
+        _systick_ms = 1;
 }
 
 /**
@@ -71,7 +71,7 @@ uint32_t HAL_GetTick(void)
 
 void HAL_IncTick(void)
 {
-    uwTick += sysTickMillisecond;
+    uwTick += _systick_ms;
 }
 
 void HAL_SuspendTick(void)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1. 使用 `SysTick_CTRL_COUNTFLAG_Msk` 位来判断是否在中断或 `HAL_GetTick` 中调用 `HAL_IncTick`
2. `SysTick_CTRL_COUNTFLAG_Msk` 位读取就被复位，中断和 `HAL_GetTick` 中判断就形成了互斥
3. 在中断未开启或在比 `SysTick_Handler` 优先级更高的中断中调用 `HAL库` 的 `API` 中的 `HAL_GetTick` 返回的 `tick` 也会走，而不会出现死循环的情况
4. 配置 `systick` 使用 `SystemCoreClock` 变量就好了，不需要不同型号都调不同的 `API` 获取时钟源
5. 把 `rt_hw_systick_init` 放到 `HAL_InitTick` 中，`HAL_Init` 和 `SystemClock_Config` 都会调用它，没必要外部调用了
6. `HAL_SYSTICK_Config` 中默认时钟源不分频，没必要 `HAL_SYSTICK_CLKSourceConfig(SYSTICK_CLKSOURCE_HCLK)`，还用宏限制型号
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
