### PR TITLE
Revert "[libc]&[dfs] remove unnecessary RT_USING_POSIX and RT_USING_DFS_DEVFS"

### DIFF
--- a/components/dfs/src/dfs.c
+++ b/components/dfs/src/dfs.c
@@ -18,7 +18,7 @@
 #include <lwp.h>
 #endif
 
-#if defined(RT_USING_DFS_DEVFS) && defined(RT_USING_LIBC)
+#if defined(RT_USING_DFS_DEVFS) && defined(RT_USING_POSIX)
 #include <libc.h>
 #endif
 
@@ -216,7 +216,7 @@ struct dfs_fd *fd_get(int fd)
     struct dfs_fd *d;
     struct dfs_fdtable *fdt;
 
-#if defined(RT_USING_DFS_DEVFS) && defined(RT_USING_LIBC)
+#if defined(RT_USING_DFS_DEVFS) && defined(RT_USING_POSIX)
     if ((0 <= fd) && (fd <= 2))
         fd = libc_stdio_get_console();
 #endif

--- a/components/libc/compilers/armlibc/libc.c
+++ b/components/libc/compilers/armlibc/libc.c
@@ -17,23 +17,23 @@
 
 int libc_system_init(void)
 {
-#ifdef RT_USING_DFS_DEVFS
+#if defined(RT_USING_DFS) & defined(RT_USING_DFS_DEVFS)
     rt_device_t dev_console;
 
     dev_console = rt_console_get_device();
     if (dev_console)
     {
-    #ifdef RT_USING_POSIX
+    #if defined(RT_USING_POSIX)
         libc_stdio_set_console(dev_console->parent.name, O_RDWR);
     #else
         libc_stdio_set_console(dev_console->parent.name, O_WRONLY);
-    #endif /* RT_USING_POSIX */
+    #endif
     }
-#endif /* RT_USING_DFS_DEVFS */
+#endif
 
-#if defined(RT_USING_PTHREADS) && !defined(RT_USING_COMPONENTS_INIT)
+#if defined RT_USING_PTHREADS && !defined RT_USING_COMPONENTS_INIT
     pthread_system_init();
-#endif /* defined(RT_USING_PTHREADS) && !defined(RT_USING_COMPONENTS_INIT) */
+#endif
 
     return 0;
 }

--- a/components/libc/compilers/armlibc/syscalls.c
+++ b/components/libc/compilers/armlibc/syscalls.c
@@ -187,14 +187,14 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
 {
 #ifdef RT_USING_DFS
     int size;
-#endif /* RT_USING_DFS */
+#endif
 
     if ((fh == STDOUT) || (fh == STDERR))
     {
 #if !defined(RT_USING_CONSOLE) || !defined(RT_USING_DEVICE)
         return 0;
 #else
-#ifdef RT_USING_DFS
+#ifdef RT_USING_POSIX
         if (libc_stdio_get_console() < 0)
         {
             LOG_W("Do not invoke standard input before initializing libc");
@@ -210,8 +210,8 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
         }
 
         return -1;
-#endif /* RT_USING_DFS */
-#endif /* !defined(RT_USING_CONSOLE) || !defined(RT_USING_DEVICE) */
+#endif
+#endif
     }
     else if (fh == STDIN)
     {
@@ -226,7 +226,7 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
         return len - size;
     else
         return -1;
-#endif /* RT_USING_DFS */
+#endif
 }
 
 /*

--- a/components/libc/compilers/dlib/libc.c
+++ b/components/libc/compilers/dlib/libc.c
@@ -17,23 +17,23 @@
 
 int libc_system_init(void)
 {
-#ifdef RT_USING_DFS_DEVFS
+#if defined(RT_USING_DFS) && defined(RT_USING_DFS_DEVFS)
     rt_device_t dev_console;
 
     dev_console = rt_console_get_device();
     if (dev_console)
     {
-    #ifdef RT_USING_POSIX
+    #if defined(RT_USING_POSIX)
         libc_stdio_set_console(dev_console->parent.name, O_RDWR);
     #else
         libc_stdio_set_console(dev_console->parent.name, O_WRONLY);
-    #endif /* RT_USING_POSIX */
+    #endif
     }
-#endif /* RT_USING_DFS_DEVFS */
+#endif
 
 #if defined (RT_USING_PTHREADS) && !defined (RT_USING_COMPONENTS_INIT)
     pthread_system_init();
-#endif /* defined (RT_USING_PTHREADS) && !defined (RT_USING_COMPONENTS_INIT) */
+#endif
 
     return 0;
 }

--- a/components/libc/compilers/dlib/syscall_write.c
+++ b/components/libc/compilers/dlib/syscall_write.c
@@ -25,7 +25,7 @@ size_t __write(int handle, const unsigned char *buf, size_t len)
 {
 #ifdef RT_USING_DFS
     int size;
-#endif /* RT_USING_DFS */
+#endif
 
     if ((handle == _LLIO_STDOUT) || (handle == _LLIO_STDERR))
     {
@@ -33,7 +33,7 @@ size_t __write(int handle, const unsigned char *buf, size_t len)
         return _LLIO_ERROR;
 #else
 
-#ifdef RT_USING_DFS
+#ifdef RT_USING_POSIX
         if (libc_stdio_get_console() < 0)
         {
             LOG_W("Do not invoke standard output before initializing libc");
@@ -50,8 +50,8 @@ size_t __write(int handle, const unsigned char *buf, size_t len)
         }
 
         return len;
-#endif /* RT_USING_DFS */
-#endif /* RT_USING_CONSOLE */
+#endif
+#endif
     }
     else if (handle == _LLIO_STDIN)
     {
@@ -63,6 +63,6 @@ size_t __write(int handle, const unsigned char *buf, size_t len)
 #else
     size = write(handle, buf, len);
     return size;
-#endif /* RT_USING_DFS */
+#endif
 }
 

--- a/components/libc/compilers/gcc/newlib/libc.c
+++ b/components/libc/compilers/gcc/newlib/libc.c
@@ -23,7 +23,7 @@ int _EXFUN(putenv,(char *__string));
 
 int libc_system_init(void)
 {
-#if defined(RT_USING_DFS_DEVFS) & defined(RT_USING_CONSOLE)
+#if defined(RT_USING_DFS) & defined(RT_USING_DFS_DEVFS) & defined(RT_USING_CONSOLE)
     rt_device_t dev_console;
 
     dev_console = rt_console_get_device();
@@ -39,11 +39,11 @@ int libc_system_init(void)
     /* set PATH and HOME */
     putenv("PATH=/bin");
     putenv("HOME=/home");
-#endif /* defined(RT_USING_DFS_DEVFS) & defined(RT_USING_CONSOLE) */
+#endif
 
-#if defined(RT_USING_PTHREADS) && !defined(RT_USING_COMPONENTS_INIT)
+#if defined RT_USING_PTHREADS && !defined RT_USING_COMPONENTS_INIT
     pthread_system_init();
-#endif /* defined(RT_USING_PTHREADS) && !defined(RT_USING_COMPONENTS_INIT) */
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Reverts RT-Thread/rt-thread#516
虽然符合本次版本的发布，但是容易给4.0.5发布埋坑，revert回去