### PR TITLE
[kernel] add return in rt_scheduler_do_irq_switch

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -627,6 +627,13 @@ void rt_scheduler_do_irq_switch(void *context)
 
                 rt_hw_context_switch_interrupt(context, (rt_ubase_t)&current_thread->sp,
                         (rt_ubase_t)&to_thread->sp, to_thread);
+
+                /*
+                 * If the content in the `context` interrupt context is not used directly in
+                 * `rt_hw_context_switch_interrupt`, then you need to return here and return
+                 * to the interrupt to restore the interrupt context.
+                 */
+                return;
             }
         }
     }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
提交原因：再做一个sparc架构移植时，发现中断上下文和线程切换上下文必须一致才能支持SMP。所以这个地方做了个改进，如果不一致也可以支持SMP。

解决问题：中断上下文和线程上下文必须一致才能支持SMP上下文切换的问题。

解决方案：在已有的“rt_hw_context_switch_interrupt”实现中，是不会返回的，而是直接从context这个变量保存的中断上下文中直接返回，就不需要往后走。但是，这是建立在中断上下文和线程切换上下文是一致的基础上的，如果不一致，那么这里将不能这么做。这个情况是在做一个SPARC架构移植时发现的，还有就是x86架构的实现也可能会是这样。中断上下文和线程切换上下文如果不一致时“rt_hw_context_switch_interrupt”就不能直接从context中返回，返回的时候返回到”rt_scheduler_do_irq_switch“函数中来，再返回到中断上下文中去。
这么处理的优点是：解决中断上下文和线程上下文不一致也可以进行切换的问题，可移植性增强。
缺点是：一定程度上改变了“rt_hw_context_switch_interrupt”的语义，不会从context中返回，而是返回到“rt_scheduler_do_irq_switch”中，不过原有实现可以不变。

测试：在一个sparc架构上进行了测试，能够行得通。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
