### PR TITLE
【更新】ipc init/create增加 flag 判断

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1350,7 +1350,7 @@ rt_event_t rt_event_create(const char *name, rt_uint8_t flag)
     RT_ASSERT((flag == RT_IPC_FLAG_FIFO) || (flag == RT_IPC_FLAG_PRIO));
 
     RT_DEBUG_NOT_IN_INTERRUPT;
-    
+
     /* allocate object */
     event = (rt_event_t)rt_object_allocate(RT_Object_Class_Event, name);
     if (event == RT_NULL)
@@ -2597,7 +2597,7 @@ rt_mq_t rt_mq_create(const char *name,
     RT_ASSERT((flag == RT_IPC_FLAG_FIFO) || (flag == RT_IPC_FLAG_PRIO));
 
     RT_DEBUG_NOT_IN_INTERRUPT;
-    
+
     /* allocate object */
     mq = (rt_mq_t)rt_object_allocate(RT_Object_Class_MessageQueue, name);
     if (mq == RT_NULL)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
问题：ipc中sem init或create时，输入错误的flag也能成功注册，但是使用时先release后take，sem可以正常运行。先以RT_WAITING_FOREVER take信号量后release会因为错误的flag导致take的线程不能从挂起状态中恢复。

解决办法：在 init或create中增加判断flag的RT_ASSERT
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
