### PR TITLE
[libc] 消除代码中将RT_LIBC_USING_FILEIO的预编译判断条件

### DIFF
--- a/components/libc/compilers/armlibc/syscalls.c
+++ b/components/libc/compilers/armlibc/syscalls.c
@@ -54,7 +54,7 @@ const char __stderr_name[] = "STDERR";
  */
 FILEHANDLE _sys_open(const char *name, int openmode)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     int fd;
     int mode = O_RDONLY;
 #endif
@@ -67,7 +67,7 @@ FILEHANDLE _sys_open(const char *name, int openmode)
     if (strcmp(name, __stderr_name) == 0)
         return (STDERR);
 
-#ifndef RT_LIBC_USING_FILEIO
+#ifndef RT_USING_POSIX
     return 0; /* error */
 #else
     /* Correct openmode from fopen to open */
@@ -101,19 +101,19 @@ FILEHANDLE _sys_open(const char *name, int openmode)
         return 0; /* error */
     else
         return fd;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 int _sys_close(FILEHANDLE fh)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     if (fh <= STDERR)
         return 0; /* error */
 
     return close(fh);
 #else
     return 0;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 /*
@@ -143,7 +143,7 @@ int _sys_close(FILEHANDLE fh)
  */
 int _sys_read(FILEHANDLE fh, unsigned char *buf, unsigned len, int mode)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     int size;
 
     if (fh == STDIN)
@@ -168,7 +168,7 @@ int _sys_read(FILEHANDLE fh, unsigned char *buf, unsigned len, int mode)
         return 0; /* error */
 #else
     return 0; /* error */
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 /*
@@ -178,13 +178,13 @@ int _sys_read(FILEHANDLE fh, unsigned char *buf, unsigned len, int mode)
  */
 int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     int size;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 
     if ((fh == STDOUT) || (fh == STDERR))
     {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
         if (libc_stdio_get_console() < 0)
         {
             LOG_W("Do not invoke standard input before initializing libc");
@@ -199,14 +199,14 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
         }
 
         return 0; /* error */
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
     }
     else if (fh == STDIN)
     {
         return 0; /* error */
     }
 
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     size = write(fh, buf, len);
     if (size >= 0)
         return len - size;
@@ -214,7 +214,7 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
         return 0; /* error */
 #else
     return 0;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 /*
@@ -223,7 +223,7 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
  */
 int _sys_seek(FILEHANDLE fh, long pos)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     if (fh < STDERR)
         return 0; /* error */
 
@@ -231,7 +231,7 @@ int _sys_seek(FILEHANDLE fh, long pos)
     return lseek(fh, pos, 0);
 #else
     return 0; /* error */
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 /**
@@ -276,7 +276,7 @@ RT_WEAK void _sys_exit(int return_code)
  */
 long _sys_flen(FILEHANDLE fh)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     struct stat stat;
 
     if (fh < STDERR)
@@ -286,7 +286,7 @@ long _sys_flen(FILEHANDLE fh)
     return stat.st_size;
 #else
     return 0;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 int _sys_istty(FILEHANDLE fh)
@@ -299,11 +299,11 @@ int _sys_istty(FILEHANDLE fh)
 
 int remove(const char *filename)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     return unlink(filename);
 #else
     return 0; /* error */
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 #ifdef __MICROLIB
@@ -324,7 +324,7 @@ int fputc(int c, FILE *f)
 
 int fgetc(FILE *f)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     char ch;
 
     if (libc_stdio_get_console() < 0)
@@ -335,7 +335,7 @@ int fgetc(FILE *f)
 
     if(read(STDIN_FILENO, &ch, 1) == 1)
         return ch;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
     return 0; /* error */
 }
 

--- a/components/libc/compilers/dlib/SConscript
+++ b/components/libc/compilers/dlib/SConscript
@@ -11,7 +11,7 @@ CPPDEFINES = ['RT_USING_DLIBC']
 
 if rtconfig.PLATFORM == 'iar':
 
-    if GetDepend('RT_LIBC_USING_FILEIO'):
+    if GetDepend('RT_USING_POSIX'):
         from distutils.version import LooseVersion
         from iar import IARVersion
 

--- a/components/libc/compilers/dlib/syscall_close.c
+++ b/components/libc/compilers/dlib/syscall_close.c
@@ -18,9 +18,9 @@ int __close(int handle)
         handle == _LLIO_STDERR ||
         handle == _LLIO_STDIN)
         return _LLIO_ERROR;
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     return close(handle);
 #else
     return _LLIO_ERROR;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }

--- a/components/libc/compilers/dlib/syscall_lseek.c
+++ b/components/libc/compilers/dlib/syscall_lseek.c
@@ -18,9 +18,9 @@ long __lseek(int handle, long offset, int whence)
         handle == _LLIO_STDERR ||
         handle == _LLIO_STDIN)
         return _LLIO_ERROR;
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     return lseek(handle, offset, whence);
 #else
     return _LLIO_ERROR;
-#endif
+#endif /* RT_USING_POSIX */
 }

--- a/components/libc/compilers/dlib/syscall_open.c
+++ b/components/libc/compilers/dlib/syscall_open.c
@@ -16,7 +16,7 @@
 
 int __open(const char *filename, int mode)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
   int handle;
   int open_mode = O_RDONLY;
 
@@ -68,5 +68,5 @@ int __open(const char *filename, int mode)
   return handle;
 #else
   return _LLIO_ERROR;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }

--- a/components/libc/compilers/dlib/syscall_read.c
+++ b/components/libc/compilers/dlib/syscall_read.c
@@ -20,7 +20,7 @@
 #pragma module_name = "?__read"
 size_t __read(int handle, unsigned char *buf, size_t len)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     int size;
 
     if (handle == _LLIO_STDIN)
@@ -41,5 +41,5 @@ size_t __read(int handle, unsigned char *buf, size_t len)
     return size;
 #else
     return _LLIO_ERROR;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }

--- a/components/libc/compilers/dlib/syscall_write.c
+++ b/components/libc/compilers/dlib/syscall_write.c
@@ -21,13 +21,13 @@
 
 size_t __write(int handle, const unsigned char *buf, size_t len)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     int size;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 
     if ((handle == _LLIO_STDOUT) || (handle == _LLIO_STDERR))
     {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
         if (libc_stdio_get_console() < 0)
         {
             LOG_W("Do not invoke standard output before initializing libc");
@@ -46,17 +46,17 @@ size_t __write(int handle, const unsigned char *buf, size_t len)
         return len;
 #else
         return _LLIO_ERROR;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
     }
     else if (handle == _LLIO_STDIN)
     {
         return _LLIO_ERROR;
     }
 
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     size = write(handle, buf, len);
     return size;
 #else
     return _LLIO_ERROR;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }

--- a/components/libc/compilers/gcc/newlib/libc.h
+++ b/components/libc/compilers/gcc/newlib/libc.h
@@ -15,10 +15,12 @@ extern "C" {
 #endif
 
 int libc_system_init(void);
+
 #ifdef RT_USING_POSIX
 int libc_stdio_get_console(void);
 int libc_stdio_set_console(const char* device_name, int mode);
 #endif /* RT_USING_POSIX */
+
 
 #ifdef __cplusplus
 }

--- a/components/libc/compilers/gcc/newlib/stdio.c
+++ b/components/libc/compilers/gcc/newlib/stdio.c
@@ -7,16 +7,14 @@
  * Date           Author       Notes
  * 2017/10/15     bernard      the first version
  */
-#include <rtthread.h>
+#include <rtconfig.h>
+#ifdef RT_USING_POSIX
 #include <stdio.h>
+#include <stdlib.h>
 #include <fcntl.h>
 #include "libc.h"
 
 #define STDIO_DEVICE_NAME_MAX   32
-
-#ifdef RT_LIBC_USING_FILEIO
-#include <stdlib.h>
-
 static FILE* std_console = NULL;
 
 int libc_stdio_set_console(const char* device_name, int mode)
@@ -76,7 +74,8 @@ int libc_stdio_set_console(const char* device_name, int mode)
         _GLOBAL_REENT->__sdidinit = 1;
     }
 
-    if (std_console) return fileno(std_console);
+    if (std_console)
+        return fileno(std_console);
 
     return -1;
 }
@@ -89,34 +88,4 @@ int libc_stdio_get_console(void)
         return -1;
 }
 
-#elif defined(RT_USING_POSIX)
-#include <unistd.h>
-static int std_fd = -1;
-
-int libc_stdio_set_console(const char* device_name, int mode)
-{
-    int fd;
-    char name[STDIO_DEVICE_NAME_MAX];
-
-    snprintf(name, sizeof(name) - 1, "/dev/%s", device_name);
-    name[STDIO_DEVICE_NAME_MAX - 1] = '\0';
-
-    fd = open(name, mode, 0);
-    if (fd >= 0)
-    {
-        if (std_fd >= 0)
-        {
-            close(std_fd);
-        }
-        std_fd = fd;
-    }
-
-    return std_fd;
-}
-
-int libc_stdio_get_console(void)
-{
-    return std_fd;
-}
-
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */

--- a/components/libc/compilers/gcc/newlib/syscalls.c
+++ b/components/libc/compilers/gcc/newlib/syscalls.c
@@ -14,6 +14,7 @@
 #include <reent.h>
 #include <rtthread.h>
 #include <stdio.h>
+#include <string.h>
 #include <stddef.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -175,7 +176,7 @@ int flock(int fd, int operation)
 
 _off_t _lseek_r(struct _reent *ptr, int fd, _off_t pos, int whence)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     _off_t rc;
 
     rc = lseek(fd, pos, whence);
@@ -183,12 +184,12 @@ _off_t _lseek_r(struct _reent *ptr, int fd, _off_t pos, int whence)
 #else
     ptr->_errno = ENOTSUP;
     return -1;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 int _mkdir_r(struct _reent *ptr, const char *name, int mode)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     int rc;
 
     rc = mkdir(name, mode);
@@ -196,25 +197,24 @@ int _mkdir_r(struct _reent *ptr, const char *name, int mode)
 #else
     ptr->_errno = ENOTSUP;
     return -1;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 int _open_r(struct _reent *ptr, const char *file, int flags, int mode)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     int rc;
-
     rc = open(file, flags, mode);
     return rc;
 #else
     ptr->_errno = ENOTSUP;
     return -1;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 _ssize_t _read_r(struct _reent *ptr, int fd, void *buf, size_t nbytes)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     _ssize_t rc;
     if (libc_stdio_get_console() < 0 && fd == STDIN_FILENO)
     {
@@ -226,12 +226,12 @@ _ssize_t _read_r(struct _reent *ptr, int fd, void *buf, size_t nbytes)
 #else
     ptr->_errno = ENOTSUP;
     return -1;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 int _rename_r(struct _reent *ptr, const char *old, const char *new)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     int rc;
 
     rc = rename(old, new);
@@ -239,12 +239,12 @@ int _rename_r(struct _reent *ptr, const char *old, const char *new)
 #else
     ptr->_errno = ENOTSUP;
     return -1;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 int _stat_r(struct _reent *ptr, const char *file, struct stat *pstat)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     int rc;
 
     rc = stat(file, pstat);
@@ -252,22 +252,22 @@ int _stat_r(struct _reent *ptr, const char *file, struct stat *pstat)
 #else
     ptr->_errno = ENOTSUP;
     return -1;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 int _unlink_r(struct _reent *ptr, const char *file)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     return unlink(file);
 #else
     ptr->_errno = ENOTSUP;
     return -1;
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
 }
 
 _ssize_t _write_r(struct _reent *ptr, int fd, const void *buf, size_t nbytes)
 {
-#ifdef RT_LIBC_USING_FILEIO
+#ifdef RT_USING_POSIX
     _ssize_t rc;
     if (libc_stdio_get_console() < 0 && fd == STDOUT_FILENO)
     {
@@ -285,7 +285,7 @@ _ssize_t _write_r(struct _reent *ptr, int fd, const void *buf, size_t nbytes)
         if (console)
             return rt_device_write(console, -1, buf, nbytes);
     }
-#endif /* RT_LIBC_USING_FILEIO */
+#endif /* RT_USING_POSIX */
     ptr->_errno = ENOTSUP;
     return -1;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
RT_LIBC_USING_FILEIO实际是一种方便用户一键配置的选项，其实际选项依然是RT_USING_POSIX和RT_USING_LIBC
因此在代码中应该使用RT_USING_POSIX或者RT_USING_LIBC来进行预编译判断
禁止在代码中使用RT_LIBC_USING_FILEIO来进行预编译判断

总之，用户通过开启RT_USING_LIBC以及RT_USING_POSIX(依赖RT_USING_DFS)就可以开启libc的所有功能了，如果用户嫌麻烦可以直接通过RT_LIBC_USING_FILENO这个Kconfig选项一键勾选上述三个宏定义，RT_LIBC_USING_FILEIO宏是方便用户在Kconfig中一键化配置使用。

这样代码就更合理了，代码中也不会引入新的RT_LIBC_USING_FILEIO宏了

至此，libc和posix的层次关系是彻底都捋清了。剩下的就是一些测试了还有细节上可能存在的小问题了。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
