### PR TITLE
[fix][libcpu][riscv][t-head] fix rt_hw_interrupt_disable/rt_hw_interupt_enable bug

### DIFF
--- a/libcpu/risc-v/t-head/e9xx/context_gcc.S
+++ b/libcpu/risc-v/t-head/e9xx/context_gcc.S
@@ -45,12 +45,12 @@ rt_hw_context_switch_to:
     /* save a0 to to_thread */
     la      t0, rt_interrupt_to_thread
     STORE   a0, (t0)
-    
+
     /* save 0 to from_thread */
     la      t0, rt_interrupt_from_thread
     li      t1, 0
     STORE   t1, (t0)
-    
+
     /* set rt_thread_switch_interrupt_flag=1 */
     la      t0, rt_thread_switch_interrupt_flag
     li      t1, 1
@@ -97,7 +97,7 @@ rt_hw_context_switch_interrupt:
     beq     t1, t2, .reswitch
     /*  set rt_thread_switch_interrupt_flag=1 */
     STORE   t2, (t0)
-  
+
     /* update from_thread */
     la      t0, rt_interrupt_from_thread
     STORE   a0, (t0)
@@ -137,7 +137,7 @@ PendSV_Handler:
     la      t0, rt_interrupt_from_thread
     lw      t1, (t0)
     beqz    t1, .switch_to_thead
-    
+
     /* restore from thread context t0,t1 */
     lw      t0, (-4)(sp)
     lw      t1, (-8)(sp)
@@ -328,6 +328,23 @@ PendSV_Handler:
 
 .pendsv_exit:
     mret
- 
 
+/*
+ * rt_base_t rt_hw_interrupt_disable(void);
+ */
+    .globl rt_hw_interrupt_disable
+    .type   rt_hw_interrupt_disable, %function
+rt_hw_interrupt_disable:
+    csrrci a0, mstatus, 8
+    ret
+
+
+/*
+ * void rt_hw_interrupt_enable(rt_base_t level);
+ */
+    .globl rt_hw_interrupt_enable
+    .type   rt_hw_interrupt_enable, %function
+rt_hw_interrupt_enable:
+    csrw mstatus, a0
+    ret
 

--- a/libcpu/risc-v/t-head/e9xx/cpuport.c
+++ b/libcpu/risc-v/t-head/e9xx/cpuport.c
@@ -134,34 +134,6 @@ rt_uint8_t *rt_hw_stack_init(void       *tentry,
     return stk;
 }
 
-
-/**
- * This function will disable global interrupt
- *
- * @param none
- *
- * @return zero
- */
-
-rt_base_t rt_hw_interrupt_disable(void)
-{
-    __asm volatile("csrrci a0, mstatus, 8");
-    return;
-}
-
-/**
- * This function will ennable global interrupt
- *
- * @param level not used
- *
- * @return none
- */
-/* XXX:rename rt_hw_interrupt_restore? */
-void rt_hw_interrupt_enable(rt_base_t level)
-{
-    __asm volatile("csrw mstatus, a0");
-}
-
 /** shutdown CPU */
 RT_WEAK void rt_hw_cpu_shutdown()
 {


### PR DESCRIPTION
[fix][libcpu][riscv][t-head] fix rt_hw_interrupt_disable/rt_hw_interupt_enable bug

使用不同的优化等级会出现不同的效果
当使用-O0 等级时，无法正确得到关闭中断之前的状态

Using different optimization levels will have different effects
When the - o0 level is used, the state before the shutdown interrupt cannot be obtained correctly

## 拉取/合并请求描述：(PR description)

[
> 原始代码

```c
rt_base_t rt_hw_interrupt_disable(void)
{
	__asm volatile("csrrci a0, mstatus, 8");
    return;
}
```



> 使用 -O2 优化等级编译结果

```assembly
rt_base_t rt_hw_interrupt_disable(void)
{
    __asm volatile("csrrci a0, mstatus, 8");
   11fbe:	30047573          	csrrci	a0,mstatus,8
    return;
}
   11fc2:	8082                	ret
```

> 使用 -O0 优化等级编译结果

```assembly
rt_base_t rt_hw_interrupt_disable(void)
{
   1494a:	1141                	addi	sp,sp,-16
   1494c:	c622                	sw	s0,12(sp)
   1494e:	0800                	addi	s0,sp,16
    __asm volatile("csrrci a0, mstatus, 8");
   14950:	30047573          	csrrci	a0,mstatus,8
    return;
   14954:	0001                	nop
   14956:	0001                	nop
}
   14958:	853e                	mv	a0,a5
   1495a:	4432                	lw	s0,12(sp)
   1495c:	0141                	addi	sp,sp,16
   1495e:	8082                	ret
```



由于写法不规范，导致在不同编译器优化等级出现不同的结果。

当优化等级为-O0时，无法正确把mstatus的值作为返回值返回，导致可能会错误的打开中断

现在使用汇编实现，避免编译器优化产生的异常



在 E907 FPGA 评估板卡做过测试和验证
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
