### PR TITLE
fix systick init

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_common.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_common.c
@@ -177,6 +177,8 @@ RT_WEAK void rt_hw_board_init()
     /* System clock initialization */
     SystemClock_Config();
 
+    rt_hw_systick_init();
+
     /* Heap initialization */
 #if defined(RT_USING_HEAP)
     rt_system_heap_init((void *)HEAP_BEGIN, (void *)HEAP_END);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
前不久有个 pr https://github.com/RT-Thread/rt-thread/commit/88133da8e529ccde484666208af0836a9b05fd02
这里把 `rt_hw_systick_init();` 的调用从 `rt_hw_board_init` 挪到了 `HAL_InitTick` 。在 `HAL_InitTick` 函数里添加 `rt_hw_systick_init` 调用的做法在这里不评断了，但是把  `rt_hw_board_init` 中调用的 `rt_hw_systick_init` 删掉这就影响到内核的 systick 中断时间间隔不是根据最新倍频之后的系统时钟计算得来的，而是倍频之前默认的内部时钟计算得来的。这是错误的。
这次修改没有改动 `HAL_InitTick` 函数，仅仅把 `rt_hw_board_init` 恢复。 `HAL_InitTick` 中的操作留作大家去讨论。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
