### PR TITLE
Bug fix: an interrupt may return to the end of function "rt_hw_context_switch_to"

### DIFF
--- a/libcpu/arm/cortex-m3/context_rvds.S
+++ b/libcpu/arm/cortex-m3/context_rvds.S
@@ -168,6 +168,30 @@ rt_hw_context_switch_to    PROC
     CPSIE   I
 
     ; never reach here!
+
+; In cortex-M uC, there is a tail-chain mechanism to fasen interrupt/exception response,
+; from simulation that it shows a mismatch of stack restore occours if:
+; an interrupt/exception happens at the moment that returning from previous interrupt
+; loop below process in case of return from MSP
+_tailchain_loop
+    ; Set pendSV bit in ICSR register / no side-effect of writting 0s
+    CPSID   I
+    MOV     r0, #0x10000000
+    LDR     r1, =0xe000ed04
+    STR     r0, [r1]
+
+    ; Current fix is to ensure no crash of stack
+    ; TODO...
+    ; 1> MSP is using now, thread's context is still kept in PSP
+    ; 2> Use a global variable & later check in pendSV handler for further process
+    ; 3> Re-schedule of task need to take care in pendSV handler,
+    ;    to rescan task list for higher priority task
+    CPSIE   I
+    NOP
+    B       _tailchain_loop
+
+    ; Never return
+    ALIGN   4
     ENDP
 
 ; compatible with old version

--- a/libcpu/arm/cortex-m3/context_rvds.S
+++ b/libcpu/arm/cortex-m3/context_rvds.S
@@ -174,20 +174,17 @@ rt_hw_context_switch_to    PROC
 ; an interrupt/exception happens at the moment that returning from previous interrupt
 ; loop below process in case of return from MSP
 _tailchain_loop
-    ; Set pendSV bit in ICSR register / no side-effect of writting 0s
-    CPSID   I
-    MOV     r0, #0x10000000
-    LDR     r1, =0xe000ed04
-    STR     r0, [r1]
-
-    ; Current fix is to ensure no crash of stack
-    ; TODO...
-    ; 1> MSP is using now, thread's context is still kept in PSP
-    ; 2> Use a global variable & later check in pendSV handler for further process
-    ; 3> Re-schedule of task need to take care in pendSV handler,
-    ;    to rescan task list for higher priority task
-    CPSIE   I
     NOP
+
+    ; trigger the PendSV exception (causes context switch)
+    CPSID   I
+    LDR     r0, =NVIC_INT_CTRL
+    LDR     r1, =NVIC_PENDSVSET
+    STR     r1, [r0]
+    CPSIE   I
+    
+    ; MSP is using now, thread's context is still kept in PSP,
+    ; Re-schedule of task need to take care in pendSV handler in this case
     B       _tailchain_loop
 
     ; Never return


### PR DESCRIPTION
[
Description:
In cortex-M uC, there is a tail-chain mechanism to fasen interrupt/exception response,
from simulation tool: KEIL V4, it shows that a mismatch of stack restore occours if: an interrupt/exception happens at the moment that returning from previous interrupt, and MSP will be restored instead of task's PSP, and it'll cause a return to the end of function: rt_hw_context_switch_to, causes a hard fault in the end.

Purpose:
To solve the issue in case an interrupt service is tail-chained by another interrupt, and return back to function rt_hw_context_switch_to

Tested Enviroment:
KEIL V4.03 with similator / STM32F103RC, with project "rt-thread-v4.0.2\rt-thread\bsp\stm32\stm32f103-yf-ufun\project.uvproj"
1> debug(simulator) => run => set breakpoint at end of function "void SysTick_Handler(void)"
2> peripherals => core peripherals => NVIC (nested vectored...) =>index 53 USART1 (Set pending bit manually)
3> run & check...
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
