### PR TITLE
remove duplicate work between idle and thread_exit

### DIFF
--- a/src/idle.c
+++ b/src/idle.c
@@ -15,6 +15,7 @@
  * 2018-07-14     armink       add idle hook list
  * 2018-11-22     Jesven       add per cpu idle task
  *                             combine the code of primary and secondary cpu
+ * 2021-11-15     THEWON       Remove duplicate work between idle and _thread_exit
  */
 
 #include <rthw.h>
@@ -136,22 +137,6 @@ rt_err_t rt_thread_idle_delhook(void (*hook)(void))
 
 #endif /* RT_USING_IDLE_HOOK */
 
-#ifdef RT_USING_MODULE
-/* Return whether there is defunctional thread to be deleted. */
-rt_inline int _idle_has_defunct_thread(void)
-{
-    /* The rt_list_isempty has prototype of "int rt_list_isempty(const rt_list_t *l)".
-     * So the compiler has a good reason that the _rt_thread_defunct list does
-     * not change within rt_thread_defunct_exceute thus optimize the "while" loop
-     * into a "if".
-     *
-     * So add the volatile qualifier here. */
-    const volatile rt_list_t *l = (const volatile rt_list_t *)&_rt_thread_defunct;
-
-    return l->next != l;
-}
-#endif /* RT_USING_MODULE */
-
 /**
  * @brief Enqueue a thread to defunct queue.
  *
@@ -167,14 +152,16 @@ void rt_thread_defunct_enqueue(rt_thread_t thread)
 
 /**
  * @brief Dequeue a thread from defunct queue.
- *
- * @note It must be called between rt_hw_interrupt_disable and rt_hw_interrupt_enable.
  */
 rt_thread_t rt_thread_defunct_dequeue(void)
 {
+    register rt_base_t lock;
     rt_thread_t thread = RT_NULL;
     rt_list_t *l = &_rt_thread_defunct;
 
+#ifdef RT_USING_SMP
+    /* disable interrupt */
+    lock = rt_hw_interrupt_disable();
     if (l->next != l)
     {
         thread = rt_list_entry(l->next,
@@ -182,6 +169,18 @@ rt_thread_t rt_thread_defunct_dequeue(void)
                 tlist);
         rt_list_remove(&(thread->tlist));
     }
+    rt_hw_interrupt_enable(lock);
+#else
+    if (l->next != l)
+    {
+        thread = rt_list_entry(l->next,
+                struct rt_thread,
+                tlist);
+        lock = rt_hw_interrupt_disable();
+        rt_list_remove(&(thread->tlist));
+        rt_hw_interrupt_enable(lock);
+    }
+#endif
     return thread;
 }
 
@@ -194,51 +193,30 @@ static void rt_defunct_execute(void)
      * will do all the cleanups. */
     while (1)
     {
-        rt_base_t lock;
         rt_thread_t thread;
         void (*cleanup)(struct rt_thread *tid);
 
 #ifdef RT_USING_MODULE
         struct rt_dlmodule *module = RT_NULL;
 #endif
-        RT_DEBUG_NOT_IN_INTERRUPT;
-
-        /* disable interrupt */
-        lock = rt_hw_interrupt_disable();
-
-#ifdef RT_USING_MODULE
-        /* check whether list is empty */
-        if (!_idle_has_defunct_thread())
+        /* get defunct thread */
+        thread = rt_thread_defunct_dequeue();
+        if (thread == RT_NULL)
         {
-            rt_hw_interrupt_enable(lock);
             break;
         }
-        /* get defunct thread */
-        thread = rt_list_entry(_rt_thread_defunct.next,
-                struct rt_thread,
-                tlist);
+#ifdef RT_USING_MODULE
         module = (struct rt_dlmodule*)thread->module_id;
         if (module)
         {
             dlmodule_destroy(module);
-        }
-        /* remove defunct thread */
-        rt_list_remove(&(thread->tlist));
-#else
-        thread = rt_thread_defunct_dequeue();
-        if (!thread)
-        {
-            rt_hw_interrupt_enable(lock);
-            break;
         }
 #endif
         /* invoke thread cleanup */
         cleanup = thread->cleanup;
         if (cleanup != RT_NULL)
         {
-            rt_hw_interrupt_enable(lock);
             cleanup(thread);
-            lock = rt_hw_interrupt_disable();
         }
 
 #ifdef RT_USING_SIGNALS
@@ -250,12 +228,9 @@ static void rt_defunct_execute(void)
         {
             /* detach this object */
             rt_object_detach((rt_object_t)thread);
-            /* enable interrupt */
-            rt_hw_interrupt_enable(lock);
         }
         else
         {
-            rt_hw_interrupt_enable(lock);
 #ifdef RT_USING_HEAP
             /* release thread's stack */
             RT_KERNEL_FREE(thread->stack_addr);

--- a/src/thread.c
+++ b/src/thread.c
@@ -27,6 +27,7 @@
  * 2018-11-22     Jesven       yield is same to rt_schedule
  *                             add support for tasks bound to cpu
  * 2021-02-24     Meco Man     rearrange rt_thread_control() - schedule the thread when close it
+ * 2021-11-15     THEWON       Remove duplicate work between idle and _thread_exit
  */
 
 #include <rthw.h>
@@ -73,30 +74,6 @@ void rt_thread_inited_sethook(void (*hook)(rt_thread_t thread))
 
 #endif /* RT_USING_HOOK */
 
-static void _thread_cleanup_execute(rt_thread_t thread)
-{
-    register rt_base_t level;
-#ifdef RT_USING_MODULE
-    struct rt_dlmodule *module = RT_NULL;
-#endif /* RT_USING_MODULE */
-    level = rt_hw_interrupt_disable();
-#ifdef RT_USING_MODULE
-    module = (struct rt_dlmodule*)thread->module_id;
-    if (module)
-    {
-        dlmodule_destroy(module);
-    }
-#endif /* RT_USING_MODULE */
-    /* invoke thread cleanup */
-    if (thread->cleanup != RT_NULL)
-        thread->cleanup(thread);
-
-#ifdef RT_USING_SIGNALS
-    rt_thread_free_sig(thread);
-#endif /* RT_USING_SIGNALS */
-    rt_hw_interrupt_enable(level);
-}
-
 static void _thread_exit(void)
 {
     struct rt_thread *thread;
@@ -108,31 +85,23 @@ static void _thread_exit(void)
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
 
-    _thread_cleanup_execute(thread);
-
     /* remove from schedule */
     rt_schedule_remove_thread(thread);
-    /* change stat */
-    thread->stat = RT_THREAD_CLOSE;
 
     /* remove it from timer list */
     rt_timer_detach(&thread->thread_timer);
 
-    if (rt_object_is_systemobject((rt_object_t)thread) == RT_TRUE)
-    {
-        rt_object_detach((rt_object_t)thread);
-    }
-    else
-    {
-        /* insert to defunct thread list */
-        rt_thread_defunct_enqueue(thread);
-    }
+    /* change stat */
+    thread->stat = RT_THREAD_CLOSE;
 
-    /* switch to next task */
-    rt_schedule();
+    /* insert to defunct thread list */
+    rt_thread_defunct_enqueue(thread);
 
     /* enable interrupt */
     rt_hw_interrupt_enable(level);
+
+    /* switch to next task */
+    rt_schedule();
 }
 
 static rt_err_t _thread_init(struct rt_thread *thread,
@@ -382,7 +351,8 @@ rt_err_t rt_thread_detach(rt_thread_t thread)
         rt_schedule_remove_thread(thread);
     }
 
-    _thread_cleanup_execute(thread);
+    /* disable interrupt */
+    lock = rt_hw_interrupt_disable();
 
     /* release thread timer */
     rt_timer_detach(&(thread->thread_timer));
@@ -390,19 +360,11 @@ rt_err_t rt_thread_detach(rt_thread_t thread)
     /* change stat */
     thread->stat = RT_THREAD_CLOSE;
 
-    if (rt_object_is_systemobject((rt_object_t)thread) == RT_TRUE)
-    {
-        rt_object_detach((rt_object_t)thread);
-    }
-    else
-    {
-        /* disable interrupt */
-        lock = rt_hw_interrupt_disable();
-        /* insert to defunct thread list */
-        rt_thread_defunct_enqueue(thread);
-        /* enable interrupt */
-        rt_hw_interrupt_enable(lock);
-    }
+    /* insert to defunct thread list */
+    rt_thread_defunct_enqueue(thread);
+
+    /* enable interrupt */
+    rt_hw_interrupt_enable(lock);
 
     return RT_EOK;
 }
@@ -492,13 +454,11 @@ rt_err_t rt_thread_delete(rt_thread_t thread)
         rt_schedule_remove_thread(thread);
     }
 
-    _thread_cleanup_execute(thread);
+    /* disable interrupt */
+    lock = rt_hw_interrupt_disable();
 
     /* release thread timer */
     rt_timer_detach(&(thread->thread_timer));
-
-    /* disable interrupt */
-    lock = rt_hw_interrupt_disable();
 
     /* change stat */
     thread->stat = RT_THREAD_CLOSE;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
本次提交基于[上次的修改 #4843](https://github.com/RT-Thread/rt-thread/pull/4843)思维逻辑，并没考虑上次提交所做改动的合理性，

本次修改的相关讨论文章[rt-thread 系统优化系列（五） 之 线程销毁谜题](https://club.rt-thread.org/ask/article/3138.html) [rt-thread 系统优化系列（六） 之 让 idle 线程闲下来](https://club.rt-thread.org/ask/article/3141.html) [rt-thread 僵尸线程销毁流程优化分析篇](https://club.rt-thread.org/ask/article/3144.html)
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
