### PR TITLE
[mutex] use RT_IPC_FLAG_PRIO to replace RT_IPC_FLAG_FIFO

### DIFF
--- a/bsp/at32/Libraries/rt_drivers/drv_sdio.c
+++ b/bsp/at32/Libraries/rt_drivers/drv_sdio.c
@@ -648,7 +648,7 @@ struct rt_mmcsd_host *sdio_host_create(struct at32_sdio_des *sdio_des)
     sdio->sdio_des.clk_get = (sdio_des->clk_get == RT_NULL ? at32_sdio_clk_get : sdio_des->clk_get);
 
     rt_event_init(&sdio->event, "sdio", RT_IPC_FLAG_FIFO);
-    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_PRIO);
 
     /* set host defautl attributes */
     host->ops = &ops;

--- a/bsp/bluetrum/ab32vg1-ab-prougen/board/board.c
+++ b/bsp/bluetrum/ab32vg1-ab-prougen/board/board.c
@@ -149,8 +149,8 @@ RT_SECTION(".irq.cache")
 void cache_init(void)
 {
     os_cache_init();
-    rt_mutex_init(&mutex_spiflash, "flash_mutex", RT_IPC_FLAG_FIFO);
-    rt_mutex_init(&mutex_cache, "cache_mutex", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&mutex_spiflash, "flash_mutex", RT_IPC_FLAG_PRIO);
+    rt_mutex_init(&mutex_cache, "cache_mutex", RT_IPC_FLAG_PRIO);
 }
 
 RT_SECTION(".irq.cache")

--- a/bsp/bluetrum/libraries/hal_drivers/drv_sdio.c
+++ b/bsp/bluetrum/libraries/hal_drivers/drv_sdio.c
@@ -570,7 +570,7 @@ struct rt_mmcsd_host *sdio_host_create(struct ab32_sdio_des *sdio_des)
     sdio->sdio_des.clk_get = (sdio_des->clk_get == RT_NULL ? ab32_sdio_clk_get : sdio_des->clk_get);
 
     rt_event_init(&sdio->event, "sdio", RT_IPC_FLAG_FIFO);
-    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_PRIO);
 
     /* set host defautl attributes */
     host->ops = &ab32_sdio_ops;

--- a/bsp/ft2004/drivers/drv_sdctrl.c
+++ b/bsp/ft2004/drivers/drv_sdctrl.c
@@ -560,7 +560,7 @@ static rt_err_t rthw_sdctrl_create(ft_sdctrl_class_t *class_p)
 
     class_p->ft_sdctrl.config = *(FSdCtrl_Config_t *)FSdCtrl_LookupConfig(0);
     rt_event_init(&class_p->event, "sdctrl", RT_IPC_FLAG_FIFO);
-    rt_mutex_init(&class_p->mutex, "sdctrl", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&class_p->mutex, "sdctrl", RT_IPC_FLAG_PRIO);
 
     class_p->host = host;
     host->ops = &ops;

--- a/bsp/k210/driver/dmalock.c
+++ b/bsp/k210/driver/dmalock.c
@@ -30,7 +30,7 @@ static struct dmac_host _dmac_host;
 void dmalock_init(void)
 {
     rt_sem_init(&_dmac_host.sem, "dma_sem", DMAC_CHANNEL_COUNT, RT_IPC_FLAG_FIFO);
-    rt_mutex_init(&_dmac_host.mutex, "dma_mutex", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&_dmac_host.mutex, "dma_mutex", RT_IPC_FLAG_PRIO);
     for (int i = 0; i < DMAC_CHANNEL_COUNT; i++)
     {
         _dmac_host.channel_used[i] = 0;

--- a/bsp/lpc54608-LPCXpresso/drivers/drv_sd.c
+++ b/bsp/lpc54608-LPCXpresso/drivers/drv_sd.c
@@ -412,7 +412,7 @@ rt_err_t mci_hw_init(const char *device_name)
     }
 
     /* initialize mutex lock */
-    rt_mutex_init(&_mci_device->lock, device_name, RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&_mci_device->lock, device_name, RT_IPC_FLAG_PRIO);
     /* create finish event */
     _mci_device->finish_event = rt_event_create(device_name, RT_IPC_FLAG_FIFO);
 

--- a/bsp/lpc55sxx/Libraries/drivers/drv_sd.c
+++ b/bsp/lpc55sxx/Libraries/drivers/drv_sd.c
@@ -232,7 +232,7 @@ int rt_hw_mci_init(void)
     }
 
     /* initialize mutex lock */
-    rt_mutex_init(&_mci_device->lock, "sdcard0", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&_mci_device->lock, "sdcard0", RT_IPC_FLAG_PRIO);
     /* create finish event */
     _mci_device->finish_event = rt_event_create("sdcard0", RT_IPC_FLAG_FIFO);
 

--- a/bsp/simulator/drivers/sd_sim.c
+++ b/bsp/simulator/drivers/sd_sim.c
@@ -140,7 +140,7 @@ rt_err_t rt_hw_sdcard_init(const char *spi_device_name)
     sd = &_sdcard;
     device = &(sd->parent);
 
-    lock = rt_mutex_create("lock", RT_IPC_FLAG_FIFO);
+    lock = rt_mutex_create("lock", RT_IPC_FLAG_PRIO);
     if (lock == RT_NULL)
     {
         LOG_E("Create mutex in rt_hw_sdcard_init failed!");

--- a/bsp/simulator/drivers/sdl_fb.c
+++ b/bsp/simulator/drivers/sdl_fb.c
@@ -220,7 +220,7 @@ static void sdlfb_hw_init(void)
 
     rt_device_register(RT_DEVICE(&_device), "sdl", RT_DEVICE_FLAG_RDWR);
 
-    sdllock = rt_mutex_create("fb", RT_IPC_FLAG_FIFO);
+    sdllock = rt_mutex_create("fb", RT_IPC_FLAG_PRIO);
     if (sdllock == RT_NULL)
     {
         LOG_E("Create mutex for sdlfb failed!");

--- a/bsp/simulator/drivers/sst25vfxx_mtd_sim.c
+++ b/bsp/simulator/drivers/sst25vfxx_mtd_sim.c
@@ -171,7 +171,7 @@ rt_err_t sst25vfxx_mtd_init(const char *nor_name,
     mtd->ops = &sst25vfxx_mtd_ops;
 
     /* initialize mutex */
-    if (rt_mutex_init(&flash_lock, nor_name, RT_IPC_FLAG_FIFO) != RT_EOK)
+    if (rt_mutex_init(&flash_lock, nor_name, RT_IPC_FLAG_PRIO) != RT_EOK)
     {
         rt_kprintf("init sd lock mutex failed\n");
     }

--- a/bsp/stm32/libraries/HAL_Drivers/drv_crypto.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_crypto.c
@@ -709,7 +709,7 @@ int stm32_hw_crypto_device_init(void)
     {
         return -1;
     }
-    rt_mutex_init(&_crypto_dev.mutex, RT_HWCRYPTO_DEFAULT_NAME, RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&_crypto_dev.mutex, RT_HWCRYPTO_DEFAULT_NAME, RT_IPC_FLAG_PRIO);
     return 0;
 }
 INIT_DEVICE_EXPORT(stm32_hw_crypto_device_init);

--- a/bsp/stm32/libraries/HAL_Drivers/drv_sdio.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_sdio.c
@@ -650,7 +650,7 @@ struct rt_mmcsd_host *sdio_host_create(struct stm32_sdio_des *sdio_des)
     sdio->sdio_des.clk_get = (sdio_des->clk_get == RT_NULL ? stm32_sdio_clk_get : sdio_des->clk_get);
 
     rt_event_init(&sdio->event, "sdio", RT_IPC_FLAG_FIFO);
-    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_PRIO);
 
     /* set host defautl attributes */
     host->ops = &ops;

--- a/bsp/stm32/stm32h750-artpi-h750/board/port/drv_sdio.c
+++ b/bsp/stm32/stm32h750-artpi-h750/board/port/drv_sdio.c
@@ -517,7 +517,7 @@ int rt_hw_sdio_init(void)
     /* wifi auto change */
     mmcsd_change(host2);
     #endif
-    mmcsd_mutex = rt_mutex_create("mmutex", RT_IPC_FLAG_FIFO);
+    mmcsd_mutex = rt_mutex_create("mmutex", RT_IPC_FLAG_PRIO);
 
     if (mmcsd_mutex == RT_NULL)
     {

--- a/bsp/stm32/stm32mp157a-st-discovery/board/ports/drv_sdio.c
+++ b/bsp/stm32/stm32mp157a-st-discovery/board/ports/drv_sdio.c
@@ -473,14 +473,14 @@ struct rt_mmcsd_host *sdio_host_create(struct stm32_sdio_des *sdio_des)
     {
         sdio->sdio_des.hw_sdio = (struct stm32_sdio *)SDIO1_BASE_ADDRESS;
         rt_event_init(&sdio->event, "sdio1", RT_IPC_FLAG_FIFO);
-        rt_mutex_init(&sdio->mutex, "sdio1", RT_IPC_FLAG_FIFO);
+        rt_mutex_init(&sdio->mutex, "sdio1", RT_IPC_FLAG_PRIO);
     }
 
     if(sdio_des->hsd.Instance == SDMMC2)
     {
         sdio->sdio_des.hw_sdio = (struct stm32_sdio *)SDIO2_BASE_ADDRESS;
         rt_event_init(&sdio->event, "sdio2", RT_IPC_FLAG_FIFO);
-        rt_mutex_init(&sdio->mutex, "sdio2", RT_IPC_FLAG_FIFO);
+        rt_mutex_init(&sdio->mutex, "sdio2", RT_IPC_FLAG_PRIO);
     }
 
     /* set host default attributes */

--- a/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_emmc.c
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_emmc.c
@@ -503,7 +503,7 @@ struct rt_mmcsd_host *sdio_host_create(struct stm32_sdio_des *sdio_des)
     sdio->sdio_des.hw_sdio = (struct stm32_sdio *)EMMC_BASE_ADDRESS;
 
     rt_event_init(&sdio->event, "sdio", RT_IPC_FLAG_FIFO);
-    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_PRIO);
     /* set host default attributes */
     host->ops = &ops;
     host->freq_min  = 400 * 1000;

--- a/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_nand.c
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/ports/drv_nand.c
@@ -640,7 +640,7 @@ int rt_hw_nand_init(void)
         LOG_D("nand flash init error!");
         return RT_ERROR;
     }
-    rt_mutex_init(&_device.lock, "nand", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&_device.lock, "nand", RT_IPC_FLAG_PRIO);
 
     nand_dev.page_size       = 4096;
     nand_dev.pages_per_block = 224;

--- a/bsp/swm320-lq100/drivers/drv_crypto.c
+++ b/bsp/swm320-lq100/drivers/drv_crypto.c
@@ -217,7 +217,7 @@ int rt_hw_crypto_init(void)
     {
         return -1;
     }
-    rt_mutex_init(&_crypto_dev.mutex, RT_HWCRYPTO_DEFAULT_NAME, RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&_crypto_dev.mutex, RT_HWCRYPTO_DEFAULT_NAME, RT_IPC_FLAG_PRIO);
     return 0;
 }
 INIT_BOARD_EXPORT(rt_hw_crypto_init);

--- a/bsp/swm320-lq100/drivers/drv_nor_flash.c
+++ b/bsp/swm320-lq100/drivers/drv_nor_flash.c
@@ -96,7 +96,7 @@ int rt_hw_norflash_init(void)
     mtd.ops = &mtd_ops;
 
     /* initialize mutex */
-    if (rt_mutex_init(&flash_lock, "nor", RT_IPC_FLAG_FIFO) != RT_EOK)
+    if (rt_mutex_init(&flash_lock, "nor", RT_IPC_FLAG_PRIO) != RT_EOK)
     {
         rt_kprintf("init sd lock mutex failed\n");
         return -RT_ERROR;

--- a/bsp/swm320-lq100/drivers/drv_sdio.c
+++ b/bsp/swm320-lq100/drivers/drv_sdio.c
@@ -495,7 +495,7 @@ struct rt_mmcsd_host *sdio_host_create(struct swm_sdio_des *sdio_des)
     rt_memcpy(&sdio->sdio_des, sdio_des, sizeof(struct swm_sdio_des));
 
     rt_event_init(&sdio->event, "sdio", RT_IPC_FLAG_FIFO);
-    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_PRIO);
 
     /* set host defautl attributes */
     host->ops = &swm_sdio_ops;

--- a/bsp/swm320/drivers/drv_crypto.c
+++ b/bsp/swm320/drivers/drv_crypto.c
@@ -217,7 +217,7 @@ int rt_hw_crypto_init(void)
     {
         return -1;
     }
-    rt_mutex_init(&_crypto_dev.mutex, RT_HWCRYPTO_DEFAULT_NAME, RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&_crypto_dev.mutex, RT_HWCRYPTO_DEFAULT_NAME, RT_IPC_FLAG_PRIO);
     return 0;
 }
 INIT_BOARD_EXPORT(rt_hw_crypto_init);

--- a/bsp/swm320/drivers/drv_nor_flash.c
+++ b/bsp/swm320/drivers/drv_nor_flash.c
@@ -96,7 +96,7 @@ int rt_hw_norflash_init(void)
     mtd.ops = &mtd_ops;
 
     /* initialize mutex */
-    if (rt_mutex_init(&flash_lock, "nor", RT_IPC_FLAG_FIFO) != RT_EOK)
+    if (rt_mutex_init(&flash_lock, "nor", RT_IPC_FLAG_PRIO) != RT_EOK)
     {
         rt_kprintf("init sd lock mutex failed\n");
         return -RT_ERROR;

--- a/bsp/swm320/drivers/drv_sdio.c
+++ b/bsp/swm320/drivers/drv_sdio.c
@@ -495,7 +495,7 @@ struct rt_mmcsd_host *sdio_host_create(struct swm_sdio_des *sdio_des)
     rt_memcpy(&sdio->sdio_des, sdio_des, sizeof(struct swm_sdio_des));
 
     rt_event_init(&sdio->event, "sdio", RT_IPC_FLAG_FIFO);
-    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&sdio->mutex, "sdio", RT_IPC_FLAG_PRIO);
 
     /* set host defautl attributes */
     host->ops = &swm_sdio_ops;

--- a/bsp/w60x/drivers/drv_crypto.c
+++ b/bsp/w60x/drivers/drv_crypto.c
@@ -732,7 +732,7 @@ int wm_hw_crypto_device_init(void)
     {
         return -1;
     }
-    rt_mutex_init(&_crypto_dev.mutex, RT_HWCRYPTO_DEFAULT_NAME, RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&_crypto_dev.mutex, RT_HWCRYPTO_DEFAULT_NAME, RT_IPC_FLAG_PRIO);
     return 0;
 }
 INIT_DEVICE_EXPORT(wm_hw_crypto_device_init);

--- a/bsp/x86/drivers/floppy.c
+++ b/bsp/x86/drivers/floppy.c
@@ -339,7 +339,7 @@ void rt_floppy_init(void)
 {
     struct rt_device *device;
 
-    rt_mutex_init(&lock,"fdlock", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&lock,"fdlock", RT_IPC_FLAG_PRIO);
     rt_sem_init(&sem, "fdsem", 0, RT_IPC_FLAG_FIFO);
 
     rt_hw_interrupt_install(FLOPPY_IRQ, rt_floppy_isr, RT_NULL, "floppy");

--- a/bsp/zynqmp-r5-axu4ev/drivers/drv_sdcard.c
+++ b/bsp/zynqmp-r5-axu4ev/drivers/drv_sdcard.c
@@ -339,7 +339,7 @@ static rt_err_t rt_sdcard_init(rt_device_t dev)
     BYTE drvnum = *((BYTE *)dev->user_data);
 
     rt_snprintf(sdlock_name, sizeof(sdlock_name), "sdlock%d", drvnum);
-    if (rt_mutex_init(&sd_lock[drvnum], sdlock_name, RT_IPC_FLAG_FIFO) != RT_EOK)
+    if (rt_mutex_init(&sd_lock[drvnum], sdlock_name, RT_IPC_FLAG_PRIO) != RT_EOK)
     {
         LOG_E("init sdlock semaphore failed\n");
     }

--- a/components/cplusplus/cxx_Mutex.cpp
+++ b/components/cplusplus/cxx_Mutex.cpp
@@ -13,7 +13,7 @@ using namespace rtthread;
 
 Mutex::Mutex(const char *name)
 {
-    rt_mutex_init(&mID, name, RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&mID, name, RT_IPC_FLAG_PRIO);
 }
 
 bool Mutex::lock(int32_t millisec)

--- a/components/dfs/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/filesystems/elmfat/dfs_elm.c
@@ -980,7 +980,7 @@ int ff_cre_syncobj(BYTE drv, FF_SYNC_t *m)
     rt_mutex_t mutex;
 
     rt_snprintf(name, sizeof(name), "fat%d", drv);
-    mutex = rt_mutex_create(name, RT_IPC_FLAG_FIFO);
+    mutex = rt_mutex_create(name, RT_IPC_FLAG_PRIO);
     if (mutex != RT_NULL)
     {
         *m = mutex;

--- a/components/dfs/src/dfs.c
+++ b/components/dfs/src/dfs.c
@@ -63,7 +63,7 @@ int dfs_init(void)
     memset(&_fdtab, 0, sizeof(_fdtab));
 
     /* create device filesystem lock */
-    rt_mutex_init(&fslock, "fslock", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&fslock, "fslock", RT_IPC_FLAG_PRIO);
 
 #ifdef DFS_USING_WORKDIR
     /* set current working directory */

--- a/components/drivers/i2c/i2c_core.c
+++ b/components/drivers/i2c/i2c_core.c
@@ -24,7 +24,7 @@ rt_err_t rt_i2c_bus_device_register(struct rt_i2c_bus_device *bus,
 {
     rt_err_t res = RT_EOK;
 
-    rt_mutex_init(&bus->lock, "i2c_bus_lock", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&bus->lock, "i2c_bus_lock", RT_IPC_FLAG_PRIO);
 
     if (bus->timeout == 0) bus->timeout = RT_TICK_PER_SECOND;
 

--- a/components/drivers/rtc/alarm.c
+++ b/components/drivers/rtc/alarm.c
@@ -790,7 +790,7 @@ int rt_alarm_system_init(void)
 
     rt_list_init(&_container.head);
     rt_event_init(&_container.event, "alarmsvc", RT_IPC_FLAG_FIFO);
-    rt_mutex_init(&_container.mutex, "alarmsvc", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&_container.mutex, "alarmsvc", RT_IPC_FLAG_PRIO);
 
     tid = rt_thread_create("alarmsvc",
                            rt_alarmsvc_thread_init, RT_NULL,

--- a/components/drivers/sdio/mmcsd_core.c
+++ b/components/drivers/sdio/mmcsd_core.c
@@ -708,7 +708,7 @@ struct rt_mmcsd_host *mmcsd_alloc_host(void)
     host->max_blk_size = 512;
     host->max_blk_count = 4096;
 
-    rt_mutex_init(&host->bus_lock, "sd_bus_lock", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&host->bus_lock, "sd_bus_lock", RT_IPC_FLAG_PRIO);
     rt_sem_init(&host->sem_ack, "sd_ack", 0, RT_IPC_FLAG_FIFO);
 
     return host;

--- a/components/drivers/sensors/sensor.c
+++ b/components/drivers/sensors/sensor.c
@@ -452,7 +452,7 @@ int rt_hw_sensor_register(rt_sensor_t sensor,
     if (sensor->module != RT_NULL && sensor->module->lock == RT_NULL)
     {
         /* Create a mutex lock for the module */
-        sensor->module->lock = rt_mutex_create(name, RT_IPC_FLAG_FIFO);
+        sensor->module->lock = rt_mutex_create(name, RT_IPC_FLAG_PRIO);
         if (sensor->module->lock == RT_NULL)
         {
             rt_free(device_name);

--- a/components/drivers/spi/enc28j60.c
+++ b/components/drivers/spi/enc28j60.c
@@ -834,7 +834,7 @@ rt_err_t enc28j60_attach(const char *spi_device_name)
     enc28j60_dev.parent.eth_rx  = enc28j60_rx;
     enc28j60_dev.parent.eth_tx  = enc28j60_tx;
 
-    rt_mutex_init(&enc28j60_dev.lock, "enc28j60", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&enc28j60_dev.lock, "enc28j60", RT_IPC_FLAG_PRIO);
 
     eth_device_init(&(enc28j60_dev.parent), "e0");
 

--- a/components/drivers/spi/spi_core.c
+++ b/components/drivers/spi/spi_core.c
@@ -29,7 +29,7 @@ rt_err_t rt_spi_bus_register(struct rt_spi_bus       *bus,
         return result;
 
     /* initialize mutex lock */
-    rt_mutex_init(&(bus->lock), name, RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&(bus->lock), name, RT_IPC_FLAG_PRIO);
     /* set ops */
     bus->ops = ops;
     /* initialize owner */

--- a/components/drivers/spi/spi_flash_sfud.c
+++ b/components/drivers/spi/spi_flash_sfud.c
@@ -318,7 +318,7 @@ rt_spi_flash_device_t rt_sfud_flash_probe_ex(const char *spi_flash_dev_name, con
     if (rtt_dev) {
         rt_memset(rtt_dev, 0, sizeof(struct spi_flash_device));
         /* initialize lock */
-        rt_mutex_init(&(rtt_dev->lock), spi_flash_dev_name, RT_IPC_FLAG_FIFO);
+        rt_mutex_init(&(rtt_dev->lock), spi_flash_dev_name, RT_IPC_FLAG_PRIO);
     }
 
     if (rtt_dev && sfud_dev && spi_flash_dev_name_bak && spi_dev_name_bak) {

--- a/components/drivers/src/pipe.c
+++ b/components/drivers/src/pipe.c
@@ -451,7 +451,7 @@ rt_pipe_t *rt_pipe_create(const char *name, int bufsz)
 
     rt_memset(pipe, 0, sizeof(rt_pipe_t));
     pipe->is_named = RT_TRUE; /* initialize as a named pipe */
-    rt_mutex_init(&(pipe->lock), name, RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&(pipe->lock), name, RT_IPC_FLAG_PRIO);
     rt_wqueue_init(&(pipe->reader_queue));
     rt_wqueue_init(&(pipe->writer_queue));
 

--- a/components/drivers/wlan/wlan_cfg.c
+++ b/components/drivers/wlan/wlan_cfg.c
@@ -84,7 +84,7 @@ void rt_wlan_cfg_init(void)
             rt_memset(cfg_cache, 0, sizeof(struct rt_wlan_cfg_des));
         }
         /* init mutex lock */
-        rt_mutex_init(&cfg_mutex, "wlan_cfg", RT_IPC_FLAG_FIFO);
+        rt_mutex_init(&cfg_mutex, "wlan_cfg", RT_IPC_FLAG_PRIO);
     }
 }
 

--- a/components/drivers/wlan/wlan_dev.c
+++ b/components/drivers/wlan/wlan_dev.c
@@ -650,7 +650,7 @@ static rt_err_t _rt_wlan_dev_init(rt_device_t dev)
     struct rt_wlan_device *wlan = (struct rt_wlan_device *)dev;
     rt_err_t result = RT_EOK;
 
-    rt_mutex_init(&wlan->lock, "wlan_dev", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&wlan->lock, "wlan_dev", RT_IPC_FLAG_PRIO);
 
     if (wlan->ops->wlan_init)
         result = wlan->ops->wlan_init(wlan);

--- a/components/drivers/wlan/wlan_mgnt.c
+++ b/components/drivers/wlan/wlan_mgnt.c
@@ -2011,10 +2011,10 @@ int rt_wlan_init(void)
         rt_memset(&_ap_mgnt, 0, sizeof(struct rt_wlan_mgnt_des));
         rt_memset(&scan_result, 0, sizeof(struct rt_wlan_scan_result));
         rt_memset(&sta_info, 0, sizeof(struct rt_wlan_sta_des));
-        rt_mutex_init(&mgnt_mutex, "mgnt", RT_IPC_FLAG_FIFO);
-        rt_mutex_init(&scan_result_mutex, "scan", RT_IPC_FLAG_FIFO);
-        rt_mutex_init(&sta_info_mutex, "sta", RT_IPC_FLAG_FIFO);
-        rt_mutex_init(&complete_mutex, "complete", RT_IPC_FLAG_FIFO);
+        rt_mutex_init(&mgnt_mutex, "mgnt", RT_IPC_FLAG_PRIO);
+        rt_mutex_init(&scan_result_mutex, "scan", RT_IPC_FLAG_PRIO);
+        rt_mutex_init(&sta_info_mutex, "sta", RT_IPC_FLAG_PRIO);
+        rt_mutex_init(&complete_mutex, "complete", RT_IPC_FLAG_PRIO);
 #ifdef RT_WLAN_AUTO_CONNECT_ENABLE
         rt_timer_init(&reconnect_time, "wifi_tim", rt_wlan_cyclic_check, RT_NULL,
                       rt_tick_from_millisecond(AUTO_CONNECTION_PERIOD_MS),

--- a/components/libc/posix/pthreads/pthread_mutex.c
+++ b/components/libc/posix/pthreads/pthread_mutex.c
@@ -121,7 +121,7 @@ int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
         mutex->attr = *attr;
 
     /* init mutex lock */
-    result = rt_mutex_init(&(mutex->lock), name, RT_IPC_FLAG_FIFO);
+    result = rt_mutex_init(&(mutex->lock), name, RT_IPC_FLAG_PRIO);
     if (result != RT_EOK)
         return EINVAL;
 

--- a/components/net/at/at_socket/at_socket.c
+++ b/components/net/at/at_socket/at_socket.c
@@ -313,7 +313,7 @@ static struct at_socket *alloc_socket_by_device(struct at_device *device, enum a
     if (at_slock == RT_NULL)
     {
         /* create AT socket lock */
-        at_slock = rt_mutex_create("at_slock", RT_IPC_FLAG_FIFO);
+        at_slock = rt_mutex_create("at_slock", RT_IPC_FLAG_PRIO);
         if (at_slock == RT_NULL)
         {
             LOG_E("No memory for socket allocation lock!");
@@ -367,7 +367,7 @@ static struct at_socket *alloc_socket_by_device(struct at_device *device, enum a
 
     rt_snprintf(name, RT_NAME_MAX, "%s%d", "at_skt", idx);
     /* create AT socket receive ring buffer lock */
-    if((sock->recv_lock = rt_mutex_create(name, RT_IPC_FLAG_FIFO)) == RT_NULL)
+    if((sock->recv_lock = rt_mutex_create(name, RT_IPC_FLAG_PRIO)) == RT_NULL)
     {
         LOG_E("No memory for socket receive mutex create.");
         rt_sem_delete(sock->recv_notice);

--- a/components/net/at/src/at_client.c
+++ b/components/net/at/src/at_client.c
@@ -835,7 +835,7 @@ static int at_client_para_init(at_client_t client)
     }
 
     rt_snprintf(name, RT_NAME_MAX, "%s%d", AT_CLIENT_LOCK_NAME, at_client_num);
-    client->lock = rt_mutex_create(name, RT_IPC_FLAG_FIFO);
+    client->lock = rt_mutex_create(name, RT_IPC_FLAG_PRIO);
     if (client->lock == RT_NULL)
     {
         LOG_E("AT client initialize failed! at_client_recv_lock create failed!");

--- a/components/net/lwip-1.4.1/src/arch/sys_arch.c
+++ b/components/net/lwip-1.4.1/src/arch/sys_arch.c
@@ -341,7 +341,7 @@ err_t sys_mutex_new(sys_mutex_t *mutex)
     rt_snprintf(tname, RT_NAME_MAX, "%s%d", SYS_LWIP_MUTEX_NAME, counter);
     counter ++;
 
-    tmpmutex = rt_mutex_create(tname, RT_IPC_FLAG_FIFO);
+    tmpmutex = rt_mutex_create(tname, RT_IPC_FLAG_PRIO);
     if (tmpmutex == RT_NULL)
         return ERR_MEM;
     else

--- a/components/net/lwip-2.0.2/src/arch/sys_arch.c
+++ b/components/net/lwip-2.0.2/src/arch/sys_arch.c
@@ -352,7 +352,7 @@ err_t sys_mutex_new(sys_mutex_t *mutex)
     rt_snprintf(tname, RT_NAME_MAX, "%s%d", SYS_LWIP_MUTEX_NAME, counter);
     counter ++;
 
-    tmpmutex = rt_mutex_create(tname, RT_IPC_FLAG_FIFO);
+    tmpmutex = rt_mutex_create(tname, RT_IPC_FLAG_PRIO);
     if (tmpmutex == RT_NULL)
         return ERR_MEM;
     else

--- a/components/net/lwip-2.0.3/src/arch/sys_arch.c
+++ b/components/net/lwip-2.0.3/src/arch/sys_arch.c
@@ -352,7 +352,7 @@ err_t sys_mutex_new(sys_mutex_t *mutex)
     rt_snprintf(tname, RT_NAME_MAX, "%s%d", SYS_LWIP_MUTEX_NAME, counter);
     counter ++;
 
-    tmpmutex = rt_mutex_create(tname, RT_IPC_FLAG_FIFO);
+    tmpmutex = rt_mutex_create(tname, RT_IPC_FLAG_PRIO);
     if (tmpmutex == RT_NULL)
         return ERR_MEM;
     else

--- a/components/net/lwip-2.1.2/src/arch/sys_arch.c
+++ b/components/net/lwip-2.1.2/src/arch/sys_arch.c
@@ -360,7 +360,7 @@ err_t sys_mutex_new(sys_mutex_t *mutex)
     rt_snprintf(tname, RT_NAME_MAX, "%s%d", SYS_LWIP_MUTEX_NAME, counter);
     counter ++;
 
-    tmpmutex = rt_mutex_create(tname, RT_IPC_FLAG_FIFO);
+    tmpmutex = rt_mutex_create(tname, RT_IPC_FLAG_PRIO);
     if (tmpmutex == RT_NULL)
         return ERR_MEM;
     else

--- a/components/net/sal_socket/src/sal_socket.c
+++ b/components/net/sal_socket/src/sal_socket.c
@@ -135,7 +135,7 @@ int sal_init(void)
     rt_memset(sal_dev_res_tbl,  0, sizeof(sal_dev_res_tbl));
 
     /* create sal socket lock */
-    rt_mutex_init(&sal_core_lock, "sal_lock", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&sal_core_lock, "sal_lock", RT_IPC_FLAG_PRIO);
 
     LOG_I("Socket Abstraction Layer initialize success.");
     init_ok = RT_TRUE;

--- a/examples/utest/testcases/kernel/mutex_tc.c
+++ b/examples/utest/testcases/kernel/mutex_tc.c
@@ -35,7 +35,7 @@ static void test_static_mutex_init(void)
         uassert_true(RT_FALSE);
     }
 
-    result = rt_mutex_init(&static_mutex, "static_mutex", RT_IPC_FLAG_FIFO);
+    result = rt_mutex_init(&static_mutex, "static_mutex", RT_IPC_FLAG_PRIO);
     if (RT_EOK != result)
     {
         uassert_true(RT_FALSE);
@@ -348,7 +348,7 @@ static void test_dynamic_mutex_create(void)
     }
 
     /* FIFO mode */
-    dynamic_mutex = rt_mutex_create("dynamic_mutex", RT_IPC_FLAG_FIFO);
+    dynamic_mutex = rt_mutex_create("dynamic_mutex", RT_IPC_FLAG_PRIO);
     if (RT_NULL == dynamic_mutex)
     {
         uassert_true(RT_FALSE);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
虽然在rt_mutex_create和rt_mutex_init函数内部已经将RT_IPC_FLAG_FIFO视为RT_IPC_FLAG_PRIO处理，但是为了防止误导使用者，即便更改从功能上没有实际意义，也需要将RT_IPC_FLAG_FIFO改为RT_IPC_FLAG_PRIO。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
