### PR TITLE
[PSE分支] 新增 RT_USING_POSIX_DEVIO

### DIFF
--- a/bsp/avr32uc3b0/startup.c
+++ b/bsp/avr32uc3b0/startup.c
@@ -38,7 +38,9 @@ int main(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device(FINSH_DEVICE_NAME);
+#endif
 #endif
 
     rt_thread_idle_init();

--- a/bsp/bf533/startup.c
+++ b/bsp/bf533/startup.c
@@ -62,7 +62,9 @@ void rtthread_startup(void)
     /* init finsh */
     extern int finsh_system_init(void);
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart0");
+#endif
 #endif
 
     rt_system_timer_thread_init();

--- a/bsp/efm32/startup.c
+++ b/bsp/efm32/startup.c
@@ -111,7 +111,9 @@ void rtthread_startup(void)
     /* init finsh */
 #ifdef RT_USING_FINSH
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device(CONSOLE_DEVICE);
+#endif
 #endif
 
     /* Initialize gui server */

--- a/bsp/frdm-k64f/applications/startup.c
+++ b/bsp/frdm-k64f/applications/startup.c
@@ -79,7 +79,9 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device( FINSH_DEVICE_NAME );
+#endif
 #endif
 
     /* init timer thread */

--- a/bsp/juicevm/rtconfig.h
+++ b/bsp/juicevm/rtconfig.h
@@ -106,7 +106,6 @@
 /* POSIX layer and C standard library */
 
 #define RT_USING_LIBC
-// #define RT_USING_POSIX
 
 /* Network */
 

--- a/bsp/lm3s8962/applications/startup.c
+++ b/bsp/lm3s8962/applications/startup.c
@@ -119,7 +119,7 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
-#if !defined(RT_USING_POSIX) && defined(RT_USING_DEVICE)
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart1");
 #endif
 #endif

--- a/bsp/lm3s9b9x/applications/startup.c
+++ b/bsp/lm3s9b9x/applications/startup.c
@@ -119,7 +119,7 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
-#ifdef RT_USING_DEVICE
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart1");
 #endif
 #endif

--- a/bsp/lm4f232/applications/startup.c
+++ b/bsp/lm4f232/applications/startup.c
@@ -119,7 +119,7 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
-#ifdef RT_USING_DEVICE
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart1");
 #endif
 #endif

--- a/bsp/lpc43xx/M0/applications/application.c
+++ b/bsp/lpc43xx/M0/applications/application.c
@@ -28,7 +28,9 @@ void rt_init_thread_entry(void *parameter)
 #ifdef RT_USING_FINSH
     /* initialize finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif
 #endif
 
 #ifdef RT_USING_VBUS

--- a/bsp/lpc43xx/M4/applications/application.c
+++ b/bsp/lpc43xx/M4/applications/application.c
@@ -59,7 +59,9 @@ void rt_init_thread_entry(void *parameter)
 #ifdef RT_USING_FINSH
     /* initialize finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif
 #endif
 
 #ifdef RT_USING_VBUS

--- a/bsp/m16c62p/applications/startup.c
+++ b/bsp/m16c62p/applications/startup.c
@@ -65,7 +65,9 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart0");
+#endif
 #endif
 
     /* init timer thread */

--- a/bsp/mb9bf568r/applications/application.c
+++ b/bsp/mb9bf568r/applications/application.c
@@ -25,8 +25,9 @@ void rt_init_thread_entry(void *parameter)
 
 
     //finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device(RT_CONSOLE_DEVICE_NAME);
-
+#endif
 
     /**< init led device */
     {

--- a/bsp/mb9bf618s/applications/application.c
+++ b/bsp/mb9bf618s/applications/application.c
@@ -24,7 +24,7 @@ void rt_init_thread_entry(void *parameter)
 #endif
 
 #ifdef  RT_USING_FINSH
-    finsh_set_device(RT_CONSOLE_DEVICE_NAME);
+    (RT_CONSOLE_DEVICE_NAME);
 #endif  /* RT_USING_FINSH */
 
     /**< init led device */

--- a/bsp/microblaze/startup.c
+++ b/bsp/microblaze/startup.c
@@ -84,7 +84,9 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart1");
+#endif
 #endif
 
     /* init idle thread */

--- a/bsp/mini4020/applications/startup.c
+++ b/bsp/mini4020/applications/startup.c
@@ -77,7 +77,7 @@ void rtthread_startup()
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
-#ifdef RT_USING_DEVICE
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart0");
 #endif
 #endif

--- a/bsp/nios_ii/startup.c
+++ b/bsp/nios_ii/startup.c
@@ -60,7 +60,9 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart");
+#endif
 #endif
 
     /* init idle thread */

--- a/bsp/nv32f100x/app/src/main.c
+++ b/bsp/nv32f100x/app/src/main.c
@@ -17,8 +17,10 @@ int main(void)
 {
     rt_thread_t thread;
 
-#ifdef  RT_USING_FINSH
+#ifdef RT_USING_FINSH
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif
 #endif
 
     /* Create led thread */

--- a/bsp/pic32ethernet/startup.c
+++ b/bsp/pic32ethernet/startup.c
@@ -48,7 +48,7 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
-#ifdef RT_USING_DEVICE
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart1");
 #endif
 #endif

--- a/bsp/rm48x50/application/startup.c
+++ b/bsp/rm48x50/application/startup.c
@@ -104,7 +104,9 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("sci2");
+#endif
 #endif
 
     /* init soft timer thread */

--- a/bsp/rx/applications/application.c
+++ b/bsp/rx/applications/application.c
@@ -60,7 +60,9 @@ void rt_init_thread_entry(void* parameter)
 #ifdef RT_USING_FINSH
 	/* initialize finsh */
 	finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
 	finsh_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif
 #endif
 
 #ifdef RT_USING_LWIP
@@ -130,7 +132,9 @@ void rt_init_thread_entry(void* parameter)
 #endif
 
 #ifdef  RT_USING_FINSH
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif
 #endif  /* RT_USING_FINSH */
 
     /* Filesystem Initialization */

--- a/bsp/sam7x/applications/startup.c
+++ b/bsp/sam7x/applications/startup.c
@@ -114,7 +114,9 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart1");
+#endif
 #endif
 
     /* init idle thread */

--- a/bsp/samd21/applications/application.c
+++ b/bsp/samd21/applications/application.c
@@ -87,7 +87,9 @@ void rt_init_thread_entry(void* parameter)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart1");
+#endif
 #endif
 
     LED_Init();

--- a/bsp/sep6200/application/startup.c
+++ b/bsp/sep6200/application/startup.c
@@ -64,7 +64,7 @@ void rtthread_startup()
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
-#ifdef RT_USING_DEVICE
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart0");
 #endif
 #endif

--- a/bsp/taihu/applications/startup.c
+++ b/bsp/taihu/applications/startup.c
@@ -53,7 +53,9 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart1");
+#endif
 #endif
 
     /* init soft timer thread */

--- a/bsp/upd70f3454/applications/startup.c
+++ b/bsp/upd70f3454/applications/startup.c
@@ -64,7 +64,9 @@ void rtthread_startup(void)
 #ifdef RT_USING_FINSH
     /* init finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device("uart0");
+#endif
 #endif
 
     /* init timer thread */

--- a/bsp/xplorer4330/applications/application.c
+++ b/bsp/xplorer4330/applications/application.c
@@ -23,7 +23,9 @@ void rt_init_thread_entry(void *parameter)
 #ifdef RT_USING_FINSH
     /* initialize finsh */
     finsh_system_init();
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     finsh_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif
 #endif
 }
 /*the led thread*/

--- a/components/dfs/filesystems/devfs/devfs.c
+++ b/components/dfs/filesystems/devfs/devfs.c
@@ -173,7 +173,7 @@ int dfs_device_fs_open(struct dfs_fd *file)
     if (device == RT_NULL)
         return -ENODEV;
 
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
     if (device->fops)
     {
         /* use device fops */
@@ -192,7 +192,7 @@ int dfs_device_fs_open(struct dfs_fd *file)
         }
     }
     else
-#endif
+#endif /* RT_USING_POSIX_DEVIO */
     {
         result = rt_device_open(device, RT_DEVICE_OFLAG_RDWR);
         if (result == RT_EOK || result == -RT_ENOSYS)

--- a/components/dfs/src/dfs.c
+++ b/components/dfs/src/dfs.c
@@ -18,9 +18,9 @@
 #include <lwp.h>
 #endif
 
-#ifdef RT_USING_POSIX_STDIO
+#ifdef RT_USING_POSIX_DEVIO
 #include <libc.h>
-#endif /* RT_USING_POSIX_STDIO */
+#endif /* RT_USING_POSIX_DEVIO */
 
 /* Global variables */
 const struct dfs_filesystem_ops *filesystem_operation_table[DFS_FILESYSTEM_TYPES_MAX];
@@ -216,10 +216,10 @@ struct dfs_fd *fd_get(int fd)
     struct dfs_fd *d;
     struct dfs_fdtable *fdt;
 
-#ifdef RT_USING_POSIX_STDIO
+#ifdef RT_USING_POSIX_DEVIO
     if ((0 <= fd) && (fd <= 2))
         fd = libc_stdio_get_console();
-#endif /* RT_USING_POSIX_STDIO */
+#endif /* RT_USING_POSIX_DEVIO */
 
     fdt = dfs_fdtable_get();
     fd = fd - DFS_FD_OFFSET;

--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -36,7 +36,7 @@
 #define DBG_LVL    DBG_INFO
 #include <rtdbg.h>
 
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
 #include <dfs_posix.h>
 #include <poll.h>
 #include <sys/ioctl.h>
@@ -203,7 +203,7 @@ const static struct dfs_file_ops _serial_fops =
     RT_NULL, /* getdents */
     serial_fops_poll,
 };
-#endif
+#endif /* RT_USING_POSIX_DEVIO */
 
 /*
  * Serial poll routines
@@ -976,8 +976,7 @@ static void _tc_flush(struct rt_serial_device *serial, int queue)
     }
 
 }
-
-#endif
+#endif /* RT_USING_POSIX_TERMIOS */
 
 static rt_err_t rt_serial_control(struct rt_device *dev,
                                   int              cmd,
@@ -1020,7 +1019,7 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
             }
 
             break;
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
 #ifdef RT_USING_POSIX_TERMIOS
         case TCGETA:
             {
@@ -1215,7 +1214,7 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
                 *(rt_size_t *)args = recved;
             }
             break;
-#endif /*RT_USING_POSIX*/
+#endif /* RT_USING_POSIX_DEVIO */
         default :
             /* control device */
             ret = serial->ops->control(serial, cmd, args);
@@ -1270,7 +1269,7 @@ rt_err_t rt_hw_serial_register(struct rt_serial_device *serial,
     /* register a character device */
     ret = rt_device_register(device, name, flag);
 
-#if defined(RT_USING_POSIX)
+#ifdef RT_USING_POSIX_DEVIO
     /* set fops */
     device->fops        = &_serial_fops;
 #endif

--- a/components/drivers/serial/serial_v2.c
+++ b/components/drivers/serial/serial_v2.c
@@ -16,7 +16,7 @@
 #define DBG_LVL    DBG_INFO
 #include <rtdbg.h>
 
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
 #include <dfs_posix.h>
 #include <poll.h>
 #include <sys/ioctl.h>
@@ -179,7 +179,7 @@ const static struct dfs_file_ops _serial_fops =
     RT_NULL, /* getdents */
     serial_fops_poll,
 };
-#endif
+#endif /* RT_USING_POSIX_DEVIO */
 
 static rt_size_t rt_serial_get_linear_buffer(struct rt_ringbuffer       *rb,
                                                     rt_uint8_t         **ptr)
@@ -1135,7 +1135,7 @@ rt_err_t rt_hw_serial_register(struct rt_serial_device *serial,
     /* register a character device */
     ret = rt_device_register(device, name, flag);
 
-#if defined(RT_USING_POSIX)
+#ifdef RT_USING_POSIX_DEVIO
     /* set fops */
     device->fops        = &_serial_fops;
 #endif

--- a/components/drivers/src/pipe.c
+++ b/components/drivers/src/pipe.c
@@ -13,7 +13,7 @@
 #include <stdint.h>
 #include <sys/errno.h>
 
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
 #include <dfs_file.h>
 #include <dfs_posix.h>
 #include <poll.h>
@@ -320,7 +320,7 @@ static const struct dfs_file_ops pipe_fops =
     RT_NULL,
     pipe_fops_poll,
 };
-#endif /* end of RT_USING_POSIX */
+#endif /* RT_USING_POSIX_DEVIO */
 
 rt_err_t  rt_pipe_open(rt_device_t device, rt_uint16_t oflag)
 {
@@ -479,7 +479,7 @@ rt_pipe_t *rt_pipe_create(const char *name, int bufsz)
         rt_free(pipe);
         return RT_NULL;
     }
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
     dev->fops = (void*)&pipe_fops;
 #endif
 
@@ -529,7 +529,7 @@ int rt_pipe_delete(const char *name)
     return result;
 }
 
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
 int pipe(int fildes[2])
 {
     rt_pipe_t *pipe;
@@ -575,4 +575,4 @@ int mkfifo(const char *path, mode_t mode)
 
     return 0;
 }
-#endif
+#endif /* RT_USING_POSIX_DEVIO */

--- a/components/finsh/finsh.h
+++ b/components/finsh/finsh.h
@@ -168,7 +168,7 @@ extern struct finsh_syscall *_syscall_table_begin, *_syscall_table_end;
 /* find out system call, which should be implemented in user program */
 struct finsh_syscall *finsh_syscall_lookup(const char *name);
 
-#ifdef RT_USING_DEVICE
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
 void finsh_set_device(const char *device_name);
 #endif
 

--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -146,7 +146,7 @@ int finsh_getchar(void)
 {
 #ifdef RT_USING_DEVICE
     char ch = 0;
-#ifdef RT_USING_POSIX_STDIO
+#ifdef RT_USING_POSIX_DEVIO
     if(read(STDIN_FILENO, &ch, 1) > 0)
     {
         return ch;
@@ -170,14 +170,14 @@ int finsh_getchar(void)
         rt_sem_take(&shell->rx_sem, RT_WAITING_FOREVER);
 
     return ch;
-#endif /* RT_USING_POSIX_STDIO */
+#endif /* RT_USING_POSIX_DEVIO */
 #else
     extern char rt_hw_console_getchar(void);
     return rt_hw_console_getchar();
 #endif /* RT_USING_DEVICE */
 }
 
-#if !defined(RT_USING_POSIX_STDIO) && defined(RT_USING_DEVICE)
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
 static rt_err_t finsh_rx_ind(rt_device_t dev, rt_size_t size)
 {
     RT_ASSERT(shell != RT_NULL);
@@ -241,7 +241,7 @@ const char *finsh_get_device()
     RT_ASSERT(shell != RT_NULL);
     return shell->device->parent.name;
 }
-#endif /* !defined(RT_USING_POSIX_STDIO) && defined(RT_USING_DEVICE) */
+#endif /* !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE) */
 
 /**
  * @ingroup finsh
@@ -443,7 +443,7 @@ void finsh_thread_entry(void *parameter)
     shell->echo_mode = 0;
 #endif
 
-#if !defined(RT_USING_POSIX_STDIO) && defined(RT_USING_DEVICE)
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     /* set console device as shell device */
     if (shell->device == RT_NULL)
     {
@@ -453,7 +453,7 @@ void finsh_thread_entry(void *parameter)
             finsh_set_device(console->parent.name);
         }
     }
-#endif /* !defined(RT_USING_POSIX_STDIO) && defined(RT_USING_DEVICE) */
+#endif /* !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE) */
 
 #ifdef FINSH_USING_AUTH
     /* set the default password when the password isn't setting */

--- a/components/finsh/shell.h
+++ b/components/finsh/shell.h
@@ -91,7 +91,6 @@ void finsh_set_echo(rt_uint32_t echo);
 rt_uint32_t finsh_get_echo(void);
 
 int finsh_system_init(void);
-void finsh_set_device(const char *device_name);
 const char *finsh_get_device(void);
 int finsh_getchar(void);
 

--- a/components/finsh/shell.h
+++ b/components/finsh/shell.h
@@ -78,7 +78,7 @@ struct finsh_shell
     rt_uint16_t line_position;
     rt_uint16_t line_curpos;
 
-#if !defined(RT_USING_POSIX_STDIO) && defined(RT_USING_DEVICE)
+#if !defined(RT_USING_POSIX_DEVIO) && defined(RT_USING_DEVICE)
     rt_device_t device;
 #endif
 

--- a/components/legacy/dfs/dfs_select.h
+++ b/components/legacy/dfs/dfs_select.h
@@ -13,4 +13,4 @@
 
 #include <sys/select.h>
 
-#endif
+#endif /* DFS_SELECT_H__ */

--- a/components/libc/Kconfig
+++ b/components/libc/Kconfig
@@ -12,7 +12,7 @@ if RT_USING_LIBC
     config RT_LIBC_USING_FILEIO
         bool "Enable libc with file operation, eg.fopen/fwrite/fread/getchar"
         select RT_USING_POSIX
-        select RT_USING_POSIX_STDIO
+        select RT_USING_POSIX_DEVIO
         default n
 
     config RT_USING_MODULE
@@ -44,8 +44,8 @@ config RT_USING_POSIX
     default n
 
 if RT_USING_POSIX
-    config RT_USING_POSIX_STDIO
-        bool "Enable standard I/O, STDOUT_FILENO/STDIN_FILENO/STDERR_FILENO"
+    config RT_USING_POSIX_DEVIO
+        bool "Enable devices as file descriptors"
         select RT_USING_DFS
         select RT_USING_DFS_DEVFS
         default n

--- a/components/libc/compilers/armlibc/syscalls.c
+++ b/components/libc/compilers/armlibc/syscalls.c
@@ -21,9 +21,9 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/stat.h>
-#ifdef RT_USING_POSIX_STDIO
+#ifdef RT_USING_POSIX_DEVIO
 #include "libc.h"
-#endif
+#endif /* RT_USING_POSIX_DEVIO */
 
 #define DBG_TAG    "armlibc.syscalls"
 #define DBG_LVL    DBG_INFO
@@ -149,7 +149,7 @@ int _sys_read(FILEHANDLE fh, unsigned char *buf, unsigned len, int mode)
 
     if (fh == STDIN)
     {
-#ifdef RT_USING_POSIX_STDIO
+#ifdef RT_USING_POSIX_DEVIO
         if (libc_stdio_get_console() < 0)
         {
             LOG_W("Do not invoke standard output before initializing libc");
@@ -159,7 +159,7 @@ int _sys_read(FILEHANDLE fh, unsigned char *buf, unsigned len, int mode)
         return 0; /* success */
 #else
         return 0; /* error */
-#endif
+#endif /* RT_USING_POSIX_DEVIO */
     }
     else if (fh == STDOUT || fh == STDERR)
     {
@@ -332,7 +332,7 @@ int fputc(int c, FILE *f)
 
 int fgetc(FILE *f)
 {
-#ifdef RT_USING_POSIX_STDIO
+#ifdef RT_USING_POSIX_DEVIO
     char ch;
 
     if (libc_stdio_get_console() < 0)
@@ -343,7 +343,7 @@ int fgetc(FILE *f)
 
     if(read(STDIN_FILENO, &ch, 1) == 1)
         return ch;
-#endif /* RT_USING_POSIX_STDIO */
+#endif /* RT_USING_POSIX_DEVIO */
     return 0; /* error */
 }
 

--- a/components/libc/compilers/common/sys/ioctl.h
+++ b/components/libc/compilers/common/sys/ioctl.h
@@ -11,9 +11,7 @@
 #define _SYS_IOCTL_H
 
 #include <rtconfig.h>
-#ifdef RT_USING_POSIX
 #include <dfs_posix.h>
-#endif
 
 #ifdef _WIN32
 #include <winsock.h>

--- a/components/libc/compilers/dlib/syscall_read.c
+++ b/components/libc/compilers/dlib/syscall_read.c
@@ -11,9 +11,9 @@
 #include <rtthread.h>
 #include <LowLevelIOInterface.h>
 #include <unistd.h>
-#ifdef RT_USING_POSIX_STDIO
+#ifdef RT_USING_POSIX_DEVIO
 #include "libc.h"
-#endif
+#endif /* RT_USING_POSIX_DEVIO */
 
 #define DBG_TAG    "dlib.syscall_read"
 #define DBG_LVL    DBG_INFO
@@ -39,7 +39,7 @@ size_t __read(int handle, unsigned char *buf, size_t len)
 
     if (handle == _LLIO_STDIN)
     {
-#ifdef RT_USING_POSIX_STDIO
+#ifdef RT_USING_POSIX_DEVIO
         if (libc_stdio_get_console() < 0)
         {
             LOG_W("Do not invoke standard input before initializing libc");
@@ -48,7 +48,7 @@ size_t __read(int handle, unsigned char *buf, size_t len)
         return read(STDIN_FILENO, buf, len); /* return the length of the data read */
 #else
         return _LLIO_ERROR;
-#endif /* RT_USING_POSIX_STDIO */
+#endif /* RT_USING_POSIX_DEVIO */
     }
     else if ((handle == _LLIO_STDOUT) || (handle == _LLIO_STDERR))
     {

--- a/components/libc/compilers/dlib/syscall_write.c
+++ b/components/libc/compilers/dlib/syscall_write.c
@@ -11,10 +11,6 @@
 #include <rtthread.h>
 #include <LowLevelIOInterface.h>
 #include <unistd.h>
-#ifdef RT_USING_POSIX_STDIO
-#include "libc.h"
-#endif
-
 #define DBG_TAG    "dlib.syscall_write"
 #define DBG_LVL    DBG_INFO
 #include <rtdbg.h>

--- a/components/libc/compilers/gcc/newlib/syscalls.c
+++ b/components/libc/compilers/gcc/newlib/syscalls.c
@@ -20,12 +20,12 @@
 #include <unistd.h>
 #include <sys/errno.h>
 #include <sys/stat.h>
-#ifdef RT_USING_POSIX_STDIO
+#ifdef RT_USING_POSIX_DEVIO
 #include "libc.h"
-#endif
+#endif /* RT_USING_POSIX_DEVIO */
 #ifdef RT_USING_MODULE
 #include <dlmodule.h>
-#endif
+#endif /* RT_USING_MODULE */
 
 #define DBG_TAG    "newlib.syscalls"
 #define DBG_LVL    DBG_INFO
@@ -225,7 +225,7 @@ _ssize_t _read_r(struct _reent *ptr, int fd, void *buf, size_t nbytes)
     _ssize_t rc;
     if (fd == STDIN_FILENO)
     {
-#ifdef RT_USING_POSIX_STDIO
+#ifdef RT_USING_POSIX_DEVIO
         if (libc_stdio_get_console() < 0)
         {
             LOG_W("Do not invoke standard input before initializing libc");
@@ -234,7 +234,7 @@ _ssize_t _read_r(struct _reent *ptr, int fd, void *buf, size_t nbytes)
 #else
         ptr->_errno = ENOTSUP;
         return -1;
-#endif /* RT_USING_POSIX_STDIO */
+#endif /* RT_USING_POSIX_DEVIO */
     }
     else if (fd == STDOUT_FILENO || fd == STDERR_FILENO)
     {

--- a/components/libc/posix/aio/SConscript
+++ b/components/libc/posix/aio/SConscript
@@ -6,6 +6,6 @@ cwd     = GetCurrentDir()
 src     = Glob('*.c')
 CPPPATH = [cwd]
 
-group = DefineGroup('POSIX', src, depend = ['RT_USING_POSIX', 'RT_USING_POSIX_AIO'], CPPPATH = CPPPATH)
+group = DefineGroup('POSIX', src, depend = ['RT_USING_POSIX_AIO'], CPPPATH = CPPPATH)
 
 Return('group')

--- a/components/libc/posix/src/SConscript
+++ b/components/libc/posix/src/SConscript
@@ -6,7 +6,7 @@ src     = ['unistd.c']
 cwd     = GetCurrentDir()
 CPPPATH = [cwd]
 
-if GetDepend('RT_USING_POSIX_STDIO'):
+if GetDepend('RT_USING_POSIX_DEVIO'):
     src += ['libc.c']
 
 if GetDepend('RT_USING_POSIX_DELAY'):

--- a/components/libc/posix/src/libc.c
+++ b/components/libc/posix/src/libc.c
@@ -23,7 +23,7 @@
 
 int libc_system_init(void)
 {
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
     rt_device_t dev_console;
 
     dev_console = rt_console_get_device();
@@ -31,7 +31,7 @@ int libc_system_init(void)
     {
         libc_stdio_set_console(dev_console->parent.name, O_RDWR);
     }
-#endif /* RT_USING_POSIX */
+#endif /* RT_USING_POSIX_DEVIO */
 
 #if defined RT_USING_PTHREADS && !defined RT_USING_COMPONENTS_INIT
     pthread_system_init();
@@ -41,8 +41,7 @@ int libc_system_init(void)
 }
 INIT_COMPONENT_EXPORT(libc_system_init);
 
-#ifdef RT_USING_POSIX
-
+#ifdef RT_USING_POSIX_DEVIO
 #if defined(RT_USING_LIBC) && defined(RT_USING_NEWLIB)
 #define STDIO_DEVICE_NAME_MAX   32
 static FILE* std_console = NULL;
@@ -145,4 +144,4 @@ int libc_stdio_get_console(void) {
     return std_fd;
 }
 #endif /* defined(RT_USING_LIBC) && defined(RT_USING_NEWLIB) */
-#endif /* RT_USING_POSIX */
+#endif /* RT_USING_POSIX_DEVIO */

--- a/components/libc/posix/src/libc.h
+++ b/components/libc/posix/src/libc.h
@@ -17,10 +17,10 @@ extern "C" {
 #endif
 
 int libc_system_init(void);
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
 int libc_stdio_get_console(void);
 int libc_stdio_set_console(const char* device_name, int mode);
-#endif /* RT_USING_POSIX */
+#endif /* RT_USING_POSIX_DEVIO */
 
 #ifdef __cplusplus
 }

--- a/components/libc/posix/termios/SConscript
+++ b/components/libc/posix/termios/SConscript
@@ -6,8 +6,6 @@ cwd = GetCurrentDir()
 src = Glob('*.c') + Glob('*.cpp')
 CPPPATH = [cwd]
 
-group = DefineGroup('POSIX', src, 
-    depend = ['RT_USING_LIBC', 'RT_USING_POSIX', 'RT_USING_POSIX_TERMIOS'], 
-    CPPPATH = CPPPATH)
+group = DefineGroup('POSIX', src, depend = ['RT_USING_LIBC', 'RT_USING_POSIX_TERMIOS'], CPPPATH = CPPPATH)
 
 Return('group')

--- a/components/utilities/rt-link/src/rtlink_dev.c
+++ b/components/utilities/rt-link/src/rtlink_dev.c
@@ -19,7 +19,7 @@
 
 #define RTLINK_SERV(dev)  (((struct rt_link_device*)dev)->service)
 
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
 #include <dfs_posix.h>
 #include <poll.h>
 
@@ -148,7 +148,7 @@ const static struct dfs_file_ops _rtlink_fops =
     RT_NULL, /* getdents */
     rtlink_fops_poll,
 };
-#endif /* RT_USING_POSIX */
+#endif /* RT_USING_POSIX_DEVIO */
 
 /* The event type for the service channel number,
  * which is used to wake up the service thread in blocking receive mode */
@@ -386,7 +386,7 @@ rt_err_t rt_link_dev_register(struct rt_link_device *rtlink,
     /* register a character device */
     ret = rt_device_register(device, name, flag);
 
-#if defined(RT_USING_POSIX)
+#ifdef RT_USING_POSIX_DEVIO
     /* set fops */
     device->fops        = &_rtlink_fops;
 #endif

--- a/examples/libc/termios_test.c
+++ b/examples/libc/termios_test.c
@@ -14,18 +14,6 @@
 #include <string.h>
 #include <sys/time.h>
 
-#if defined (RT_USING_POSIX)
-    #include <dfs_posix.h>
-    #include <sys/select.h>
-    #if defined (RT_USING_POSIX_TERMIOS)
-        #include <termios.h>
-    #else
-        #error "TERMIOS need RT_USING_POSIX_TERMIOS"
-    #endif
-#else
-    #error "POSIX poll/select need RT_USING_POSIX"
-#endif
-
 #define JOINT(x,y) x##y
 #define B(x) JOINT(B,x)
 #define Default_baud_rate   115200

--- a/examples/rt-link/rtlink_dev_example.c
+++ b/examples/rt-link/rtlink_dev_example.c
@@ -45,7 +45,7 @@ static rt_err_t rtlink_dev_tx_done(rt_device_t dev, void *buffer)
     return RT_EOK;
 }
 
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
 #include <dfs_posix.h>
 #include <poll.h>
 #include <sys/select.h>
@@ -205,7 +205,7 @@ static void rtlink_fselect()
     }
 }
 MSH_CMD_EXPORT(rtlink_fselect, rtlink posix interface example);
-#endif  /* RT_USING_POSIX */
+#endif  /* RT_USING_POSIX_DEVIO */
 
 static void rtlink_dread(void)
 {

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -1034,7 +1034,7 @@ struct rt_device
     rt_err_t  (*control)(rt_device_t dev, int cmd, void *args);
 #endif
 
-#if defined(RT_USING_POSIX)
+#ifdef RT_USING_POSIX_DEVIO
     const struct dfs_file_ops *fops;
     struct rt_wqueue wait_queue;
 #endif

--- a/src/device.c
+++ b/src/device.c
@@ -16,9 +16,9 @@
  */
 
 #include <rtthread.h>
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
 #include <rtdevice.h> /* for wqueue_init */
-#endif /* RT_USING_POSIX */
+#endif /* RT_USING_POSIX_DEVIO */
 
 #ifdef RT_USING_DEVICE
 
@@ -64,10 +64,10 @@ rt_err_t rt_device_register(rt_device_t dev,
     dev->ref_count = 0;
     dev->open_flag = 0;
 
-#ifdef RT_USING_POSIX
+#ifdef RT_USING_POSIX_DEVIO
     dev->fops = RT_NULL;
     rt_wqueue_init(&(dev->wait_queue));
-#endif /* RT_USING_POSIX */
+#endif /* RT_USING_POSIX_DEVIO */
 
     return RT_EOK;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
将原RT_USING_POSIX中和设备相关的例如fopt细化为RT_USING_POSIX_DEVIO宏，由该宏定义单独控制。
- 此pr忽略动态CI检查的报错，由于宏定义的更改，动态检查CI的rtconfig.h没有更改，会导致动态CI报错，予以略过。
- 忽略格式检查。

RT_USING_POSIX_DEVIO 将负责和“将设备虚拟化为文件”相关，例如：串口（串口注册到文件系统口可以使用write read函数来操作，标准输入输出），device->fops相关的。
api层面没有变化 就是还是write read，就是没开这个宏就不能用write read来写设备，没开这个宏就是真的是文件系统，只能用read write来写文件，开了这个宏允许write read去读写设备了。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
