### PR TITLE
[PSE分支] 增加RT_USING_POSIX_FS

### DIFF
--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -362,7 +362,7 @@ static void _serial_check_buffer_size(void)
     }
 }
 
-#if defined(RT_USING_POSIX) || defined(RT_SERIAL_USING_DMA)
+#if defined(RT_USING_POSIX_DEVIO) || defined(RT_SERIAL_USING_DMA)
 static rt_size_t _serial_fifo_calc_recved_len(struct rt_serial_device *serial)
 {
     struct rt_serial_rx_fifo *rx_fifo = (struct rt_serial_rx_fifo *) serial->serial_rx;
@@ -385,7 +385,7 @@ static rt_size_t _serial_fifo_calc_recved_len(struct rt_serial_device *serial)
         }
     }
 }
-#endif /* RT_USING_POSIX || RT_SERIAL_USING_DMA */
+#endif /* RT_USING_POSIX_DEVIO || RT_SERIAL_USING_DMA */
 
 #ifdef RT_SERIAL_USING_DMA
 /**
@@ -1133,6 +1133,7 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
                 }
                 else
                 {
+                    #include <shell.h>
                     #define _TIO_BUFLEN 20
                     char _tio_buf[_TIO_BUFLEN];
                     unsigned char cnt1, cnt2, cnt3, i;
@@ -1148,7 +1149,7 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
                     i = 0;
                     while(i < _TIO_BUFLEN)
                     {
-                        _tio_buf[i] = getchar();
+                        _tio_buf[i] = finsh_getchar();
                         if(_tio_buf[i] != 't')
                         {
                             i ++;

--- a/components/libc/Kconfig
+++ b/components/libc/Kconfig
@@ -2,7 +2,6 @@ menu "POSIX layer and C standard library"
 
 config RT_USING_LIBC
     bool "Enable libc APIs from toolchain"
-    select RT_USING_HEAP
     default n
 
 if RT_USING_LIBC
@@ -10,8 +9,8 @@ if RT_USING_LIBC
         default y
 
     config RT_LIBC_USING_FILEIO
-        bool "Enable libc with file operation, eg.fopen/fwrite/fread/getchar"
-        select RT_USING_POSIX
+        bool "Enable libc with file operation, eg.fopen/fwrite/fread/getchar/STDIO"
+        select RT_USING_POSIX_FS
         select RT_USING_POSIX_DEVIO
         default n
 
@@ -38,50 +37,50 @@ config RT_LIBC_DEFAULT_TIMEZONE
     range -12 12
     default 8
 
-config RT_USING_POSIX
-    bool "Enable basic POSIX layer, open()/read()/write()/close() etc"
+config RT_USING_POSIX_FS
+    bool "Enable POSIX file system, open()/read()/write()/close() etc"
     select RT_USING_DFS
+    select DFS_USING_POSIX
     default n
 
-if RT_USING_POSIX
+if RT_USING_POSIX_FS
     config RT_USING_POSIX_DEVIO
         bool "Enable devices as file descriptors"
-        select RT_USING_DFS
         select RT_USING_DFS_DEVFS
         default n
 
     config RT_USING_POSIX_POLL
         bool "Enable poll()"
-        select RT_USING_DFS
         default n
 
     config RT_USING_POSIX_SELECT
         bool "Enable select()"
-        select RT_USING_DFS
         select RT_USING_POSIX_POLL
         default n
-
-    config RT_USING_POSIX_DELAY
-        bool "Enable delay APIs, sleep()/usleep()/msleep() etc"
-        default n
-
-    config RT_USING_POSIX_GETLINE
-        bool "Enable getline()/getdelim()"
-        default n
-
-    config RT_USING_POSIX_MMAP
-        bool "Enable mmap()"
-        select RT_USING_DFS
-        default n
-
-    config RT_USING_POSIX_TERMIOS
-        bool "Enable termios APIs"
-        default n
-
-    config RT_USING_POSIX_AIO
-        bool "Enable AIO APIs"
-        default n
 endif
+
+config RT_USING_POSIX_DELAY
+    bool "Enable delay APIs, sleep()/usleep()/msleep() etc"
+    default n
+
+config RT_USING_POSIX_GETLINE
+    bool "Enable getline()/getdelim()"
+    select RT_USING_LIBC
+    select RT_LIBC_USING_FILEIO
+    default n
+
+config RT_USING_POSIX_MMAP
+    bool "Enable mmap()"
+    select RT_USING_POSIX_FS
+    default n
+
+config RT_USING_POSIX_TERMIOS
+    bool "Enable termios APIs"
+    default n
+
+config RT_USING_POSIX_AIO
+    bool "Enable AIO APIs"
+    default n
 
 config RT_USING_PTHREADS
     bool "Enable pthreads APIs"

--- a/components/libc/compilers/common/sys/time.h
+++ b/components/libc/compilers/common/sys/time.h
@@ -72,7 +72,6 @@ int settimeofday(const struct timeval *tv, const struct timezone *tz);
 struct tm *gmtime_r(const time_t *timep, struct tm *r);
 #endif
 
-#ifdef RT_USING_POSIX
 /* POSIX clock and timer */
 #define MILLISECOND_PER_SECOND  1000UL
 #define MICROSECOND_PER_SECOND  1000000UL
@@ -103,8 +102,8 @@ int clock_getres  (clockid_t clockid, struct timespec *res);
 int clock_gettime (clockid_t clockid, struct timespec *tp);
 int clock_settime (clockid_t clockid, const struct timespec *tp);
 int rt_timespec_to_tick(const struct timespec *time);
-#endif /* RT_USING_POSIX */
 
+/* timezone */
 void tz_set(int8_t tz);
 int8_t tz_get(void);
 int8_t tz_is_dst(void);

--- a/components/libc/compilers/common/time.c
+++ b/components/libc/compilers/common/time.c
@@ -486,8 +486,6 @@ RTM_EXPORT(settimeofday);
 RTM_EXPORT(difftime);
 RTM_EXPORT(strftime);
 
-#ifdef RT_USING_POSIX
-
 #ifdef RT_USING_RTC
 static volatile struct timeval _timevalue;
 static int _rt_clock_time_system_init()
@@ -689,9 +687,6 @@ int rt_timespec_to_tick(const struct timespec *time)
     return tick;
 }
 RTM_EXPORT(rt_timespec_to_tick);
-
-#endif /* RT_USING_POSIX */
-
 
 /* timezone */
 #ifndef RT_LIBC_DEFAULT_TIMEZONE

--- a/components/libc/posix/getline/SConscript
+++ b/components/libc/posix/getline/SConscript
@@ -3,11 +3,9 @@
 from building import *
 
 cwd = GetCurrentDir()
-src = Glob('*.c') + Glob('*.cpp')
+src = Glob('*.c')
 CPPPATH = [cwd]
 
-group = DefineGroup('POSIX', src,
-    depend = ['RT_USING_LIBC', 'RT_USING_POSIX','RT_USING_POSIX_GETLINE'], 
-    CPPPATH = CPPPATH)
+group = DefineGroup('POSIX', src, depend = ['RT_USING_POSIX_GETLINE'], CPPPATH = CPPPATH)
 
 Return('group')

--- a/components/libc/posix/getline/posix_getline.c
+++ b/components/libc/posix/getline/posix_getline.c
@@ -75,4 +75,3 @@ ssize_t getdelim(char **lineptr, size_t *n, int delim, FILE *stream) {
 ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
     return getdelim(lineptr, n, '\n', stream);
 }
-

--- a/components/libc/posix/src/SConscript
+++ b/components/libc/posix/src/SConscript
@@ -2,25 +2,35 @@
 
 from building import *
 
-src     = ['unistd.c']
+src     = []
 cwd     = GetCurrentDir()
 CPPPATH = [cwd]
+group   = []
+
+flag = False
+src += ['unistd.c'] #TODO
 
 if GetDepend('RT_USING_POSIX_DEVIO'):
     src += ['libc.c']
+    flag = True
 
 if GetDepend('RT_USING_POSIX_DELAY'):
     src += ['delay.c']
+    flag = True
 
 if GetDepend('RT_USING_POSIX_POLL'):
     src += ['poll.c']
+    flag = True
 
 if GetDepend('RT_USING_POSIX_SELECT'):
     src += ['select.c']
+    flag = True
 
 if GetDepend('RT_USING_POSIX_MMAP'):
     src += ['mmap.c']
+    flag = True
 
-group = DefineGroup('POSIX', src, depend = ['RT_USING_POSIX'], CPPPATH = CPPPATH)
+if flag == True:
+    group = DefineGroup('POSIX', src, depend = [], CPPPATH = CPPPATH)
 
 Return('group')

--- a/components/lwp/Kconfig
+++ b/components/lwp/Kconfig
@@ -1,6 +1,6 @@
 config RT_USING_LWP
     bool "Using light-weight process"
-    select RT_USING_POSIX
+    select RT_USING_POSIX_FS
     select RT_USING_POSIX_SELECT
     select RT_USING_LIBC
     depends on ARCH_ARM_CORTEX_M || ARCH_ARM_ARM9 || ARCH_ARM_CORTEX_A

--- a/components/net/Kconfig
+++ b/components/net/Kconfig
@@ -41,7 +41,7 @@ config RT_USING_SAL
         config SAL_USING_POSIX
             bool "Enable BSD socket operated by file system API"
             default n
-            select RT_USING_POSIX
+            select RT_USING_POSIX_FS
             select RT_USING_POSIX_SELECT
             help
                 Let BSD socket operated by file system API, such as read/write and involveed in select/poll POSIX APIs.


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
![image](https://user-images.githubusercontent.com/34888354/143821858-4d46ec86-df1c-4e75-b89b-3629675bba85.png)
- RT_USING_POSIX_FS 是 剥离RT_USING_POSIX有关的关键一步，在之前的RT_USING_POSIX宏中，不管posix相关的功能是否需要文件系统，都会强迫选定文件系统。
- 整理之后增加RT_USING_POSIX_FS ， 把和文件系统相关的集中在RT_USING_POSIX_FS 目录之下，其他不需要posix文件系统的与RT_USING_POSIX_FS并列，不必强制选定文件系统。
- 同时RT_USING_POSIX_FS 也是作为快捷键，方便熟悉posix但是不熟悉rt-thread的用户，可以不必翻来翻去找去配置dfs，直接RT_USING_POSIX_FS一键搞定, RT_USING_POSIX_FS 内部会自动选定RT_USING_DFS以及DFS_USING_POSIX


STM32潘多拉测试通过, 忽略CI报警

注意：RT_USING_POSIX_FS和 RT_LIBC_USING_FILEIO宏定义属于方便用户的快捷方式，在sconscript脚本中不能使用GetDefine('RT_LIBC_USING_FILEIO') 来判断，要用GetDefine('DFS_USING_POSIX')来判断；RT_LIBC_USING_FILEIO同理。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
