### PR TITLE
[SDIO] Fix infinite-loop in rt_mmcsd_blk_remove.

### DIFF
--- a/components/drivers/include/drivers/mmcsd_card.h
+++ b/components/drivers/include/drivers/mmcsd_card.h
@@ -161,7 +161,7 @@ struct rt_mmcsd_card {
     struct rt_sdio_cccr    cccr;  /* common card info */
     struct rt_sdio_cis     cis;  /* common tuple info */
     struct rt_sdio_function *sdio_function[SDIO_MAX_FUNCTIONS + 1]; /* SDIO functions (devices) */
-
+    rt_list_t blk_devices;  /* for block device list */
 };
 
 #ifdef __cplusplus

--- a/components/drivers/include/drivers/mmcsd_host.h
+++ b/components/drivers/include/drivers/mmcsd_host.h
@@ -96,6 +96,8 @@ struct rt_mmcsd_host {
     rt_uint32_t max_blk_size;   /* maximum block size */
     rt_uint32_t max_blk_count;  /* maximum block count */
 
+    rt_uint32_t id;          /* Assigned host id */
+
     rt_uint32_t   spi_use_crc;
     struct rt_mutex  bus_lock;
     struct rt_semaphore  sem_ack;

--- a/components/drivers/sdio/block_dev.c
+++ b/components/drivers/sdio/block_dev.c
@@ -449,7 +449,7 @@ rt_int32_t rt_mmcsd_blk_probe(struct rt_mmcsd_card *card)
     status = rt_mmcsd_req_blk(card, 0, sector, 1, 0);
     if (status == RT_EOK)
     {
-        rt_uint8_t i; 
+        rt_uint8_t i;
         char dname[8];
         struct dfs_partition part;
         struct mmcsd_blk_device *blk_dev = RT_NULL;

--- a/components/drivers/sdio/block_dev.c
+++ b/components/drivers/sdio/block_dev.c
@@ -496,7 +496,7 @@ void rt_mmcsd_blk_remove(struct rt_mmcsd_card *card)
     rt_list_t *l, *n;
     struct mmcsd_blk_device *blk_dev;
 
-    for (l = (&blk_devices)->next, n = l->next; l != &blk_devices; l = n)
+    for (l = (&blk_devices)->next, n = l->next; l != &blk_devices; l = n, n = n->next)
     {
         blk_dev = (struct mmcsd_blk_device *)rt_list_entry(l, struct mmcsd_blk_device, list);
         if (blk_dev->card == card)

--- a/components/drivers/sdio/block_dev.c
+++ b/components/drivers/sdio/block_dev.c
@@ -475,7 +475,7 @@ rt_int32_t rt_mmcsd_blk_probe(struct rt_mmcsd_card *card)
             {
                 break;
             }
-        } // for
+        }
 
         /* Always create the super node, given name is with allocated host id. */
         rt_snprintf(dname, sizeof(dname), "sd%d", host_id);

--- a/components/drivers/sdio/mmcsd_core.c
+++ b/components/drivers/sdio/mmcsd_core.c
@@ -711,7 +711,7 @@ struct rt_mmcsd_host *mmcsd_alloc_host(void)
     host->id = allocated_host_num;
     allocated_host_num++;
 
-    rt_mutex_init(&host->bus_lock, "sd_bus_lock", RT_IPC_FLAG_FIFO);
+    rt_mutex_init(&host->bus_lock, "sd_bus_lock", RT_IPC_FLAG_PRIO);
     rt_sem_init(&host->sem_ack, "sd_ack", 0, RT_IPC_FLAG_FIFO);
 
     return host;

--- a/components/drivers/sdio/mmcsd_core.c
+++ b/components/drivers/sdio/mmcsd_core.c
@@ -40,6 +40,7 @@ static struct rt_mailbox  mmcsd_detect_mb;
 static rt_uint32_t mmcsd_detect_mb_pool[4];
 static struct rt_mailbox mmcsd_hotpluge_mb;
 static rt_uint32_t mmcsd_hotpluge_mb_pool[4];
+static rt_uint32_t allocated_host_num = 0;
 
 void mmcsd_host_lock(struct rt_mmcsd_host *host)
 {
@@ -707,8 +708,10 @@ struct rt_mmcsd_host *mmcsd_alloc_host(void)
     host->max_dma_segs = 1;
     host->max_blk_size = 512;
     host->max_blk_count = 4096;
+    host->id = allocated_host_num;
+    allocated_host_num++;
 
-    rt_mutex_init(&host->bus_lock, "sd_bus_lock", RT_IPC_FLAG_PRIO);
+    rt_mutex_init(&host->bus_lock, "sd_bus_lock", RT_IPC_FLAG_FIFO);
     rt_sem_init(&host->sem_ack, "sd_ack", 0, RT_IPC_FLAG_FIFO);
 
     return host;


### PR DESCRIPTION
1. Issue on traveling second node in list if multi-partitions on card.

## 拉取/合并请求描述：(PR description)

[
修複 移除 "多分區"的SD卡時，造成的 infinite-loop
支持多卡多分區掛載/缷載
    1. New naming rule for multiple cards: sdXpY. Ex: sd0, sd0p0, sd0p1, sd1, sd1p0, sd1p1, .... sdXpY.
    2. Always create super-node block device for backward-compatible and fdisk-like utility. EX: sd0, sd1, ..... sdX.
    3. Shrink code.

Tested on Nuvoton MA35D1 platform.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
