### PR TITLE
[tools][building.py] 修复加入空列表和空字符串的问题

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -616,6 +616,17 @@ def MergeGroup(src_group, group):
         else:
             src_group['LOCAL_ASFLAGS'] = group['LOCAL_ASFLAGS']
 
+def _PretreatListParameters(target_list):
+    while '' in target_list: # remove null strings
+        target_list.remove('')
+    while ' ' in target_list: # remove ' '
+        target_list.remove(' ')
+
+    if(len(target_list) == 0):
+        return False # ignore this list, don't add this list to the parameter
+
+    return True # permit to add this list to the parameter
+
 def DefineGroup(name, src, depend, **parameters):
     global Env
     if not GetDepend(depend):
@@ -640,19 +651,29 @@ def DefineGroup(name, src, depend, **parameters):
         group['src'] = src
 
     if 'CCFLAGS' in group:
-        Env.AppendUnique(CCFLAGS = group['CCFLAGS'])
+        target = group['CCFLAGS']
+        if len(target) > 0:
+            Env.AppendUnique(CCFLAGS = target)
     if 'CPPPATH' in group:
-        paths = []
-        for item in group['CPPPATH']:
-            paths.append(os.path.abspath(item))
-        group['CPPPATH'] = paths
-        Env.AppendUnique(CPPPATH = group['CPPPATH'])
+        target = group['CPPPATH']
+        if _PretreatListParameters(target) == True:
+            paths = []
+            for item in target:
+                paths.append(os.path.abspath(item))
+            target = paths
+            Env.AppendUnique(CPPPATH = target)
     if 'CPPDEFINES' in group:
-        Env.AppendUnique(CPPDEFINES = group['CPPDEFINES'])
+        target = group['CPPDEFINES']
+        if _PretreatListParameters(target) == True:
+            Env.AppendUnique(CPPDEFINES = target)
     if 'LINKFLAGS' in group:
-        Env.AppendUnique(LINKFLAGS = group['LINKFLAGS'])
+        target = group['LINKFLAGS']
+        if len(target) > 0:
+            Env.AppendUnique(LINKFLAGS = target)
     if 'ASFLAGS' in group:
-        Env.AppendUnique(ASFLAGS = group['ASFLAGS'])
+        target = group['ASFLAGS']
+        if len(target) > 0:
+            Env.AppendUnique(ASFLAGS = target)
     if 'LOCAL_CPPPATH' in group:
         paths = []
         for item in group['LOCAL_CPPPATH']:
@@ -675,9 +696,13 @@ def DefineGroup(name, src, depend, **parameters):
                 os.unlink(fn)
 
     if 'LIBS' in group:
-        Env.AppendUnique(LIBS = group['LIBS'])
+        target = group['LIBS']
+        if _PretreatListParameters(target) == True:
+            Env.AppendUnique(LIBS = target)
     if 'LIBPATH' in group:
-        Env.AppendUnique(LIBPATH = group['LIBPATH'])
+        target = group['LIBPATH']
+        if _PretreatListParameters(target) == True:
+            Env.AppendUnique(LIBPATH = target)
 
     # check whether to build group library
     if 'LIBRARY' in group:


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
本pr旨在修复创建时没有剔除空白object的问题：
![7964930483f127e60a8fad4cf350e8b](https://user-images.githubusercontent.com/34888354/143993030-4462292e-c004-4a76-b42c-81c66f81f4bf.png)

![fd64fa72f3556800e67ad8bb3c40875](https://user-images.githubusercontent.com/34888354/143993001-c7b1286f-e014-42e5-81e7-eaf642450cad.png)

![70ea9d6bb880a9ac667ab221dc6cc51](https://user-images.githubusercontent.com/34888354/143993148-f076dc1b-8e2e-4c55-ba26-f1b12f4c3c7e.png)


对以下两种情况进行检查：
1. 检查列表中是否有空字符串，如果有就剔除掉
2. 检查列表是否为空列表，如果是空列表，说明给定的参数是无效的，不加入到env中。

依然存在的问题，需要其他PR来处理：
1.添加的参数在其他Group是否已经添加过了，即需要做防重复添加检查；
2.在src为空的情况下，就不需要添加group名了，否则会在IAR里创建一个空的工程文件夹出来。
3.local_group 没有处理

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
