### PR TITLE
[PSE分支] 替换宏定义 将posix单独划分为一个Kconfig目录

### DIFF
--- a/bsp/lpc55sxx/lpc55s69_nxp_evk/board/Kconfig
+++ b/bsp/lpc55sxx/lpc55s69_nxp_evk/board/Kconfig
@@ -137,7 +137,6 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_SDIO
         select RT_USING_DFS
         select RT_USING_DFS_ELMFAT
-        select RT_USING_LIBC
         select RT_LIBC_USING_TIME
         default y
 

--- a/bsp/stm32/stm32l475-atk-pandora/board/Kconfig
+++ b/bsp/stm32/stm32l475-atk-pandora/board/Kconfig
@@ -137,8 +137,8 @@ menu "Onboard Peripheral Drivers"
             select RT_WLAN_PROT_LWIP_PBUF_FORCE
             select RT_USING_LWIP
             select RT_USING_LIBC
-            select RT_USING_POSIX
             select RT_USING_DFS
+            select DFS_USING_POSIX
             select PKG_USING_FAL
             select PKG_USING_EASYFLASH
             select RT_USING_WIFI_6181_LIB

--- a/components/cplusplus/Kconfig
+++ b/components/cplusplus/Kconfig
@@ -10,7 +10,7 @@ if RT_USING_CPLUSPLUS
         bool "Enable c++11 threading feature support"
         default n
         select RT_USING_LIBC
-        select RT_USING_DFS
+        select RT_LIBC_USING_FILEIO
         select RT_USING_PTHREADS
         select RT_USING_RTC
 

--- a/components/drivers/src/pipe.c
+++ b/components/drivers/src/pipe.c
@@ -439,7 +439,7 @@ const static struct rt_device_ops pipe_ops =
     rt_pipe_write,
     rt_pipe_control,
 };
-#endif
+#endif /* RT_USING_DEVICE_OPS */
 
 rt_pipe_t *rt_pipe_create(const char *name, int bufsz)
 {
@@ -481,7 +481,7 @@ rt_pipe_t *rt_pipe_create(const char *name, int bufsz)
     }
 #ifdef RT_USING_POSIX_DEVIO
     dev->fops = (void*)&pipe_fops;
-#endif
+#endif /* RT_USING_POSIX_DEVIO */
 
     return pipe;
 }

--- a/components/libc/Kconfig
+++ b/components/libc/Kconfig
@@ -1,7 +1,7 @@
 menu "POSIX layer and C standard library"
 
 config RT_USING_LIBC
-    bool "Enable libc APIs from toolchain"
+    bool "Enable libc APIs from the toolchain"
     default n
 
 if RT_USING_LIBC
@@ -37,59 +37,6 @@ config RT_LIBC_DEFAULT_TIMEZONE
     range -12 12
     default 8
 
-config RT_USING_POSIX_FS
-    bool "Enable POSIX file system, open()/read()/write()/close() etc"
-    select RT_USING_DFS
-    select DFS_USING_POSIX
-    default n
-
-if RT_USING_POSIX_FS
-    config RT_USING_POSIX_DEVIO
-        bool "Enable devices as file descriptors"
-        select RT_USING_DFS_DEVFS
-        default n
-
-    config RT_USING_POSIX_POLL
-        bool "Enable poll()"
-        default n
-
-    config RT_USING_POSIX_SELECT
-        bool "Enable select()"
-        select RT_USING_POSIX_POLL
-        default n
-endif
-
-config RT_USING_POSIX_DELAY
-    bool "Enable delay APIs, sleep()/usleep()/msleep() etc"
-    default n
-
-config RT_USING_POSIX_GETLINE
-    bool "Enable getline()/getdelim()"
-    select RT_USING_LIBC
-    select RT_LIBC_USING_FILEIO
-    default n
-
-config RT_USING_POSIX_MMAP
-    bool "Enable mmap()"
-    select RT_USING_POSIX_FS
-    default n
-
-config RT_USING_POSIX_TERMIOS
-    bool "Enable termios APIs"
-    default n
-
-config RT_USING_POSIX_AIO
-    bool "Enable AIO APIs"
-    default n
-
-config RT_USING_PTHREADS
-    bool "Enable pthreads APIs"
-    default n
-
-if RT_USING_PTHREADS
-    config PTHREAD_NUM_MAX
-        int "Maximum number of pthreads"
-        default 8
-endif
+source "$RTT_DIR/components/libc/posix/Kconfig"
 
 endmenu

--- a/components/libc/compilers/armlibc/syscalls.c
+++ b/components/libc/compilers/armlibc/syscalls.c
@@ -156,22 +156,26 @@ int _sys_read(FILEHANDLE fh, unsigned char *buf, unsigned len, int mode)
             return 0; /* error, but keep going */
         }
         size = read(STDIN_FILENO, buf, len);
-        return 0; /* success */
+        return len - size; /* success */
 #else
         return 0; /* error */
 #endif /* RT_USING_POSIX_DEVIO */
     }
     else if (fh == STDOUT || fh == STDERR)
     {
-        return 0; /* error */
+        return -1; /* 100% error */
     }
     else
     {
         size = read(fh, buf, len);
         if (size >= 0)
+        {
             return len - size; /* success */
+        }
         else
+        {
             return 0; /* error */
+        }
     }
 #else
     return 0; /* error */
@@ -209,16 +213,20 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
     }
     else if (fh == STDIN)
     {
-        return 0; /* error */
+        return -1; /* 100% error */
     }
     else
     {
 #ifdef DFS_USING_POSIX
         size = write(fh, buf, len);
         if (size >= 0)
-            return 0; /* success */
+        {
+            return len - size; /* success */
+        }
         else
+        {
             return 0; /* error */
+        }
 #else
         return 0; /* error */
 #endif /* DFS_USING_POSIX */

--- a/components/libc/posix/Kconfig
+++ b/components/libc/posix/Kconfig
@@ -1,0 +1,58 @@
+menu "POSIX (Portable Operating System Interface) layer"
+
+config RT_USING_POSIX_FS
+    bool "Enable POSIX file system, open()/read()/write()/close() etc"
+    select RT_USING_DFS
+    select DFS_USING_POSIX
+    default n
+
+if RT_USING_POSIX_FS
+    config RT_USING_POSIX_DEVIO
+        bool "Enable devices as file descriptors"
+        select RT_USING_DFS_DEVFS
+        default n
+
+    config RT_USING_POSIX_POLL
+        bool "Enable poll()"
+        default n
+
+    config RT_USING_POSIX_SELECT
+        bool "Enable select()"
+        select RT_USING_POSIX_POLL
+        default n
+endif
+
+config RT_USING_POSIX_DELAY
+    bool "Enable delay APIs, sleep()/usleep()/msleep() etc"
+    default n
+
+config RT_USING_POSIX_GETLINE
+    bool "Enable getline()/getdelim()"
+    select RT_USING_LIBC
+    select RT_LIBC_USING_FILEIO
+    default n
+
+config RT_USING_POSIX_MMAP
+    bool "Enable mmap()"
+    select RT_USING_POSIX_FS
+    default n
+
+config RT_USING_POSIX_TERMIOS
+    bool "Enable termios APIs"
+    default n
+
+config RT_USING_POSIX_AIO
+    bool "Enable AIO APIs"
+    default n
+
+config RT_USING_PTHREADS
+    bool "Enable pthreads APIs"
+    default n
+
+if RT_USING_PTHREADS
+    config PTHREAD_NUM_MAX
+        int "Maximum number of pthreads"
+        default 8
+endif
+
+endmenu

--- a/components/utilities/ymodem/ry_sy.c
+++ b/components/utilities/ymodem/ry_sy.c
@@ -17,6 +17,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef DFS_USING_POSIX
+#error "Please enable DFS_USING_POSIX"
+#endif
+
 struct custom_ctx
 {
     struct rym_ctx parent;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
替换宏定义; 将posix单独划分为一个Kconfig目录
![image](https://user-images.githubusercontent.com/34888354/144154014-81f36986-b7a4-4f4d-9832-96b4ef898fc0.png)
![image](https://user-images.githubusercontent.com/34888354/144154042-e491957e-06e2-49a5-a407-409f1275c298.png)

目前RT_USING_DFS在bsp里边的没有增加select DFS_USING_POSIX, 这个不作为强制选定，让用户自己确定是否使用read还是dfs_file_read (默认DFS_USING_POSIX为y)


DMODULE的RT_USING_POSIX暂时不替换，等dfs_posix.h脱敏的时候一起替换掉就可以了，这个暂时不对主代码构成影响。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [X] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [X] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [X] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [X] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [X] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [X] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [X] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
