### PR TITLE
[ulog] Add ulog backend filter.

### DIFF
--- a/components/utilities/ulog/backend/console_be.c
+++ b/components/utilities/ulog/backend/console_be.c
@@ -17,7 +17,7 @@
 #error "The thread stack size must more than 384 when using async output by thread (ULOG_ASYNC_OUTPUT_BY_THREAD)"
 #endif
 
-static struct ulog_backend console;
+static struct ulog_backend console = { 0 };
 
 void ulog_console_backend_output(struct ulog_backend *backend, rt_uint32_t level, const char *tag, rt_bool_t is_raw,
         const char *log, size_t len)

--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -244,7 +244,6 @@ static char *get_log_buf(void)
     }
 }
 
-extern struct tm* localtime_r(const time_t* t, struct tm* r);
 RT_WEAK rt_size_t ulog_formater(char *log_buf, rt_uint32_t level, const char *tag, rt_bool_t newline,
         const char *format, va_list args)
 {
@@ -275,6 +274,7 @@ RT_WEAK rt_size_t ulog_formater(char *log_buf, rt_uint32_t level, const char *ta
     /* add time info */
     {
 #ifdef ULOG_TIME_USING_TIMESTAMP
+        extern struct tm* localtime_r(const time_t* t, struct tm* r);
         static struct timeval now;
         static struct tm *tm, tm_tmp;
         static rt_bool_t check_usec_support = RT_FALSE, usec_is_support = RT_FALSE;

--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -244,6 +244,7 @@ static char *get_log_buf(void)
     }
 }
 
+extern struct tm* localtime_r(const time_t* t, struct tm* r);
 RT_WEAK rt_size_t ulog_formater(char *log_buf, rt_uint32_t level, const char *tag, rt_bool_t newline,
         const char *format, va_list args)
 {
@@ -439,6 +440,11 @@ void ulog_output_to_all_backend(rt_uint32_t level, const char *tag, rt_bool_t is
 #if !defined(ULOG_USING_COLOR) || defined(ULOG_USING_SYSLOG)
         backend->output(backend, level, tag, is_raw, log, size);
 #else
+        if (backend->filter && backend->filter(backend, level, tag, is_raw, log, size) == RT_FALSE)
+        {
+            /* backend's filter is not match, so skip output */
+            continue;
+        }
         if (backend->support_color || is_raw)
         {
             backend->output(backend, level, tag, is_raw, log, size);
@@ -447,7 +453,7 @@ void ulog_output_to_all_backend(rt_uint32_t level, const char *tag, rt_bool_t is
         {
             /* recalculate the log start address and log size when backend not supported color */
             rt_size_t color_info_len = 0, output_size = size;
-            char *output_log = log;
+            const char *output_log = log;
 
             if (color_output_info[level] != RT_NULL)
                 color_info_len = rt_strlen(color_output_info[level]);
@@ -1298,6 +1304,41 @@ rt_err_t ulog_backend_unregister(ulog_backend_t backend)
     rt_hw_interrupt_enable(level);
 
     return RT_EOK;
+}
+
+rt_err_t ulog_backend_set_filter(ulog_backend_t backend, ulog_backend_filter_t filter)
+{
+    rt_base_t level;
+    RT_ASSERT(backend);
+
+    level = rt_hw_interrupt_disable();
+    backend->filter = filter;
+    rt_hw_interrupt_enable(level);
+
+    return RT_EOK;
+}
+
+ulog_backend_t ulog_backend_find(const char *name)
+{
+    rt_base_t level;
+    rt_slist_t *node;
+    ulog_backend_t backend;
+
+    RT_ASSERT(ulog.init_ok);
+
+    level = rt_hw_interrupt_disable();
+    for (node = rt_slist_first(&ulog.backend_list); node; node = rt_slist_next(node))
+    {
+        backend = rt_slist_entry(node, struct ulog_backend, list);
+        if (rt_strncmp(backend->name, name, RT_NAME_MAX) == 0)
+        {
+            rt_hw_interrupt_enable(level);
+            return backend;
+        }
+    }
+
+    rt_hw_interrupt_enable(level);
+    return RT_NULL;
 }
 
 #ifdef ULOG_USING_ASYNC_OUTPUT

--- a/components/utilities/ulog/ulog.h
+++ b/components/utilities/ulog/ulog.h
@@ -54,6 +54,8 @@ void ulog_deinit(void);
  */
 rt_err_t ulog_backend_register(ulog_backend_t backend, const char *name, rt_bool_t support_color);
 rt_err_t ulog_backend_unregister(ulog_backend_t backend);
+rt_err_t ulog_backend_set_filter(ulog_backend_t backend, ulog_backend_filter_t filter);
+ulog_backend_t ulog_backend_find(const char *name);
 
 #ifdef ULOG_USING_FILTER
 /*

--- a/components/utilities/ulog/ulog_def.h
+++ b/components/utilities/ulog/ulog_def.h
@@ -211,9 +211,12 @@ struct ulog_backend
     void (*output)(struct ulog_backend *backend, rt_uint32_t level, const char *tag, rt_bool_t is_raw, const char *log, size_t len);
     void (*flush) (struct ulog_backend *backend);
     void (*deinit)(struct ulog_backend *backend);
+    /* The filter will be call before output. It will return TRUE when the filter condition is math. */
+    rt_bool_t (*filter)(struct ulog_backend *backend, rt_uint32_t level, const char *tag, rt_bool_t is_raw, const char *log, size_t len);
     rt_slist_t list;
 };
 typedef struct ulog_backend *ulog_backend_t;
+typedef rt_bool_t (*ulog_backend_filter_t)(struct ulog_backend *backend, rt_uint32_t level, const char *tag, rt_bool_t is_raw, const char *log, size_t len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

为每个 ulog 后端增加独立的过滤器，方便控制每个后端的输出方式

大致用法：

- 定义过滤器函数

```c
rt_bool_t console_backend_filter(struct ulog_backend *backend, rt_uint32_t level, const char *tag, rt_bool_t is_raw,
        const char *log, size_t len)
{
    rt_uint32_t setting_level = DBG_INFO;
    if (level > setting_level && rt_strstr(log, "XYZ") != RT_NULL)
    {
        return RT_TRUE;
    }
    else
    {
        return RT_FALSE;
    }
}
```

- 在代码中设置过滤器，可以看到只有符合过滤器条件的日志才会被输出
```C
ulog_backend_set_filter(ulog_backend_find("console"), console_backend_filter);
```

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [X] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [X] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [X] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [X] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [X] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [X] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [X] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [X] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
