### PR TITLE
[lwip] solve the conflict between multi BYTE_ORDER(s)

### DIFF
--- a/components/net/lwip-1.4.1/src/arch/include/arch/cc.h
+++ b/components/net/lwip-1.4.1/src/arch/include/arch/cc.h
@@ -40,6 +40,14 @@
 #include <string.h>
 #include <stdint.h>
 
+#ifndef BYTE_ORDER
+#ifdef RT_USING_BIG_ENDIAN
+#define BYTE_ORDER BIG_ENDIAN
+#else
+#define BYTE_ORDER LITTLE_ENDIAN
+#endif /* RT_USING_BIG_ENDIAN */
+#endif /* BYTE_ORDER */
+
 typedef uint8_t   u8_t;
 typedef int8_t    s8_t;
 typedef uint16_t  u16_t;

--- a/components/net/lwip-1.4.1/src/arch/include/arch/sys_arch.h
+++ b/components/net/lwip-1.4.1/src/arch/include/arch/sys_arch.h
@@ -36,19 +36,12 @@
 #define __ARCH_SYS_ARCH_H__
 
 #include "arch/cc.h"
-
 #include <rtthread.h>
-
-#ifdef RT_USING_BIG_ENDIAN
-#define BYTE_ORDER BIG_ENDIAN
-#else
-#define BYTE_ORDER LITTLE_ENDIAN
-#endif
 
 #define SYS_MBOX_NULL RT_NULL
 #define SYS_SEM_NULL  RT_NULL
 
-typedef u32_t sys_prot_t;
+typedef rt_uint32_t sys_prot_t;
 
 #define SYS_MBOX_SIZE 10
 #define SYS_LWIP_TIMER_NAME "timer"

--- a/components/net/lwip-1.4.1/src/lwipopts.h
+++ b/components/net/lwip-1.4.1/src/lwipopts.h
@@ -37,10 +37,6 @@
 
 #define LWIP_PLATFORM_BYTESWAP      0
 
-#ifndef BYTE_ORDER
-#define BYTE_ORDER                  LITTLE_ENDIAN
-#endif
-
 /* #define RT_LWIP_DEBUG */
 
 #ifdef RT_LWIP_DEBUG

--- a/components/net/lwip-2.0.2/src/arch/include/arch/cc.h
+++ b/components/net/lwip-2.0.2/src/arch/include/arch/cc.h
@@ -39,6 +39,14 @@
 #include <rtthread.h>
 #include <string.h>
 
+#ifndef BYTE_ORDER
+#ifdef RT_USING_BIG_ENDIAN
+#define BYTE_ORDER BIG_ENDIAN
+#else
+#define BYTE_ORDER LITTLE_ENDIAN
+#endif /* RT_USING_BIG_ENDIAN */
+#endif /* BYTE_ORDER */
+
 #define U16_F "hu"
 #define S16_F "hd"
 #define X16_F "hx"

--- a/components/net/lwip-2.0.2/src/arch/include/arch/sys_arch.h
+++ b/components/net/lwip-2.0.2/src/arch/include/arch/sys_arch.h
@@ -36,19 +36,12 @@
 #define __ARCH_SYS_ARCH_H__
 
 #include "arch/cc.h"
-
 #include <rtthread.h>
-
-#ifdef RT_USING_BIG_ENDIAN
-#define BYTE_ORDER BIG_ENDIAN
-#else
-#define BYTE_ORDER LITTLE_ENDIAN
-#endif
 
 #define SYS_MBOX_NULL RT_NULL
 #define SYS_SEM_NULL  RT_NULL
 
-typedef u32_t sys_prot_t;
+typedef rt_uint32_t sys_prot_t;
 
 #define SYS_MBOX_SIZE 10
 #define SYS_LWIP_TIMER_NAME "timer"

--- a/components/net/lwip-2.0.2/src/lwipopts.h
+++ b/components/net/lwip-2.0.2/src/lwipopts.h
@@ -45,10 +45,6 @@
 
 #define LWIP_PLATFORM_BYTESWAP      0
 
-#ifndef BYTE_ORDER
-#define BYTE_ORDER                  LITTLE_ENDIAN
-#endif
-
 /* #define RT_LWIP_DEBUG */
 
 #ifdef RT_LWIP_DEBUG

--- a/components/net/lwip-2.0.3/src/arch/include/arch/cc.h
+++ b/components/net/lwip-2.0.3/src/arch/include/arch/cc.h
@@ -39,6 +39,13 @@
 #include <rtthread.h>
 #include <string.h>
 
+#ifndef BYTE_ORDER
+#ifdef RT_USING_BIG_ENDIAN
+#define BYTE_ORDER BIG_ENDIAN
+#else
+#define BYTE_ORDER LITTLE_ENDIAN
+#endif /* RT_USING_BIG_ENDIAN */
+#endif /* BYTE_ORDER */
 
 #define U16_F "hu"
 #define S16_F "hd"

--- a/components/net/lwip-2.0.3/src/arch/include/arch/sys_arch.h
+++ b/components/net/lwip-2.0.3/src/arch/include/arch/sys_arch.h
@@ -36,19 +36,12 @@
 #define __ARCH_SYS_ARCH_H__
 
 #include "arch/cc.h"
-
 #include <rtthread.h>
-
-#ifdef RT_USING_BIG_ENDIAN
-#define BYTE_ORDER BIG_ENDIAN
-#else
-#define BYTE_ORDER LITTLE_ENDIAN
-#endif
 
 #define SYS_MBOX_NULL RT_NULL
 #define SYS_SEM_NULL  RT_NULL
 
-typedef u32_t sys_prot_t;
+typedef rt_uint32_t sys_prot_t;
 
 #define SYS_MBOX_SIZE 10
 #define SYS_LWIP_TIMER_NAME "timer"

--- a/components/net/lwip-2.0.3/src/lwipopts.h
+++ b/components/net/lwip-2.0.3/src/lwipopts.h
@@ -45,10 +45,6 @@
 
 #define LWIP_PLATFORM_BYTESWAP      0
 
-#ifndef BYTE_ORDER
-#define BYTE_ORDER                  LITTLE_ENDIAN
-#endif
-
 /* #define RT_LWIP_DEBUG */
 
 #ifdef RT_LWIP_DEBUG

--- a/components/net/lwip-2.1.2/src/arch/include/arch/cc.h
+++ b/components/net/lwip-2.1.2/src/arch/include/arch/cc.h
@@ -39,6 +39,14 @@
 #include <rtthread.h>
 #include <string.h>
 
+#ifndef BYTE_ORDER
+#ifdef RT_USING_BIG_ENDIAN
+#define BYTE_ORDER BIG_ENDIAN
+#else
+#define BYTE_ORDER LITTLE_ENDIAN
+#endif /* RT_USING_BIG_ENDIAN */
+#endif /* BYTE_ORDER */
+
 #define U16_F "hu"
 #define S16_F "hd"
 #define X16_F "hx"

--- a/components/net/lwip-2.1.2/src/arch/include/arch/sys_arch.h
+++ b/components/net/lwip-2.1.2/src/arch/include/arch/sys_arch.h
@@ -36,19 +36,12 @@
 #define __ARCH_SYS_ARCH_H__
 
 #include "arch/cc.h"
-
 #include <rtthread.h>
-
-#ifdef RT_USING_BIG_ENDIAN
-#define BYTE_ORDER BIG_ENDIAN
-#else
-#define BYTE_ORDER LITTLE_ENDIAN
-#endif
 
 #define SYS_MBOX_NULL RT_NULL
 #define SYS_SEM_NULL  RT_NULL
 
-typedef u32_t sys_prot_t;
+typedef rt_uint32_t sys_prot_t;
 
 #define SYS_MBOX_SIZE 10
 #define SYS_LWIP_TIMER_NAME "timer"

--- a/components/net/lwip-2.1.2/src/lwipopts.h
+++ b/components/net/lwip-2.1.2/src/lwipopts.h
@@ -47,10 +47,6 @@
 
 #define LWIP_PLATFORM_BYTESWAP      0
 
-#ifndef BYTE_ORDER
-#define BYTE_ORDER                  LITTLE_ENDIAN
-#endif
-
 /* #define RT_LWIP_DEBUG */
 
 #ifdef RT_LWIP_DEBUG


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
BYTE_ORDER 的定义应该放在cc.h中
![1638684548(1)](https://user-images.githubusercontent.com/34888354/144736302-c69c9f56-f3c8-4a4c-9246-72d099dc3250.png)

在GCC和Keil下 1.4.1 2.0.2 2.0.3 2.1.2冲突已经解决

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
