### PR TITLE
[bugfix] libcpu/arm/cortex-m/context_gcc: 修复thumb指令集汇编语法错误

### DIFF
--- a/libcpu/arm/cortex-m33/context_gcc.S
+++ b/libcpu/arm/cortex-m33/context_gcc.S
@@ -143,6 +143,7 @@ contex_ns_store:
 
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
     TST     lr, #0x10                               /* if(!EXC_RETURN[4]) */
+    IT      EQ
     VSTMDBEQ  r1!, {d8 - d15}                       /* push FPU register s16~s31 */
 #endif
 
@@ -187,6 +188,7 @@ contex_ns_load:
 
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
     TST     lr, #0x10                               /* if(!EXC_RETURN[4]) */
+    IT      EQ
     VLDMIAEQ  r1!, {d8 - d15}                       /* pop FPU register s16~s31 */
 #endif
 

--- a/libcpu/arm/cortex-m4/context_gcc.S
+++ b/libcpu/arm/cortex-m4/context_gcc.S
@@ -107,6 +107,7 @@ PendSV_Handler:
     
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
     TST     lr, #0x10           /* if(!EXC_RETURN[4]) */
+    IT      EQ
     VSTMDBEQ r1!, {d8 - d15}    /* push FPU register s16~s31 */
 #endif
     
@@ -116,6 +117,7 @@ PendSV_Handler:
     MOV     r4, #0x00           /* flag = 0 */
 
     TST     lr, #0x10           /* if(!EXC_RETURN[4]) */
+    IT      EQ
     MOVEQ   r4, #0x01           /* flag = 1 */
 
     STMFD   r1!, {r4}           /* push flag */
@@ -137,6 +139,7 @@ switch_to_thread:
 
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
     CMP     r3,  #0             /* if(flag_r3 != 0) */
+    IT      NE
     VLDMIANE  r1!, {d8 - d15}   /* pop FPU register s16~s31 */
 #endif
 
@@ -145,6 +148,7 @@ switch_to_thread:
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
     ORR     lr, lr, #0x10       /* lr |=  (1 << 4), clean FPCA. */
     CMP     r3,  #0             /* if(flag_r3 != 0) */
+    IT      NE
     BICNE   lr, lr, #0x10       /* lr &= ~(1 << 4), set FPCA. */
 #endif
 

--- a/libcpu/arm/cortex-m7/context_gcc.S
+++ b/libcpu/arm/cortex-m7/context_gcc.S
@@ -107,6 +107,7 @@ PendSV_Handler:
     
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
     TST     lr, #0x10           /* if(!EXC_RETURN[4]) */
+    IT      EQ
     VSTMDBEQ r1!, {d8 - d15}    /* push FPU register s16~s31 */
 #endif
     
@@ -116,6 +117,7 @@ PendSV_Handler:
     MOV     r4, #0x00           /* flag = 0 */
 
     TST     lr, #0x10           /* if(!EXC_RETURN[4]) */
+    IT      EQ
     MOVEQ   r4, #0x01           /* flag = 1 */
 
     STMFD   r1!, {r4}           /* push flag */
@@ -137,6 +139,7 @@ switch_to_thread:
 
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
     CMP     r3,  #0             /* if(flag_r3 != 0) */
+    IT      NE
     VLDMIANE  r1!, {d8 - d15}   /* pop FPU register s16~s31 */
 #endif
 
@@ -145,6 +148,7 @@ switch_to_thread:
 #if defined (__VFP_FP__) && !defined(__SOFTFP__)
     ORR     lr, lr, #0x10       /* lr |=  (1 << 4), clean FPCA. */
     CMP     r3,  #0             /* if(flag_r3 != 0) */
+    IT      NE
     BICNE   lr, lr, #0x10       /* lr &= ~(1 << 4), set FPCA. */
 #endif
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
当使用thumb指令集时，要求汇编语法中的“条件执行”要跟在IT指令后面，否则会编译不通过。
报错如下：Error: thumb conditional instruction should be in IT block -- `moveq r4,#0x01'

对于4.x版本的gcc编译器，可以通过指定编译选项：-mimplicit-it=thumb 来告诉编译器识别隐式的IT指令，从而通过编译。
但是对于高版本的gcc编译器，已经取消了此编译选项。故必须手动的加上IT指令才能通过编译。

thumb指令集“条件执行”arm官网文档：
    https://developer.arm.com/documentation/dui0473/m/condition-codes/conditional-execution-in-thumb-state

参考论坛帖子：
    https://club.rt-thread.org/ask/question/433887.html （包含复现方法）
    https://club.rt-thread.org/ask/question/4188.html

Signed-off-by: Mingrui Ren <jiladahe1997@gmail.com>
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [X] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [X] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [X] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [X] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
