### PR TITLE
BugFix: Raspi3 GPIO driver write bug

### DIFF
--- a/bsp/raspberry-pi/raspi3-32/driver/drv_gpio.c
+++ b/bsp/raspberry-pi/raspi3-32/driver/drv_gpio.c
@@ -137,7 +137,7 @@ static void raspi_pin_write(struct rt_device *dev, rt_base_t pin, rt_base_t valu
     if (value)
         BCM283X_GPIO_GPSET(pin / 32) |= (1 << (pin %32));
     else
-        BCM283X_GPIO_GPCLR(pin / 32) |= (0 << (pin %32));
+        BCM283X_GPIO_GPCLR(pin / 32) |= (1 << (pin %32));
 
 }
 

--- a/bsp/raspberry-pi/raspi3-32/driver/raspi.h
+++ b/bsp/raspberry-pi/raspi3-32/driver/raspi.h
@@ -172,19 +172,19 @@ typedef enum
 
 /* Defines for GPIO */
 #define BCM283X_GPIO_BASE     (PER_BASE + GPIO_BASE_OFFSET)
-#define BCM283X_GPIO_GPFSEL(n) HWREG32(BCM283X_GPIO_BASE + 0x0000 + 0x4 * n) /* GPIO Function Select 32bit R/W */
-#define BCM283X_GPIO_GPSET(n) HWREG32(BCM283X_GPIO_BASE + 0x001C + 0x4 * n) /* GPIO Pin Output Set */
-#define BCM283X_GPIO_GPCLR(n) HWREG32(BCM283X_GPIO_BASE + 0x0028 + 0x4 * n) /* GPIO Pin Output Clear */
-#define BCM2835_GPIO_GPLEV(n) HWREG32(BCM283X_GPIO_BASE + 0x0034 + 0x4 * n) /* GPIO Pin Level */
-#define BCM283X_GPIO_GPEDS(n) HWREG32(BCM283X_GPIO_BASE + 0x0040 + 0x4 * n) /* GPIO Pin Event Detect Status */
-#define BCM283X_GPIO_GPREN(n) HWREG32(BCM283X_GPIO_BASE + 0x004c + 0x4 * n) /* GPIO Pin Rising Edge Detect Enable */
-#define BCM283X_GPIO_GPFEN(n) HWREG32(BCM283X_GPIO_BASE + 0x0058 + 0x4 * n) /* GPIO Pin Falling Edge Detect Enable */
-#define BCM283X_GPIO_GPHEN(n) HWREG32(BCM283X_GPIO_BASE + 0x0064 + 0x4 * n) /* GPIO Pin High Detect Enable  */
-#define BCM283X_GPIO_GPLEN(n) HWREG32(BCM283X_GPIO_BASE + 0x0070 + 0x4 * n) /* GPIO Pin Low Detect Enable */
-#define BCM283X_GPIO_GPAREN(n) HWREG32(BCM283X_GPIO_BASE + 0x007C + 0x4 * n) /* GPIO Pin Async. Rising Edge Detect */
-#define BCM283X_GPIO_GPAFEN(n) HWREG32(BCM283X_GPIO_BASE + 0x0088 + 0x4 * n) /* GPIO Pin Async. Falling Edge Detect */
+#define BCM283X_GPIO_GPFSEL(n) HWREG32(BCM283X_GPIO_BASE + 0x0000 + 0x4 * (n)) /* GPIO Function Select 32bit R/W */
+#define BCM283X_GPIO_GPSET(n) HWREG32(BCM283X_GPIO_BASE + 0x001C + 0x4 * (n)) /* GPIO Pin Output Set */
+#define BCM283X_GPIO_GPCLR(n) HWREG32(BCM283X_GPIO_BASE + 0x0028 + 0x4 * (n)) /* GPIO Pin Output Clear */
+#define BCM2835_GPIO_GPLEV(n) HWREG32(BCM283X_GPIO_BASE + 0x0034 + 0x4 * (n)) /* GPIO Pin Level */
+#define BCM283X_GPIO_GPEDS(n) HWREG32(BCM283X_GPIO_BASE + 0x0040 + 0x4 * (n)) /* GPIO Pin Event Detect Status */
+#define BCM283X_GPIO_GPREN(n) HWREG32(BCM283X_GPIO_BASE + 0x004c + 0x4 * (n)) /* GPIO Pin Rising Edge Detect Enable */
+#define BCM283X_GPIO_GPFEN(n) HWREG32(BCM283X_GPIO_BASE + 0x0058 + 0x4 * (n)) /* GPIO Pin Falling Edge Detect Enable */
+#define BCM283X_GPIO_GPHEN(n) HWREG32(BCM283X_GPIO_BASE + 0x0064 + 0x4 * (n)) /* GPIO Pin High Detect Enable  */
+#define BCM283X_GPIO_GPLEN(n) HWREG32(BCM283X_GPIO_BASE + 0x0070 + 0x4 * (n)) /* GPIO Pin Low Detect Enable */
+#define BCM283X_GPIO_GPAREN(n) HWREG32(BCM283X_GPIO_BASE + 0x007C + 0x4 * (n)) /* GPIO Pin Async. Rising Edge Detect */
+#define BCM283X_GPIO_GPAFEN(n) HWREG32(BCM283X_GPIO_BASE + 0x0088 + 0x4 * (n)) /* GPIO Pin Async. Falling Edge Detect */
 #define BCM283X_GPIO_GPPUD     HWREG32(BCM283X_GPIO_BASE + 0x0094)     /* GPIO Pin Pull-up/down Enable */
-#define BCM283X_GPIO_GPPUDCLK(n)    HWREG32(BCM283X_GPIO_BASE + 0x0098 + 0x4 * n) /* GPIO Pin Pull-up/down Enable Clock */
+#define BCM283X_GPIO_GPPUDCLK(n)    HWREG32(BCM283X_GPIO_BASE + 0x0098 + 0x4 * (n)) /* GPIO Pin Pull-up/down Enable Clock */
 
 #define GPIO_FSEL_NUM(pin)  (pin/10)
 #define GPIO_FSEL_SHIFT(pin)  ((pin%10)*3)

--- a/bsp/raspberry-pi/raspi3-64/driver/drv_gpio.c
+++ b/bsp/raspberry-pi/raspi3-64/driver/drv_gpio.c
@@ -138,7 +138,7 @@ static void raspi_pin_write(struct rt_device *dev, rt_base_t pin, rt_base_t valu
     if (value)
         BCM283X_GPIO_GPSET(pin / 32) |= (1 << (pin %32));
     else
-        BCM283X_GPIO_GPCLR(pin / 32) |= (0 << (pin %32));
+        BCM283X_GPIO_GPCLR(pin / 32) |= (1 << (pin %32));
 
 }
 

--- a/bsp/raspberry-pi/raspi3-64/driver/raspi.h
+++ b/bsp/raspberry-pi/raspi3-64/driver/raspi.h
@@ -176,19 +176,19 @@ typedef enum
 
 /* Defines for GPIO */
 #define BCM283X_GPIO_BASE     (PER_BASE + GPIO_BASE_OFFSET)
-#define BCM283X_GPIO_GPFSEL(n) __REG32(BCM283X_GPIO_BASE + 0x0000 + 0x4 * n) /* GPIO Function Select 32bit R/W */
-#define BCM283X_GPIO_GPSET(n) __REG32(BCM283X_GPIO_BASE + 0x001C + 0x4 * n) /* GPIO Pin Output Set */
-#define BCM283X_GPIO_GPCLR(n) __REG32(BCM283X_GPIO_BASE + 0x0028 + 0x4 * n) /* GPIO Pin Output Clear */
-#define BCM2835_GPIO_GPLEV(n) __REG32(BCM283X_GPIO_BASE + 0x0034 + 0x4 * n) /* GPIO Pin Level */
-#define BCM283X_GPIO_GPEDS(n) __REG32(BCM283X_GPIO_BASE + 0x0040 + 0x4 * n) /* GPIO Pin Event Detect Status */
-#define BCM283X_GPIO_GPREN(n) __REG32(BCM283X_GPIO_BASE + 0x004c + 0x4 * n) /* GPIO Pin Rising Edge Detect Enable */
-#define BCM283X_GPIO_GPFEN(n) __REG32(BCM283X_GPIO_BASE + 0x0058 + 0x4 * n) /* GPIO Pin Falling Edge Detect Enable */
-#define BCM283X_GPIO_GPHEN(n) __REG32(BCM283X_GPIO_BASE + 0x0064 + 0x4 * n) /* GPIO Pin High Detect Enable  */
-#define BCM283X_GPIO_GPLEN(n) __REG32(BCM283X_GPIO_BASE + 0x0070 + 0x4 * n) /* GPIO Pin Low Detect Enable */
-#define BCM283X_GPIO_GPAREN(n) __REG32(BCM283X_GPIO_BASE + 0x007C + 0x4 * n) /* GPIO Pin Async. Rising Edge Detect */
-#define BCM283X_GPIO_GPAFEN(n) __REG32(BCM283X_GPIO_BASE + 0x0088 + 0x4 * n) /* GPIO Pin Async. Falling Edge Detect */
+#define BCM283X_GPIO_GPFSEL(n) __REG32(BCM283X_GPIO_BASE + 0x0000 + 0x4 * (n)) /* GPIO Function Select 32bit R/W */
+#define BCM283X_GPIO_GPSET(n) __REG32(BCM283X_GPIO_BASE + 0x001C + 0x4 * (n)) /* GPIO Pin Output Set */
+#define BCM283X_GPIO_GPCLR(n) __REG32(BCM283X_GPIO_BASE + 0x0028 + 0x4 * (n)) /* GPIO Pin Output Clear */
+#define BCM2835_GPIO_GPLEV(n) __REG32(BCM283X_GPIO_BASE + 0x0034 + 0x4 * (n)) /* GPIO Pin Level */
+#define BCM283X_GPIO_GPEDS(n) __REG32(BCM283X_GPIO_BASE + 0x0040 + 0x4 * (n)) /* GPIO Pin Event Detect Status */
+#define BCM283X_GPIO_GPREN(n) __REG32(BCM283X_GPIO_BASE + 0x004c + 0x4 * (n)) /* GPIO Pin Rising Edge Detect Enable */
+#define BCM283X_GPIO_GPFEN(n) __REG32(BCM283X_GPIO_BASE + 0x0058 + 0x4 * (n)) /* GPIO Pin Falling Edge Detect Enable */
+#define BCM283X_GPIO_GPHEN(n) __REG32(BCM283X_GPIO_BASE + 0x0064 + 0x4 * (n)) /* GPIO Pin High Detect Enable  */
+#define BCM283X_GPIO_GPLEN(n) __REG32(BCM283X_GPIO_BASE + 0x0070 + 0x4 * (n)) /* GPIO Pin Low Detect Enable */
+#define BCM283X_GPIO_GPAREN(n) __REG32(BCM283X_GPIO_BASE + 0x007C + 0x4 * (n)) /* GPIO Pin Async. Rising Edge Detect */
+#define BCM283X_GPIO_GPAFEN(n) __REG32(BCM283X_GPIO_BASE + 0x0088 + 0x4 * (n)) /* GPIO Pin Async. Falling Edge Detect */
 #define BCM283X_GPIO_GPPUD     __REG32(BCM283X_GPIO_BASE + 0x0094)     /* GPIO Pin Pull-up/down Enable */
-#define BCM283X_GPIO_GPPUDCLK(n)    __REG32(BCM283X_GPIO_BASE + 0x0098 + 0x4 * n) /* GPIO Pin Pull-up/down Enable Clock */
+#define BCM283X_GPIO_GPPUDCLK(n)    __REG32(BCM283X_GPIO_BASE + 0x0098 + 0x4 * (n)) /* GPIO Pin Pull-up/down Enable Clock */
 
 #define GPIO_FSEL_NUM(pin)  (pin/10)
 #define GPIO_FSEL_SHIFT(pin)  ((pin%10)*3)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
当使用树莓派3B进行开发时，使用GPIO时出现Coredump，检查后发现寄存器偏移量错误，遂跟踪到所修改的代码，位于`bsp/raspberry-pi/raspi3-32(或64)/driver/driver_gpio.c`与`bsp/raspberry-pi/raspi3-32(或64)/driver/raspi.h`。

问题1：
```c
static void raspi_pin_write(struct rt_device *dev, rt_base_t pin, rt_base_t value)
{
...
        BCM283X_GPIO_GPCLR(pin / 32) |= (0 << (pin %32)); // 原始代码 移位值为0，会导致无法清空该GPIO
        BCM283X_GPIO_GPCLR(pin / 32) |= (1 << (pin %32)); // 修改为1，在树莓派3B上64位版本系统测试正常，32位系统未做测试。
...
}
```

问题2：
```c
/* Defines for GPIO */
...
#define BCM283X_GPIO_GPCLR(n) HWREG32(BCM283X_GPIO_BASE + 0x0028 + 0x4 * n) /* GPIO Pin Output Clear */
// GPIO控制寄存器地址计算，每32个GPIO为一个寄存器控制，计算时宏参数未加括号，导致在问题1函数中调用时，如果使用GPIO号大于一定值（如BCM GPIO21，计算表达式0x4 * 21 / 32=2），会导致越界访问，应当先计算除法，如下方更改。
#define BCM283X_GPIO_GPCLR(n) HWREG32(BCM283X_GPIO_BASE + 0x0028 + 0x4 * (n)) /* GPIO Pin Output Clear */
```

本commit中的修改已在树莓派3B上使用64位版本系统测试正常，32位系统未做测试。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
