### PR TITLE
[kernel] 将rt_thread_timeout设置为私有函数

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -155,7 +155,6 @@ rt_err_t rt_thread_mdelay(rt_int32_t ms);
 rt_err_t rt_thread_control(rt_thread_t thread, int cmd, void *arg);
 rt_err_t rt_thread_suspend(rt_thread_t thread);
 rt_err_t rt_thread_resume(rt_thread_t thread);
-void rt_thread_timeout(void *parameter);
 
 #ifdef RT_USING_SIGNALS
 void rt_thread_alloc_sig(rt_thread_t tid);

--- a/src/thread.c
+++ b/src/thread.c
@@ -105,6 +105,43 @@ static void _thread_exit(void)
     rt_schedule();
 }
 
+/**
+ * @brief   This function is the timeout function for thread, normally which is invoked
+ *          when thread is timeout to wait some resource.
+ *
+ * @param   parameter is the parameter of thread timeout function
+ */
+static void _thread_timeout(void *parameter)
+{
+    struct rt_thread *thread;
+    register rt_base_t temp;
+
+    thread = (struct rt_thread *)parameter;
+
+    /* thread check */
+    RT_ASSERT(thread != RT_NULL);
+    RT_ASSERT((thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND);
+    RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);
+
+    /* disable interrupt */
+    temp = rt_hw_interrupt_disable();
+
+    /* set error number */
+    thread->error = -RT_ETIMEOUT;
+
+    /* remove from suspend list */
+    rt_list_remove(&(thread->tlist));
+
+    /* insert to schedule ready list */
+    rt_schedule_insert_thread(thread);
+
+    /* enable interrupt */
+    rt_hw_interrupt_enable(temp);
+
+    /* do schedule */
+    rt_schedule();
+}
+
 static rt_err_t _thread_init(struct rt_thread *thread,
                              const char       *name,
                              void (*entry)(void *parameter),
@@ -173,7 +210,7 @@ static rt_err_t _thread_init(struct rt_thread *thread,
     /* initialize thread timer */
     rt_timer_init(&(thread->thread_timer),
                   thread->name,
-                  rt_thread_timeout,
+                  _thread_timeout,
                   thread,
                   0,
                   RT_TIMER_FLAG_ONE_SHOT);
@@ -854,44 +891,6 @@ rt_err_t rt_thread_resume(rt_thread_t thread)
     return RT_EOK;
 }
 RTM_EXPORT(rt_thread_resume);
-
-/**
- * @brief   This function is the timeout function for thread, normally which is invoked
- *          when thread is timeout to wait some resource.
- *
- * @param   parameter is the parameter of thread timeout function
- */
-void rt_thread_timeout(void *parameter)
-{
-    struct rt_thread *thread;
-    register rt_base_t temp;
-
-    thread = (struct rt_thread *)parameter;
-
-    /* thread check */
-    RT_ASSERT(thread != RT_NULL);
-    RT_ASSERT((thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND);
-    RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);
-
-    /* disable interrupt */
-    temp = rt_hw_interrupt_disable();
-
-    /* set error number */
-    thread->error = -RT_ETIMEOUT;
-
-    /* remove from suspend list */
-    rt_list_remove(&(thread->tlist));
-
-    /* insert to schedule ready list */
-    rt_schedule_insert_thread(thread);
-
-    /* enable interrupt */
-    rt_hw_interrupt_enable(temp);
-
-    /* do schedule */
-    rt_schedule();
-}
-RTM_EXPORT(rt_thread_timeout);
 
 /**
  * @brief   This function will find the specified thread.


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

该函数作为线程内建定时器的回调函数，应该仅作为私有函数使用，不应该暴露出来，并更名为_thread_timeout

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
