### PR TITLE
[kernel] Add __attribute__(...) for rt_kprintf() to let the compiler check the format string parameters

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -572,7 +572,7 @@ void rt_components_board_init(void);
 #define rt_kputs(str)
 #else
 #if defined(__ARMCC_VERSION) || defined(__GNUC__) || \
-    defined(__TI_COMPILER_VERSION__)
+    defined(__ICCARM__) || defined(__TI_COMPILER_VERSION__)
 int rt_kprintf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 #else
 int rt_kprintf(const char *fmt, ...);

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -571,7 +571,12 @@ void rt_components_board_init(void);
 #define rt_kprintf(...)
 #define rt_kputs(str)
 #else
+#if defined(__ARMCC_VERSION) || defined(__GNUC__) || \
+    defined(__TI_COMPILER_VERSION__)
+int rt_kprintf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+#else
 int rt_kprintf(const char *fmt, ...);
+#endif
 void rt_kputs(const char *str);
 #endif
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

Add __attribute__(...) for rt_kprintf() to let the compiler check the format string parameters.

Tested in the following environment：
1. Keil uVersion：Arm Compiler v5.06、v6.7、v6.16  
2. Atollic TrueSTUDIO for STM32：GNU v6.3.1  
3. Code Composer Studio：TI Compiler v20.2.2.LTS、GNU v7.2.1
4. IAR Embedded Workbench：IAR C/C++ Compiler for ARM 9.20.2.320

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
