### PR TITLE
Revert "[kernel] Add __attribute__(...) for rt_kprintf() to let the compiler check the format string parameters"

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -571,7 +571,7 @@ void rt_components_board_init(void);
 #define rt_kputs(str)
 #else
 #if defined(__ARMCC_VERSION) || defined(__GNUC__) || \
-    defined(__ICCARM__) || defined(__TI_COMPILER_VERSION__)
+    defined(__TI_COMPILER_VERSION__)
 int rt_kprintf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 #else
 int rt_kprintf(const char *fmt, ...);

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -570,12 +570,7 @@ void rt_components_board_init(void);
 #define rt_kprintf(...)
 #define rt_kputs(str)
 #else
-#if defined(__ARMCC_VERSION) || defined(__GNUC__) || \
-    defined(__TI_COMPILER_VERSION__)
-int rt_kprintf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-#else
 int rt_kprintf(const char *fmt, ...);
-#endif
 void rt_kputs(const char *str);
 #endif
 


### PR DESCRIPTION
Reverts RT-Thread/rt-thread#5432

This PR causes many of warnings. We can fix these warnings and then merge this PR.