### PR TITLE
[components][sdio] fix compile warning and optimized code.

### DIFF
--- a/components/drivers/sdio/mmc.c
+++ b/components/drivers/sdio/mmc.c
@@ -294,11 +294,6 @@ static int mmc_select_bus_width(struct rt_mmcsd_card *card, rt_uint8_t *ext_csd)
     EXT_CSD_BUS_WIDTH_4,
     EXT_CSD_BUS_WIDTH_1
   };
-  rt_uint32_t bus_widths[] = {
-    MMCSD_BUS_WIDTH_8,
-    MMCSD_BUS_WIDTH_4,
-    MMCSD_BUS_WIDTH_1
-  };
   struct rt_mmcsd_host *host = card->host;
   unsigned idx, trys, bus_width = 0;
   int err = 0;
@@ -312,7 +307,7 @@ static int mmc_select_bus_width(struct rt_mmcsd_card *card, rt_uint8_t *ext_csd)
   * the supported bus width or compare the ext csd values of current
   * bus width and ext csd values of 1 bit mode read earlier.
   */
-  for (idx = 0; idx < sizeof(bus_widths)/sizeof(rt_uint32_t); idx++) {
+  for (idx = 0; idx < sizeof(ext_csd_bits)/sizeof(rt_uint32_t); idx++) {
     /*
     * Host is capable of 8bit transfer, then switch
     * the device to work in 8bit transfer mode. If the


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
 优化代码，修复编译警告。mmc.c中函数mmc_select_bus_width的局部变量数组bus_widths实际上没有用，只用来算了个数，用来索引ext_csd_bits数组成员。实际改成用ext_csd_bits数组本身来算个数会更加合理，也去除了编译器警告。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
