### PR TITLE
[bsp/stm32] Fix some can and pwm bug in stm32.

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_can.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_can.c
@@ -325,7 +325,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
                 }
                  /**
                  * ID     | CAN_FxR1[31:24] | CAN_FxR1[23:16] | CAN_FxR1[15:8] | CAN_FxR1[7:0]       |
-                 * MASK   | CAN_FxR2[31:24] | CAN_FxR1[23:16] | CAN_FxR1[15:8] | CAN_FxR1[7:0]       |
+                 * MASK   | CAN_FxR2[31:24] | CAN_FxR2[23:16] | CAN_FxR2[15:8] | CAN_FxR2[7:0]       |
                  * STD ID |     STID[10:3]  | STDID[2:0] |<-                21bit                  ->|
                  * EXT ID |    EXTID[28:21] | EXTID[20:13]    | EXTID[12:5]    | EXTID[4:0] IDE RTR 0|
                  * @note the 32bit STD ID must << 21 to fill CAN_FxR1[31:21] and EXT ID must << 3,
@@ -464,7 +464,7 @@ static int _can_sendmsg(struct rt_can_device *can, const void *buf, rt_uint32_t 
             if (HAL_IS_BIT_SET(hcan->Instance->TSR, CAN_TSR_TME0) != SET)
             {
                 /* Change CAN state */
-                hcan->State = HAL_CAN_STATE_ERROR;
+                // hcan->State = HAL_CAN_STATE_ERROR;
                 /* Return function status */
                 return -RT_ERROR;
             }
@@ -473,7 +473,7 @@ static int _can_sendmsg(struct rt_can_device *can, const void *buf, rt_uint32_t 
             if (HAL_IS_BIT_SET(hcan->Instance->TSR, CAN_TSR_TME1) != SET)
             {
                 /* Change CAN state */
-                hcan->State = HAL_CAN_STATE_ERROR;
+                // hcan->State = HAL_CAN_STATE_ERROR;
                 /* Return function status */
                 return -RT_ERROR;
             }
@@ -482,7 +482,7 @@ static int _can_sendmsg(struct rt_can_device *can, const void *buf, rt_uint32_t 
             if (HAL_IS_BIT_SET(hcan->Instance->TSR, CAN_TSR_TME2) != SET)
             {
                 /* Change CAN state */
-                hcan->State = HAL_CAN_STATE_ERROR;
+                // hcan->State = HAL_CAN_STATE_ERROR;
                 /* Return function status */
                 return -RT_ERROR;
             }
@@ -714,6 +714,10 @@ void CAN1_TX_IRQHandler(void)
         /* Write 0 to Clear transmission status flag RQCPx */
         SET_BIT(hcan->Instance->TSR, CAN_TSR_RQCP2);
     }
+    else
+    {
+      rt_hw_can_isr(&drv_can1.device, RT_CAN_EVENT_TX_FAIL | 0 << 8);
+    }
     rt_interrupt_leave();
 }
 
@@ -833,6 +837,10 @@ void CAN2_TX_IRQHandler(void)
         }
         /* Write 0 to Clear transmission status flag RQCPx */
         SET_BIT(hcan->Instance->TSR, CAN_TSR_RQCP2);
+    }
+    else
+    {
+      rt_hw_can_isr(&drv_can2.device, RT_CAN_EVENT_TX_FAIL | 0 << 8);
     }
     rt_interrupt_leave();
 }

--- a/bsp/stm32/libraries/HAL_Drivers/drv_can.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_can.c
@@ -37,7 +37,11 @@ static const struct stm32_baud_rate_tab can_baud_rate_tab[] =
 #elif defined (SOC_SERIES_STM32F4)/* APB1 45MHz(max) */
 static const struct stm32_baud_rate_tab can_baud_rate_tab[] =
 {
+#ifdef BSP_USING_CAN168M
+    {CAN1MBaud, (CAN_SJW_1TQ | CAN_BS1_3TQ  | CAN_BS2_3TQ | 6)},
+#else
     {CAN1MBaud, (CAN_SJW_2TQ | CAN_BS1_9TQ  | CAN_BS2_5TQ | 3)},
+#endif
     {CAN800kBaud, (CAN_SJW_2TQ | CAN_BS1_8TQ  | CAN_BS2_5TQ | 4)},
     {CAN500kBaud, (CAN_SJW_2TQ | CAN_BS1_9TQ  | CAN_BS2_5TQ | 6)},
     {CAN250kBaud, (CAN_SJW_2TQ | CAN_BS1_9TQ  | CAN_BS2_5TQ | 12)},

--- a/bsp/stm32/libraries/HAL_Drivers/drv_can.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_can.c
@@ -463,8 +463,6 @@ static int _can_sendmsg(struct rt_can_device *can, const void *buf, rt_uint32_t 
         case CAN_TX_MAILBOX0:
             if (HAL_IS_BIT_SET(hcan->Instance->TSR, CAN_TSR_TME0) != SET)
             {
-                /* Change CAN state */
-                // hcan->State = HAL_CAN_STATE_ERROR;
                 /* Return function status */
                 return -RT_ERROR;
             }
@@ -472,8 +470,6 @@ static int _can_sendmsg(struct rt_can_device *can, const void *buf, rt_uint32_t 
         case CAN_TX_MAILBOX1:
             if (HAL_IS_BIT_SET(hcan->Instance->TSR, CAN_TSR_TME1) != SET)
             {
-                /* Change CAN state */
-                // hcan->State = HAL_CAN_STATE_ERROR;
                 /* Return function status */
                 return -RT_ERROR;
             }
@@ -481,8 +477,6 @@ static int _can_sendmsg(struct rt_can_device *can, const void *buf, rt_uint32_t 
         case CAN_TX_MAILBOX2:
             if (HAL_IS_BIT_SET(hcan->Instance->TSR, CAN_TSR_TME2) != SET)
             {
-                /* Change CAN state */
-                // hcan->State = HAL_CAN_STATE_ERROR;
                 /* Return function status */
                 return -RT_ERROR;
             }

--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -581,6 +581,12 @@ static void pwm_get_channel(void)
 #ifdef BSP_USING_PWM9_CH4
     stm32_pwm_obj[PWM9_INDEX].channel |= 1 << 3;
 #endif
+#ifdef BSP_USING_PWM10_CH1
+    stm32_pwm_obj[PWM10_INDEX].channel |= 1 << 0;
+#endif
+#ifdef BSP_USING_PWM11_CH1
+    stm32_pwm_obj[PWM11_INDEX].channel |= 1 << 0;
+#endif
 #ifdef BSP_USING_PWM12_CH1
     stm32_pwm_obj[PWM12_INDEX].channel |= 1 << 0;
 #endif


### PR DESCRIPTION
…fine of BSP_USING_CAN168M in kconfig while using 168M frequency

## 拉取/合并请求描述：(PR description)

[
[bsp/stm32] stm32F4 adapt 168M frequency of 1M can baud, remember to add the define of BSP_USING_CAN168M in kconfig while using 168M frequency. Has been tested on stm32f407ig.
[bsp/stm32] fix the bug of 'can' being stucked when short cricuit the canH and canL, change some wrong annotations. Has been tested on stm32f407ig.
[bsp/stm32] fix the bug of uart that not define pwm10 and pwm11. Has been tested on stm32f407ig.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
