### PR TITLE
[sconscript] 代替+=的表述方法

### DIFF
--- a/bsp/qemu-vexpress-a9/applications/lvgl/SConscript
+++ b/bsp/qemu-vexpress-a9/applications/lvgl/SConscript
@@ -12,6 +12,6 @@ for d in list:
     if os.path.isfile(os.path.join(path, 'SConscript')):
         group = group + SConscript(os.path.join(d, 'SConscript'))
 
-group += DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
+group = group + DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
 
 Return('group')

--- a/bsp/ra6m4-cpk/ra_cfg/SConscript
+++ b/bsp/ra6m4-cpk/ra_cfg/SConscript
@@ -15,5 +15,5 @@ elif rtconfig.CROSS_TOOL == 'gcc':
     src = Glob('*.c')
     CPPPATH = [cwd+'/fsp_cfg', cwd + '/fsp_cfg/bsp']
 
-group += DefineGroup('ra_cfg', src, depend = [''], CPPPATH = CPPPATH)
+group = group + DefineGroup('ra_cfg', src, depend = [''], CPPPATH = CPPPATH)
 Return('group')

--- a/bsp/simulator/applications/lvgl/SConscript
+++ b/bsp/simulator/applications/lvgl/SConscript
@@ -12,6 +12,6 @@ for d in list:
     if os.path.isfile(os.path.join(path, 'SConscript')):
         group = group + SConscript(os.path.join(d, 'SConscript'))
 
-group += DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
+group = group + DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
 
 Return('group')

--- a/bsp/stm32/stm32f407-atk-explorer/applications/lvgl/SConscript
+++ b/bsp/stm32/stm32f407-atk-explorer/applications/lvgl/SConscript
@@ -12,5 +12,5 @@ for d in list:
     if os.path.isfile(os.path.join(path, 'SConscript')):
         group = group + SConscript(os.path.join(d, 'SConscript'))
 
-group += DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
+group = group + DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
 Return('group')

--- a/bsp/stm32/stm32f407-atk-explorer/applications/lvgl/demo/SConscript
+++ b/bsp/stm32/stm32f407-atk-explorer/applications/lvgl/demo/SConscript
@@ -12,5 +12,5 @@ for d in list:
     if os.path.isfile(os.path.join(path, 'SConscript')):
         group = group + SConscript(os.path.join(d, 'SConscript'))
 
-group += DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
+group = group + DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
 Return('group')

--- a/bsp/stm32/stm32f469-st-disco/applications/lvgl/SConscript
+++ b/bsp/stm32/stm32f469-st-disco/applications/lvgl/SConscript
@@ -13,6 +13,6 @@ for d in list:
     if os.path.isfile(os.path.join(path, 'SConscript')):
         group = group + SConscript(os.path.join(d, 'SConscript'))
 
-group += DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH, CPPDEFINES = CPPDEFINES)
+group = group + DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH, CPPDEFINES = CPPDEFINES)
 
 Return('group')

--- a/bsp/stm32/stm32l475-atk-pandora/applications/arduino/SConscript
+++ b/bsp/stm32/stm32l475-atk-pandora/applications/arduino/SConscript
@@ -7,6 +7,6 @@ inc = [cwd]
 group = DefineGroup('Arduino', src, depend = ['RT_USING_ARDUINO'], CPPPATH = inc)
 
 src = ['arduino_main.cpp']
-group += DefineGroup('Applications', src, depend = ['RT_USING_ARDUINO'])
+group = group + DefineGroup('Applications', src, depend = ['RT_USING_ARDUINO'])
 
 Return('group')

--- a/bsp/stm32/stm32l475-atk-pandora/applications/lvgl/SConscript
+++ b/bsp/stm32/stm32l475-atk-pandora/applications/lvgl/SConscript
@@ -12,5 +12,5 @@ for d in list:
     if os.path.isfile(os.path.join(path, 'SConscript')):
         group = group + SConscript(os.path.join(d, 'SConscript'))
 
-group += DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
+group = group + DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
 Return('group')

--- a/bsp/stm32/stm32l475-atk-pandora/applications/lvgl/demo/SConscript
+++ b/bsp/stm32/stm32l475-atk-pandora/applications/lvgl/demo/SConscript
@@ -12,5 +12,5 @@ for d in list:
     if os.path.isfile(os.path.join(path, 'SConscript')):
         group = group + SConscript(os.path.join(d, 'SConscript'))
 
-group += DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
+group = group + DefineGroup('LVGL-port', src, depend = ['BSP_USING_LVGL'], CPPPATH = CPPPATH)
 Return('group')


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

python中 group = group + xxx 和 group += xxx 这两种表述方法的行为是不一样的
现在已经证实 至少在keil下，如果使用group += 可能会出现分组上的问题，造成同一个.c文件被同时分配到不同的group。
因此在sconscript中要老老实实的用group = group + xxx的表达方式，不能偷懒成+=

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
