### PR TITLE
[bsp/stm32] fix the bug of can filter conflict

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_can.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_can.c
@@ -331,10 +331,25 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
             {
                 if (filter_cfg->items[i].hdr == -1)
                 {
-                    drv_can->FilterConfig.FilterBank = i;
+                    /* use default filter bank settings */
+                    /**
+                     * because can1 and can2 use the same filter groups, 
+                     * separate the groups of can1 and can2, to prevent being covered.
+                     */
+                    if (drv_can->name == "can1")
+                    {
+                        /* can1 banks 0~13 */
+                        drv_can->FilterConfig.FilterBank = i;
+                    }
+                    else if (drv_can->name == "can2")
+                    {
+                        /* can1 banks 14~27 */
+                        drv_can->FilterConfig.FilterBank = i + 14;
+                    }
                 }
                 else
                 {
+                    /* use user-defined filter bank settings */
                     drv_can->FilterConfig.FilterBank = filter_cfg->items[i].hdr;
                 }
                  /**

--- a/bsp/stm32/libraries/HAL_Drivers/drv_can.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_can.c
@@ -332,10 +332,6 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
                 if (filter_cfg->items[i].hdr == -1)
                 {
                     /* use default filter bank settings */
-                    /**
-                     * because can1 and can2 use the same filter groups, 
-                     * separate the groups of can1 and can2, to prevent being covered.
-                     */
                     if (drv_can->name == "can1")
                     {
                         /* can1 banks 0~13 */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
[bsp/stm32] fix the bug of can filter conflict
- bug : can1 and can2 of stm32 share the same filter groups, if use the default setting of RTT (when "hdr=-1"), and use can1 and can2 at the same time, the later filter settings will cover the filter settings before. 
- fix : check the name of can devices, can1 use the bank of 0 ~ 13, and can2 use the bank of 14 ~ 27, to prevent the first can device being covered by another can device. 
- attention : neither of these two can devices can set more than 14 filter groups, so I suggest to add an "RT_ASSERT" to find if defined more than 14 groups when defining the can filters. 
- attention : the two can devices' name must be "can1" and "can2". I suggest to inform users in the document.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
