### PR TITLE
[drivers][serial] add the serial port data bit length to 9.

### DIFF
--- a/components/drivers/serial/serial.c
+++ b/components/drivers/serial/serial.c
@@ -26,6 +26,7 @@
  *                             when using interrupt tx
  * 2020-12-14     Meco Man     implement function of setting window's size(TIOCSWINSZ)
  * 2021-08-22     Meco Man     implement function of getting window's size(TIOCGWINSZ)
+ * 2021-12-17     svchao       add support for MCU with a data bit length of 9.
  */
 
 #include <rthw.h>
@@ -1044,6 +1045,8 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
                     tio->c_cflag = CS7;
                 else if (serial->config.data_bits == DATA_BITS_8)
                     tio->c_cflag = CS8;
+                else if (serial->config.data_bits == DATA_BITS_9)
+                    tio->c_cflag = CS9;
 
                 if (serial->config.stop_bits == STOP_BITS_2)
                     tio->c_cflag |= CSTOPB;
@@ -1082,6 +1085,9 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
                     break;
                 case CS7:
                     config.data_bits = DATA_BITS_7;
+                    break;
+                case CS9:
+                    config.data_bits = DATA_BITS_9;
                     break;
                 default:
                     config.data_bits = DATA_BITS_8;

--- a/components/libc/posix/io/termios/termios.h
+++ b/components/libc/posix/io/termios/termios.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2017/08/30     Bernard      The first version
+ * 2021/12/17     svchao       add the definition of CS9
  */
 
 #ifndef __TERMIOS_H__
@@ -134,11 +135,12 @@ struct termios {
 #define B3500000 0010016
 #define B4000000 0010017
 
-#define CSIZE  0000060
+#define CSIZE  0000070
 #define CS5    0000000
 #define CS6    0000020
 #define CS7    0000040
 #define CS8    0000060
+#define CS9    0000010
 #define CSTOPB 0000100
 #define CREAD  0000200
 #define PARENB 0000400


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
添加了串口数据位长度为9的支持。例如stm32如果使用奇偶校验，则必须配置为9位长度。
具体可看考以下链接：
[stm32+libmodbus+奇偶校验的数据位配置问题](https://club.rt-thread.org/ask/article/3238.html)

english:
Added support for serial data bit length of 9. For example, stm32 uses parity, it must be configured to be 9 bits long.
see details：
[stm32+libmodbus+奇偶校验的数据位配置问题](https://club.rt-thread.org/ask/article/3238.html)
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
