### PR TITLE
tools: fix generate eclipse project file error.

### DIFF
--- a/tools/eclipse.py
+++ b/tools/eclipse.py
@@ -365,7 +365,7 @@ def UpdateProjectStructure(env, prj_name):
     out = open('.project', 'w')
     out.write('<?xml version="1.0" encoding="UTF-8"?>\n')
     xml_indent(root)
-    out.write(etree.tostring(root, encoding='utf-8'))
+    out.write(etree.tostring(root, encoding='utf-8').decode('utf-8'))
     out.close()
 
     return
@@ -504,7 +504,7 @@ def UpdateCproject(env, project, excluding, reset, prj_name):
     out.write('<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n')
     out.write('<?fileVersion 4.0.0?>')
     xml_indent(root)
-    out.write(etree.tostring(root, encoding='utf-8'))
+    out.write(etree.tostring(root, encoding='utf-8').decode('utf-8'))
     out.close()
 
 


### PR DESCRIPTION
[
问题场景：
进入bsp/allwinner_tina 目录下执行scons --target=eclipse --project-name=tina，eclipse.py文件出现报错: write argument must be str, not bytes；导致创建.project文件失败
解决的问题：
tools工具目录下，eclipse.py文件在创建.project及.cproject文件时，open的文件属性与write的字符不匹配；etree.tostring()转换后为bytes类型，不符合本次write需要写入的str类型；

测试场景：
基于allwinner_tina版型测试，执行scons --project-name=tina --target=eclipse可以正常执行
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

当前拉取/合并请求的状态 Intent for your PR
必须选择一项 Choose one (Mandatory):

[*] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo
代码质量 Code Quality：
我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

[*] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
[*] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
[*] 没有垃圾代码，代码尽量精简，不包含#if 0代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
[*] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
[*] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
[*] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
[*] 本拉取/合并使用formatting等源码格式化工具确保格式符合RT-Thread代码规范 This PR complies with RT-Thread code specification