### PR TITLE
[bsp/n32g452xx] add rt_pin_get support

### DIFF
--- a/bsp/n32g452xx/Libraries/rt_drivers/drv_gpio.c
+++ b/bsp/n32g452xx/Libraries/rt_drivers/drv_gpio.c
@@ -20,9 +20,9 @@
 #define __N32_PIN(index, rcc, gpio, gpio_index) \
 { \
 0, RCC_##rcc##_PERIPH_GPIO##gpio, GPIO##gpio, GPIO_PIN_##gpio_index \
-, GPIO##gpio##_PORT_SOURCE, GPIO_PIN_SOURCE##gpio_index \
+, GPIO##gpio##_PORT_SOURCE, GPIO_PIN_SOURCE##gpio_index, "P" #gpio "." #gpio_index \
 }
-#define __N32_PIN_DEFAULT {-1, 0, 0, 0, 0, 0}
+#define __N32_PIN_DEFAULT {-1, 0, 0, 0, 0, 0, ""}
 
 /* N32 GPIO driver */
 struct pin_index
@@ -33,6 +33,7 @@ struct pin_index
     uint32_t pin;
     uint8_t port_source;
     uint8_t pin_source;
+    const char* name;
 };
 
 static const struct pin_index pins[] =
@@ -473,6 +474,23 @@ const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
+rt_base_t n32_pin_get(const char *name)
+{
+    rt_base_t i;
+
+    for (i = 0; i < ITEM_NUM(pins); i++)
+    {
+        if (rt_strcmp(pins[i].name, name) == 0)
+        {
+            /* in get_pin function, use pin parameter as index of pins array */
+            return i;
+        }
+    }
+
+    /* refers content of pins array, map to __N32_PIN_DEFAULT */
+    return 0;
+}
+
 void n32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
 {
     const struct pin_index *index;
@@ -754,6 +772,7 @@ const static struct rt_pin_ops _n32_pin_ops =
     n32_pin_attach_irq,
     n32_pin_dettach_irq,
     n32_pin_irq_enable,
+    n32_pin_get
 };
 
 int n32_hw_pin_init(void)

--- a/bsp/n32g452xx/n32g452xx-mini-system/applications/main.c
+++ b/bsp/n32g452xx/n32g452xx-mini-system/applications/main.c
@@ -12,19 +12,24 @@
 #include <rtdevice.h>
 
 /* defined the LED1 pin: PB5 */
-#define LED1_PIN    57
+#define LED1_NAME "PB.5"
+rt_base_t led1_pin;
 
 int main(void)
 {
     uint32_t Speed = 200;
+
+    /* get LED1 pin id by name */
+    led1_pin = rt_pin_get(LED1_NAME);
+
     /* set LED1 pin mode to output */
-    rt_pin_mode(LED1_PIN, PIN_MODE_OUTPUT);
+    rt_pin_mode(led1_pin, PIN_MODE_OUTPUT);
 
     while (1)
     {
-        rt_pin_write(LED1_PIN, PIN_LOW);
+        rt_pin_write(led1_pin, PIN_LOW);
         rt_thread_mdelay(Speed);
-        rt_pin_write(LED1_PIN, PIN_HIGH);
+        rt_pin_write(led1_pin, PIN_HIGH);
         rt_thread_mdelay(Speed);
     }
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
【解决的问题】
为 N32G45X 开发板添加了 rt_pin_get 接口支持，name 字符串参数的风格保持 STM32 pin驱动的命名风格，例如PB5使用： `"PB.5"` 字符串

【解决方案】
1. 在原有pin上下文类型`struct pin_index`中添加一个`const char* name`成员；
2. `__N32_PIN`宏中，添加对`name`成员值的填充，采用宏拼接的方式实现；
3. 添加`n32_pin_get`函数，函数中遍历`pins`数组，查到`name`匹配的条目后，返回下标；
4. 将`n32_pin_get`函数绑定到`struct rt_pin_ops _n32_pin_ops `变量的`pin_get`函数指针上；

【测试情况】
已在国民技术N32G45XVL-STB-V1.1开发板测试通过；
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
