### PR TITLE
避免警告，变量可能未初始化就使用

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
@@ -930,6 +930,10 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         DMA_Handle = &uart->dma_tx.handle;
         dma_config = uart->config->dma_tx;
     }
+    else
+    {
+        return;
+    }
     LOG_D("%s dma config start", uart->config->name);
 
     {

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
@@ -971,6 +971,10 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         DMA_Handle = &uart->dma_tx.handle;
         dma_config = uart->config->dma_tx;
     }
+    else
+    {
+        return;
+    }
     LOG_D("%s dma config start", uart->config->name);
 
     {


### PR DESCRIPTION
避免警告，变量dma_config,DMA_Handle可能未初始化就使用