### PR TITLE
避免警告，变量可能未初始化就使用

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
@@ -918,6 +918,7 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
     struct stm32_uart *uart;
 
     RT_ASSERT(serial != RT_NULL);
+    RT_ASSERT(flag == RT_DEVICE_FLAG_DMA_TX || flag == RT_DEVICE_FLAG_DMA_RX);
     uart = rt_container_of(serial, struct stm32_uart, serial);
 
     if (RT_DEVICE_FLAG_DMA_RX == flag)
@@ -925,7 +926,7 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         DMA_Handle = &uart->dma_rx.handle;
         dma_config = uart->config->dma_rx;
     }
-    else if (RT_DEVICE_FLAG_DMA_TX == flag)
+    else
     {
         DMA_Handle = &uart->dma_tx.handle;
         dma_config = uart->config->dma_tx;

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
@@ -930,6 +930,10 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         DMA_Handle = &uart->dma_tx.handle;
         dma_config = uart->config->dma_tx;
     }
+    else
+    {
+        return;
+    }
     LOG_D("%s dma config start", uart->config->name);
 
     {

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
@@ -926,7 +926,7 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         DMA_Handle = &uart->dma_rx.handle;
         dma_config = uart->config->dma_rx;
     }
-    else
+    else /* RT_DEVICE_FLAG_DMA_TX == flag */
     {
         DMA_Handle = &uart->dma_tx.handle;
         dma_config = uart->config->dma_tx;

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
@@ -931,10 +931,6 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         DMA_Handle = &uart->dma_tx.handle;
         dma_config = uart->config->dma_tx;
     }
-    else
-    {
-        return;
-    }
     LOG_D("%s dma config start", uart->config->name);
 
     {

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
@@ -971,6 +971,10 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         DMA_Handle = &uart->dma_tx.handle;
         dma_config = uart->config->dma_tx;
     }
+    else
+    {
+        return;
+    }
     LOG_D("%s dma config start", uart->config->name);
 
     {

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
@@ -959,6 +959,7 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
     struct stm32_uart *uart;
 
     RT_ASSERT(serial != RT_NULL);
+    RT_ASSERT(flag == RT_DEVICE_FLAG_DMA_TX || flag == RT_DEVICE_FLAG_DMA_RX);
     uart = rt_container_of(serial, struct stm32_uart, serial);
 
     if (RT_DEVICE_FLAG_DMA_RX == flag)
@@ -966,7 +967,7 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         DMA_Handle = &uart->dma_rx.handle;
         dma_config = uart->config->dma_rx;
     }
-    else if (RT_DEVICE_FLAG_DMA_TX == flag)
+    else
     {
         DMA_Handle = &uart->dma_tx.handle;
         dma_config = uart->config->dma_tx;

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
@@ -972,10 +972,6 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         DMA_Handle = &uart->dma_tx.handle;
         dma_config = uart->config->dma_tx;
     }
-    else
-    {
-        return;
-    }
     LOG_D("%s dma config start", uart->config->name);
 
     {

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
@@ -967,7 +967,7 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         DMA_Handle = &uart->dma_rx.handle;
         dma_config = uart->config->dma_rx;
     }
-    else
+    else /* RT_DEVICE_FLAG_DMA_TX == flag */
     {
         DMA_Handle = &uart->dma_tx.handle;
         dma_config = uart->config->dma_tx;


### PR DESCRIPTION
避免警告，变量可能未初始化就使用