### PR TITLE
return thread error when resumed by signal

### DIFF
--- a/components/drivers/ipc/waitqueue.c
+++ b/components/drivers/ipc/waitqueue.c
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018/06/26     Bernard      Fix the wait queue issue when wakeup a soon
  *                             to blocked thread.
+ * 2022-01-24     THEWON       let rt_wqueue_wait return thread->error when using signal
  */
 
 #include <stdint.h>
@@ -141,6 +142,10 @@ int rt_wqueue_wait(rt_wqueue_t *queue, int condition, int msec)
     rt_list_init(&__wait.list);
 
     level = rt_hw_interrupt_disable();
+
+    /* reset thread error */
+    tid->error = RT_EOK;
+
     if (queue->flag == RT_WQ_FLAG_WAKEUP)
     {
         /* already wakeup */
@@ -171,5 +176,5 @@ __exit_wakeup:
 
     rt_wqueue_remove(&__wait);
 
-    return 0;
+    return tid->error;
 }

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -40,6 +40,7 @@
  * 2021-01-03     Meco Man     implement rt_mb_urgent()
  * 2021-05-30     Meco Man     implement rt_mutex_trytake()
  * 2022-01-07     Gabriel      Moving __on_rt_xxxxx_hook to ipc.c
+ * 2022-01-24     THEWON       let rt_mutex_take return thread->error when using signal
  */
 
 #include <rtthread.h>
@@ -947,9 +948,6 @@ rt_err_t rt_mutex_take(rt_mutex_t mutex, rt_int32_t time)
     }
     else
     {
-#ifdef RT_USING_SIGNALS
-__again:
-#endif /* RT_USING_SIGNALS */
         /* The value of mutex is 1 in initial status. Therefore, if the
          * value is great than 0, it indicates the mutex is avaible.
          */
@@ -1026,11 +1024,6 @@ __again:
 
                 if (thread->error != RT_EOK)
                 {
-#ifdef RT_USING_SIGNALS
-                    /* interrupt by signal, try it again */
-                    if (thread->error == -RT_EINTR) goto __again;
-#endif /* RT_USING_SIGNALS */
-
                     /* return error */
                     return thread->error;
                 }

--- a/src/thread.c
+++ b/src/thread.c
@@ -30,6 +30,7 @@
  * 2021-11-15     THEWON       Remove duplicate work between idle and _thread_exit
  * 2021-12-27     Meco Man     remove .init_priority
  * 2022-01-07     Gabriel      Moving __on_rt_xxxxx_hook to thread.c
+ * 2022-01-24     THEWON       let rt_thread_sleep return thread->error when using signal
  */
 
 #include <rthw.h>
@@ -566,6 +567,9 @@ rt_err_t rt_thread_sleep(rt_tick_t tick)
     /* disable interrupt */
     temp = rt_hw_interrupt_disable();
 
+    /* reset thread error */
+    thread->error = RT_EOK;
+
     /* suspend thread */
     rt_thread_suspend(thread);
 
@@ -582,7 +586,7 @@ rt_err_t rt_thread_sleep(rt_tick_t tick)
     if (thread->error == -RT_ETIMEOUT)
         thread->error = RT_EOK;
 
-    return RT_EOK;
+    return thread->error;
 }
 
 /**
@@ -625,6 +629,9 @@ rt_err_t rt_thread_delay_until(rt_tick_t *tick, rt_tick_t inc_tick)
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
 
+    /* reset thread error */
+    thread->error = RT_EOK;
+
     cur_tick = rt_tick_get();
     if (cur_tick - *tick < inc_tick)
     {
@@ -657,7 +664,7 @@ rt_err_t rt_thread_delay_until(rt_tick_t *tick, rt_tick_t inc_tick)
         rt_hw_interrupt_enable(level);
     }
 
-    return RT_EOK;
+    return thread->error;
 }
 RTM_EXPORT(rt_thread_delay_until);
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
有些长时间阻塞 api ，在启用 signal 的时候，可能被 signal 提前唤醒，却没有告知应用层是因为 INTR 错误返回的。
修改部分函数，当线程状态错误时直接返回线程状态
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
