### PR TITLE
fixed wlan driver dhcp multitask safety

### DIFF
--- a/components/drivers/wlan/wlan_lwip.c
+++ b/components/drivers/wlan/wlan_lwip.c
@@ -170,7 +170,7 @@ static void netif_set_connected(void *parameter)
             LOG_D("F:%s L:%d dhcp start run", __FUNCTION__, __LINE__);
             netifapi_netif_common(eth_dev->netif, netif_set_link_up, NULL);
 #ifdef RT_LWIP_DHCP
-            dhcp_start(eth_dev->netif);
+            netifapi_dhcp_start(eth_dev->netif);
 #endif
             rt_timer_start(&lwip_prot->timer);
         }
@@ -198,7 +198,7 @@ static void netif_set_connected(void *parameter)
 #ifdef RT_LWIP_DHCP
         {
             ip_addr_t ip_addr = { 0 };
-            dhcp_stop(eth_dev->netif);
+            netifapi_dhcp_stop(eth_dev->netif);
             netif_set_addr(eth_dev->netif, &ip_addr, &ip_addr, &ip_addr);
         }
 #endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修复wlan驱动框架里调用LWIP.dhcp接口多任务安全引起的临界资源访问错误的问题。
当触发此问题时会出现如下类似错误信息：
```
dhcp_create_msg: dhcp->p_out == NULL
Assertion: 1823 in rt-thread/components/net/lwip-2.0.3/src/core/ipv4/dhcp.c, thread tcpip
(0) assertion failed at function:sys_arch_assert, line number:621
```
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
