### PR TITLE
[kernel] fix the bug of #4891

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -652,13 +652,13 @@ struct rt_thread
 #endif
     rt_uint32_t number_mask;
 
-#if defined(RT_USING_EVENT)
+#ifdef RT_USING_EVENT
     /* thread event */
     rt_uint32_t event_set;
     rt_uint8_t  event_info;
 #endif
 
-#if defined(RT_USING_SIGNALS)
+#ifdef RT_USING_SIGNALS
     rt_sigset_t     sig_pending;                        /**< the pending signals */
     rt_sigset_t     sig_mask;                           /**< the mask bits of signal */
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -191,6 +191,12 @@ static rt_err_t _thread_init(struct rt_thread *thread,
     thread->current_priority = priority;
 
     thread->number_mask = 0;
+
+#ifdef RT_USING_EVENT
+    thread->event_set = 0;
+    thread->event_info = 0;
+#endif
+
 #if RT_THREAD_PRIORITY_MAX > 32
     thread->number = 0;
     thread->high_mask = 0;
@@ -246,6 +252,12 @@ static rt_err_t _thread_init(struct rt_thread *thread,
 #ifdef RT_USING_CPU_USAGE
     thread->duration_tick = 0;
 #endif
+
+#ifdef RT_USING_MODULE
+    thread->module_id = 0;
+#endif
+
+    thread->user_data = 0;
 
     RT_OBJECT_HOOK_CALL(rt_thread_inited_hook, (thread));
 


### PR DESCRIPTION
#4891 所提的解决方法过于粗糙

此外经过逐一对比，发现在rt_thread_init/create阶段，除了module成员变量没有初始化之外，还有以下thread所属成员变量是**垃圾值**：

```c
#if defined(RT_USING_EVENT)
    /* thread event */
    rt_uint32_t event_set;
    rt_uint8_t  event_info;
#endif

    rt_ubase_t user_data;    
```


已经都清0

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
