### PR TITLE
improve ULOG_OUTPUT_FLOAT, which avoids using inherent vsnprintf

### DIFF
--- a/components/utilities/Kconfig
+++ b/components/utilities/Kconfig
@@ -137,6 +137,7 @@ config RT_USING_ULOG
             config ULOG_OUTPUT_FLOAT
                 bool "Enable float number support. It will using more thread stack."
                 default n
+                select PKG_USING_RT_VSNPRINTF_FULL
                 help
                     The default formater is using rt_vsnprint and it not supported float number.
                     When enable this option then it will enable libc. The formater will change to vsnprint on libc.

--- a/components/utilities/ulog/syslog/syslog.c
+++ b/components/utilities/ulog/syslog/syslog.c
@@ -14,10 +14,6 @@
 #include <stdint.h>
 #include "syslog.h"
 
-#ifdef ULOG_OUTPUT_FLOAT
-#include <stdio.h>
-#endif
-
 /*
  * reference:
  * http://pubs.opengroup.org/onlinepubs/7908799/xsh/syslog.h.html
@@ -227,12 +223,7 @@ RT_WEAK rt_size_t syslog_formater(char *log_buf, int level, const char *tag, rt_
 #endif /* ULOG_OUTPUT_THREAD_NAME */
 
     log_len += ulog_strcpy(log_len, log_buf + log_len, ": ");
-
-#ifdef ULOG_OUTPUT_FLOAT
-    fmt_result = vsnprintf(log_buf + log_len, ULOG_LINE_BUF_SIZE - log_len, format, args);
-#else
     fmt_result = rt_vsnprintf(log_buf + log_len, ULOG_LINE_BUF_SIZE - log_len, format, args);
-#endif /* ULOG_OUTPUT_FLOAT */
 
     /* calculate log length */
     if ((log_len + fmt_result <= ULOG_LINE_BUF_SIZE) && (fmt_result > -1))

--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -16,10 +16,6 @@
 #include <syslog.h>
 #endif
 
-#ifdef ULOG_OUTPUT_FLOAT
-#include <stdio.h>
-#endif
-
 #ifdef ULOG_TIME_USING_TIMESTAMP
 #include <sys/time.h>
 #endif
@@ -367,12 +363,7 @@ RT_WEAK rt_size_t ulog_formater(char *log_buf, rt_uint32_t level, const char *ta
 #endif /* ULOG_OUTPUT_THREAD_NAME */
 
     log_len += ulog_strcpy(log_len, log_buf + log_len, ": ");
-
-#ifdef ULOG_OUTPUT_FLOAT
-    fmt_result = vsnprintf(log_buf + log_len, ULOG_LINE_BUF_SIZE - log_len, format, args);
-#else
     fmt_result = rt_vsnprintf(log_buf + log_len, ULOG_LINE_BUF_SIZE - log_len, format, args);
-#endif /* ULOG_OUTPUT_FLOAT */
 
     /* calculate log length */
     if ((log_len + fmt_result <= ULOG_LINE_BUF_SIZE) && (fmt_result > -1))
@@ -674,15 +665,10 @@ void ulog_raw(const char *format, ...)
 
     /* lock output */
     output_lock();
+
     /* args point to the first variable parameter */
     va_start(args, format);
-
-#ifdef ULOG_OUTPUT_FLOAT
-    fmt_result = vsnprintf(log_buf, ULOG_LINE_BUF_SIZE, format, args);
-#else
     fmt_result = rt_vsnprintf(log_buf, ULOG_LINE_BUF_SIZE, format, args);
-#endif /* ULOG_OUTPUT_FLOAT */
-
     va_end(args);
 
     /* calculate log length */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
优化ULOG_OUTPUT_FLOAT，避免使用内置libc的vsnprintf函数
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
