### PR TITLE
[bsp][stm32]修复CRC自定义多项式无法使用相关bug

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_crypto.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_crypto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Winner Microelectronics Co., Ltd.
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -85,7 +85,32 @@ static rt_uint32_t _crc_update(struct hwcrypto_crc *ctx, const rt_uint8_t *in, r
             goto _exit;
         }
 
-        HW_TypeDef->Init.CRCLength = ctx ->crc_cfg.width;
+        switch(ctx ->crc_cfg.width)
+        {
+#if defined(CRC_POLYLENGTH_7B) && defined(CRC_POLYLENGTH_8B) && defined(CRC_POLYLENGTH_16B) && defined(CRC_POLYLENGTH_32B)
+        case 7:
+            HW_TypeDef->Init.CRCLength = CRC_POLYLENGTH_7B;
+            break;
+        case 8:
+            HW_TypeDef->Init.CRCLength = CRC_POLYLENGTH_8B;
+            break;
+        case 16:
+            HW_TypeDef->Init.CRCLength = CRC_POLYLENGTH_16B;
+            break;
+        case 32:
+            HW_TypeDef->Init.CRCLength = CRC_POLYLENGTH_32B;
+            break;
+        default :
+            goto _exit;
+#else
+        case 32:
+            HW_TypeDef->Init.CRCLength = CRC_POLYLENGTH_32B;
+            break;
+        default :
+            goto _exit;
+#endif /* defined(CRC_POLYLENGTH_7B) && defined(CRC_POLYLENGTH_8B) && defined(CRC_POLYLENGTH_16B) && defined(CRC_POLYLENGTH_32B) */
+        }
+		
         if (HW_TypeDef->Init.DefaultInitValueUse == DEFAULT_INIT_VALUE_DISABLE)
         {
             HW_TypeDef->Init.InitValue = ctx ->crc_cfg.last_val;
@@ -404,7 +429,7 @@ static rt_err_t _crypto_create(struct rt_hwcrypto_ctx *ctx)
         hcrc->Instance = CRC;
 #endif
 #if defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32MP1)
-        hcrc->Init.DefaultPolynomialUse = DEFAULT_POLYNOMIAL_ENABLE;
+        hcrc->Init.DefaultPolynomialUse = DEFAULT_POLYNOMIAL_DISABLE;
         hcrc->Init.DefaultInitValueUse = DEFAULT_INIT_VALUE_DISABLE;
         hcrc->Init.InputDataInversionMode = CRC_INPUTDATA_INVERSION_BYTE;
         hcrc->Init.OutputDataInversionMode = CRC_OUTPUTDATA_INVERSION_ENABLE;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
参考[官方例程](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/programming-manual/device/crypto/crypto?id=crc-%e5%86%97%e4%bd%99%e6%a0%a1%e9%aa%8c)，使用CRC功能时，CRC32的计算结果没问题，尝试CRC16、CRC8，计算结果明显不对，返回结果还是32位数。

Debug发现了两个问题：
**1、**_crypto_create()函数在创建hcrc结构体时使能了默认多项式：
`hcrc->Init.DefaultPolynomialUse = DEFAULT_POLYNOMIAL_ENABLE;`
而_crc_update()进行了如下判断，导致多项式固定设置为默认多项式。
`if (HW_TypeDef->Init.DefaultPolynomialUse == DEFAULT_POLYNOMIAL_DISABLE)
        {
            HW_TypeDef->Init.GeneratingPolynomial = ctx ->crc_cfg.poly;
        }
        else
        {
            HW_TypeDef->Init.GeneratingPolynomial = DEFAULT_CRC32_POLY;
        }
`
禁用后可以使用自定义多项式。
**2、**_crc_update()中，直接将crc_cfg中的width赋值给初始化结构体中的CRCLength，
`HW_TypeDef->Init.CRCLength = ctx ->crc_cfg.width;`

后续初始化最终调用了：
`HAL_CRCEx_Polynomial_Set(hcrc, hcrc->Init.GeneratingPolynomial, hcrc->Init.CRCLength)`
查看stm32f072的HAL库，CRCLength只能为
`
#define CRC_POLYLENGTH_32B                  (0x00000000U)
#define CRC_POLYLENGTH_16B                  ((uint32_t)CRC_CR_POLYSIZE_0)
#define CRC_POLYLENGTH_8B                   ((uint32_t)CRC_CR_POLYSIZE_1)
#define CRC_POLYLENGTH_7B                   ((uint32_t)CRC_CR_POLYSIZE)
`
不正确的width值会导致CRC设备初始化失败。

根据STM32F0参考手册，仅有部分型号支持自定义多项式功能，其余型号只支持固定多项式，可以判断有无相关值的宏定义来确定功能的支持情况。

在STM32F072VBT6上测试CRC32、CRC16、CRC8，结果没问题。[http://www.ip33.com/crc.html]
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/coding_style_en.txt) 
