### PR TITLE
[kernel] Revert modifications to the semaphore

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -485,9 +485,6 @@ rt_err_t rt_sem_take(rt_sem_t sem, rt_int32_t time)
     RT_ASSERT(sem != RT_NULL);
     RT_ASSERT(rt_object_get_type(&sem->parent.parent) == RT_Object_Class_Semaphore);
 
-    /* current context checking */
-    RT_DEBUG_SCHEDULER_AVAILABLE(time != 0);
-
     RT_OBJECT_HOOK_CALL(rt_object_trytake_hook, (&(sem->parent.parent)));
 
     /* disable interrupt */
@@ -517,6 +514,9 @@ rt_err_t rt_sem_take(rt_sem_t sem, rt_int32_t time)
         }
         else
         {
+            /* current context checking */
+            RT_DEBUG_SCHEDULER_AVAILABLE(RT_TRUE);
+
             /* semaphore is unavailable, push to suspend list */
             /* get current thread */
             thread = rt_thread_self();

--- a/src/memheap.c
+++ b/src/memheap.c
@@ -203,7 +203,7 @@ void *rt_memheap_alloc(struct rt_memheap *heap, rt_size_t size)
         free_size = 0;
 
         /* lock memheap */
-        if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+        if (heap->locked == RT_FALSE)
         {
             result = rt_sem_take(&(heap->lock), RT_WAITING_FOREVER);
             if (result != RT_EOK)
@@ -316,7 +316,7 @@ void *rt_memheap_alloc(struct rt_memheap *heap, rt_size_t size)
                 rt_memcpy(header_ptr->owner_thread_name, "NONE", sizeof(header_ptr->owner_thread_name));
 #endif /* RT_USING_MEMTRACE */
 
-            if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+            if (heap->locked == RT_FALSE)
             {
                 /* release lock */
                 rt_sem_release(&(heap->lock));
@@ -332,7 +332,7 @@ void *rt_memheap_alloc(struct rt_memheap *heap, rt_size_t size)
             return (void *)((rt_uint8_t *)header_ptr + RT_MEMHEAP_SIZE);
         }
 
-        if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+        if (heap->locked == RT_FALSE)
         {
             /* release lock */
             rt_sem_release(&(heap->lock));
@@ -394,7 +394,7 @@ void *rt_memheap_realloc(struct rt_memheap *heap, void *ptr, rt_size_t newsize)
         void *new_ptr;
         struct rt_memheap_item *next_ptr;
 
-        if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+        if (heap->locked == RT_FALSE)
         {
             /* lock memheap */
             result = rt_sem_take(&(heap->lock), RT_WAITING_FOREVER);
@@ -475,7 +475,7 @@ void *rt_memheap_realloc(struct rt_memheap *heap, void *ptr, rt_size_t newsize)
                 RT_DEBUG_LOG(RT_DEBUG_MEMHEAP, ("new ptr: next_free 0x%08x, prev_free 0x%08x",
                                                 next_ptr->next_free,
                                                 next_ptr->prev_free));
-                if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+                if (heap->locked == RT_FALSE)
                 {
                     /* release lock */
                     rt_sem_release(&(heap->lock));
@@ -485,7 +485,7 @@ void *rt_memheap_realloc(struct rt_memheap *heap, void *ptr, rt_size_t newsize)
             }
         }
 
-        if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+        if (heap->locked == RT_FALSE)
         {
             /* release lock */
             rt_sem_release(&(heap->lock));
@@ -506,7 +506,7 @@ void *rt_memheap_realloc(struct rt_memheap *heap, void *ptr, rt_size_t newsize)
     if (newsize + RT_MEMHEAP_SIZE + RT_MEMHEAP_MINIALLOC >= oldsize)
         return ptr;
 
-    if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+    if (heap->locked == RT_FALSE)
     {
         /* lock memheap */
         result = rt_sem_take(&(heap->lock), RT_WAITING_FOREVER);
@@ -577,7 +577,7 @@ void *rt_memheap_realloc(struct rt_memheap *heap, void *ptr, rt_size_t newsize)
     /* increment the available byte count.  */
     heap->available_size = heap->available_size + MEMITEM_SIZE(new_ptr);
 
-    if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+    if (heap->locked == RT_FALSE)
     {
         /* release lock */
         rt_sem_release(&(heap->lock));
@@ -630,7 +630,7 @@ void rt_memheap_free(void *ptr)
     RT_ASSERT(heap);
     RT_ASSERT(rt_object_get_type(&heap->parent) == RT_Object_Class_MemHeap);
 
-    if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+    if (heap->locked == RT_FALSE)
     {
         /* lock memheap */
         result = rt_sem_take(&(heap->lock), RT_WAITING_FOREVER);
@@ -716,7 +716,7 @@ void rt_memheap_free(void *ptr)
     rt_memset(header_ptr->owner_thread_name, ' ', sizeof(header_ptr->owner_thread_name));
 #endif /* RT_USING_MEMTRACE */
 
-    if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+    if (heap->locked == RT_FALSE)
     {
         /* release lock */
         rt_sem_release(&(heap->lock));
@@ -744,7 +744,7 @@ void rt_memheap_info(struct rt_memheap *heap,
 {
     rt_err_t result;
 
-    if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+    if (heap->locked == RT_FALSE)
     {
         /* lock memheap */
         result = rt_sem_take(&(heap->lock), RT_WAITING_FOREVER);
@@ -764,7 +764,7 @@ void rt_memheap_info(struct rt_memheap *heap,
     if (max_used != RT_NULL)
         *max_used = heap->max_used_size;
 
-    if (heap->locked == RT_FALSE && rt_thread_self() != RT_NULL)
+    if (heap->locked == RT_FALSE)
     {
         /* release lock */
         rt_sem_release(&(heap->lock));


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
[kernel] Revert modifications to the semaphore

has been tested at stm32-l496-alideviloper.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
