### PR TITLE
[tools]keil.py Distinguish LOCAL_CFLAGS/LOCAL_CXXFLAGS, refine file c…

### DIFF
--- a/tools/keil.py
+++ b/tools/keil.py
@@ -137,7 +137,7 @@ def MDK4AddLibToGroup(ProjectFiles, group, name, filename, project_path):
 
     return group
 
-def MDK4AddGroup(ProjectFiles, parent, name, files, project_path):
+def MDK4AddGroup(ProjectFiles, parent, name, files, project_path, group_scons):
     # don't add an empty group
     if len(files) == 0:
         return
@@ -176,8 +176,35 @@ def MDK4AddGroup(ProjectFiles, parent, name, files, project_path):
         file_type = SubElement(file, 'FileType')
         file_type.text = '%d' % _get_filetype(name)
         file_path = SubElement(file, 'FilePath')
-
         file_path.text = path # path.decode(fs_encoding)
+
+        # for local LOCAL_CFLAGS/LOCAL_CXXFLAGS/LOCAL_CCFLAGS/LOCAL_CPPPATH/LOCAL_CPPDEFINES
+        MiscControls_text = ' '
+        if file_type.text == '1' and 'LOCAL_CFLAGS' in group_scons:
+            MiscControls_text = MiscControls_text + group_scons['LOCAL_CFLAGS']
+        elif file_type.text == '8' and 'LOCAL_CXXFLAGS' in group_scons:
+            MiscControls_text = MiscControls_text + group_scons['LOCAL_CXXFLAGS']
+        if 'LOCAL_CCFLAGS' in group_scons:
+            MiscControls_text = MiscControls_text + group_scons['LOCAL_CCFLAGS']
+        if MiscControls_text != ' ':
+            FileOption     = SubElement(file,  'FileOption')
+            FileArmAds     = SubElement(FileOption, 'FileArmAds')
+            Cads            = SubElement(FileArmAds, 'Cads')
+            VariousControls = SubElement(Cads, 'VariousControls')
+            MiscControls    = SubElement(VariousControls, 'MiscControls')
+            MiscControls.text = MiscControls_text
+            Define          = SubElement(VariousControls, 'Define')
+            if 'LOCAL_CPPDEFINES' in group_scons:
+                Define.text     = ', '.join(set(group_scons['LOCAL_CPPDEFINES']))
+            else:
+                Define.text     = ' '
+            Undefine        = SubElement(VariousControls, 'Undefine')
+            Undefine.text   = ' '
+            IncludePath     = SubElement(VariousControls, 'IncludePath')
+            if 'LOCAL_CPPPATH' in group_scons:
+                IncludePath.text = ';'.join([_make_path_relative(project_path, os.path.normpath(i)) for i in group_scons['LOCAL_CPPPATH']])
+            else:
+                IncludePath.text = ' '
 
     return group
 
@@ -201,31 +228,7 @@ def MDK45Project(tree, target, script):
         groups = SubElement(tree.find('Targets/Target'), 'Groups')
     groups.clear() # clean old groups
     for group in script:
-        group_tree = MDK4AddGroup(ProjectFiles, groups, group['name'], group['src'], project_path)
-
-        # for local CPPPATH/CPPDEFINES
-        if (group_tree != None) and ('LOCAL_CPPPATH' in group or 'LOCAL_CFLAGS' in group or 'LOCAL_CPPDEFINES' in group):
-            GroupOption     = SubElement(group_tree,  'GroupOption')
-            GroupArmAds     = SubElement(GroupOption, 'GroupArmAds')
-            Cads            = SubElement(GroupArmAds, 'Cads')
-            VariousControls = SubElement(Cads, 'VariousControls')
-            MiscControls    = SubElement(VariousControls, 'MiscControls')
-            if 'LOCAL_CFLAGS' in group:
-                MiscControls.text = group['LOCAL_CFLAGS']
-            else:
-                MiscControls.text = ' '
-            Define          = SubElement(VariousControls, 'Define')
-            if 'LOCAL_CPPDEFINES' in group:
-                Define.text     = ', '.join(set(group['LOCAL_CPPDEFINES']))
-            else:
-                Define.text     = ' '
-            Undefine        = SubElement(VariousControls, 'Undefine')
-            Undefine.text   = ' '
-            IncludePath     = SubElement(VariousControls, 'IncludePath')
-            if 'LOCAL_CPPPATH' in group:
-                IncludePath.text = ';'.join([_make_path_relative(project_path, os.path.normpath(i)) for i in group['LOCAL_CPPPATH']])
-            else:
-                IncludePath.text = ' '
+        group_tree = MDK4AddGroup(ProjectFiles, groups, group['name'], group['src'], project_path, group)
 
         # get each include path
         if 'CPPPATH' in group and group['CPPPATH']:


### PR DESCRIPTION
…ontrol

## 拉取/合并请求描述：(PR description)

[
fixed LOCAL_CCFLAGS not work at keil.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
