### PR TITLE
fix: select the input clk of spi based on SPI instance

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
@@ -149,12 +149,30 @@ static rt_err_t stm32_spi_init(struct stm32_spi *spi_drv, struct rt_spi_configur
 
     uint32_t SPI_APB_CLOCK;
 
+/* special series */
 #if defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32G0)
     SPI_APB_CLOCK = HAL_RCC_GetPCLK1Freq();
-#elif defined(SOC_SERIES_STM32H7)
-    SPI_APB_CLOCK = HAL_RCC_GetSysClockFreq();
+
+/* normal series */
 #else
-    SPI_APB_CLOCK = HAL_RCC_GetPCLK2Freq();
+/* SPI2 and SPI3 on APB1 */
+    if(spi_drv->config->Instance == SPI2 || spi_drv->config->Instance == SPI3)
+    {
+        SPI_APB_CLOCK = HAL_RCC_GetPCLK1Freq();
+    }
+/* SPI1, SPI4 and SPI5 on APB2 */
+    else if(spi_drv->config->Instance == SPI1 || spi_drv->config->Instance == SPI4 || spi_drv->config->Instance == SPI5)
+    {
+        SPI_APB_CLOCK = HAL_RCC_GetPCLK2Freq();
+    }
+/* SPI6 get the input clk from APB4(such as on STM32H7). However, there is no HAL_RCC_GetPCLK4Freq api provided.
+   APB4 has same prescale factor as APB1 from HPRE Clock by default in CubeMx, so we assign APB1 to it . 
+   if you change the default prescale factor of APB4, please modify SPI_APB_CLOCK accordingly.
+*/
+    else
+    {
+        SPI_APB_CLOCK = HAL_RCC_GetPCLK1Freq();
+    }
 #endif
 
     if (cfg->max_hz >= SPI_APB_CLOCK / 2)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1.在STM32F4上使用SPI2时发现CLK与设置的一直不一样，查看数据手册发现，SPI2使用APB1作为输入时钟
另外，我查看了STM32G，STM32F1, STM32F4, STM32L4, STM32H7发现SPI输入CLK是有规律的：
默认 SPI1, SPI4, SPI5挂在APB2上，一般是高速SPI；SPI2, SPI3挂在APB1上 ,一般属于低速SPI; SPI6(目前只在高系列H7上看到)挂到APB4上。STM32G0，STM32F比较特殊，只有一个APB。
2.另外为了兼容多个SPI 总线，根据spi_drv->config->Instance选择APB
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
