### PR TITLE
[libcpu/risc-v] 修复risc-v scons编译中间文件不能输出到build/kernel/libcpu目录问题

### DIFF
--- a/libcpu/risc-v/SConscript
+++ b/libcpu/risc-v/SConscript
@@ -17,12 +17,12 @@ elif rtconfig.CPU == "nuclei" :
 elif rtconfig.CPU == "virt64" :
     group = group
 else :
-    group = group + SConscript(os.path.join(cwd, 'common', 'SConscript'))
+    group = group + SConscript(os.path.join('common', 'SConscript'))
 
 # cpu porting code files
 if  rtconfig.CPU == "e9xx" :
-    group = group + SConscript(os.path.join(cwd, rtconfig.VENDOR, rtconfig.CPU, 'SConscript'))
+    group = group + SConscript(os.path.join(rtconfig.VENDOR, rtconfig.CPU, 'SConscript'))
 else :
-    group = group + SConscript(os.path.join(cwd, rtconfig.CPU, 'SConscript'))
+    group = group + SConscript(os.path.join(rtconfig.CPU, 'SConscript'))
 
 Return('group')


### PR DESCRIPTION
[
在移植ch32v103 bsp时 发现scons编译libcpu的中间文件，直接放到源文件目录下，不是tool/building.py指定的
build/kernel/libcpu, variant_dir设置未起作用。同时也会生成.s 文件，污染内核，git追踪也麻烦。
```
    if not has_libcpu:
        objs.extend(SConscript(Rtt_Root + '/libcpu/SConscript',
                    variant_dir=kernel_vdir + '/libcpu', duplicate=0))
```
对比libcp/arm SConscript发现libcp/risc-v下的Sconscript 目标使用了绝对地址引用。
改成相对地址后，在ch32v103r-r1， ab32vg1-ab-prougen，gd32vf103v-eva bsp上测试，正常输出到build/kernel/libcpu。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
