### PR TITLE
解决bsp/rm48x50工程使用arm-gcc编译不通过，以及程序出现prefetch abort异常的问题。

### DIFF
--- a/libcpu/arm/cortex-r4/cpu.c
+++ b/libcpu/arm/cortex-r4/cpu.c
@@ -87,9 +87,11 @@ void rt_hw_cpu_dcache_disable()
 }
 
 #elif __GNUC__
+#ifdef RT_USING_CPU_FFS
 int __rt_ffs(int value)
 {
     return __builtin_ffs(value);
 }
+#endif
 #endif
 /*@}*/

--- a/libcpu/arm/cortex-r4/start_gcc.S
+++ b/libcpu/arm/cortex-r4/start_gcc.S
@@ -54,6 +54,23 @@ _reset:
 @-------------------------------------------------------------------------------
 @ Initialize CPU Registers
 @ After reset, the CPU is in the Supervisor mode (M = 10011)
+        mov r0, #0x0000
+        mov r1, #0x0000
+        mov r2, #0x0000
+        mov r3, #0x0000
+        mov r4, #0x0000
+        mov r5, #0x0000
+        mov r6, #0x0000
+        mov r7, #0x0000
+        mov r8, #0x0000
+        mov r9, #0x0000
+        mov r10, #0x0000
+        mov r11, #0x0000
+        mov r12, #0x0000
+        mov r13, #0x0000
+        mrs r1, cpsr
+        msr spsr_cxsf, r1
+
         cpsid  if, #19
 
 #if defined (__VFP_FP__) && !defined(__SOFTFP__) && defined(RT_VFP_LAZY_STACKING)


### PR DESCRIPTION


## 拉取/合并请求描述：(PR description)

[
1、当未在rtconfig.h中定义“RT_USING_CPU_FFS”宏时，在src\kservice.c的1706行和libcpu\arm\cortex-r4\cpu.c的90行都存在 __rt_ffs()函数的定义，__rt_ffs()函数重定义导致编译无法通过。
2、基于TI的rm48芯片(cortex-r4核) 的板卡进行rt-thread移植时，在bsp/rm48x50下使用scons生成的rt-thread studio工程，编译后烧写到板卡上后上电运行出现prefetch abort异常，程序挂掉。经过与TI的官方demo代码进行对比，libcpu/arm/cortex-r4/start_gcc.S的reset处相较于TI的官方demo，少了r0-r13以及spsr寄存器的初始化代码。


1*、修改后，不定义RT_USING_CPU_FFS宏的情况下，使用arm-gcc编译也不会出现__rt_ffs()函数重定义，程序编译通过。
2*、在libcpu/arm/cortex-r4/start_gcc.S的reset处添加了r0-r13、spsr寄存器的初始化代码后，重新编译下载到rm48板卡上电后程序正常运行，不再出现prefetch abort异常。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
