### PR TITLE
[dfs][romfs]支持相对地址模式

### DIFF
--- a/components/dfs/filesystems/romfs/dfs_romfs.c
+++ b/components/dfs/filesystems/romfs/dfs_romfs.c
@@ -16,19 +16,37 @@
 
 int dfs_romfs_mount(struct dfs_filesystem *fs, unsigned long rwflag, const void *data)
 {
-    struct romfs_dirent *root_dirent;
+    struct root_data *root_data;
 
     if (data == NULL)
         return -EIO;
 
-    root_dirent = (struct romfs_dirent *)data;
-    fs->data = root_dirent;
+    root_data = (struct root_data *)rt_malloc(sizeof(struct root_data));
+    if (root_data)
+    {
+        long long size = sizeof(struct romfs_dirent);
+        root_data->dirent = (struct romfs_dirent *)data;
+        if ((const char *)root_data->dirent->data - root_data->dirent->name != 0x04)
+            root_data->offset = 0;
+        else
+            root_data->offset = (long long)root_data->dirent->name != size ? ((long long)data - (long long)root_data->dirent->name + size) : (long long)data;
+        fs->data = root_data;
+    }
+    else
+    {
+        return -RT_ENOMEM;
+    }
 
     return RT_EOK;
 }
 
 int dfs_romfs_unmount(struct dfs_filesystem *fs)
 {
+    if (fs->data)
+    {
+        rt_free(fs->data);
+    }
+
     return RT_EOK;
 }
 
@@ -45,7 +63,7 @@ rt_inline int check_dirent(struct romfs_dirent *dirent)
     return 0;
 }
 
-struct romfs_dirent *dfs_romfs_lookup(struct romfs_dirent *root_dirent, const char *path, rt_size_t *size)
+struct romfs_dirent *dfs_romfs_lookup(struct root_data *root_data, const char *path, rt_size_t *size)
 {
     rt_size_t index, found;
     const char *subpath, *subpath_end;
@@ -53,18 +71,18 @@ struct romfs_dirent *dfs_romfs_lookup(struct romfs_dirent *root_dirent, const ch
     rt_size_t dirent_size;
 
     /* Check the root_dirent. */
-    if (check_dirent(root_dirent) != 0)
+    if (check_dirent(root_data->dirent) != 0)
         return NULL;
 
     if (path[0] == '/' && path[1] == '\0')
     {
-        *size = root_dirent->size;
-        return root_dirent;
+        *size = root_data->dirent->size;
+        return root_data->dirent;
     }
 
-    /* goto root directory entries */
-    dirent = (struct romfs_dirent *)root_dirent->data;
-    dirent_size = root_dirent->size;
+    /* goto root directy entries */
+    dirent = (struct romfs_dirent *)(root_data->dirent->data + root_data->offset);
+    dirent_size = root_data->dirent->size;
 
     /* get the end position of this subpath */
     subpath_end = path;
@@ -84,8 +102,8 @@ struct romfs_dirent *dfs_romfs_lookup(struct romfs_dirent *root_dirent, const ch
         {
             if (check_dirent(&dirent[index]) != 0)
                 return NULL;
-            if (rt_strlen(dirent[index].name) == (subpath_end - subpath) &&
-                    rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
+            if (rt_strlen(dirent[index].name + root_data->offset) == (subpath_end - subpath) &&
+                    rt_strncmp(dirent[index].name + root_data->offset, subpath, (subpath_end - subpath)) == 0)
             {
                 dirent_size = dirent[index].size;
 
@@ -105,7 +123,7 @@ struct romfs_dirent *dfs_romfs_lookup(struct romfs_dirent *root_dirent, const ch
                 if (dirent[index].type == ROMFS_DIRENT_DIR)
                 {
                     /* enter directory */
-                    dirent = (struct romfs_dirent *)dirent[index].data;
+                    dirent = (struct romfs_dirent *)(dirent[index].data + root_data->offset);
                     found = 1;
                     break;
                 }
@@ -132,7 +150,9 @@ int dfs_romfs_read(struct dfs_fd *file, void *buf, size_t count)
 {
     rt_size_t length;
     struct romfs_dirent *dirent;
+    struct root_data *root_data;
 
+    root_data = (struct root_data *)file->fs->data;
     dirent = (struct romfs_dirent *)file->data;
     RT_ASSERT(dirent != NULL);
 
@@ -147,7 +167,7 @@ int dfs_romfs_read(struct dfs_fd *file, void *buf, size_t count)
         length = file->size - file->pos;
 
     if (length > 0)
-        rt_memcpy(buf, &(dirent->data[file->pos]), length);
+        memcpy(buf, &(dirent->data[file->pos]) + root_data->offset, length);
 
     /* update file current position */
     file->pos += length;
@@ -157,7 +177,7 @@ int dfs_romfs_read(struct dfs_fd *file, void *buf, size_t count)
 
 int dfs_romfs_lseek(struct dfs_fd *file, off_t offset)
 {
-    if (offset <= file->size)
+    if (offset <= (off_t)file->size)
     {
         file->pos = offset;
         return file->pos;
@@ -176,19 +196,17 @@ int dfs_romfs_open(struct dfs_fd *file)
 {
     rt_size_t size;
     struct romfs_dirent *dirent;
-    struct romfs_dirent *root_dirent;
-    struct dfs_filesystem *fs;
+    struct root_data *root_data;
 
-    fs = (struct dfs_filesystem *)file->data;
-    root_dirent = (struct romfs_dirent *)fs->data;
+    root_data = (struct root_data *)file->fs->data;
 
-    if (check_dirent(root_dirent) != 0)
+    if (check_dirent(root_data->dirent) != 0)
         return -EIO;
 
     if (file->flags & (O_CREAT | O_WRONLY | O_APPEND | O_TRUNC | O_RDWR))
         return -EINVAL;
 
-    dirent = dfs_romfs_lookup(root_dirent, file->path, &size);
+    dirent = dfs_romfs_lookup(root_data, file->path, &size);
     if (dirent == NULL)
         return -ENOENT;
 
@@ -216,10 +234,10 @@ int dfs_romfs_stat(struct dfs_filesystem *fs, const char *path, struct stat *st)
 {
     rt_size_t size;
     struct romfs_dirent *dirent;
-    struct romfs_dirent *root_dirent;
+    struct root_data *root_data;
 
-    root_dirent = (struct romfs_dirent *)fs->data;
-    dirent = dfs_romfs_lookup(root_dirent, path, &size);
+    root_data = (struct root_data *)fs->data;
+    dirent = dfs_romfs_lookup(root_data, path, &size);
 
     if (dirent == NULL)
         return -ENOENT;
@@ -242,18 +260,20 @@ int dfs_romfs_stat(struct dfs_filesystem *fs, const char *path, struct stat *st)
 
 int dfs_romfs_getdents(struct dfs_fd *file, struct dirent *dirp, uint32_t count)
 {
-    rt_size_t index;
+    uint32_t index;
     const char *name;
     struct dirent *d;
     struct romfs_dirent *dirent, *sub_dirent;
+    struct root_data *root_data;
 
+    root_data = (struct root_data *)file->fs->data;
     dirent = (struct romfs_dirent *)file->data;
     if (check_dirent(dirent) != 0)
         return -EIO;
     RT_ASSERT(dirent->type == ROMFS_DIRENT_DIR);
 
     /* enter directory */
-    dirent = (struct romfs_dirent *)dirent->data;
+    dirent = (struct romfs_dirent *)(dirent->data + root_data->offset);
 
     /* make integer count */
     count = (count / sizeof(struct dirent));
@@ -261,12 +281,12 @@ int dfs_romfs_getdents(struct dfs_fd *file, struct dirent *dirp, uint32_t count)
         return -EINVAL;
 
     index = 0;
-    for (index = 0; index < count && file->pos < file->size; index ++)
+    for (index = 0; index < count && (size_t)file->pos < file->size; index ++)
     {
         d = dirp + index;
 
         sub_dirent = &dirent[file->pos];
-        name = sub_dirent->name;
+        name = sub_dirent->name + root_data->offset;
 
         /* fill dirent */
         if (sub_dirent->type == ROMFS_DIRENT_DIR)
@@ -276,7 +296,7 @@ int dfs_romfs_getdents(struct dfs_fd *file, struct dirent *dirp, uint32_t count)
 
         d->d_namlen = rt_strlen(name);
         d->d_reclen = (rt_uint16_t)sizeof(struct dirent);
-        rt_strncpy(d->d_name, name, DFS_PATH_MAX);
+        rt_strncpy(d->d_name, name, rt_strlen(name) + 1);
 
         /* move to next position */
         ++ file->pos;

--- a/components/dfs/filesystems/romfs/dfs_romfs.h
+++ b/components/dfs/filesystems/romfs/dfs_romfs.h
@@ -25,6 +25,12 @@ struct romfs_dirent
     rt_size_t        size;  /* file size */
 };
 
+struct root_data
+{
+    struct romfs_dirent *dirent;  /* root dirent */
+    long long offset;
+};
+
 int dfs_romfs_init(void);
 extern const struct romfs_dirent romfs_root;
 

--- a/tools/mkromfs.py
+++ b/tools/mkromfs.py
@@ -191,7 +191,7 @@ class Folder(object):
             else:
                 assert False, 'Unkown instance:%s' % str(c)
 
-            name = bytes(c.bin_name)
+            name = bytes(c.bin_name.encode('utf-8'))
             name_addr = v_len
             v_len += len(name)
 
@@ -200,7 +200,7 @@ class Folder(object):
             # pad the data to 4 bytes boundary
             pad_len = 4
             if len(data) % pad_len != 0:
-                data += '\0' * (pad_len - len(data) % pad_len)
+                data += ('\0' * (pad_len - len(data) % pad_len)).encode('utf-8')
             v_len += len(data)
 
             d_li.append(self.bin_fmt.pack(*self.bin_item(
@@ -232,7 +232,7 @@ const struct romfs_dirent {name} = {{
 
 def get_bin_data(tree, base_addr):
     v_len = base_addr + Folder.bin_fmt.size
-    name = bytes('/\0\0\0')
+    name = bytes('/\0\0\0'.encode("utf-8"))
     name_addr = v_len
     v_len += len(name)
     data_addr = v_len


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
## 背景

1. 希望打包出来的 ROMFS 文件系统，不是绝对地址的。这样子就能在多个平台上进行使用。
2. simulator 上会将 ROMFS 载入内存进行使用，每次加载的内存地址可能不一致，也必须使用相对地址

## 修改

1. ROMFS 支持相对地址功能，采用挂载地址 + 偏移的方式读取文件
2. 相对地址与绝对地址自适应
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
