### PR TITLE
[drivers][rtc] 优化 RTC 及 Alarm 代码

### DIFF
--- a/components/drivers/include/drivers/rtc.h
+++ b/components/drivers/include/drivers/rtc.h
@@ -8,6 +8,7 @@
  * 2012-10-10     aozima       first version.
  * 2021-06-11     iysheng      implement RTC framework V2.0
  * 2021-07-30     Meco Man     move rtc_core.h to rtc.h
+ * 2022-04-05     tyx          add timestamp function
  */
 
 #ifndef __RTC_H__

--- a/components/drivers/include/drivers/rtc.h
+++ b/components/drivers/include/drivers/rtc.h
@@ -51,6 +51,8 @@ rt_err_t rt_hw_rtc_register(rt_rtc_dev_t  *rtc,
 
 rt_err_t set_date(rt_uint32_t year, rt_uint32_t month, rt_uint32_t day);
 rt_err_t set_time(rt_uint32_t hour, rt_uint32_t minute, rt_uint32_t second);
+rt_err_t set_timestamp(time_t timestamp);
+rt_err_t get_timestamp(time_t *timestamp);
 
 #ifdef __cplusplus
 }

--- a/components/drivers/include/drivers/rtc.h
+++ b/components/drivers/include/drivers/rtc.h
@@ -14,6 +14,11 @@
 #define __RTC_H__
 
 #include <rtdef.h>
+#include <sys/time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define RT_DEVICE_CTRL_RTC_GET_TIME     0x20            /**< get second time */
 #define RT_DEVICE_CTRL_RTC_SET_TIME     0x21            /**< set second time */
@@ -25,12 +30,12 @@
 struct rt_rtc_ops
 {
     rt_err_t (*init)(void);
-    rt_err_t (*get_secs)(void *arg);
-    rt_err_t (*set_secs)(void *arg);
-    rt_err_t (*get_alarm)(void *arg);
-    rt_err_t (*set_alarm)(void *arg);
-    rt_err_t (*get_timeval)(void *arg);
-    rt_err_t (*set_timeval)(void *arg);
+    rt_err_t (*get_secs)(time_t *sec);
+    rt_err_t (*set_secs)(time_t *sec);
+    rt_err_t (*get_alarm)(struct rt_rtc_wkalarm *alarm);
+    rt_err_t (*set_alarm)(struct rt_rtc_wkalarm *alarm);
+    rt_err_t (*get_timeval)(struct timeval *tv);
+    rt_err_t (*set_timeval)(struct timeval *tv);
 };
 
 typedef struct rt_rtc_device
@@ -46,5 +51,9 @@ rt_err_t rt_hw_rtc_register(rt_rtc_dev_t  *rtc,
 
 rt_err_t set_date(rt_uint32_t year, rt_uint32_t month, rt_uint32_t day);
 rt_err_t set_time(rt_uint32_t hour, rt_uint32_t minute, rt_uint32_t second);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __RTC_H__ */

--- a/components/drivers/rtc/alarm.c
+++ b/components/drivers/rtc/alarm.c
@@ -170,11 +170,14 @@ static void alarm_wakeup(struct rt_alarm *alarm, struct tm *now)
         case RT_ALARM_WEEKLY:
         {
             /* alarm at wday */
-            sec_alarm += alarm->wktime.tm_wday * 24 * 3600;
-            sec_now += now->tm_wday * 24 * 3600;
+            if (alarm->wktime.tm_wday == now->tm_wday)
+            {
+                sec_alarm += alarm->wktime.tm_wday * 24 * 3600;
+                sec_now += now->tm_wday * 24 * 3600;
 
-            if (((sec_now - sec_alarm) <= RT_ALARM_DELAY) && (sec_now >= sec_alarm))
-                wakeup = RT_TRUE;
+                if (sec_now == sec_alarm)
+                    wakeup = RT_TRUE;
+            }
         }
         break;
         case RT_ALARM_MONTHLY:
@@ -201,7 +204,8 @@ static void alarm_wakeup(struct rt_alarm *alarm, struct tm *now)
 
         if ((wakeup == RT_TRUE) && (alarm->callback != RT_NULL))
         {
-            timestamp = time(RT_NULL);
+            timestamp = (time_t)0;
+            get_timestamp(&timestamp);
             alarm->callback(alarm, timestamp);
         }
     }

--- a/components/drivers/rtc/alarm.c
+++ b/components/drivers/rtc/alarm.c
@@ -217,7 +217,7 @@ static void alarm_update(rt_uint32_t event)
     struct rt_alarm *alarm;
     rt_int32_t sec_now, sec_alarm, sec_tmp;
     rt_int32_t sec_next = 24 * 3600, sec_prev = 0;
-    time_t timestamp;
+    time_t timestamp = (time_t)0;
     struct tm now;
     rt_list_t *next;
 
@@ -225,12 +225,8 @@ static void alarm_update(rt_uint32_t event)
     if (!rt_list_isempty(&_container.head))
     {
         /* get time of now */
-        timestamp = time(RT_NULL);
-#ifdef _WIN32
-        _gmtime32_s(&now, &timestamp);
-#else
+        get_timestamp(&timestamp);
         gmtime_r(&timestamp, &now);
-#endif
 
         for (next = _container.head.next; next != &_container.head; next = next->next)
         {
@@ -239,12 +235,9 @@ static void alarm_update(rt_uint32_t event)
             alarm_wakeup(alarm, &now);
         }
 
-        timestamp = time(RT_NULL);
-#ifdef _WIN32
-        _gmtime32_s(&now, &timestamp);
-#else
+        /* get time of now */
+        get_timestamp(&timestamp);
         gmtime_r(&timestamp, &now);
-#endif
         sec_now = alarm_mkdaysec(&now);
 
         for (next = _container.head.next; next != &_container.head; next = next->next)
@@ -297,9 +290,9 @@ static void alarm_update(rt_uint32_t event)
     rt_mutex_release(&_container.mutex);
 }
 
-static rt_uint32_t days_of_year_month(int tm_year, int tm_mon)
+static int days_of_year_month(int tm_year, int tm_mon)
 {
-    rt_uint32_t ret, year;
+    int ret, year;
 
     year = tm_year + 1900;
     if (tm_mon == 1)
@@ -342,18 +335,14 @@ static rt_bool_t is_valid_date(struct tm *date)
 static rt_err_t alarm_setup(rt_alarm_t alarm, struct tm *wktime)
 {
     rt_err_t ret = RT_ERROR;
-    time_t timestamp;
+    time_t timestamp = (time_t)0;
     struct tm *setup, now;
 
     setup = &alarm->wktime;
     *setup = *wktime;
-    timestamp = time(RT_NULL);
-
-#ifdef _WIN32
-    _gmtime32_s(&now, &timestamp);
-#else
+    /* get time of now */
+    get_timestamp(&timestamp);
     gmtime_r(&timestamp, &now);
-#endif
 
     /* if these are a "don't care" value,we set them to now*/
     if ((setup->tm_sec > 59) || (setup->tm_sec < 0))
@@ -551,7 +540,7 @@ rt_err_t rt_alarm_start(rt_alarm_t alarm)
 {
     rt_int32_t sec_now, sec_old, sec_new;
     rt_err_t ret = RT_EOK;
-    time_t timestamp;
+    time_t timestamp = (time_t)0;
     struct tm now;
 
     if (alarm == RT_NULL)
@@ -566,12 +555,9 @@ rt_err_t rt_alarm_start(rt_alarm_t alarm)
             goto _exit;
         }
 
-        timestamp = time(RT_NULL);
-#ifdef _WIN32
-        _gmtime32_s(&now, &timestamp);
-#else
+        /* get time of now */
+        get_timestamp(&timestamp);
         gmtime_r(&timestamp, &now);
-#endif
 
         alarm->flag |= RT_ALARM_STATE_START;
 

--- a/components/drivers/rtc/alarm.c
+++ b/components/drivers/rtc/alarm.c
@@ -753,21 +753,20 @@ void rt_alarm_dump(void)
     rt_alarm_t alarm;
     rt_uint8_t index = 0;
 
-    rt_kprintf("| id | YYYY-MM-DD hh:mm:ss | week | flag | en |\n");
-    rt_kprintf("+----+---------------------+------+------+----+\n");
+    rt_kprintf("| hh:mm:ss | week | flag | en |\n");
+    rt_kprintf("+----------+------+------+----+\n");
     for (next = _container.head.next; next != &_container.head; next = next->next)
     {
         alarm = rt_list_entry(next, struct rt_alarm, list);
         rt_uint8_t flag_index = get_alarm_flag_index(alarm->flag);
-        rt_kprintf("| %2d | %04d-%02d-%02d %02d:%02d:%02d |  %2d  |  %2s  | %2d |\n",
-            index++, alarm->wktime.tm_year + 1900, alarm->wktime.tm_mon + 1, alarm->wktime.tm_mday,
+        rt_kprintf("| %02d:%02d:%02d |  %2d  |  %2s  | %2d |\n",
             alarm->wktime.tm_hour, alarm->wktime.tm_min, alarm->wktime.tm_sec,
             alarm->wktime.tm_wday, _alarm_flag_tbl[flag_index].name, alarm->flag & RT_ALARM_STATE_START);
     }
-    rt_kprintf("+----+---------------------+------+------+----+\n");
+    rt_kprintf("+----------+------+------+----+\n");
 }
 
-MSH_CMD_EXPORT_ALIAS(rt_alarm_dump, rt_alarm_dump, dump alarm info);
+MSH_CMD_EXPORT_ALIAS(rt_alarm_dump, list_alarm, list alarm info);
 
 /** \brief initialize alarm service system
  *

--- a/components/drivers/rtc/rtc.c
+++ b/components/drivers/rtc/rtc.c
@@ -228,6 +228,49 @@ rt_err_t set_time(rt_uint32_t hour, rt_uint32_t minute, rt_uint32_t second)
     return ret;
 }
 
+/**
+ * Set timestamp(utc).
+ *
+ * @param time_t timestamp
+ *
+ * @return rt_err_t if set success, return RT_EOK.
+ */
+rt_err_t set_timestamp(time_t timestamp)
+{
+    if (_rtc_device == RT_NULL)
+    {
+        _rtc_device = rt_device_find("rtc");
+        if (_rtc_device == RT_NULL)
+        {
+            return -RT_ERROR;
+        }
+    }
+
+    /* update to RTC device. */
+    return rt_device_control(_rtc_device, RT_DEVICE_CTRL_RTC_SET_TIME, &timestamp);
+}
+
+/**
+ * Get timestamp(utc).
+ *
+ * @param time_t* timestamp
+ *
+ * @return rt_err_t if set success, return RT_EOK.
+ */
+rt_err_t get_timestamp(time_t *timestamp)
+{
+    if (_rtc_device == RT_NULL)
+    {
+        _rtc_device = rt_device_find("rtc");
+        if (_rtc_device == RT_NULL)
+        {
+            return -RT_ERROR;
+        }
+    }
+
+    /* Get timestamp from RTC device. */
+    return rt_device_control(_rtc_device, RT_DEVICE_CTRL_RTC_GET_TIME, timestamp);
+}
 
 #ifdef RT_USING_FINSH
 #include <finsh.h>

--- a/components/drivers/rtc/rtc.c
+++ b/components/drivers/rtc/rtc.c
@@ -229,7 +229,7 @@ rt_err_t set_time(rt_uint32_t hour, rt_uint32_t minute, rt_uint32_t second)
 }
 
 /**
- * Set timestamp(utc).
+ * Set timestamp(UTC).
  *
  * @param time_t timestamp
  *
@@ -251,7 +251,7 @@ rt_err_t set_timestamp(time_t timestamp)
 }
 
 /**
- * Get timestamp(utc).
+ * Get timestamp(UTC).
  *
  * @param time_t* timestamp
  *


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
## 规范接口参数

时间是有 UTC 时间与本地时间之分的，当前 RTC 时间的设置及使用比较混乱，其中一个原因，是之前的 libc 没有时区的概念。怎么设置都行，只要自己认识就可以。目前 libc time 函数十分完毕，也有时区的机制在里面 。为了避免对 API 的理解偏差，导致业务中时间混乱的问题，rtc 设备框架的 API 行为也要确定下来。

现规定：

### rtc ops 接口

1. `rt_err_t (*get_secs)(time_t *sec)` 获取 UTC 时间戳，无时区
2. `rt_err_t (*set_secs)(time_t *sec)` 设置 UTC 时间戳，无时区
3. `rt_err_t (*get_alarm)(struct rt_rtc_wkalarm *alarm)` 获取闹钟时分秒，无时区
4. `rt_err_t (*set_alarm)(struct rt_rtc_wkalarm *alarm)` 设置闹钟时分秒，无时区
5. `rt_err_t (*get_timeval)(struct timeval *tv)` 获取 UTC 毫秒时间戳，无时区
6. `rt_err_t (*set_timeval)(struct timeval *tv)` 设置 UTC 毫秒时间戳，无时区

### rtc 设备框架

#### ctrl 命令接口

1. RT_DEVICE_CTRL_RTC_GET_TIME 命令传递的 arg 类型是 `time_t *`，从 RTC 设备获取 UTC 时间
2. RT_DEVICE_CTRL_RTC_SET_TIME 命令传递的 arg 类型是 `time_t *`，设置 UTC 时间到 RTC 设备
3. RT_DEVICE_CTRL_RTC_GET_ALARM 命令传递的 arg 类型是 `struct rt_rtc_wkalarm *`，获取已经设置的闹钟时间，其中的时分秒是 UTC 时间的时分秒，未设置闹钟返回错误
4. RT_DEVICE_CTRL_RTC_SET_ALARM 命令传递的 arg 类型是 `struct rt_rtc_wkalarm *`，设置闹钟时间，获取的是 UTC 时间的十分秒

#### api 接口

1. `rt_err_t set_date(rt_uint32_t year, rt_uint32_t month, rt_uint32_t day)` 设置`本地时间`年月日，有时区
2. `rt_err_t set_time(rt_uint32_t hour, rt_uint32_t minute, rt_uint32_t second)` 设置`本地时间`时分秒，有时区
3. `rt_err_t set_timestamp(time_t timestamp)` 设置 UTC 时间戳，无时区
4. `rt_err_t get_timestamp(time_t *timestamp)` 获取 UTC 时间戳，无时区

#### date 命令

获取时间：本地时间，UTC 时间戳，时区
设置时间：本地时间

### Alarm 设备框架

#### ctrl 命令接口

1. RT_ALARM_CTRL_MODIFY 命令传递的 arg 类型是 `struct rt_alarm_setup *`，修改闹钟`时分秒星期`等，无时区

#### api 接口

1.  `rt_alarm_t rt_alarm_create(rt_alarm_callback_t callback, struct rt_alarm_setup *setup)` 根据`时分秒星期`创建闹钟，无时区

## 代码改动点

1.  rtc ops 函数入参全部 void *，非常不直观，将 ops 参数确定下来
2. 优化 set_date 及 set_time 函数
    - 保存 rtc 设备局部，避免每次查找设备
    - 优化获取当前时间的方式 `time -> rt_device_control(RT_DEVICE_CTRL_RTC_GET_TIME)` 减少一层函数调用
3. 添加时间戳获取/设置函数
4. 增强 date 命令
    - 增强查询时间的信息输出：本地时间，UTC 时间戳，时区
    - 增强设置时间：直接设置时间戳，显示设置前后的本地时间
 5. 修复星期闹钟 BUG
     - 判定星期几闹钟时，之前是只检查了星期，没有检查时分秒。目前全部都检查
 6. 优化 alarm 部分代码
     - 去掉不必要的条件编译宏
    - 更换时间戳获取函数

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
