### PR TITLE
[kconfig] add 64bit default value for stack size. set tick HZ as 1000 by default

### DIFF
--- a/components/Kconfig
+++ b/components/Kconfig
@@ -11,7 +11,9 @@ config RT_USING_USER_MAIN
     if RT_USING_USER_MAIN
         config RT_MAIN_THREAD_STACK_SIZE
             int "Set main thread stack size"
+            default 6144 if ARCH_CPU_64BIT
             default 2048
+
         config RT_MAIN_THREAD_PRIORITY
             int "Set main thread priority" 
             default 4  if RT_THREAD_PRIORITY_8

--- a/components/libc/compilers/common/stdlib.c
+++ b/components/libc/compilers/common/stdlib.c
@@ -25,21 +25,17 @@ void __rt_libc_exit(int status)
     }
 }
 
-#if defined(RT_USING_MSH) && defined(RT_USING_HEAP)
+#ifdef RT_USING_MSH
 int system(const char *command)
 {
     extern int msh_exec(char *cmd, rt_size_t length);
 
-    int ret = -RT_ENOMEM;
-    char *cmd = rt_strdup(command);
-
-    if (cmd)
+    if (command)
     {
-        ret = msh_exec(cmd, rt_strlen(cmd));
-        rt_free(cmd);
+        msh_exec((char *)command, rt_strlen(command));
     }
 
-    return ret;
+    return 0;
 }
 RTM_EXPORT(system);
-#endif /* defined(RT_USING_MSH) && defined(RT_USING_HEAP) */
+#endif /* RT_USING_MSH */

--- a/components/libc/compilers/common/stdlib.c
+++ b/components/libc/compilers/common/stdlib.c
@@ -25,7 +25,7 @@ void __rt_libc_exit(int status)
     }
 }
 
-#ifdef RT_USING_MSH
+#if defined(RT_USING_MSH) && defined(RT_USING_HEAP)
 int system(const char *command)
 {
     extern int msh_exec(char *cmd, rt_size_t length);
@@ -42,4 +42,4 @@ int system(const char *command)
     return ret;
 }
 RTM_EXPORT(system);
-#endif
+#endif /* defined(RT_USING_MSH) && defined(RT_USING_HEAP) */

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -639,7 +639,7 @@ char *rt_strdup(const char *s);
 #else
 #define rt_strnlen(s, maxlen)       strnlen(s, maxlen)
 #ifdef RT_USING_HEAP
-#define rt_strdup(s, maxlen)        strdup(s, maxlen)
+#define rt_strdup(s)                strdup(s)
 #endif /* RT_USING_HEAP */
 #endif /* !defined(RT_KSERVICE_USING_STDLIB) || defined(__ARMCC_VERSION) */
 

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -631,24 +631,17 @@ rt_size_t rt_strlen(const char *src);
 #define rt_strlen(src)              strlen(src)
 #endif /*RT_KSERVICE_USING_STDLIB*/
 
+char *rt_strdup(const char *s);
+
 #if !defined(RT_KSERVICE_USING_STDLIB) || defined(__ARMCC_VERSION)
 rt_size_t rt_strnlen(const char *s, rt_ubase_t maxlen);
-#ifdef RT_USING_HEAP
-char *rt_strdup(const char *s);
-#endif /* RT_USING_HEAP */
 #else
 #define rt_strnlen(s, maxlen)       strnlen(s, maxlen)
-#ifdef RT_USING_HEAP
-#define rt_strdup(s)                strdup(s)
-#endif /* RT_USING_HEAP */
 #endif /* !defined(RT_KSERVICE_USING_STDLIB) || defined(__ARMCC_VERSION) */
 
 #ifdef __ARMCC_VERSION
 /* MDK doesn't have these APIs */
 rt_size_t strnlen(const char *s, rt_size_t maxlen);
-#ifdef RT_USING_HEAP
-char* strdup(const char* str);
-#endif /* RT_USING_HEAP */
 #endif /* __ARMCC_VERSION */
 
 void rt_show_version(void);

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -599,17 +599,14 @@ int *_rt_errno(void);
 
 int __rt_ffs(int value);
 
-#ifndef RT_KSERVICE_USING_STDLIB_MEMSET
+#ifndef RT_KSERVICE_USING_STDLIB_MEMXXX
 void *rt_memset(void *src, int c, rt_ubase_t n);
-#endif /* RT_KSERVICE_USING_STDLIB_MEMSET */
-#ifndef RT_KSERVICE_USING_STDLIB_MEMCPY
 void *rt_memcpy(void *dest, const void *src, rt_ubase_t n);
-#endif /* RT_KSERVICE_USING_STDLIB_MEMCPY */
-char *rt_strdup(const char *s);
-
-#ifndef RT_KSERVICE_USING_STDLIB
 void *rt_memmove(void *dest, const void *src, rt_size_t n);
 rt_int32_t rt_memcmp(const void *cs, const void *ct, rt_size_t count);
+#endif /* RT_KSERVICE_USING_STDLIB_MEMXXX */
+
+#ifndef RT_KSERVICE_USING_STDLIB
 char *rt_strstr(const char *str1, const char *str2);
 rt_int32_t rt_strcasecmp(const char *a, const char *b);
 char *rt_strcpy(char *dst, const char *src);
@@ -619,14 +616,12 @@ rt_int32_t rt_strcmp(const char *cs, const char *ct);
 rt_size_t rt_strlen(const char *src);
 #else
 #include <string.h>
-#ifdef RT_KSERVICE_USING_STDLIB_MEMSET
+#ifdef RT_KSERVICE_USING_STDLIB_MEMXXX
 #define rt_memset(s, c, count)      memset(s, c, count)
-#endif /* RT_KSERVICE_USING_STDLIB_MEMSET */
-#ifdef RT_KSERVICE_USING_STDLIB_MEMCPY
 #define rt_memcpy(dst, src, count)  memcpy(dst, src, count)
-#endif /* RT_KSERVICE_USING_STDLIB_MEMCPY */
 #define rt_memmove(dest, src, n)    memmove(dest, src, n)
 #define rt_memcmp(cs, ct, count)    memcmp(cs, ct, count)
+#endif /* RT_KSERVICE_USING_STDLIB_MEMXXX */
 #define rt_strstr(str1, str2)       strstr(str1, str2)
 #define rt_strcasecmp(a, b)         strcasecmp(a, b)
 #define rt_strcpy(dest, src)        strcpy(dest, src)
@@ -638,14 +633,22 @@ rt_size_t rt_strlen(const char *src);
 
 #if !defined(RT_KSERVICE_USING_STDLIB) || defined(__ARMCC_VERSION)
 rt_size_t rt_strnlen(const char *s, rt_ubase_t maxlen);
+#ifdef RT_USING_HEAP
+char *rt_strdup(const char *s);
+#endif /* RT_USING_HEAP */
 #else
 #define rt_strnlen(s, maxlen)       strnlen(s, maxlen)
+#ifdef RT_USING_HEAP
+#define rt_strdup(s, maxlen)        strdup(s, maxlen)
+#endif /* RT_USING_HEAP */
 #endif /* !defined(RT_KSERVICE_USING_STDLIB) || defined(__ARMCC_VERSION) */
 
 #ifdef __ARMCC_VERSION
 /* MDK doesn't have these APIs */
-char* strdup(const char* str);
 rt_size_t strnlen(const char *s, rt_size_t maxlen);
+#ifdef RT_USING_HEAP
+char* strdup(const char* str);
+#endif /* RT_USING_HEAP */
 #endif /* __ARMCC_VERSION */
 
 void rt_show_version(void);

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -599,12 +599,12 @@ int *_rt_errno(void);
 
 int __rt_ffs(int value);
 
-#ifndef RT_KSERVICE_USING_STDLIB_MEMXXX
+#ifndef RT_KSERVICE_USING_STDLIB_MEMORY
 void *rt_memset(void *src, int c, rt_ubase_t n);
 void *rt_memcpy(void *dest, const void *src, rt_ubase_t n);
 void *rt_memmove(void *dest, const void *src, rt_size_t n);
 rt_int32_t rt_memcmp(const void *cs, const void *ct, rt_size_t count);
-#endif /* RT_KSERVICE_USING_STDLIB_MEMXXX */
+#endif /* RT_KSERVICE_USING_STDLIB_MEMORY */
 
 #ifndef RT_KSERVICE_USING_STDLIB
 char *rt_strstr(const char *str1, const char *str2);
@@ -616,12 +616,12 @@ rt_int32_t rt_strcmp(const char *cs, const char *ct);
 rt_size_t rt_strlen(const char *src);
 #else
 #include <string.h>
-#ifdef RT_KSERVICE_USING_STDLIB_MEMXXX
+#ifdef RT_KSERVICE_USING_STDLIB_MEMORY
 #define rt_memset(s, c, count)      memset(s, c, count)
 #define rt_memcpy(dst, src, count)  memcpy(dst, src, count)
 #define rt_memmove(dest, src, n)    memmove(dest, src, n)
 #define rt_memcmp(cs, ct, count)    memcmp(cs, ct, count)
-#endif /* RT_KSERVICE_USING_STDLIB_MEMXXX */
+#endif /* RT_KSERVICE_USING_STDLIB_MEMORY */
 #define rt_strstr(str1, str2)       strstr(str1, str2)
 #define rt_strcasecmp(a, b)         strcasecmp(a, b)
 #define rt_strcpy(dest, src)        strcpy(dest, src)

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -148,9 +148,13 @@ menu "kservice optimization"
         bool "Enable kservice to use tiny finding first bit set method"
         default n
 
-    config RT_PRINTF_LONGLONG
-        bool "Enable rt_printf-family functions to support long long format"
+    config RT_KPRINTF_USING_LONGLONG
+        bool "Enable rt_printf-family functions to support long-long format"
+        default y if ARCH_CPU_64BIT
         default n
+        help
+            Enable rt_printf()/rt_snprintf()/rt_sprintf()/rt_vsnprintf()/rt_vsprintf()
+            functions to support long-long format
 
 endmenu
 

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -132,15 +132,11 @@ menu "kservice optimization"
 
     config RT_KSERVICE_USING_STDLIB
         bool "Enable kservice to use standard C library"
-        default n
+        default y
 
     if RT_KSERVICE_USING_STDLIB
-        config RT_KSERVICE_USING_STDLIB_MEMCPY
-            bool "Use memcpy to replace rt_memcpy (faster, but not safe)"
-            default n
-
-        config RT_KSERVICE_USING_STDLIB_MEMSET
-            bool "Use memset to replace rt_memset (faster, but not safe)"
+        config RT_KSERVICE_USING_STDLIB_MEMXXX
+            bool "Use memxxx to replace rt_memxxx (faster, but not safe)"
             default n
     endif
 

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -62,7 +62,7 @@ config RT_THREAD_PRIORITY_MAX
 config RT_TICK_PER_SECOND
     int "Tick frequency, Hz"
     range 10 1000
-    default 100
+    default 1000
     help
         System's tick frequency, Hz.
 
@@ -80,10 +80,11 @@ config RT_USING_HOOK
     help
         Enable the hook function when system running, such as idle thread hook,
         thread context switch etc.
+
     if RT_USING_HOOK
         config RT_HOOK_USING_FUNC_PTR
-        bool "Using function pointers as system hook"
-        default y
+            bool "Using function pointers as system hook"
+            default y
     endif
 
 config RT_USING_IDLE_HOOK
@@ -91,16 +92,17 @@ config RT_USING_IDLE_HOOK
     default y if RT_USING_HOOK
 
     if RT_USING_IDLE_HOOK
-    config RT_IDLE_HOOK_LIST_SIZE
-        int "The max size of idle hook list"
-        default 4
-        range 1 16
-        help
-            The system has a hook list. This is the hook list size.
+        config RT_IDLE_HOOK_LIST_SIZE
+            int "The max size of idle hook list"
+            default 4
+            range 1 16
+            help
+                The system has a hook list. This is the hook list size.
     endif
 
 config IDLE_THREAD_STACK_SIZE
     int "The stack size of idle thread"
+    default 1024 if ARCH_CPU_64BIT
     default 256
 
 config SYSTEM_THREAD_STACK_SIZE
@@ -122,6 +124,7 @@ if RT_USING_TIMER_SOFT
 
     config RT_TIMER_THREAD_STACK_SIZE
         int "The stack size of timer thread"
+        default 2048 if ARCH_CPU_64BIT
         default 512
 endif
 

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -135,9 +135,11 @@ menu "kservice optimization"
         default y
 
     if RT_KSERVICE_USING_STDLIB
-        config RT_KSERVICE_USING_STDLIB_MEMXXX
-            bool "Use memxxx to replace rt_memxxx (faster, but not safe)"
+        config RT_KSERVICE_USING_STDLIB_MEMORY
+            bool "Use stdlib memory functions to replace (faster, but not safe)"
             default n
+            help
+                e.g. use memcpy to replace rt_memcpy
     endif
 
     config RT_KSERVICE_USING_TINY_SIZE

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -117,7 +117,7 @@ int *_rt_errno(void)
 }
 RTM_EXPORT(_rt_errno);
 
-#ifndef RT_KSERVICE_USING_STDLIB_MEMXXX
+#ifndef RT_KSERVICE_USING_STDLIB_MEMORY
 /**
  * This function will set the content of memory to specified value.
  *
@@ -349,7 +349,7 @@ rt_int32_t rt_memcmp(const void *cs, const void *ct, rt_size_t count)
     return res;
 }
 RTM_EXPORT(rt_memcmp);
-#endif /* RT_KSERVICE_USING_STDLIB_MEMXXX*/
+#endif /* RT_KSERVICE_USING_STDLIB_MEMORY*/
 
 #ifndef RT_KSERVICE_USING_STDLIB
 /**

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -573,6 +573,7 @@ RTM_EXPORT(rt_strnlen);
 #ifdef __ARMCC_VERSION
 rt_size_t strnlen(const char *s, rt_size_t maxlen) __attribute__((alias("rt_strnlen")));
 #endif /* __ARMCC_VERSION */
+#endif /* !defined(RT_KSERVICE_USING_STDLIB) || defined(__ARMCC_VERSION) */
 
 #ifdef RT_USING_HEAP
 /**
@@ -599,7 +600,6 @@ RTM_EXPORT(rt_strdup);
 char *strdup(const char *s) __attribute__((alias("rt_strdup")));
 #endif /* __ARMCC_VERSION */
 #endif /* RT_USING_HEAP */
-#endif /* !defined(RT_KSERVICE_USING_STDLIB) || defined(__ARMCC_VERSION) */
 
 /**
  * This function will show the version of rt-thread rtos

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -117,7 +117,7 @@ int *_rt_errno(void)
 }
 RTM_EXPORT(_rt_errno);
 
-#ifndef RT_KSERVICE_USING_STDLIB_MEMSET
+#ifndef RT_KSERVICE_USING_STDLIB_MEMXXX
 /**
  * This function will set the content of memory to specified value.
  *
@@ -203,9 +203,7 @@ RT_WEAK void *rt_memset(void *s, int c, rt_ubase_t count)
 #endif /* RT_KSERVICE_USING_TINY_SIZE */
 }
 RTM_EXPORT(rt_memset);
-#endif /* RT_KSERVICE_USING_STDLIB_MEMSET */
 
-#ifndef RT_KSERVICE_USING_STDLIB_MEMCPY
 /**
  * This function will copy memory content from source address to destination address.
  *
@@ -289,9 +287,6 @@ RT_WEAK void *rt_memcpy(void *dst, const void *src, rt_ubase_t count)
 #endif /* RT_KSERVICE_USING_TINY_SIZE */
 }
 RTM_EXPORT(rt_memcpy);
-#endif /* RT_KSERVICE_USING_STDLIB_MEMCPY */
-
-#ifndef RT_KSERVICE_USING_STDLIB
 
 /**
  * This function will move memory content from source address to destination
@@ -354,7 +349,9 @@ rt_int32_t rt_memcmp(const void *cs, const void *ct, rt_size_t count)
     return res;
 }
 RTM_EXPORT(rt_memcmp);
+#endif /* RT_KSERVICE_USING_STDLIB_MEMXXX*/
 
+#ifndef RT_KSERVICE_USING_STDLIB
 /**
  * This function will return the first occurrence of a string, without the
  * terminator '\0'.
@@ -576,7 +573,6 @@ RTM_EXPORT(rt_strnlen);
 #ifdef __ARMCC_VERSION
 rt_size_t strnlen(const char *s, rt_size_t maxlen) __attribute__((alias("rt_strnlen")));
 #endif /* __ARMCC_VERSION */
-#endif /* !defined(RT_KSERVICE_USING_STDLIB) || defined(__ARMCC_VERSION) */
 
 #ifdef RT_USING_HEAP
 /**
@@ -603,6 +599,7 @@ RTM_EXPORT(rt_strdup);
 char *strdup(const char *s) __attribute__((alias("rt_strdup")));
 #endif /* __ARMCC_VERSION */
 #endif /* RT_USING_HEAP */
+#endif /* !defined(RT_KSERVICE_USING_STDLIB) || defined(__ARMCC_VERSION) */
 
 /**
  * This function will show the version of rt-thread rtos

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -626,18 +626,18 @@ RTM_EXPORT(rt_show_version);
  *
  * @return the duplicated string pointer.
  */
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KPRINTF_USING_LONGLONG
 rt_inline int divide(long long *n, int base)
 #else
 rt_inline int divide(long *n, int base)
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KPRINTF_USING_LONGLONG */
 {
     int res;
 
     /* optimized for processor which does not support divide instructions. */
     if (base == 10)
     {
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KPRINTF_USING_LONGLONG
         res = (int)(((unsigned long long)*n) % 10U);
         *n = (long long)(((unsigned long long)*n) / 10U);
 #else
@@ -647,7 +647,7 @@ rt_inline int divide(long *n, int base)
     }
     else
     {
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KPRINTF_USING_LONGLONG
         res = (int)(((unsigned long long)*n) % 16U);
         *n = (long long)(((unsigned long long)*n) / 16U);
 #else
@@ -678,11 +678,11 @@ rt_inline int skip_atoi(const char **s)
 
 static char *print_number(char *buf,
                           char *end,
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KPRINTF_USING_LONGLONG
                           long long  num,
 #else
                           long  num,
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KPRINTF_USING_LONGLONG */
                           int   base,
                           int   s,
 #ifdef RT_PRINTF_PRECISION
@@ -691,11 +691,11 @@ static char *print_number(char *buf,
                           int   type)
 {
     char c, sign;
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KPRINTF_USING_LONGLONG
     char tmp[32];
 #else
     char tmp[16];
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KPRINTF_USING_LONGLONG */
     int precision_bak = precision;
     const char *digits;
     static const char small_digits[] = "0123456789abcdef";
@@ -852,11 +852,11 @@ static char *print_number(char *buf,
  */
 RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list args)
 {
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KPRINTF_USING_LONGLONG
     unsigned long long num;
 #else
     rt_uint32_t num;
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KPRINTF_USING_LONGLONG */
     int i, len;
     char *str, *end, c;
     const char *s;
@@ -938,21 +938,21 @@ RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list arg
 #endif /* RT_PRINTF_PRECISION */
         /* get the conversion qualifier */
         qualifier = 0;
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KPRINTF_USING_LONGLONG
         if (*fmt == 'h' || *fmt == 'l' || *fmt == 'L')
 #else
         if (*fmt == 'h' || *fmt == 'l')
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KPRINTF_USING_LONGLONG */
         {
             qualifier = *fmt;
             ++ fmt;
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KPRINTF_USING_LONGLONG
             if (qualifier == 'l' && *fmt == 'l')
             {
                 qualifier = 'L';
                 ++ fmt;
             }
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KPRINTF_USING_LONGLONG */
         }
 
         /* the default base */
@@ -1070,12 +1070,12 @@ RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list arg
             continue;
         }
 
-#ifdef RT_PRINTF_LONGLONG
+#ifdef RT_KPRINTF_USING_LONGLONG
         if (qualifier == 'L') num = va_arg(args, long long);
         else if (qualifier == 'l')
 #else
         if (qualifier == 'l')
-#endif /* RT_PRINTF_LONGLONG */
+#endif /* RT_KPRINTF_USING_LONGLONG */
         {
             num = va_arg(args, rt_uint32_t);
             if (flags & SIGN) num = (rt_int32_t)num;


### PR DESCRIPTION
- 为64位cpu设置单独的栈默认大小，否则64cpu按照目前的栈大小，直接就死机
- 将 tick 频率调整为默认是1000，由于RT-Thread只支持32位和64位CPU, 以目前的MCU性能，支持1000Hz中断是不成问题的
- 优化rt_kprintf支持longlong的能力，默认在64位CPU为开启状态
- 将RT_KSERVICE_USING_STDLIB_MEMXXX代替RT_KSERVICE_USING_STDLIB_MEMCP/MEMSET
- 将RT_KSERVICE_USING_STDLIB设置为默认开启

后两点是基于这样考虑的：
由于memxxx函数的不安全，现在必须建议用户默认使用rt_memxxx来代替memxxx，但是就rt_strxxx函数而言，这些函数在不同编译平台下是安全的，因此无需要再默认搞出另一套rt_strxxx，占了ROM空间，可以默认将rt_strxxx直接等效成strxxx函数即可。
修改之后，用户使用rt_memcpy rt_memset等函数还是走的rt-thread这边的安全函数，使用rt_strlen等函数会默认直接走编译器标准C库的strlen。


### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
