### PR TITLE
[bsp] Make all warnings into errors with qemu-vexpress-a9 qemu-virt64…

### DIFF
--- a/bsp/qemu-vexpress-a9/rtconfig.py
+++ b/bsp/qemu-vexpress-a9/rtconfig.py
@@ -57,7 +57,7 @@ if PLATFORM == 'gcc':
     STRIP = PREFIX + 'strip'
 
     DEVICE = ' -march=armv7-a -marm -msoft-float'
-    CFLAGS = DEVICE + ' -Wall'
+    CFLAGS = DEVICE + ' -Wall -Werror'
     AFLAGS = ' -c' + DEVICE + ' -x assembler-with-cpp -D__ASSEMBLY__ -I.'
     LINK_SCRIPT = 'link.lds'
     LFLAGS = DEVICE + ' -nostartfiles -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,system_vectors'+\

--- a/bsp/qemu-virt64-aarch64/rtconfig.py
+++ b/bsp/qemu-virt64-aarch64/rtconfig.py
@@ -39,7 +39,7 @@ if PLATFORM == 'gcc':
     OBJCPY  = PREFIX + 'objcopy'
 
     DEVICE = ' -g -march=armv8-a -mtune=cortex-a53'
-    CFLAGS = DEVICE + ' -Wall'
+    CFLAGS = DEVICE + ' -Wall -Werror'
     AFLAGS = ' -c' + ' -x assembler-with-cpp -D__ASSEMBLY__'
     LFLAGS  = DEVICE + ' -nostartfiles -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,system_vectors -T link.lds'
     CPATH   = ''

--- a/bsp/stm32/stm32f411-st-nucleo/rtconfig.py
+++ b/bsp/stm32/stm32f411-st-nucleo/rtconfig.py
@@ -44,7 +44,7 @@ if PLATFORM == 'gcc':
     OBJCPY = PREFIX + 'objcopy'
 
     DEVICE = ' -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard -ffunction-sections -fdata-sections'
-    CFLAGS = DEVICE + ' -Dgcc'
+    CFLAGS = DEVICE + ' -Dgcc' + ' -Wall -Werror'
     AFLAGS = ' -c' + DEVICE + ' -x assembler-with-cpp -Wa,-mimplicit-it=thumb '
     LFLAGS = DEVICE + ' -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,Reset_Handler -T board/linker_scripts/link.lds'
 

--- a/components/drivers/include/drivers/alarm.h
+++ b/components/drivers/include/drivers/alarm.h
@@ -39,15 +39,6 @@
 typedef struct rt_alarm *rt_alarm_t;
 typedef void (*rt_alarm_callback_t)(rt_alarm_t alarm, time_t timestamp);
 
-/* used for low level RTC driver */
-struct rt_rtc_wkalarm
-{
-    rt_bool_t  enable;               /* 0 = alarm disabled, 1 = alarm enabled */
-    rt_int32_t tm_sec;               /* alarm at tm_sec */
-    rt_int32_t tm_min;               /* alarm at tm_min */
-    rt_int32_t tm_hour;              /* alarm at tm_hour */
-};
-
 struct rt_alarm
 {
     rt_list_t list;

--- a/components/drivers/include/drivers/rtc.h
+++ b/components/drivers/include/drivers/rtc.h
@@ -28,6 +28,15 @@ extern "C" {
 #define RT_DEVICE_CTRL_RTC_GET_ALARM    (RT_DEVICE_CTRL_BASE(RTC) + 0x05)              /**< get alarm */
 #define RT_DEVICE_CTRL_RTC_SET_ALARM    (RT_DEVICE_CTRL_BASE(RTC) + 0x06)              /**< set alarm */
 
+/* used for alarm function */
+struct rt_rtc_wkalarm
+{
+    rt_bool_t  enable;               /* 0 = alarm disabled, 1 = alarm enabled */
+    rt_int32_t tm_sec;               /* alarm at tm_sec */
+    rt_int32_t tm_min;               /* alarm at tm_min */
+    rt_int32_t tm_hour;              /* alarm at tm_hour */
+};
+
 struct rt_rtc_ops
 {
     rt_err_t (*init)(void);

--- a/components/drivers/rtc/alarm.c
+++ b/components/drivers/rtc/alarm.c
@@ -748,7 +748,6 @@ void rt_alarm_dump(void)
 {
     rt_list_t *next;
     rt_alarm_t alarm;
-    rt_uint8_t index = 0;
 
     rt_kprintf("| hh:mm:ss | week | flag | en |\n");
     rt_kprintf("+----------+------+------+----+\n");

--- a/examples/utest/testcases/kernel/mailbox_tc.c
+++ b/examples/utest/testcases/kernel/mailbox_tc.c
@@ -191,19 +191,19 @@ static void thread1_recv_static_mb(void *arg)
     rt_err_t result = RT_EOK;
 
     result = rt_mb_recv(&test_static_mb, (rt_ubase_t *)&mb_recv_str1, RT_WAITING_FOREVER);
-    if (result != RT_EOK || strcmp(mb_recv_str1, mb_send_str1) != 0)
+    if (result != RT_EOK || rt_strcmp((const char *)mb_recv_str1, (const char *)mb_send_str1) != 0)
     {
         uassert_false(1);
     }
 
     result = rt_mb_recv(&test_static_mb, (rt_ubase_t *)&mb_recv_str2, RT_WAITING_FOREVER);
-    if (result != RT_EOK || strcmp(mb_recv_str2, mb_send_str2) != 0)
+    if (result != RT_EOK || rt_strcmp((const char *)mb_recv_str2, (const char *)mb_send_str2) != 0)
     {
         uassert_false(1);
     }
 
     result = rt_mb_recv(&test_static_mb, (rt_ubase_t *)&mb_recv_str3, RT_WAITING_FOREVER);
-    if (result != RT_EOK || strcmp(mb_recv_str3, mb_send_str3) != 0)
+    if (result != RT_EOK || rt_strcmp((const char *)mb_recv_str3, (const char *)mb_send_str3) != 0)
     {
         uassert_false(1);
     }
@@ -284,19 +284,19 @@ static void thread3_recv_dynamic_mb(void *arg)
     rt_err_t result = RT_EOK;
 
     result = rt_mb_recv(test_dynamic_mb, (rt_ubase_t *)&mb_recv_str1, RT_WAITING_FOREVER);
-    if (result != RT_EOK || strcmp(mb_recv_str1, mb_send_str1) != 0)
+    if (result != RT_EOK || rt_strcmp((const char *)mb_recv_str1, (const char *)mb_send_str1) != 0)
     {
         uassert_false(1);
     }
 
     result = rt_mb_recv(test_dynamic_mb, (rt_ubase_t *)&mb_recv_str2, RT_WAITING_FOREVER);
-    if (result != RT_EOK || strcmp(mb_recv_str2, mb_send_str2) != 0)
+    if (result != RT_EOK || rt_strcmp((const char *)mb_recv_str2, (const char *)mb_send_str2) != 0)
     {
         uassert_false(1);
     }
 
     result = rt_mb_recv(test_dynamic_mb, (rt_ubase_t *)&mb_recv_str3, RT_WAITING_FOREVER);
-    if (result != RT_EOK || strcmp(mb_recv_str3, mb_send_str3) != 0)
+    if (result != RT_EOK || rt_strcmp((const char *)mb_recv_str3, (const char *)mb_send_str3) != 0)
     {
         uassert_false(1);
     }

--- a/examples/utest/testcases/kernel/semaphore_tc.c
+++ b/examples/utest/testcases/kernel/semaphore_tc.c
@@ -269,7 +269,6 @@ static void test_static_semaphore_release_isr(void)
 #ifdef RT_USING_HEAP
 static void test_dynamic_semaphore_create(void)
 {
-    rt_err_t result;
     int rand_num = rand() % 0x10000;
 
     for (int i = 0; i < rand_num; i++)

--- a/examples/utest/testcases/kernel/signal_tc.c
+++ b/examples/utest/testcases/kernel/signal_tc.c
@@ -121,8 +121,8 @@ void rt_signal_wait_thread(void *parm)
     rt_signal_install(SIGUSR1, sig_handle_default);
     rt_signal_unmask(SIGUSR1);
 
-    sigemptyset(&selectset);
-    sigaddset(&selectset, SIGUSR1);
+    (void)sigemptyset(&selectset);
+    (void)sigaddset(&selectset, SIGUSR1);
 
     /* case 5:rt_signal_wait, two thread, thread1: install and unmask, then wait 1s; thread2: kill, should received. */
     if (rt_signal_wait(&selectset, &recive_si, RT_TICK_PER_SECOND) != RT_EOK)


### PR DESCRIPTION
…-aarch64 and stm32f411-st-nucleo.

## 拉取/合并请求描述：(PR description)

[
方便 CI 及时检查一些编译警告，在编译 qemu-vexpress-a9 qemu-virt64-aarch64 和 stm32f411-st-nucleo 这三个 bsp 时，将大部分警告标记为错误。

并确认并列出已经在什么情况或板卡上进行了测试。
qemu-vexpress-a9 qemu-virt64-aarch64 和 stm32f411-st-nucleo 测试。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
