### PR TITLE
Revert "[dfs][romfs]支持相对地址模式"

### DIFF
--- a/components/dfs/filesystems/romfs/dfs_romfs.c
+++ b/components/dfs/filesystems/romfs/dfs_romfs.c
@@ -16,37 +16,19 @@
 
 int dfs_romfs_mount(struct dfs_filesystem *fs, unsigned long rwflag, const void *data)
 {
-    struct root_data *root_data;
+    struct romfs_dirent *root_dirent;
 
     if (data == NULL)
         return -EIO;
 
-    root_data = (struct root_data *)rt_malloc(sizeof(struct root_data));
-    if (root_data)
-    {
-        long long size = sizeof(struct romfs_dirent);
-        root_data->dirent = (struct romfs_dirent *)data;
-        if ((const char *)root_data->dirent->data - root_data->dirent->name != 0x04)
-            root_data->offset = 0;
-        else
-            root_data->offset = (long long)root_data->dirent->name != size ? ((long long)data - (long long)root_data->dirent->name + size) : (long long)data;
-        fs->data = root_data;
-    }
-    else
-    {
-        return -RT_ENOMEM;
-    }
+    root_dirent = (struct romfs_dirent *)data;
+    fs->data = root_dirent;
 
     return RT_EOK;
 }
 
 int dfs_romfs_unmount(struct dfs_filesystem *fs)
 {
-    if (fs->data)
-    {
-        rt_free(fs->data);
-    }
-
     return RT_EOK;
 }
 
@@ -63,7 +45,7 @@ rt_inline int check_dirent(struct romfs_dirent *dirent)
     return 0;
 }
 
-struct romfs_dirent *dfs_romfs_lookup(struct root_data *root_data, const char *path, rt_size_t *size)
+struct romfs_dirent *dfs_romfs_lookup(struct romfs_dirent *root_dirent, const char *path, rt_size_t *size)
 {
     rt_size_t index, found;
     const char *subpath, *subpath_end;
@@ -71,18 +53,18 @@ struct romfs_dirent *dfs_romfs_lookup(struct root_data *root_data, const char *p
     rt_size_t dirent_size;
 
     /* Check the root_dirent. */
-    if (check_dirent(root_data->dirent) != 0)
+    if (check_dirent(root_dirent) != 0)
         return NULL;
 
     if (path[0] == '/' && path[1] == '\0')
     {
-        *size = root_data->dirent->size;
-        return root_data->dirent;
+        *size = root_dirent->size;
+        return root_dirent;
     }
 
-    /* goto root directy entries */
-    dirent = (struct romfs_dirent *)(root_data->dirent->data + root_data->offset);
-    dirent_size = root_data->dirent->size;
+    /* goto root directory entries */
+    dirent = (struct romfs_dirent *)root_dirent->data;
+    dirent_size = root_dirent->size;
 
     /* get the end position of this subpath */
     subpath_end = path;
@@ -102,8 +84,8 @@ struct romfs_dirent *dfs_romfs_lookup(struct root_data *root_data, const char *p
         {
             if (check_dirent(&dirent[index]) != 0)
                 return NULL;
-            if (rt_strlen(dirent[index].name + root_data->offset) == (subpath_end - subpath) &&
-                    rt_strncmp(dirent[index].name + root_data->offset, subpath, (subpath_end - subpath)) == 0)
+            if (rt_strlen(dirent[index].name) == (subpath_end - subpath) &&
+                    rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
             {
                 dirent_size = dirent[index].size;
 
@@ -123,7 +105,7 @@ struct romfs_dirent *dfs_romfs_lookup(struct root_data *root_data, const char *p
                 if (dirent[index].type == ROMFS_DIRENT_DIR)
                 {
                     /* enter directory */
-                    dirent = (struct romfs_dirent *)(dirent[index].data + root_data->offset);
+                    dirent = (struct romfs_dirent *)dirent[index].data;
                     found = 1;
                     break;
                 }
@@ -150,9 +132,7 @@ int dfs_romfs_read(struct dfs_fd *file, void *buf, size_t count)
 {
     rt_size_t length;
     struct romfs_dirent *dirent;
-    struct root_data *root_data;
 
-    root_data = (struct root_data *)file->fs->data;
     dirent = (struct romfs_dirent *)file->data;
     RT_ASSERT(dirent != NULL);
 
@@ -167,7 +147,7 @@ int dfs_romfs_read(struct dfs_fd *file, void *buf, size_t count)
         length = file->size - file->pos;
 
     if (length > 0)
-        memcpy(buf, &(dirent->data[file->pos]) + root_data->offset, length);
+        rt_memcpy(buf, &(dirent->data[file->pos]), length);
 
     /* update file current position */
     file->pos += length;
@@ -177,7 +157,7 @@ int dfs_romfs_read(struct dfs_fd *file, void *buf, size_t count)
 
 int dfs_romfs_lseek(struct dfs_fd *file, off_t offset)
 {
-    if (offset <= (off_t)file->size)
+    if (offset <= file->size)
     {
         file->pos = offset;
         return file->pos;
@@ -196,17 +176,19 @@ int dfs_romfs_open(struct dfs_fd *file)
 {
     rt_size_t size;
     struct romfs_dirent *dirent;
-    struct root_data *root_data;
+    struct romfs_dirent *root_dirent;
+    struct dfs_filesystem *fs;
 
-    root_data = (struct root_data *)file->fs->data;
+    fs = (struct dfs_filesystem *)file->data;
+    root_dirent = (struct romfs_dirent *)fs->data;
 
-    if (check_dirent(root_data->dirent) != 0)
+    if (check_dirent(root_dirent) != 0)
         return -EIO;
 
     if (file->flags & (O_CREAT | O_WRONLY | O_APPEND | O_TRUNC | O_RDWR))
         return -EINVAL;
 
-    dirent = dfs_romfs_lookup(root_data, file->path, &size);
+    dirent = dfs_romfs_lookup(root_dirent, file->path, &size);
     if (dirent == NULL)
         return -ENOENT;
 
@@ -234,10 +216,10 @@ int dfs_romfs_stat(struct dfs_filesystem *fs, const char *path, struct stat *st)
 {
     rt_size_t size;
     struct romfs_dirent *dirent;
-    struct root_data *root_data;
+    struct romfs_dirent *root_dirent;
 
-    root_data = (struct root_data *)fs->data;
-    dirent = dfs_romfs_lookup(root_data, path, &size);
+    root_dirent = (struct romfs_dirent *)fs->data;
+    dirent = dfs_romfs_lookup(root_dirent, path, &size);
 
     if (dirent == NULL)
         return -ENOENT;
@@ -260,20 +242,18 @@ int dfs_romfs_stat(struct dfs_filesystem *fs, const char *path, struct stat *st)
 
 int dfs_romfs_getdents(struct dfs_fd *file, struct dirent *dirp, uint32_t count)
 {
-    uint32_t index;
+    rt_size_t index;
     const char *name;
     struct dirent *d;
     struct romfs_dirent *dirent, *sub_dirent;
-    struct root_data *root_data;
 
-    root_data = (struct root_data *)file->fs->data;
     dirent = (struct romfs_dirent *)file->data;
     if (check_dirent(dirent) != 0)
         return -EIO;
     RT_ASSERT(dirent->type == ROMFS_DIRENT_DIR);
 
     /* enter directory */
-    dirent = (struct romfs_dirent *)(dirent->data + root_data->offset);
+    dirent = (struct romfs_dirent *)dirent->data;
 
     /* make integer count */
     count = (count / sizeof(struct dirent));
@@ -281,12 +261,12 @@ int dfs_romfs_getdents(struct dfs_fd *file, struct dirent *dirp, uint32_t count)
         return -EINVAL;
 
     index = 0;
-    for (index = 0; index < count && (size_t)file->pos < file->size; index ++)
+    for (index = 0; index < count && file->pos < file->size; index ++)
     {
         d = dirp + index;
 
         sub_dirent = &dirent[file->pos];
-        name = sub_dirent->name + root_data->offset;
+        name = sub_dirent->name;
 
         /* fill dirent */
         if (sub_dirent->type == ROMFS_DIRENT_DIR)
@@ -296,7 +276,7 @@ int dfs_romfs_getdents(struct dfs_fd *file, struct dirent *dirp, uint32_t count)
 
         d->d_namlen = rt_strlen(name);
         d->d_reclen = (rt_uint16_t)sizeof(struct dirent);
-        rt_strncpy(d->d_name, name, rt_strlen(name) + 1);
+        rt_strncpy(d->d_name, name, DFS_PATH_MAX);
 
         /* move to next position */
         ++ file->pos;

--- a/components/dfs/filesystems/romfs/dfs_romfs.h
+++ b/components/dfs/filesystems/romfs/dfs_romfs.h
@@ -25,12 +25,6 @@ struct romfs_dirent
     rt_size_t        size;  /* file size */
 };
 
-struct root_data
-{
-    struct romfs_dirent *dirent;  /* root dirent */
-    long long offset;
-};
-
 int dfs_romfs_init(void);
 extern const struct romfs_dirent romfs_root;
 

--- a/tools/mkromfs.py
+++ b/tools/mkromfs.py
@@ -191,7 +191,7 @@ class Folder(object):
             else:
                 assert False, 'Unkown instance:%s' % str(c)
 
-            name = bytes(c.bin_name.encode('utf-8'))
+            name = bytes(c.bin_name)
             name_addr = v_len
             v_len += len(name)
 
@@ -200,7 +200,7 @@ class Folder(object):
             # pad the data to 4 bytes boundary
             pad_len = 4
             if len(data) % pad_len != 0:
-                data += ('\0' * (pad_len - len(data) % pad_len)).encode('utf-8')
+                data += '\0' * (pad_len - len(data) % pad_len)
             v_len += len(data)
 
             d_li.append(self.bin_fmt.pack(*self.bin_item(
@@ -232,7 +232,7 @@ const struct romfs_dirent {name} = {{
 
 def get_bin_data(tree, base_addr):
     v_len = base_addr + Folder.bin_fmt.size
-    name = bytes('/\0\0\0'.encode("utf-8"))
+    name = bytes('/\0\0\0')
     name_addr = v_len
     v_len += len(name)
     data_addr = v_len


### PR DESCRIPTION
Reverts RT-Thread/rt-thread#5768

这类方式太投机取巧了，并不是一份正式的模式