### PR TITLE
[kernel] enable RT_DEBUG_DEVICE by default and move weak rt_hw_dealy_us in kservice.c

### DIFF
--- a/components/libc/posix/delay/delay.c
+++ b/components/libc/posix/delay/delay.c
@@ -11,15 +11,6 @@
 #include <sys/types.h>
 #include <rtthread.h>
 #include <rthw.h>
-#define DBG_TAG    "POSIX.delay"
-#define DBG_LVL    DBG_INFO
-#include <rtdbg.h>
-
-RT_WEAK void rt_hw_us_delay(rt_uint32_t us)
-{
-    (void) us;
-    LOG_W("Please consider implementing rt_hw_us_delay() in another file.");
-}
 
 void msleep(unsigned int msecs)
 {

--- a/include/rtdebug.h
+++ b/include/rtdebug.h
@@ -53,7 +53,7 @@
 #endif
 
 #ifndef RT_DEBUG_DEVICE
-#define RT_DEBUG_DEVICE                0
+#define RT_DEBUG_DEVICE                1
 #endif
 
 #ifndef RT_DEBUG_INIT

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -45,6 +45,13 @@ static volatile int __rt_errno;
 static rt_device_t _console_device = RT_NULL;
 #endif
 
+RT_WEAK void rt_hw_us_delay(rt_uint32_t us)
+{
+    (void) us;
+    RT_DEBUG_LOG(RT_DEBUG_DEVICE, ("rt_hw_us_delay() doesn't support for this board."
+        "Please consider implementing rt_hw_us_delay() in another file."));
+}
+
 /**
  * This function gets the global errno for the current thread.
  *


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
RT_DEBUG_DEVICE 默认修改为enable
![image](https://user-images.githubusercontent.com/34888354/163486287-68a05473-49e2-4108-9294-14de737b01d3.png)

此外，rt_hw_dealy_us应该由kernel负责定义weak函数，不应该由posix来负责。在nano中，一些人也会上来就用rt_hw_us_delay这个函数，应该给一些提示。而且rt_hw_delay_us这个函数声明是在rtthread.h中。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
