### PR TITLE
[adc] 支持adc框架获取BSP的ADC分辨率

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -70,6 +70,29 @@ static rt_err_t stm32_adc_enabled(struct rt_adc_device *device, rt_uint32_t chan
     return RT_EOK;
 }
 
+static rt_uint8_t stm32_adc_get_resolution(struct rt_adc_device *device)
+{
+    ADC_HandleTypeDef *stm32_adc_handler;
+
+    RT_ASSERT(device != RT_NULL);
+
+    stm32_adc_handler = device->parent.user_data;
+
+    switch(stm32_adc_handler->Init.Resolution)
+    {
+        case ADC_RESOLUTION_12B:
+            return 12;
+        case ADC_RESOLUTION_10B:
+            return 10;
+        case ADC_RESOLUTION_8B:
+            return 8;
+        case ADC_RESOLUTION_6B:
+            return 6;
+        default:
+            return 0;
+    }
+}
+
 static rt_uint32_t stm32_adc_get_channel(rt_uint32_t channel)
 {
     rt_uint32_t stm32_channel = 0;
@@ -147,7 +170,7 @@ static rt_uint32_t stm32_adc_get_channel(rt_uint32_t channel)
     return stm32_channel;
 }
 
-static rt_err_t stm32_get_adc_value(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value)
+static rt_err_t stm32_adc_get_value(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value)
 {
     ADC_ChannelConfTypeDef ADC_ChanConf;
     ADC_HandleTypeDef *stm32_adc_handler;
@@ -260,7 +283,8 @@ static rt_err_t stm32_get_adc_value(struct rt_adc_device *device, rt_uint32_t ch
 static const struct rt_adc_ops stm_adc_ops =
 {
     .enabled = stm32_adc_enabled,
-    .convert = stm32_get_adc_value,
+    .convert = stm32_adc_get_value,
+    .get_resolution = stm32_adc_get_resolution,
 };
 
 static int stm32_adc_init(void)

--- a/components/drivers/include/drivers/adc.h
+++ b/components/drivers/include/drivers/adc.h
@@ -18,6 +18,7 @@ struct rt_adc_ops
 {
     rt_err_t (*enabled)(struct rt_adc_device *device, rt_uint32_t channel, rt_bool_t enabled);
     rt_err_t (*convert)(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value);
+    rt_uint8_t (*get_resolution)(struct rt_adc_device *device);
 };
 
 struct rt_adc_device
@@ -31,6 +32,7 @@ typedef enum
 {
     RT_ADC_CMD_ENABLE = RT_DEVICE_CTRL_BASE(ADC) + 1,
     RT_ADC_CMD_DISABLE = RT_DEVICE_CTRL_BASE(ADC) + 2,
+    RT_ADC_CMD_GET_RESOLUTION = RT_DEVICE_CTRL_BASE(ADC) + 3,
 } rt_adc_cmd_t;
 
 rt_err_t rt_hw_adc_register(rt_adc_device_t adc,const char *name, const struct rt_adc_ops *ops, const void *user_data);

--- a/components/drivers/misc/adc.c
+++ b/components/drivers/misc/adc.c
@@ -41,20 +41,26 @@ static rt_size_t _adc_read(rt_device_t dev, rt_off_t pos, void *buffer, rt_size_
 
 static rt_err_t _adc_control(rt_device_t dev, int cmd, void *args)
 {
-    rt_err_t result = RT_EOK;
+    rt_err_t result = -RT_EINVAL;
     rt_adc_device_t adc = (struct rt_adc_device *)dev;
 
-    if (adc->ops->enabled == RT_NULL)
-    {
-        return -RT_ENOSYS;
-    }
-    if (cmd == RT_ADC_CMD_ENABLE)
+    if (cmd == RT_ADC_CMD_ENABLE && adc->ops->enabled)
     {
         result = adc->ops->enabled(adc, (rt_uint32_t)args, RT_TRUE);
     }
-    else if (cmd == RT_ADC_CMD_DISABLE)
+    else if (cmd == RT_ADC_CMD_DISABLE && adc->ops->enabled)
     {
         result = adc->ops->enabled(adc, (rt_uint32_t)args, RT_FALSE);
+    }
+    else if (cmd == RT_ADC_CMD_GET_RESOLUTION && adc->ops->get_resolution)
+    {
+        rt_uint8_t resolution = adc->ops->get_resolution(adc);
+        if(resolution != 0)
+        {
+            *((rt_uint8_t*)args) = resolution;
+            LOG_D("ADC resolution:%d", resolution);
+            result = RT_EOK;
+        }
     }
 
     return result;
@@ -115,6 +121,7 @@ rt_err_t rt_adc_enable(rt_adc_device_t dev, rt_uint32_t channel)
     rt_err_t result = RT_EOK;
 
     RT_ASSERT(dev);
+
     if (dev->ops->enabled != RT_NULL)
     {
         result = dev->ops->enabled(dev, channel, RT_TRUE);
@@ -132,6 +139,7 @@ rt_err_t rt_adc_disable(rt_adc_device_t dev, rt_uint32_t channel)
     rt_err_t result = RT_EOK;
 
     RT_ASSERT(dev);
+
     if (dev->ops->enabled != RT_NULL)
     {
         result = dev->ops->enabled(dev, channel, RT_FALSE);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
https://github.com/mysterywolf/RTduino/pull/8
已经在RTduino兼容层上得到了验证
目前适配了STM32 其他bsp的分辨率会显示0，同时获取的时候错误码也是返回错误的，表示不支持此指令，需要其他芯片自己去填写自己的adc分辨率

相关issue：https://github.com/RT-Thread/rt-thread/issues/5817
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
