### PR TITLE
[spi device] remove _spi_bus_device_control

### DIFF
--- a/components/drivers/spi/spi_dev.c
+++ b/components/drivers/spi/spi_dev.c
@@ -39,22 +39,6 @@ static rt_size_t _spi_bus_device_write(rt_device_t dev,
     return rt_spi_transfer(bus->owner, buffer, RT_NULL, size);
 }
 
-static rt_err_t _spi_bus_device_control(rt_device_t dev,
-                                        int         cmd,
-                                        void       *args)
-{
-    /* TODO: add control command handle */
-    switch (cmd)
-    {
-    case 0: /* set device */
-        break;
-    case 1:
-        break;
-    }
-
-    return RT_EOK;
-}
-
 #ifdef RT_USING_DEVICE_OPS
 const static struct rt_device_ops spi_bus_ops =
 {
@@ -63,7 +47,7 @@ const static struct rt_device_ops spi_bus_ops =
     RT_NULL,
     _spi_bus_device_read,
     _spi_bus_device_write,
-    _spi_bus_device_control
+    RT_NULL
 };
 #endif
 
@@ -85,7 +69,7 @@ rt_err_t rt_spi_bus_device_init(struct rt_spi_bus *bus, const char *name)
     device->close   = RT_NULL;
     device->read    = _spi_bus_device_read;
     device->write   = _spi_bus_device_write;
-    device->control = _spi_bus_device_control;
+    device->control = RT_NULL;
 #endif
 
     /* register to device manager */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
_spi_bus_device_control 该函数没有实际被使用到予以移除

一些设备框架的错误码返回值处理不是很仔细，在没有任何有效操作的情况下，也会返回RT_EOK，这对用户的误导非常大。
今天在调试的时候顺道发现了spi control存在类似的问题。
此外在论坛上也有此类问题的反应：http://bbs.eeworld.com.cn/thread-1196113-1-1.html

考虑在4.1.1之前对此类问题进行一次摸排

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
