### PR TITLE
[stm32][cmsis] avoid conflict between cmsis5 and bsp cmsis

### DIFF
--- a/bsp/stm32/libraries/STM32F0xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32F0xx_HAL/SConscript
@@ -77,8 +77,10 @@ if GetDepend(['BSP_USING_ON_CHIP_FLASH']):
     src += ['STM32F0xx_HAL_Driver/Src/stm32f0xx_hal_flash_ex.c']
 
 path = [cwd + '/CMSIS/Device/ST/STM32F0xx/Include', 
-    cwd + '/STM32F0xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Include']
+    cwd + '/STM32F0xx_HAL_Driver/Inc']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32F1xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32F1xx_HAL/SConscript
@@ -83,8 +83,10 @@ if GetDepend(['BSP_USING_ON_CHIP_FLASH']):
     src += ['STM32F1xx_HAL_Driver/Src/stm32f1xx_hal_flash_ex.c']
 
 path = [cwd + '/CMSIS/Device/ST/STM32F1xx/Include', 
-    cwd + '/STM32F1xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Include']
+    cwd + '/STM32F1xx_HAL_Driver/Inc']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32F2xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32F2xx_HAL/SConscript
@@ -78,8 +78,10 @@ if GetDepend(['BSP_USING_ON_CHIP_FLASH']):
     src += ['STM32F2xx_HAL_Driver/Src/stm32f2xx_hal_flash_ex.c']
 
 path = [cwd + '/CMSIS/Device/ST/STM32F2xx/Include', 
-    cwd + '/STM32F2xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Include']
+    cwd + '/STM32F2xx_HAL_Driver/Inc']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32F3xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32F3xx_HAL/SConscript
@@ -81,8 +81,10 @@ if GetDepend(['BSP_USING_ON_CHIP_FLASH']):
     src += ['STM32F3xx_HAL_Driver/Src/stm32f3xx_hal_flash_ex.c']
 
 path = [cwd + '/STM32F3xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32F3xx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32F3xx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32F4xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32F4xx_HAL/SConscript
@@ -109,8 +109,10 @@ if GetDepend(['BSP_USING_LTDC']):
     src += ['STM32F4xx_HAL_Driver/Src/stm32f4xx_hal_dsi.c']
 
 path = [cwd + '/STM32F4xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32F4xx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32F4xx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32F7xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32F7xx_HAL/SConscript
@@ -102,8 +102,10 @@ if GetDepend(['BSP_USING_LTDC']):
     src += ['STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_dsi.c']
 
 path = [cwd + '/STM32F7xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32F7xx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32F7xx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32G0xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32G0xx_HAL/SConscript
@@ -56,8 +56,10 @@ if GetDepend(['RT_USING_RTC']):
     src += ['STM32G0xx_HAL_Driver/Src/stm32g0xx_ll_rtc.c']
 
 path = [cwd + '/STM32G0xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32G0xx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32G0xx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32G4xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32G4xx_HAL/SConscript
@@ -106,8 +106,10 @@ if GetDepend(['BSP_USING_LTDC']):
     src += ['STM32G4xx_HAL_Driver/Src/stm32g4xx_hal_dsi.c']
 
 path = [cwd + '/STM32G4xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32G4xx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32G4xx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32H7xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32H7xx_HAL/SConscript
@@ -108,8 +108,10 @@ if GetDepend(['BSP_USING_DCMI']):
     src += ['STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_dcmi.c']
 
 path = [cwd + '/STM32H7xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32H7xx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32H7xx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32L0xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32L0xx_HAL/SConscript
@@ -84,8 +84,10 @@ if GetDepend(['BSP_USING_ON_CHIP_FLASH']):
     src += ['STM32L0xx_HAL_Driver/Src/stm32l0xx_hal_flash_ramfunc.c']
 
 path = [cwd + '/STM32L0xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32L0xx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32L0xx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32L1xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32L1xx_HAL/SConscript
@@ -66,15 +66,15 @@ if GetDepend(['RT_USING_SDIO']):
 if GetDepend(['RT_USING_AUDIO']):
     src += ['STM32L1xx_HAL_Driver/Src/stm32L1xx_hal_i2s.c']
 
-
-
 if GetDepend(['BSP_USING_ON_CHIP_FLASH']):
     src += ['STM32L1xx_HAL_Driver/Src/stm32L1xx_hal_flash.c']
     src += ['STM32L1xx_HAL_Driver/Src/stm32L1xx_hal_flash_ex.c']
 
 path = [cwd + '/CMSIS/Device/ST/STM32L1xx/Include', 
-    cwd + '/STM32L1xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Include']
+    cwd + '/STM32L1xx_HAL_Driver/Inc']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32L4xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32L4xx_HAL/SConscript
@@ -109,12 +109,12 @@ if GetDepend(['BSP_USING_DSI']):
 	
 if GetDepend(['BSP_USING_SRAM']):
     src += ['STM32L4xx_HAL_Driver/Src/stm32l4xx_hal_sram.c']	
-	
-	
 
 path = [cwd + '/STM32L4xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32L4xx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32L4xx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32L5xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32L5xx_HAL/SConscript
@@ -109,12 +109,12 @@ if GetDepend(['BSP_USING_DSI']):
 	
 if GetDepend(['BSP_USING_SRAM']):
     src += ['STM32L5xx_HAL_Driver/Src/stm32l5xx_hal_sram.c']	
-	
-	
 
 path = [cwd + '/STM32L5xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32L5xx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32L5xx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32MPxx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32MPxx_HAL/SConscript
@@ -124,9 +124,10 @@ if GetDepend(['BSP_USING_RTC']):
     src += ['STM32MP1xx_HAL_Driver/Src/stm32mp1xx_hal_rtc_ex.c']
 
 path = [cwd + '/STM32MP1xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32MP1xx/Include',
-    cwd + '/CMSIS/Core/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32MP1xx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32U5xx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32U5xx_HAL/SConscript
@@ -111,11 +111,11 @@ if GetDepend(['BSP_USING_DSI']):
 if GetDepend(['BSP_USING_SRAM']):
     src += ['STM32U5xx_HAL_Driver/Src/stm32u5xx_hal_sram.c']	
 	
-	
-
 path = [cwd + '/STM32U5xx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32U5xx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32U5xx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32WBxx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32WBxx_HAL/SConscript
@@ -76,13 +76,12 @@ if GetDepend(['BSP_USING_ON_CHIP_FLASH']):
     src += ['STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_flash.c']
     src += ['STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_flash_ex.c']
 #    src += ['STM32WBxx_HAL_Driver/Src/stm32wbxx_hal_flash_ramfunc.c']
-	
-	
-	
 
 path = [cwd + '/STM32WBxx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32WBxx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32WBxx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('Libraries', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/stm32/libraries/STM32WLxx_HAL/SConscript
+++ b/bsp/stm32/libraries/STM32WLxx_HAL/SConscript
@@ -69,8 +69,10 @@ if GetDepend(['BSP_USING_SUBGHZ']):
     src += ['STM32WLxx_HAL_Driver/Src/stm32wlxx_hal_subghz.c']
 	
 path = [cwd + '/STM32WLxx_HAL_Driver/Inc',
-    cwd + '/CMSIS/Device/ST/STM32WLxx/Include',
-    cwd + '/CMSIS/Include']
+    cwd + '/CMSIS/Device/ST/STM32WLxx/Include']
+
+if not GetDepend('PKG_CMSIS_CORE'):
+    path += [cwd + '/CMSIS/Include']
 
 CPPDEFINES = ['USE_HAL_DRIVER']
 group = DefineGroup('STM32_HAL', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
