### PR TITLE
[bsp][stm32][drv_crypto] Enable RNG Clock

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_crypto.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_crypto.c
@@ -395,6 +395,7 @@ static rt_err_t _crypto_create(struct rt_hwcrypto_ctx *ctx)
 #if defined(BSP_USING_RNG)
     case HWCRYPTO_TYPE_RNG:
     {
+        __HAL_RCC_RNG_CLK_ENABLE();
         RNG_HandleTypeDef *hrng = rt_calloc(1, sizeof(RNG_HandleTypeDef));
         if (RT_NULL == hrng)
         {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

最近在移植密码学的软件包 `libsodium` 和 `libhydrogen` 的时候，发现选中硬件加密组件后， STM32 的硬件随机数时钟没有打开，文档中心例程返回的随机数全部是0。

测试板卡：STM32F407VET6 工控板

```
#include <hw_rng.h>

void hw_rng(void)
{
    rt_uint32_t result=0;
    int i, num0=0, num1 =0;
    const int max_test = 1000;


    for (i = 0; i < max_test; i++)
    {
        result = rt_hwcrypto_rng_update();
        result%2 ? num1++ : num0++;
    }
    LOG_I(" num1: %d, num0: %d ",num1, num0);
}
```

使用 RT-Thread Studio 打开 CubeMX 配置好 RNG 后生成的 `SystemClock_Config()` 不包含 `__HAL_RCC_RNG_CLK_ENABLE()`，需要在驱动里打开时钟。

---------

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
