### PR TITLE
[rt_drv_pwm.c] add finsh pwm function

### DIFF
--- a/components/drivers/misc/rt_drv_pwm.c
+++ b/components/drivers/misc/rt_drv_pwm.c
@@ -13,7 +13,7 @@
 
 static rt_err_t _pwm_control(rt_device_t dev, int cmd, void *args)
 {
-    rt_err_t result = RT_EOK;
+    rt_err_t result = -RT_ERROR;
     struct rt_device_pwm *pwm = (struct rt_device_pwm *)dev;
 
     if (pwm->ops->control)
@@ -32,7 +32,7 @@ size : number of pulse, only set to sizeof(rt_uint32_t).
 */
 static rt_size_t _pwm_read(rt_device_t dev, rt_off_t pos, void *buffer, rt_size_t size)
 {
-    rt_err_t result = RT_EOK;
+    rt_err_t result = -RT_ERROR;
     struct rt_device_pwm *pwm = (struct rt_device_pwm *)dev;
     rt_uint32_t *pulse = (rt_uint32_t *)buffer;
     struct rt_pwm_configuration configuration = {0};
@@ -60,7 +60,7 @@ size : number of pulse, only set to sizeof(rt_uint32_t).
 */
 static rt_size_t _pwm_write(rt_device_t dev, rt_off_t pos, const void *buffer, rt_size_t size)
 {
-    rt_err_t result = RT_EOK;
+    rt_err_t result = -RT_ERROR;
     struct rt_device_pwm *pwm = (struct rt_device_pwm *)dev;
     rt_uint32_t *pulse = (rt_uint32_t *)buffer;
     struct rt_pwm_configuration configuration = {0};
@@ -101,7 +101,7 @@ static const struct rt_device_ops pwm_device_ops =
 
 rt_err_t rt_device_pwm_register(struct rt_device_pwm *device, const char *name, const struct rt_pwm_ops *ops, const void *user_data)
 {
-    rt_err_t result = RT_EOK;
+    rt_err_t result = -RT_ERROR;
 
     rt_memset(device, 0, sizeof(struct rt_device_pwm));
 
@@ -127,7 +127,7 @@ rt_err_t rt_device_pwm_register(struct rt_device_pwm *device, const char *name, 
 
 rt_err_t rt_pwm_enable(struct rt_device_pwm *device, int channel)
 {
-    rt_err_t result = RT_EOK;
+    rt_err_t result = -RT_ERROR;
     struct rt_pwm_configuration configuration = {0};
 
     if (!device)
@@ -144,7 +144,7 @@ rt_err_t rt_pwm_enable(struct rt_device_pwm *device, int channel)
 
 rt_err_t rt_pwm_disable(struct rt_device_pwm *device, int channel)
 {
-    rt_err_t result = RT_EOK;
+    rt_err_t result = -RT_ERROR;
     struct rt_pwm_configuration configuration = {0};
 
     if (!device)
@@ -161,7 +161,7 @@ rt_err_t rt_pwm_disable(struct rt_device_pwm *device, int channel)
 
 rt_err_t rt_pwm_set(struct rt_device_pwm *device, int channel, rt_uint32_t period, rt_uint32_t pulse)
 {
-    rt_err_t result = RT_EOK;
+    rt_err_t result = -RT_ERROR;
     struct rt_pwm_configuration configuration = {0};
 
     if (!device)
@@ -179,7 +179,7 @@ rt_err_t rt_pwm_set(struct rt_device_pwm *device, int channel, rt_uint32_t perio
 
 rt_err_t rt_pwm_get(struct rt_device_pwm *device, struct rt_pwm_configuration *cfg)
 {
-    rt_err_t result = RT_EOK;
+    rt_err_t result = -RT_ERROR;
 
     if (!device)
     {
@@ -198,7 +198,7 @@ rt_err_t rt_pwm_get(struct rt_device_pwm *device, struct rt_pwm_configuration *c
 
 static int pwm(int argc, char **argv)
 {
-    int result = RT_EOK;
+    rt_err_t result = -RT_ERROR;
     char *result_str;
     static struct rt_device_pwm *pwm_device = RT_NULL;
     struct rt_pwm_configuration cfg = {0};
@@ -215,14 +215,14 @@ static int pwm(int argc, char **argv)
             }
             else
             {
-               rt_kprintf("pwm probe <pwm_name>  - probe pwm by name\n");
+               rt_kprintf("pwm probe <device name>  - probe pwm by name\n");
             }
         }
         else
         {
             if(pwm_device == RT_NULL)
             {
-                rt_kprintf("Please using 'pwm probe <pwm_name>' first.\n");
+                rt_kprintf("Please using 'pwm probe <device name>' first.\n");
                 return -RT_ERROR;
             }
             if(!strcmp(argv[1], "enable"))
@@ -288,7 +288,7 @@ static int pwm(int argc, char **argv)
     else
     {
        rt_kprintf("Usage: \n");
-       rt_kprintf("pwm probe <pwm_name> - probe pwm by name\n");
+       rt_kprintf("pwm probe <device name> - probe pwm by name\n");
        rt_kprintf("pwm enable <channel> - enable pwm channel\n");
        rt_kprintf("pwm disable <channel>- disable pwm channel\n");
        rt_kprintf("pwm get <channel>    - get pwm channel info\n");
@@ -299,6 +299,6 @@ static int pwm(int argc, char **argv)
 
     return RT_EOK;
 }
-MSH_CMD_EXPORT(pwm, pwm functions);
+MSH_CMD_EXPORT(pwm, pwm <device name> <option> <channel>);
 
 #endif /* RT_USING_FINSH */

--- a/components/drivers/misc/rt_drv_pwm.c
+++ b/components/drivers/misc/rt_drv_pwm.c
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-05-07     aozima       the first version
+ * 2002-05-14     Stanley Lwin add pwm function
  */
 
 #include <drivers/rt_drv_pwm.h>
@@ -192,130 +193,112 @@ rt_err_t rt_pwm_get(struct rt_device_pwm *device, struct rt_pwm_configuration *c
 
 #ifdef RT_USING_FINSH
 #include <stdlib.h>
+#include <string.h>
 #include <finsh.h>
 
-static int pwm_enable(int argc, char **argv)
+static int pwm(int argc, char **argv)
 {
-    int result = 0;
-    struct rt_device_pwm *device = RT_NULL;
-
-    if (argc != 3)
-    {
-        rt_kprintf("Usage: pwm_enable pwm1 1\n");
-        rt_kprintf("       pwm_enable <pwm_dev> <channel/-channel>\n");
-        result = -RT_ERROR;
-        goto _exit;
-    }
-
-    device = (struct rt_device_pwm *)rt_device_find(argv[1]);
-    if (!device)
-    {
-        result = -RT_EIO;
-        goto _exit;
-    }
-
-    /* If channel is complementary(1), make the channel number to nagetive */
-    result = rt_pwm_enable(device, atoi(argv[2]));
-
-_exit:
-    return result;
-}
-MSH_CMD_EXPORT(pwm_enable, pwm_enable <pwm_dev> <channel/-channel>);
-
-static int pwm_disable(int argc, char **argv)
-{
-    int result = 0;
-    struct rt_device_pwm *device = RT_NULL;
-
-    if (argc != 3)
-    {
-        rt_kprintf("Usage: pwm_disable pwm1 1\n");
-        rt_kprintf("       pwm_disable <pwm_dev> <channel/-channel> \n");
-        result = -RT_ERROR;
-        goto _exit;
-    }
-
-    device = (struct rt_device_pwm *)rt_device_find(argv[1]);
-    if (!device)
-    {
-        result = -RT_EIO;
-        goto _exit;
-    }
-
-    /* If channel is complementary(1), make the channel number to nagetive */
-    result = rt_pwm_disable(device, atoi(argv[2]));
-
-_exit:
-    return result;
-}
-MSH_CMD_EXPORT(pwm_disable, pwm_disable <pwm_dev> <channel/-channel>);
-
-static int pwm_set(int argc, char **argv)
-{
-    int result = 0;
-    struct rt_device_pwm *device = RT_NULL;
-
-    if (argc != 5)
-    {
-        rt_kprintf("Usage: pwm_set pwm1 1 100 50\n");
-        rt_kprintf("Usage: pwm_set <pwm_dev> <channel> <period> <pulse>\n");
-        result = -RT_ERROR;
-        goto _exit;
-    }
-
-    device = (struct rt_device_pwm *)rt_device_find(argv[1]);
-    if (!device)
-    {
-        result = -RT_EIO;
-        goto _exit;
-    }
-
-    result = rt_pwm_set(device, atoi(argv[2]), atoi(argv[3]), atoi(argv[4]));
-
-_exit:
-    return result;
-}
-MSH_CMD_EXPORT(pwm_set, pwm_set <pwm_dev> <channel> <period> <pulse>);
-
-
-static int pwm_get(int argc, char **argv)
-{
-    int result = 0;
-    struct rt_device_pwm *device = RT_NULL;
+    int result = RT_EOK;
+    char *result_str;
+    static struct rt_device_pwm *pwm_device = RT_NULL;
     struct rt_pwm_configuration cfg = {0};
 
-    if (argc != 3)
+    if(argc > 1)
     {
-        rt_kprintf("Usage: pwm_get pwm1 1\n");
-        rt_kprintf("       pwm_get <pwm_dev> <channel>\n");
-        result = -RT_ERROR;
-        goto _exit;
-    }
+        if(!strcmp(argv[1], "probe"))
+        {
+            if(argc == 3)
+            {
+                pwm_device = (struct rt_device_pwm *)rt_device_find(argv[2]);
+                result_str = (pwm_device == RT_NULL) ? "failure" : "success";
+                rt_kprintf("probe %s %s\n", argv[2], result_str);
+            }
+            else
+            {
+               rt_kprintf("pwm probe <pwm_name>  - probe pwm by name\n");
+            }
+        }
+        else
+        {
+            if(pwm_device == RT_NULL)
+            {
+                rt_kprintf("Please using 'pwm probe <pwm_name>' first.\n");
+                return -RT_ERROR;
+            }
+            if(!strcmp(argv[1], "enable"))
+            {
+                if(argc == 3)
+                {
+                    result = rt_pwm_enable(pwm_device, atoi(argv[2]));
+                    result_str = (result == RT_EOK) ? "success" : "failure";
+                    rt_kprintf("%s channel %d is enabled %s \n", pwm_device->parent.parent.name, atoi(argv[2]), result_str);
+                }
+                else
+                {
+                 rt_kprintf("pwm enable <channel>  - enable pwm channel\n");
+                }
+             }
+            else if(!strcmp(argv[1], "disable"))
+            {
+                if(argc == 3)
+                {
+                    result = rt_pwm_disable(pwm_device, atoi(argv[2]));
+                }
+                else
+                {
+                    rt_kprintf("pwm disable <channel> - disable pwm channel\n");
+                }
+            }
+            else if(!strcmp(argv[1], "get"))
+            {
+                cfg.channel = atoi(argv[2]);
+                result = rt_pwm_get(pwm_device, &cfg);
+                if(result == RT_EOK)
+                {
+                rt_kprintf("Info of device [%s] channel [%d]:\n",pwm_device, atoi(argv[2]));
+                rt_kprintf("period      : %d\n", cfg.period);
+                rt_kprintf("pulse       : %d\n", cfg.pulse);
+                rt_kprintf("Duty cycle  : %d%%\n",(int)(((double)(cfg.pulse)/(cfg.period)) * 100));
+                }
+                else
+                {
+                    rt_kprintf("Get info of device: [%s] error.\n", pwm_device);
+                }
+            }
+            else if (!strcmp(argv[1], "set"))
+            {
+                if(argc == 5)
+                {
+                    result = rt_pwm_set(pwm_device, atoi(argv[2]), atoi(argv[3]), atoi(argv[4]));
+                    rt_kprintf("pwm info set on %s at channel %d\n",pwm_device,atoi(argv[2]));
+                }
+                else
+                {
+                    rt_kprintf("Set info of device: [%s] error\n", pwm_device);
+                    rt_kprintf("Usage: pwm set <channel> <period> <pulse>\n");
+                }
+            }
 
-    device = (struct rt_device_pwm *)rt_device_find(argv[1]);
-    if (!device)
-    {
-        result = -RT_EIO;
-        goto _exit;
-    }
-
-    cfg.channel = atoi(argv[2]);
-    result = rt_pwm_get(device, &cfg);
-    if (result != RT_EOK)
-    {
-        rt_kprintf("Get info of device: [%s] error.\n", argv[1]);
+            else
+            {
+                rt_kprintf("pwm get <channel> - get pwm channel info\n");
+            }
+        }
     }
     else
     {
-        rt_kprintf("Get info of device: [%s]:\n", argv[1]);
-        rt_kprintf("period     : %d\n", cfg.period);
-        rt_kprintf("pulse      : %d\n", cfg.pulse);
-        rt_kprintf("Duty cycle : %d%%\n", (int)(((double)(cfg.pulse)/(cfg.period)) * 100));
-    }
+       rt_kprintf("Usage: \n");
+       rt_kprintf("pwm probe <pwm_name> - probe pwm by name\n");
+       rt_kprintf("pwm enable <channel> - enable pwm channel\n");
+       rt_kprintf("pwm disable <channel>- disable pwm channel\n");
+       rt_kprintf("pwm get <channel>    - get pwm channel info\n");
+       rt_kprintf("pwm set <channel> <period> <pulse> - set pwm channel info\n");
 
-_exit:
-    return result;
+       result = - RT_ERROR;
+    }
+    
+    return RT_EOK;
 }
-MSH_CMD_EXPORT(pwm_get, pwm_get <pwm_dev> <channel>);
+MSH_CMD_EXPORT(pwm, pwm functions);
 
 #endif /* RT_USING_FINSH */

--- a/components/drivers/misc/rt_drv_pwm.c
+++ b/components/drivers/misc/rt_drv_pwm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -296,7 +296,7 @@ static int pwm(int argc, char **argv)
 
        result = - RT_ERROR;
     }
-    
+
     return RT_EOK;
 }
 MSH_CMD_EXPORT(pwm, pwm functions);

--- a/components/drivers/misc/rt_drv_pwm.c
+++ b/components/drivers/misc/rt_drv_pwm.c
@@ -13,7 +13,7 @@
 
 static rt_err_t _pwm_control(rt_device_t dev, int cmd, void *args)
 {
-    rt_err_t result = -RT_ERROR;
+    rt_err_t result = -RT_EOK;
     struct rt_device_pwm *pwm = (struct rt_device_pwm *)dev;
 
     if (pwm->ops->control)
@@ -32,7 +32,7 @@ size : number of pulse, only set to sizeof(rt_uint32_t).
 */
 static rt_size_t _pwm_read(rt_device_t dev, rt_off_t pos, void *buffer, rt_size_t size)
 {
-    rt_err_t result = -RT_ERROR;
+    rt_err_t result = RT_EOK;
     struct rt_device_pwm *pwm = (struct rt_device_pwm *)dev;
     rt_uint32_t *pulse = (rt_uint32_t *)buffer;
     struct rt_pwm_configuration configuration = {0};
@@ -60,7 +60,7 @@ size : number of pulse, only set to sizeof(rt_uint32_t).
 */
 static rt_size_t _pwm_write(rt_device_t dev, rt_off_t pos, const void *buffer, rt_size_t size)
 {
-    rt_err_t result = -RT_ERROR;
+    rt_err_t result = RT_EOK;
     struct rt_device_pwm *pwm = (struct rt_device_pwm *)dev;
     rt_uint32_t *pulse = (rt_uint32_t *)buffer;
     struct rt_pwm_configuration configuration = {0};
@@ -101,7 +101,7 @@ static const struct rt_device_ops pwm_device_ops =
 
 rt_err_t rt_device_pwm_register(struct rt_device_pwm *device, const char *name, const struct rt_pwm_ops *ops, const void *user_data)
 {
-    rt_err_t result = -RT_ERROR;
+    rt_err_t result = RT_EOK;
 
     rt_memset(device, 0, sizeof(struct rt_device_pwm));
 
@@ -127,7 +127,7 @@ rt_err_t rt_device_pwm_register(struct rt_device_pwm *device, const char *name, 
 
 rt_err_t rt_pwm_enable(struct rt_device_pwm *device, int channel)
 {
-    rt_err_t result = -RT_ERROR;
+    rt_err_t result = RT_EOK;
     struct rt_pwm_configuration configuration = {0};
 
     if (!device)
@@ -144,7 +144,7 @@ rt_err_t rt_pwm_enable(struct rt_device_pwm *device, int channel)
 
 rt_err_t rt_pwm_disable(struct rt_device_pwm *device, int channel)
 {
-    rt_err_t result = -RT_ERROR;
+    rt_err_t result = RT_EOK;
     struct rt_pwm_configuration configuration = {0};
 
     if (!device)
@@ -161,7 +161,7 @@ rt_err_t rt_pwm_disable(struct rt_device_pwm *device, int channel)
 
 rt_err_t rt_pwm_set(struct rt_device_pwm *device, int channel, rt_uint32_t period, rt_uint32_t pulse)
 {
-    rt_err_t result = -RT_ERROR;
+    rt_err_t result = RT_EOK;
     struct rt_pwm_configuration configuration = {0};
 
     if (!device)
@@ -179,7 +179,7 @@ rt_err_t rt_pwm_set(struct rt_device_pwm *device, int channel, rt_uint32_t perio
 
 rt_err_t rt_pwm_get(struct rt_device_pwm *device, struct rt_pwm_configuration *cfg)
 {
-    rt_err_t result = -RT_ERROR;
+    rt_err_t result = RT_EOK;
 
     if (!device)
     {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[rt_drv_pwm.c] add finsh pwm function
[
这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
