### PR TITLE
[schedule] reduce unnecessary schedule by comparing new ready thread's priority and current 

### DIFF
--- a/components/drivers/audio/audio_pipe.c
+++ b/components/drivers/audio/audio_pipe.c
@@ -26,9 +26,9 @@ static void _rt_pipe_resume_writer(struct rt_audio_pipe *pipe)
                                tlist);
 
         /* resume the write thread */
-        rt_thread_resume(thread);
+        if(rt_thread_resume(thread) == RT_EOK)
+            rt_schedule();
 
-        rt_schedule();
     }
 }
 
@@ -108,9 +108,8 @@ static void _rt_pipe_resume_reader(struct rt_audio_pipe *pipe)
                                tlist);
 
         /* resume the read thread */
-        rt_thread_resume(thread);
-
-        rt_schedule();
+        if(rt_thread_resume(thread) == RT_EOK)
+            rt_schedule();
     }
 }
 

--- a/components/drivers/ipc/completion.c
+++ b/components/drivers/ipc/completion.c
@@ -124,6 +124,7 @@ RTM_EXPORT(rt_completion_wait);
 void rt_completion_done(struct rt_completion *completion)
 {
     rt_base_t level;
+    rt_bool_t need_schedule = RT_FALSE;
     RT_ASSERT(completion != RT_NULL);
 
     if (completion->flag == RT_COMPLETED)
@@ -143,11 +144,14 @@ void rt_completion_done(struct rt_completion *completion)
                                tlist);
 
         /* resume it */
-        rt_thread_resume(thread);
+        if(rt_thread_resume(thread) == RT_EOK)
+            need_schedule = RT_TRUE;
+
         rt_hw_interrupt_enable(level);
 
         /* perform a schedule */
-        rt_schedule();
+        if (need_schedule == RT_TRUE)
+            rt_schedule();
     }
     else
     {

--- a/components/drivers/ipc/dataqueue.c
+++ b/components/drivers/ipc/dataqueue.c
@@ -92,6 +92,7 @@ rt_err_t rt_data_queue_push(struct rt_data_queue *queue,
                             rt_int32_t timeout)
 {
     rt_base_t level;
+    rt_bool_t need_schedule = RT_FALSE;
     rt_thread_t thread;
     rt_err_t    result;
 
@@ -165,11 +166,14 @@ rt_err_t rt_data_queue_push(struct rt_data_queue *queue,
                                tlist);
 
         /* resume it */
-        rt_thread_resume(thread);
+        if(rt_thread_resume(thread) == RT_EOK)
+            need_schedule = RT_TRUE;
+
         rt_hw_interrupt_enable(level);
 
         /* perform a schedule */
-        rt_schedule();
+        if (need_schedule == RT_TRUE)
+            rt_schedule();
 
         return result;
     }
@@ -209,6 +213,7 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
                            rt_int32_t timeout)
 {
     rt_base_t level;
+    rt_bool_t need_schedule = RT_FALSE;
     rt_thread_t thread;
     rt_err_t    result;
 
@@ -286,11 +291,14 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
                                    tlist);
 
             /* resume it */
-            rt_thread_resume(thread);
+            if(rt_thread_resume(thread) == RT_EOK)
+                need_schedule = RT_TRUE;
+
             rt_hw_interrupt_enable(level);
 
             /* perform a schedule */
-            rt_schedule();
+            if (need_schedule == RT_TRUE)
+                rt_schedule();
         }
         else
         {
@@ -362,6 +370,7 @@ RTM_EXPORT(rt_data_queue_peek);
 void rt_data_queue_reset(struct rt_data_queue *queue)
 {
     rt_base_t level;
+    rt_bool_t need_schedule = RT_FALSE;
     struct rt_thread *thread;
 
     RT_ASSERT(queue != RT_NULL);
@@ -397,7 +406,8 @@ void rt_data_queue_reset(struct rt_data_queue *queue)
          * In rt_thread_resume function, it will remove current thread from
          * suspend list
          */
-        rt_thread_resume(thread);
+        if(rt_thread_resume(thread) == RT_EOK)
+            need_schedule = RT_TRUE;
 
         /* enable interrupt */
         rt_hw_interrupt_enable(level);
@@ -421,14 +431,16 @@ void rt_data_queue_reset(struct rt_data_queue *queue)
          * In rt_thread_resume function, it will remove current thread from
          * suspend list
          */
-        rt_thread_resume(thread);
+        if(rt_thread_resume(thread) == RT_EOK)
+            need_schedule = RT_TRUE;
 
         /* enable interrupt */
         rt_hw_interrupt_enable(level);
     }
     rt_exit_critical();
 
-    rt_schedule();
+    if (need_schedule == RT_TRUE)
+        rt_schedule();
 }
 RTM_EXPORT(rt_data_queue_reset);
 

--- a/components/drivers/ipc/waitqueue.c
+++ b/components/drivers/ipc/waitqueue.c
@@ -75,7 +75,7 @@ int __wqueue_default_wake(struct rt_wqueue_node *wait, void *key)
 void rt_wqueue_wakeup(rt_wqueue_t *queue, void *key)
 {
     rt_base_t level;
-    int need_schedule = 0;
+    rt_bool_t need_schedule = RT_FALSE;
 
     rt_list_t *queue_list;
     struct rt_list_node *node;
@@ -94,8 +94,8 @@ void rt_wqueue_wakeup(rt_wqueue_t *queue, void *key)
             entry = rt_list_entry(node, struct rt_wqueue_node, list);
             if (entry->wakeup(entry, key) == 0)
             {
-                rt_thread_resume(entry->polling_thread);
-                need_schedule = 1;
+                if(rt_thread_resume(entry->polling_thread) == RT_EOK)
+                    need_schedule = RT_TRUE;
 
                 rt_wqueue_remove(entry);
                 break;
@@ -104,7 +104,7 @@ void rt_wqueue_wakeup(rt_wqueue_t *queue, void *key)
     }
     rt_hw_interrupt_enable(level);
 
-    if (need_schedule)
+    if (need_schedule == RT_TRUE)
         rt_schedule();
 }
 

--- a/components/drivers/ipc/workqueue.c
+++ b/components/drivers/ipc/workqueue.c
@@ -93,6 +93,7 @@ static rt_err_t _workqueue_submit_work(struct rt_workqueue *queue,
         struct rt_work *work, rt_tick_t ticks)
 {
     rt_base_t level;
+    rt_bool_t need_schedule = RT_FALSE;
     rt_err_t err;
 
     level = rt_hw_interrupt_disable();
@@ -119,9 +120,14 @@ static rt_err_t _workqueue_submit_work(struct rt_workqueue *queue,
             ((queue->work_thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND))
         {
             /* resume work thread */
-            rt_thread_resume(queue->work_thread);
+            if(rt_thread_resume(queue->work_thread) == RT_EOK)
+                need_schedule = RT_TRUE;
+
             rt_hw_interrupt_enable(level);
-            rt_schedule();
+
+            /* perform a schedule */
+            if (need_schedule == RT_TRUE)
+                rt_schedule();
         }
         else
         {
@@ -180,6 +186,7 @@ static void _delayed_work_timeout_handler(void *parameter)
     struct rt_work *work;
     struct rt_workqueue *queue;
     rt_base_t level;
+    rt_bool_t need_schedule = RT_FALSE;
 
     work = (struct rt_work *)parameter;
     queue = work->workqueue;
@@ -201,9 +208,14 @@ static void _delayed_work_timeout_handler(void *parameter)
         ((queue->work_thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND))
     {
         /* resume work thread */
-        rt_thread_resume(queue->work_thread);
+        if(rt_thread_resume(queue->work_thread) == RT_EOK)
+            need_schedule = RT_TRUE;
+
         rt_hw_interrupt_enable(level);
-        rt_schedule();
+
+        /* perform a schedule */
+        if (need_schedule == RT_TRUE)
+            rt_schedule();
     }
     else
     {
@@ -346,6 +358,7 @@ rt_err_t rt_workqueue_submit_work(struct rt_workqueue *queue, struct rt_work *wo
 rt_err_t rt_workqueue_urgent_work(struct rt_workqueue *queue, struct rt_work *work)
 {
     rt_base_t level;
+    rt_bool_t need_schedule = RT_FALSE;
 
     RT_ASSERT(queue != RT_NULL);
     RT_ASSERT(work != RT_NULL);
@@ -359,9 +372,14 @@ rt_err_t rt_workqueue_urgent_work(struct rt_workqueue *queue, struct rt_work *wo
         ((queue->work_thread->stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND))
     {
         /* resume work thread */
-        rt_thread_resume(queue->work_thread);
+        if(rt_thread_resume(queue->work_thread) == RT_EOK)
+            need_schedule = RT_TRUE;
+
         rt_hw_interrupt_enable(level);
-        rt_schedule();
+
+        /* perform a schedule */
+        if (need_schedule == RT_TRUE)
+            rt_schedule();
     }
     else
     {

--- a/components/vbus/prio_queue.c
+++ b/components/vbus/prio_queue.c
@@ -137,6 +137,7 @@ rt_err_t rt_prio_queue_push(struct rt_prio_queue *que,
                             rt_int32_t timeout)
 {
     rt_base_t level;
+    rt_bool_t need_schedule = RT_FALSE;
     struct rt_prio_queue_item *item;
 
     RT_ASSERT(que);
@@ -164,11 +165,14 @@ rt_err_t rt_prio_queue_push(struct rt_prio_queue *que,
                                struct rt_thread,
                                tlist);
         /* resume it */
-        rt_thread_resume(thread);
+        if(rt_thread_resume(thread) == RT_EOK)
+            need_schedule = RT_TRUE;
+
         rt_hw_interrupt_enable(level);
 
         /* perform a schedule */
-        rt_schedule();
+        if (need_schedule == RT_TRUE)
+            rt_schedule();
 
         return RT_EOK;
     }

--- a/components/vbus/vbus.c
+++ b/components/vbus/vbus.c
@@ -288,8 +288,8 @@ static void _bus_out_entry(void *param)
 
 void rt_vbus_resume_out_thread(void)
 {
-    rt_thread_resume(&_bus_out_thread);
-    rt_schedule();
+    if(rt_thread_resume(&_bus_out_thread) == RT_EOK)
+        rt_schedule();
 }
 
 rt_err_t rt_vbus_post(rt_uint8_t id,

--- a/components/vbus/watermark_queue.h
+++ b/components/vbus/watermark_queue.h
@@ -100,7 +100,8 @@ rt_inline rt_err_t rt_wm_que_inc(struct rt_watermark_queue *wg,
  */
 rt_inline void rt_wm_que_dec(struct rt_watermark_queue *wg)
 {
-    int need_sched = 0;
+    rt_bool_t need_schedule = RT_FALSE;
+
     rt_base_t level;
 
     if (wg->level == 0)
@@ -119,12 +120,14 @@ rt_inline void rt_wm_que_dec(struct rt_watermark_queue *wg)
             thread = rt_list_entry(wg->suspended_threads.next,
                                    struct rt_thread,
                                    tlist);
-            rt_thread_resume(thread);
-            need_sched = 1;
+            /* resume it */
+            if(rt_thread_resume(thread) == RT_EOK)
+                need_schedule = RT_TRUE;
         }
     }
     rt_hw_interrupt_enable(level);
 
-    if (need_sched)
+    /* perform a schedule */
+    if (need_schedule == RT_TRUE)
         rt_schedule();
 }

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -418,6 +418,7 @@ void rt_mp_free(void *block)
     struct rt_mempool *mp;
     struct rt_thread *thread;
     rt_base_t level;
+    rt_bool_t need_schedule = RT_FALSE;
 
     /* parameter check */
     if (block == RT_NULL) return;
@@ -449,13 +450,14 @@ void rt_mp_free(void *block)
         thread->error = RT_EOK;
 
         /* resume thread */
-        rt_thread_resume(thread);
-
+        if( rt_thread_resume(thread) == RT_EOK)
+            need_schedule = RT_TRUE;
         /* enable interrupt */
         rt_hw_interrupt_enable(level);
 
         /* do a schedule */
-        rt_schedule();
+        if(need_schedule == RT_TRUE)
+            rt_schedule();
 
         return;
     }

--- a/src/signal.c
+++ b/src/signal.c
@@ -92,6 +92,7 @@ static void _signal_entry(void *parameter)
 static void _signal_deliver(rt_thread_t tid)
 {
     rt_base_t level;
+    rt_bool_t need_schedule = RT_FALSE;
 
     level = rt_hw_interrupt_disable();
 
@@ -105,14 +106,16 @@ static void _signal_deliver(rt_thread_t tid)
     if ((tid->stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND)
     {
         /* resume thread to handle signal */
-        rt_thread_resume(tid);
+        if(rt_thread_resume(tid) == RT_EOK)
+            need_schedule = RT_TRUE;
         /* add signal state */
         tid->stat |= (RT_THREAD_STAT_SIGNAL | RT_THREAD_STAT_SIGNAL_PENDING);
 
         rt_hw_interrupt_enable(level);
 
         /* re-schedule */
-        rt_schedule();
+        if (need_schedule == RT_TRUE)
+            rt_schedule();
     }
     else
     {

--- a/src/thread.c
+++ b/src/thread.c
@@ -875,13 +875,16 @@ RTM_EXPORT(rt_thread_suspend);
  *
  * @param   thread is the thread to be resumed.
  *
- * @return  Return the operation status. If the return value is RT_EOK, the function is successfully executed.
- *          If the return value is any other values, it means this operation failed.
+ * @return   Return the operation status.
+ *           When the return value is RT_EOK, the new ready thread have highest priority, need to schedule immediately
+ *           When the return value is RT_EBUSY, although have readied the thread but its priority is not the highest.
+ *           If the return value is any other values, it means this operation failed.
  */
 rt_err_t rt_thread_resume(rt_thread_t thread)
 {
     rt_base_t level;
-
+    rt_err_t result = RT_EOK;
+    extern rt_uint8_t rt_current_priority;
     /* parameter check */
     RT_ASSERT(thread != RT_NULL);
     RT_ASSERT(rt_object_get_type((rt_object_t)thread) == RT_Object_Class_Thread);
@@ -907,11 +910,21 @@ rt_err_t rt_thread_resume(rt_thread_t thread)
     /* insert to schedule ready list */
     rt_schedule_insert_thread(thread);
 
+    /* compare the priority with rt_current_priority*/
+    if(thread->current_priority < rt_current_priority)
+    {
+        result == RT_EOK;
+    }
+    else
+    {
+        result == RT_EBUSY;
+    }
+
     /* enable interrupt */
     rt_hw_interrupt_enable(level);
 
     RT_OBJECT_HOOK_CALL(rt_thread_resume_hook, (thread));
-    return RT_EOK;
+    return result;
 }
 RTM_EXPORT(rt_thread_resume);
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -505,8 +505,8 @@ rt_err_t rt_timer_start(rt_timer_t timer)
            ((_timer_thread.stat & RT_THREAD_STAT_MASK) == RT_THREAD_SUSPEND))
         {
             /* resume timer thread to check soft timer */
-            rt_thread_resume(&_timer_thread);
-            need_schedule = RT_TRUE;
+            if(rt_thread_resume(&_timer_thread) == RT_EOK)
+                need_schedule = RT_TRUE;
         }
     }
 #endif /* RT_USING_TIMER_SOFT */
@@ -514,7 +514,7 @@ rt_err_t rt_timer_start(rt_timer_t timer)
     /* enable interrupt */
     rt_hw_interrupt_enable(level);
 
-    if (need_schedule)
+    if (need_schedule == RT_TRUE)
     {
         rt_schedule();
     }


### PR DESCRIPTION
[
当前因为超时，或者资源唤醒就会主动发起一次rt_schedule， 但有时新ready的任务的优先级并没有当前的高
这样就会进入rt_schedule： 关中断，获取highest_ready_priority，rt_list_entry得到highest_priority_thread，再一堆比较
一顿操作最后发现做了无用功，降低了系统的实时性和效率。

新的优化策略是修改rt_thread_resume： 恢复thread状态后，再比较优先级大小：
```
rt_err_t rt_thread_resume(rt_thread_t thread)
{
    rt_base_t level;
    rt_err_t result = RT_EOK;
    extern rt_uint8_t rt_current_priority;

     .........

    /* disable interrupt */
    level = rt_hw_interrupt_disable();

    /* remove from suspend list */
    rt_list_remove(&(thread->tlist));

    rt_timer_stop(&thread->thread_timer);

    /* insert to schedule ready list */
    rt_schedule_insert_thread(thread);

    /* compare the priority with rt_current_priority*/
    if(thread->current_priority < rt_current_priority)
    {
        result == RT_EOK;
    }
    else
    {
        result == RT_EBUSY;
    }

    /* enable interrupt */
    rt_hw_interrupt_enable(level);

    RT_OBJECT_HOOK_CALL(rt_thread_resume_hook, (thread));
    return result;
}
```
外面的timer_check 和 资源类 api根据rt_thread_resume返回结果，决定是否有必要发起一次rt_schedule
这个和freertos的策略一致
```
					/* If there was a task waiting for data to arrive on the
					queue then unblock it now. */
					if( listLIST_IS_EMPTY( &( pxQueue->xTasksWaitingToReceive ) ) == pdFALSE )
					{
						if( xTaskRemoveFromEventList( &( pxQueue->xTasksWaitingToReceive ) ) != pdFALSE )
						{
							/* The unblocked task has a priority higher than
							our own so yield immediately.  Yes it is ok to do
							this from within the critical section - the kernel
							takes care of that. */
							queueYIELD_IF_USING_PREEMPTION();
						}
						else
						{
							mtCOVERAGE_TEST_MARKER();
						}
					}
```


> 初始版本使用的是rt_schedule_insert_thread返回值，虽然不需要extern rt_uint8_t rt_current_priority，但改动太多,放弃了

**测试**
已在stm32f4disc1上测试，目前正常
还需要测试更多的ipc api 和其他改动验证

先提上来看看有没有问题！

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
