### PR TITLE
[tools/kconfig-frontends] append path for scons env

### DIFF
--- a/tools/kconfig-frontends/SConstruct
+++ b/tools/kconfig-frontends/SConstruct
@@ -1,6 +1,7 @@
 import os
 
 env = Environment()
+env.AppendENVPath('PATH', os.environ['PATH'])
 env['CPPPATH'] = ['libs/parser', 'libs']
 env['CPPDEFINES'] = ['CURSES_LOC=\\"ncurses.h\\"', 'HAVE_CONFIG_H', 
     'ROOTMENU=\\"Configuration\\"', 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

在 `scons --menuconfig` 时， kconfig-frontends 的 SConstruct 应该读取 PATH 环境变量，我在使用时找不到 gcc，发现是这个原因， gcc 不一定在 /usr/bin 下面，比如 NixOS 在 /run/current-system/sw/bin/gcc，可以根据环境变量找到它
这里用的 Append 而不是 Prepend，对别人应该没影响

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
