### PR TITLE
[device][adc] implement adc_get_vref

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -10,6 +10,7 @@
  * 2019-02-01     yuneizhilin  fix the stm32_adc_init function initialization issue
  * 2020-06-17     thread-liu   Porting for stm32mp1xx
  * 2020-10-14     Dozingfiretruck   Porting for stm32wbxx
+ * 2022-05-22     Stanley Lwin Add stm32_adc_get_vref
  */
 
 #include <board.h>
@@ -169,7 +170,11 @@ static rt_uint32_t stm32_adc_get_channel(rt_uint32_t channel)
 
     return stm32_channel;
 }
-
+static rt_uint32_t stm32_adc_get_vref (struct rt_adc_device *device)
+{
+    RT_ASSERT(device);
+    return 3300;
+}
 static rt_err_t stm32_adc_get_value(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value)
 {
     ADC_ChannelConfTypeDef ADC_ChanConf;
@@ -285,6 +290,7 @@ static const struct rt_adc_ops stm_adc_ops =
     .enabled = stm32_adc_enabled,
     .convert = stm32_adc_get_value,
     .get_resolution = stm32_adc_get_resolution,
+    .get_vref = stm32_adc_get_vref,
 };
 
 static int stm32_adc_init(void)

--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -171,7 +171,7 @@ static rt_uint32_t stm32_adc_get_channel(rt_uint32_t channel)
     return stm32_channel;
 }
 
-static rt_uint16_t stm32_adc_get_vref (struct rt_adc_device *device)
+static rt_int16_t stm32_adc_get_vref (struct rt_adc_device *device)
 {
     RT_ASSERT(device);
     return 3300;

--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -170,11 +170,13 @@ static rt_uint32_t stm32_adc_get_channel(rt_uint32_t channel)
 
     return stm32_channel;
 }
-static rt_uint32_t stm32_adc_get_vref (struct rt_adc_device *device)
+
+static rt_uint16_t stm32_adc_get_vref (struct rt_adc_device *device)
 {
     RT_ASSERT(device);
     return 3300;
 }
+
 static rt_err_t stm32_adc_get_value(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value)
 {
     ADC_ChannelConfTypeDef ADC_ChanConf;

--- a/components/drivers/include/drivers/adc.h
+++ b/components/drivers/include/drivers/adc.h
@@ -20,7 +20,7 @@ struct rt_adc_ops
     rt_err_t (*enabled)(struct rt_adc_device *device, rt_uint32_t channel, rt_bool_t enabled);
     rt_err_t (*convert)(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value);
     rt_uint8_t (*get_resolution)(struct rt_adc_device *device);
-    rt_uint16_t (*get_vref) (const struct rt_adc_device *device);
+    rt_int16_t (*get_vref) (const struct rt_adc_device *device);
 };
 
 struct rt_adc_device
@@ -43,6 +43,6 @@ rt_err_t rt_hw_adc_register(rt_adc_device_t adc,const char *name, const struct r
 rt_uint32_t rt_adc_read(rt_adc_device_t dev, rt_uint32_t channel);
 rt_err_t rt_adc_enable(rt_adc_device_t dev, rt_uint32_t channel);
 rt_err_t rt_adc_disable(rt_adc_device_t dev, rt_uint32_t channel);
-rt_uint32_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel);
+rt_int16_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel);
 
 #endif /* __ADC_H__ */

--- a/components/drivers/include/drivers/adc.h
+++ b/components/drivers/include/drivers/adc.h
@@ -20,7 +20,7 @@ struct rt_adc_ops
     rt_err_t (*enabled)(struct rt_adc_device *device, rt_uint32_t channel, rt_bool_t enabled);
     rt_err_t (*convert)(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value);
     rt_uint8_t (*get_resolution)(struct rt_adc_device *device);
-    rt_uint32_t (*get_vref) (struct rt_adc_device *device);
+    rt_uint16_t (*get_vref) (const struct rt_adc_device *device);
 };
 
 struct rt_adc_device
@@ -34,8 +34,8 @@ typedef enum
 {
     RT_ADC_CMD_ENABLE = RT_DEVICE_CTRL_BASE(ADC) + 1,
     RT_ADC_CMD_DISABLE = RT_DEVICE_CTRL_BASE(ADC) + 2,
-    RT_ADC_CMD_GET_RESOLUTION = RT_DEVICE_CTRL_BASE(ADC) + 3,
-    RT_ADC_CMD_GET_VREF = RT_DEVICE_CTRL_BASE(ADC) + 4,
+    RT_ADC_CMD_GET_RESOLUTION = RT_DEVICE_CTRL_BASE(ADC) + 3, /* get the resolution in bits */
+    RT_ADC_CMD_GET_VREF = RT_DEVICE_CTRL_BASE(ADC) + 4, /* get reference voltage */
 } rt_adc_cmd_t;
 
 rt_err_t rt_hw_adc_register(rt_adc_device_t adc,const char *name, const struct rt_adc_ops *ops, const void *user_data);

--- a/components/drivers/include/drivers/adc.h
+++ b/components/drivers/include/drivers/adc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -7,7 +7,7 @@
  * Date           Author       Notes
  * 2018-05-07     aozima       the first version
  * 2018-11-16     Ernest Chen  add finsh command and update adc function
- * 2022-05-11      Stanley Lwin add finsh voltage conversion command
+ * 2022-05-11     Stanley Lwin add finsh voltage conversion command
  */
 
 #ifndef __ADC_H__
@@ -20,6 +20,7 @@ struct rt_adc_ops
     rt_err_t (*enabled)(struct rt_adc_device *device, rt_uint32_t channel, rt_bool_t enabled);
     rt_err_t (*convert)(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value);
     rt_uint8_t (*get_resolution)(struct rt_adc_device *device);
+    rt_uint32_t (*get_vref) (struct rt_adc_device *device);
 };
 
 struct rt_adc_device
@@ -34,6 +35,7 @@ typedef enum
     RT_ADC_CMD_ENABLE = RT_DEVICE_CTRL_BASE(ADC) + 1,
     RT_ADC_CMD_DISABLE = RT_DEVICE_CTRL_BASE(ADC) + 2,
     RT_ADC_CMD_GET_RESOLUTION = RT_DEVICE_CTRL_BASE(ADC) + 3,
+    RT_ADC_CMD_GET_VREF = RT_DEVICE_CTRL_BASE(ADC) + 4,
 } rt_adc_cmd_t;
 
 rt_err_t rt_hw_adc_register(rt_adc_device_t adc,const char *name, const struct rt_adc_ops *ops, const void *user_data);

--- a/components/drivers/misc/adc.c
+++ b/components/drivers/misc/adc.c
@@ -177,17 +177,14 @@ rt_int16_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel)
     }
 
     /*get the reference voltage*/
-   if( _adc_control((rt_device_t) dev, RT_ADC_CMD_GET_VREF, &vref) != RT_EOK)
-   {
+    if( _adc_control((rt_device_t) dev, RT_ADC_CMD_GET_VREF, &vref) != RT_EOK)
+    {
        goto _voltage_exit;
-   }
+    }
 
     /*read the value and convert to voltage*/
-    if(resolution != RT_NULL && vref != RT_NULL)
-    {
-        dev->ops->convert(dev, channel, &value);
-        voltage = value * vref / (1 << resolution);
-    }
+    dev->ops->convert(dev, channel, &value);
+    voltage = value * vref / (1 << resolution);
 
 _voltage_exit:
     return voltage;

--- a/components/drivers/misc/adc.c
+++ b/components/drivers/misc/adc.c
@@ -170,16 +170,16 @@ rt_int16_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel)
 
     RT_ASSERT(dev);
 
-    /*get the convert bits*/
-    if(_adc_control((rt_device_t) dev, RT_ADC_CMD_GET_RESOLUTION, &resolution) != RT_EOK)
+    /*get the resolution in bits*/
+    if (_adc_control((rt_device_t) dev, RT_ADC_CMD_GET_RESOLUTION, &resolution) != RT_EOK)
     {
         goto _voltage_exit;
     }
 
     /*get the reference voltage*/
-    if( _adc_control((rt_device_t) dev, RT_ADC_CMD_GET_VREF, &vref) != RT_EOK)
+    if (_adc_control((rt_device_t) dev, RT_ADC_CMD_GET_VREF, &vref) != RT_EOK)
     {
-       goto _voltage_exit;
+        goto _voltage_exit;
     }
 
     /*read the value and convert to voltage*/

--- a/components/drivers/misc/adc.c
+++ b/components/drivers/misc/adc.c
@@ -159,7 +159,7 @@ rt_err_t rt_adc_disable(rt_adc_device_t dev, rt_uint32_t channel)
 
 rt_uint32_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel)
 {
-   rt_uint32_t value = 0, voltage = 0, vref = 0;
+    rt_uint32_t value = 0, voltage = 0, vref = 0;
 
     RT_ASSERT(dev);
 

--- a/components/drivers/misc/adc.c
+++ b/components/drivers/misc/adc.c
@@ -171,10 +171,16 @@ rt_int16_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel)
     RT_ASSERT(dev);
 
     /*get the convert bits*/
-    _adc_control((rt_device_t) dev, RT_ADC_CMD_GET_RESOLUTION, &resolution);
+    if(_adc_control((rt_device_t) dev, RT_ADC_CMD_GET_RESOLUTION, &resolution) != RT_EOK)
+    {
+        goto _voltage_exit;
+    }
 
     /*get the reference voltage*/
-    _adc_control((rt_device_t) dev, RT_ADC_CMD_GET_VREF, &vref);
+   if( _adc_control((rt_device_t) dev, RT_ADC_CMD_GET_VREF, &vref) != RT_EOK)
+   {
+       goto _voltage_exit;
+   }
 
     /*read the value and convert to voltage*/
     if(resolution != RT_NULL && vref != RT_NULL)
@@ -183,6 +189,7 @@ rt_int16_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel)
         voltage = value * vref / (1 << resolution);
     }
 
+_voltage_exit:
     return voltage;
 }
 #ifdef RT_USING_FINSH

--- a/components/drivers/misc/adc.c
+++ b/components/drivers/misc/adc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -7,7 +7,7 @@
  * Date           Author       Notes
  * 2018-05-07     aozima       the first version
  * 2018-11-16     Ernest Chen  add finsh command and update adc function
- * 2022-05-11      Stanley Lwin add finsh voltage conversion command
+ * 2022-05-11     Stanley Lwin add finsh voltage conversion command
  */
 
 #include <rtthread.h>
@@ -17,7 +17,6 @@
 #include <stdlib.h>
 
 #define DBG_TAG "adc"
-#define REFER_VOLTAGE 330       /*reference voltage, multiplied by 100 and reserve 2 decimal places for data accuracy*/
 #define DBG_LVL DBG_INFO
 #include <rtdbg.h>
 
@@ -63,6 +62,10 @@ static rt_err_t _adc_control(rt_device_t dev, int cmd, void *args)
             LOG_D("resolution: %d bits", resolution);
             result = RT_EOK;
         }
+    }
+    else if (cmd == RT_ADC_CMD_GET_VREF && adc->ops->get_resolution)
+    {
+        result = adc->ops->get_vref(adc);
     }
 
     return result;
@@ -156,17 +159,20 @@ rt_err_t rt_adc_disable(rt_adc_device_t dev, rt_uint32_t channel)
 
 rt_uint32_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel)
 {
-   rt_uint32_t value = 0, voltage = 0;
+   rt_uint32_t value = 0, voltage = 0, vref = 0;
 
     RT_ASSERT(dev);
 
     /*read the value and convert to voltage*/
     if (dev->ops->get_resolution != RT_NULL && dev->ops->convert != RT_NULL)
     {
+        /*get reference voltage*/
+        vref = _adc_control((rt_device_t) dev, RT_ADC_CMD_GET_VREF, RT_NULL );
+
         /*get the convert bits*/
         rt_uint8_t resolution = dev->ops->get_resolution(dev);
         dev->ops->convert(dev, channel, &value);
-        voltage = value * REFER_VOLTAGE / (1 << resolution);
+        voltage = value * vref / (1 << resolution);
     }
 
     return voltage;
@@ -246,7 +252,7 @@ static int adc(int argc, char **argv)
                 {
                     voltage = rt_adc_voltage(adc_device, atoi(argv[2]));
                     result_str = (result == RT_EOK) ? "success" : "failure";
-                    rt_kprintf("%s channel %d voltage is %d.%02d \n", adc_device->parent.parent.name, atoi(argv[2]), voltage / 100, voltage % 100);
+                    rt_kprintf("%s channel %d voltage is %d.%03dV \n", adc_device->parent.parent.name, atoi(argv[2]), voltage / 1000, voltage % 1000);
                 }
                 else
                 {

--- a/components/drivers/misc/adc.c
+++ b/components/drivers/misc/adc.c
@@ -169,10 +169,10 @@ rt_err_t rt_adc_disable(rt_adc_device_t dev, rt_uint32_t channel)
     return result;
 }
 
-rt_uint32_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel)
+rt_int16_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel)
 {
-    rt_uint32_t value = 0, voltage = 0;
-    rt_int16_t vref = 0;
+    rt_uint32_t value = 0;
+    rt_int16_t vref = 0, voltage = 0;
 
     RT_ASSERT(dev);
 
@@ -197,7 +197,8 @@ rt_uint32_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel)
 
 static int adc(int argc, char **argv)
 {
-    int value = 0, voltage = 0;
+    int value = 0;
+    rt_int16_t voltage = 0;
     rt_err_t result = -RT_ERROR;
     static rt_adc_device_t adc_device = RT_NULL;
     char *result_str;

--- a/components/drivers/misc/adc.c
+++ b/components/drivers/misc/adc.c
@@ -192,6 +192,7 @@ rt_int16_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel)
 _voltage_exit:
     return voltage;
 }
+
 #ifdef RT_USING_FINSH
 
 static int adc(int argc, char **argv)

--- a/components/drivers/misc/adc.c
+++ b/components/drivers/misc/adc.c
@@ -166,7 +166,7 @@ rt_int16_t rt_adc_voltage(rt_adc_device_t dev, rt_uint32_t channel)
 {
     rt_uint32_t value = 0;
     rt_int16_t vref = 0, voltage = 0;
-    rt_uint8_t resolution;
+    rt_uint8_t resolution = 0;
 
     RT_ASSERT(dev);
 


### PR DESCRIPTION
add stm32_adc_get_vref

## 拉取/合并请求描述：(PR description)

[
这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
