### PR TITLE
[libc] remove strnlen from rtthread.h

### DIFF
--- a/bsp/simulator/drivers/SConscript
+++ b/bsp/simulator/drivers/SConscript
@@ -8,7 +8,7 @@ src = ['board.c', 'uart_console.c']
 LIBS = []
 LIBPATH = []
 CPPPATH = [cwd]
-CPPDEFINES = []
+CPPDEFINES = ['RT_USING_LIBC']
 
 if rtconfig.CROSS_TOOL == 'msvc':
     CPPDEFINES += \

--- a/components/libc/compilers/armlibc/SConscript
+++ b/components/libc/compilers/armlibc/SConscript
@@ -4,7 +4,7 @@ Import('rtconfig')
 src   = Glob('*.c')
 group = []
 
-CPPDEFINES = ['RT_USING_ARM_LIBC', 'RT_USING_LIBC']
+CPPDEFINES = ['RT_USING_ARM_LIBC', 'RT_USING_LIBC', '__STDC_LIMIT_MACROS']
 
 if rtconfig.PLATFORM in ['armcc', 'armclang']:
     group = DefineGroup('Compiler', src, depend = [''], CPPDEFINES = CPPDEFINES)

--- a/components/libc/compilers/dlib/SConscript
+++ b/components/libc/compilers/dlib/SConscript
@@ -4,7 +4,7 @@ Import('rtconfig')
 src   = Glob('*.c')
 group = []
 
-CPPDEFINES = ['RT_USING_DLIBC', 'RT_USING_LIBC']
+CPPDEFINES = ['RT_USING_DLIBC', 'RT_USING_LIBC', '_DLIB_ADD_EXTRA_SYMBOLS=0']
 
 if rtconfig.PLATFORM == 'iar':
     if GetDepend('DFS_USING_POSIX'):

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -605,7 +605,8 @@ void *rt_memcpy(void *dest, const void *src, rt_ubase_t n);
 void *rt_memmove(void *dest, const void *src, rt_size_t n);
 rt_int32_t rt_memcmp(const void *cs, const void *ct, rt_size_t count);
 #endif /* RT_KSERVICE_USING_STDLIB_MEMORY */
-
+char *rt_strdup(const char *s);
+rt_size_t rt_strnlen(const char *s, rt_ubase_t maxlen);
 #ifndef RT_KSERVICE_USING_STDLIB
 char *rt_strstr(const char *str1, const char *str2);
 rt_int32_t rt_strcasecmp(const char *a, const char *b);
@@ -630,19 +631,6 @@ rt_size_t rt_strlen(const char *src);
 #define rt_strcmp(cs, ct)           strcmp(cs, ct)
 #define rt_strlen(src)              strlen(src)
 #endif /*RT_KSERVICE_USING_STDLIB*/
-
-char *rt_strdup(const char *s);
-
-#if !defined(RT_KSERVICE_USING_STDLIB) || defined(__ARMCC_VERSION)
-rt_size_t rt_strnlen(const char *s, rt_ubase_t maxlen);
-#else
-#define rt_strnlen(s, maxlen)       strnlen(s, maxlen)
-#endif /* !defined(RT_KSERVICE_USING_STDLIB) || defined(__ARMCC_VERSION) */
-
-#ifdef __ARMCC_VERSION
-/* MDK doesn't have these APIs */
-rt_size_t strnlen(const char *s, rt_size_t maxlen);
-#endif /* __ARMCC_VERSION */
 
 void rt_show_version(void);
 


### PR DESCRIPTION
remove strnlen from rtthread.h
add __STDC_LIMIT_MACROS macro in Keil
add RT_USING_LIBC in simulator
add _DLIB_ADD_EXTRA_SYMBOLS=0 in IAR

strnlen 不属于ISO/ANSI-C标准库的函数
string.h中部分glibc/POSIX拓展函数各个编译平台不一致
 例如strnlen 在IAR中定义 但是keil gcc下没有定义
IAR取消扩展C函数声明
取消strnlen函数在rtthread.h中的定义

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
