### PR TITLE
[libcpu/risc-v/virt64]: fix parameter for call handle_trap

### DIFF
--- a/libcpu/risc-v/virt64/interrupt_gcc.S
+++ b/libcpu/risc-v/virt64/interrupt_gcc.S
@@ -114,8 +114,9 @@ trap_entry:
     /* handle interrupt */
     call  rt_interrupt_enter
     csrr  a0, SRC_XCAUSE
-    csrr  a1, SRC_XEPC
-    mv    a2, s0
+    csrr  a1, SRC_XTVAL
+    csrr  a2, SRC_XEPC
+    mv    a3, s0
     call  handle_trap
     call  rt_interrupt_leave
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

查看 risc-v/virt64/interrupt.c：
对于函数是
void handle_trap(rt_size_t xcause,rt_size_t xtval,rt_size_t xepc,struct rt_hw_stack_frame *sp)

调用参数应该为：
```
    csrr  a0, SRC_XCAUSE
    csrr  a1, SRC_XTVAL
    csrr  a2, SRC_XEPC
    mv    a3, s0
    call  handle_trap

```

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
