### PR TITLE
[kernel][mem.c] tighten size before check with mem_size_aligned

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -299,16 +299,16 @@ void *rt_smem_alloc(rt_smem_t m, rt_size_t size)
     /* alignment size */
     size = RT_ALIGN(size, RT_ALIGN_SIZE);
 
+    /* every data block must be at least MIN_SIZE_ALIGNED long */
+    if (size < MIN_SIZE_ALIGNED)
+        size = MIN_SIZE_ALIGNED;
+
     if (size > small_mem->mem_size_aligned)
     {
         RT_DEBUG_LOG(RT_DEBUG_MEM, ("no memory\n"));
 
         return RT_NULL;
     }
-
-    /* every data block must be at least MIN_SIZE_ALIGNED long */
-    if (size < MIN_SIZE_ALIGNED)
-        size = MIN_SIZE_ALIGNED;
 
     for (ptr = (rt_uint8_t *)small_mem->lfree - small_mem->heap_ptr;
          ptr <= small_mem->mem_size_aligned - size;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

```c
if (size > small_mem->mem_size_aligned)
        return RT_NULL;

if (size < MIN_SIZE_ALIGNED)
        size = MIN_SIZE_ALIGNED;
```
这2个连着看这很不舒服，在判断 size 是否 > 剩余空间之后，可能把size变大

不过 mem_size_aligned 应该是对齐的，MIN_SIZE_ALIGNED 的倍数，不是bug。但我觉得换下位置没有任何害处，而且看着舒服点。

当然工作人员如果觉得没必要，直接关了就行了


### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
