### PR TITLE
添加HC32F460系列CAN设备驱动支持

### DIFF
--- a/bsp/hc32/ev_hc32f460_lqfp100_v2/board/Kconfig
+++ b/bsp/hc32/ev_hc32f460_lqfp100_v2/board/Kconfig
@@ -78,6 +78,16 @@ menu "On-chip Peripheral Drivers"
                 depends on BSP_USING_UART4 && RT_SERIAL_USING_DMA
                 default n
         endif
+		
+	menuconfig BSP_USING_CAN
+        bool "Enable CAN"
+        default n
+        select RT_USING_CAN
+        if BSP_USING_CAN
+            config BSP_USING_CAN1
+                bool "using can1"
+                default n
+        endif
 
 endmenu
 

--- a/bsp/hc32/ev_hc32f460_lqfp100_v2/board/board.c
+++ b/bsp/hc32/ev_hc32f460_lqfp100_v2/board/board.c
@@ -87,10 +87,6 @@ void SystemClock_Config(void)
 static void PeripheralClock_Config(void)
 {
 #if defined(HC32F460)
-#if defined(BSP_USING_CAN1)
-    CLK_SetCANClockSrc(CLK_CAN1, CLK_CANCLK_SYSCLK_DIV6);
-#endif
-
 #if defined(RT_USING_ADC)
     CLK_SetPeriClockSrc(CLK_PERIPHCLK_PCLK);
 #endif

--- a/bsp/hc32/ev_hc32f460_lqfp100_v2/board/board_config.c
+++ b/bsp/hc32/ev_hc32f460_lqfp100_v2/board/board_config.c
@@ -60,3 +60,29 @@ rt_err_t rt_hw_board_uart_init(CM_USART_TypeDef *USARTx)
 }
 #endif
 
+#if defined(RT_USING_CAN)
+void CanPhyEnable(void)
+{
+    GPIO_ResetPins(CAN_STB_PORT, CAN_STB_PIN);
+    GPIO_OutputCmd(CAN_STB_PORT, CAN_STB_PIN, ENABLE);
+}
+rt_err_t rt_hw_board_can_init(CM_CAN_TypeDef *CANx)
+{
+    rt_err_t result = RT_EOK;
+
+    switch ((rt_uint32_t)CANx)
+    {
+#if defined(BSP_USING_CAN1)
+case (rt_uint32_t)CM_CAN:
+    GPIO_SetFunc(CAN1_TX_PORT, CAN1_TX_PIN, CAN1_TX_PIN_FUNC);
+    GPIO_SetFunc(CAN1_RX_PORT, CAN1_RX_PIN, CAN1_RX_PIN_FUNC);
+    break;
+#endif
+default:
+    result = -RT_ERROR;
+    break;
+    }
+
+    return result;
+}
+#endif

--- a/bsp/hc32/ev_hc32f460_lqfp100_v2/board/board_config.c
+++ b/bsp/hc32/ev_hc32f460_lqfp100_v2/board/board_config.c
@@ -23,6 +23,27 @@ rt_err_t rt_hw_board_uart_init(CM_USART_TypeDef *USARTx)
 
     switch ((rt_uint32_t)USARTx)
     {
+#if defined(BSP_USING_UART1)
+    case (rt_uint32_t)CM_USART1:
+        /* Configure USART RX/TX pin. */
+        GPIO_SetFunc(USART1_RX_PORT, USART1_RX_PIN, GPIO_FUNC_33);
+        GPIO_SetFunc(USART1_TX_PORT, USART1_TX_PIN, GPIO_FUNC_32);
+        break;
+#endif
+#if defined(BSP_USING_UART2)
+    case (rt_uint32_t)CM_USART2:
+        /* Configure USART RX/TX pin. */
+        GPIO_SetFunc(USART2_RX_PORT, USART2_RX_PIN, GPIO_FUNC_37);
+        GPIO_SetFunc(USART2_TX_PORT, USART2_TX_PIN, GPIO_FUNC_36);
+        break;
+#endif
+#if defined(BSP_USING_UART3)
+    case (rt_uint32_t)CM_USART3:
+        /* Configure USART RX/TX pin. */
+        GPIO_SetFunc(USART3_RX_PORT, USART3_RX_PIN, GPIO_FUNC_33);
+        GPIO_SetFunc(USART3_TX_PORT, USART3_TX_PIN, GPIO_FUNC_32);
+        break;
+#endif
 #if defined(BSP_USING_UART4)
     case (rt_uint32_t)CM_USART4:
         /* Configure USART RX/TX pin. */

--- a/bsp/hc32/ev_hc32f460_lqfp100_v2/board/board_config.h
+++ b/bsp/hc32/ev_hc32f460_lqfp100_v2/board/board_config.h
@@ -29,7 +29,7 @@
 
 #if defined(BSP_USING_UART2)
     #define USART2_RX_PORT                  (GPIO_PORT_A)
-    #define USART2_RX_PIN                   (GPIO_PIN_04)
+    #define USART2_RX_PIN                   (GPIO_PIN_03)
 
     #define USART2_TX_PORT                  (GPIO_PORT_A)
     #define USART2_TX_PIN                   (GPIO_PIN_02)

--- a/bsp/hc32/ev_hc32f460_lqfp100_v2/board/board_config.h
+++ b/bsp/hc32/ev_hc32f460_lqfp100_v2/board/board_config.h
@@ -51,4 +51,18 @@
     #define USART4_TX_PIN                   (GPIO_PIN_06)
 #endif
 
+/***********  CAN configure *********/
+#if defined(BSP_USING_CAN1)
+    #define CAN1_TX_PORT                     (GPIO_PORT_B)
+    #define CAN1_TX_PIN                      (GPIO_PIN_07)
+    #define CAN1_TX_PIN_FUNC                 (GPIO_FUNC_50)
+
+    #define CAN1_RX_PORT                     (GPIO_PORT_B)
+    #define CAN1_RX_PIN                      (GPIO_PIN_06)
+    #define CAN1_RX_PIN_FUNC                 (GPIO_FUNC_51)
+
+    #define CAN_STB_PORT                     (GPIO_PORT_D)
+    #define CAN_STB_PIN                      (GPIO_PIN_15)
+#endif
+
 #endif

--- a/bsp/hc32/ev_hc32f460_lqfp100_v2/board/config/can_config.h
+++ b/bsp/hc32/ev_hc32f460_lqfp100_v2/board/config/can_config.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2006-2022, RT-Thread Development Team
+ * Copyright (c) 2022, Xiaohua Semiconductor Co., Ltd.
+ * Copyright (c) 2022, xiaoxiaolisunny
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author                   Notes
+ * 2022-06-07     xiaoxiaolisunny          first version
+ */
+
+#ifndef __CAN_CONFIG_H__
+#define __CAN_CONFIG_H__
+
+#include <rtthread.h>
+#include "irq_config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef BSP_USING_CAN1
+#ifndef CAN1_INIT_PARAMS
+#define CAN1_INIT_PARAMS                                    \
+    {                                                       \
+       .name = "can1",                                      \
+    }
+#endif /* CAN1_INIT_PARAMS */
+#endif /* BSP_USING_CAN1 */
+
+/* Bit time config
+  Restrictions: u32TimeSeg1 >= u32TimeSeg2 + 1, u32TimeSeg2 >= u32SJW.
+
+  Baudrate = CANClock/(u32Prescaler*(u32TimeSeg1 + u32TimeSeg2))
+  TQ = u32Prescaler / CANClock.
+  Bit time = (u32TimeSeg1 + u32TimeSeg2) x TQ.
+
+  The following bit time configures are based on CAN Clock 8M
+*/
+#define CAN_BIT_TIME_CONFIG_1M_BAUD                         \
+    {                                                       \
+        .u32Prescaler = 1,                                  \
+        .u32TimeSeg1 = 5,                                  \
+        .u32TimeSeg2 = 3,                                   \
+        .u32SJW = 3                                         \
+    }
+
+#define CAN_BIT_TIME_CONFIG_800K_BAUD                       \
+    {                                                       \
+        .u32Prescaler = 1,                                  \
+        .u32TimeSeg1 = 6,                                  \
+        .u32TimeSeg2 = 4,                                   \
+        .u32SJW = 3                                         \
+    }
+
+#define CAN_BIT_TIME_CONFIG_500K_BAUD                       \
+    {                                                       \
+        .u32Prescaler = 2,                                  \
+        .u32TimeSeg1 = 5,                                  \
+        .u32TimeSeg2 = 3,                                   \
+        .u32SJW = 3                                         \
+    }
+
+#define CAN_BIT_TIME_CONFIG_250K_BAUD                       \
+    {                                                       \
+        .u32Prescaler = 4,                                  \
+        .u32TimeSeg1 = 5,                                  \
+        .u32TimeSeg2 = 3,                                   \
+        .u32SJW = 3                                         \
+    }
+
+#define CAN_BIT_TIME_CONFIG_125K_BAUD                       \
+    {                                                       \
+        .u32Prescaler = 8,                                 \
+        .u32TimeSeg1 = 5,                                  \
+        .u32TimeSeg2 = 3,                                   \
+        .u32SJW = 3                                         \
+    }
+
+#define CAN_BIT_TIME_CONFIG_100K_BAUD                       \
+    {                                                       \
+        .u32Prescaler = 10,                                 \
+        .u32TimeSeg1 = 5,                                  \
+        .u32TimeSeg2 = 3,                                   \
+        .u32SJW = 3                                         \
+    }
+
+#define CAN_BIT_TIME_CONFIG_50K_BAUD                        \
+    {                                                       \
+        .u32Prescaler = 20,                                 \
+        .u32TimeSeg1 = 5,                                  \
+        .u32TimeSeg2 = 3,                                   \
+        .u32SJW = 3                                         \
+    }
+
+#define CAN_BIT_TIME_CONFIG_20K_BAUD                        \
+    {                                                       \
+        .u32Prescaler = 50,                                \
+        .u32TimeSeg1 = 5,                                  \
+        .u32TimeSeg2 = 3,                                   \
+        .u32SJW = 3                                         \
+    }
+
+#define CAN_BIT_TIME_CONFIG_10K_BAUD                        \
+    {                                                       \
+        .u32Prescaler = 100,                                \
+        .u32TimeSeg1 = 5,                                  \
+        .u32TimeSeg2 = 3,                                   \
+        .u32SJW = 3                                         \
+    }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CAN_CONFIG_H__ */
+
+

--- a/bsp/hc32/ev_hc32f460_lqfp100_v2/board/drv_config.h
+++ b/bsp/hc32/ev_hc32f460_lqfp100_v2/board/drv_config.h
@@ -22,6 +22,7 @@ extern "C" {
 #include "dma_config.h"
 #include "uart_config.h"
 #include "gpio_config.h"
+#include "can_config.h"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1. 添加HC32F460系列的CAN设备驱动支持；
2. 修改drv_can.c中的几处问题。发送函数中添加IDE赋值操作，解决无法发送正确的扩展帧ID问题。修改接收函数中判断ID类型的值，CAN_ID_STD值为0x40000000，而IDE的值只有0和1，因此不能直接用二者判断。can初始化中过滤器修改为接收标准帧和扩展帧。
3. 修改board.c中时钟配置，HC32F460库中没有CLK_SetCANClockSrc函数，也不需要配置，删掉该操作。

本次PR内容已在ev_hc32f460_lqfp100_v1开发板测试通过（V1和V2开发板CAN部分接口一样），在自己板子上移植测试也正常。
![1](https://user-images.githubusercontent.com/88809599/172534877-2d265387-b70f-418f-a430-b3ba3795d0d7.png)

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
