### PR TITLE
Fix rt_qspi_send symbol extension BUG

### DIFF
--- a/components/drivers/spi/qspi_core.c
+++ b/components/drivers/spi/qspi_core.c
@@ -186,7 +186,7 @@ rt_err_t rt_qspi_send(struct rt_qspi_device *device, const void *send_buf, rt_si
     RT_ASSERT(length != 0);
 
     struct rt_qspi_message message;
-    char *ptr = (char *)send_buf;
+    unsigned char *ptr = (unsigned char *)send_buf;
     rt_size_t  count = 0;
     rt_err_t result = 0;
 
@@ -241,7 +241,6 @@ rt_err_t rt_qspi_send(struct rt_qspi_device *device, const void *send_buf, rt_si
     else
     {
         message.qspi_data_lines = 0;
-
     }
 
     /* set send buf and send size */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
根据c标准，char类型为 Implementation Defined。

在不同的编译器上，如果将 `char *ptr ` 认为是 `signed` 那么将会有可能会导致最高位为 1 ，这样最终就会影响到 FLASH 操作的地址将会是一个非常大的地址，也就会出现读写数据错误。

论坛上已经出现过此类[问题](https://club.rt-thread.org/ask/question/82fe3d63596811fb.html)
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
