### PR TITLE
禁用同步模式时钟输出

### DIFF
--- a/bsp/hc32/libraries/hc32_drivers/drv_usart.c
+++ b/bsp/hc32/libraries/hc32_drivers/drv_usart.c
@@ -156,16 +156,6 @@ static rt_err_t hc32_configure(struct rt_serial_device *serial, struct serial_co
     uart_init.u32OverSampleBit = USART_OVER_SAMPLE_8BIT;
     uart_init.u32Baudrate = cfg->baud_rate;
     uart_init.u32ClockSrc = USART_CLK_SRC_INTERNCLK;
-#if defined (HC32F4A0)
-    if ((CM_USART1 == uart->config->Instance) || (CM_USART2 == uart->config->Instance) || \
-            (CM_USART6 == uart->config->Instance) || (CM_USART7 == uart->config->Instance))
-#elif defined (HC32F460)
-    if ((CM_USART1 == uart->config->Instance) || (CM_USART2 == uart->config->Instance) || \
-            (CM_USART3 == uart->config->Instance) || (CM_USART4 == uart->config->Instance))
-#endif
-    {
-        uart_init.u32CKOutput = USART_CK_OUTPUT_ENABLE;
-    }
 
     switch (cfg->data_bits)
     {


### PR DESCRIPTION
串口同步模式用的比较少，且rtt本身的对串口的配置好像没同步模式，这里建议直接禁用同步模式时钟输出

