### PR TITLE
接收错误中断未触发的问题

### DIFF
--- a/bsp/hc32/libraries/hc32_drivers/drv_usart.c
+++ b/bsp/hc32/libraries/hc32_drivers/drv_usart.c
@@ -264,7 +264,7 @@ static rt_err_t hc32_configure(struct rt_serial_device *serial, struct serial_co
 
     /* Enable error interrupt */
     NVIC_EnableIRQ(uart->config->rxerr_irq.irq_config.irq_num);
-    USART_FuncCmd(uart->config->Instance, USART_TX | USART_RX, ENABLE);
+    USART_FuncCmd(uart->config->Instance, USART_TX | USART_RX | USART_INT_RX, ENABLE);
 
     return RT_EOK;
 }


### PR DESCRIPTION
/* Enable error interrupt */
NVIC_EnableIRQ(uart->config->rxerr_irq.irq_config.irq_num);
上述代码使能错误接收中断后需要使能串口的接收中断`USART_INT_RX`才可以正常触发中断
