### PR TITLE
version numbers be friendly to macro expansion

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -61,9 +61,9 @@ extern "C" {
 /**@{*/
 
 /* RT-Thread version information */
-#define RT_VERSION                      4L              /**< major version number */
-#define RT_SUBVERSION                   1L              /**< minor version number */
-#define RT_REVISION                     1L              /**< revise version number */
+#define RT_VERSION                      4               /**< major version number */
+#define RT_SUBVERSION                   1               /**< minor version number */
+#define RT_REVISION                     1               /**< revise version number */
 
 /* RT-Thread version */
 #define RTTHREAD_VERSION                ((RT_VERSION * 10000) + \


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
The trailing `L`s in version numbers are not friendly to C preprocessors.

To create a version string at compile time using below macros,
what we get is `RT-Thread (4L.1L.1L)`, which is annoying.

```c
#define expand2(X) #X
#define expand(X) expand2(X)

const char version_str[] = "RT-Thread (" expand(RT_VERSION) "." expand(RT_SUBVERSION) "." expand(RT_REVISION) ")";
```

From definition of `RTTHREAD_VERSION`, we can infer that `RT_SUBVERSION` and
`RT_REVISION` will not exceed `100`. So, it's safe to discard these two trailing `L`s.

I think it is also okay to leave out the `L` in RT_VERSION in the near future.
]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
