### PR TITLE
[fix] use atomic operation to protect pthread conditional variable.

### DIFF
--- a/components/libc/posix/pthreads/pthread_cond.c
+++ b/components/libc/posix/pthreads/pthread_cond.c
@@ -9,6 +9,7 @@
  * 2022-06-27     xiangxistu   use atomic operation to protect pthread conditional variable
  */
 
+#include <rthw.h>
 #include <pthread.h>
 #include "pthread_internal.h"
 

--- a/components/libc/posix/pthreads/pthread_cond.c
+++ b/components/libc/posix/pthreads/pthread_cond.c
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2010-10-26     Bernard      the first version
+ * 2022-06-27     xiangxistu   use atomic operation to protect pthread conditional variable
  */
 
 #include <pthread.h>
@@ -31,14 +32,14 @@ int pthread_condattr_init(pthread_condattr_t *attr)
 RTM_EXPORT(pthread_condattr_init);
 
 int pthread_condattr_getclock(const pthread_condattr_t *attr,
-                              clockid_t                *clock_id)
+                              clockid_t *clock_id)
 {
     return 0;
 }
 RTM_EXPORT(pthread_condattr_getclock);
 
 int pthread_condattr_setclock(pthread_condattr_t *attr,
-                              clockid_t           clock_id)
+                              clockid_t clock_id)
 {
     return 0;
 }
@@ -55,7 +56,7 @@ int pthread_condattr_getpshared(const pthread_condattr_t *attr, int *pshared)
 }
 RTM_EXPORT(pthread_condattr_getpshared);
 
-int pthread_condattr_setpshared(pthread_condattr_t*attr, int pshared)
+int pthread_condattr_setpshared(pthread_condattr_t *attr, int pshared)
 {
     if ((pshared != PTHREAD_PROCESS_PRIVATE) &&
         (pshared != PTHREAD_PROCESS_SHARED))
@@ -84,14 +85,21 @@ int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr)
 
     rt_snprintf(cond_name, sizeof(cond_name), "cond%02d", cond_num++);
 
-    if (attr == RT_NULL) /* use default value */
+    /* use default value */
+    if (attr == RT_NULL)
+    {
         cond->attr = PTHREAD_PROCESS_PRIVATE;
+    }
     else
+    {
         cond->attr = *attr;
+    }
 
     result = rt_sem_init(&cond->sem, cond_name, 0, RT_IPC_FLAG_FIFO);
     if (result != RT_EOK)
+    {
         return EINVAL;
+    }
 
     /* detach the object from system object container */
     rt_object_detach(&(cond->sem.parent.parent));
@@ -105,13 +113,26 @@ int pthread_cond_destroy(pthread_cond_t *cond)
 {
     rt_err_t result;
     if (cond == RT_NULL)
+    {
         return EINVAL;
+    }
+    /* which is not initialized */
     if (cond->attr == -1)
-        return 0; /* which is not initialized */
+    {
+        return 0;
+    }
 
-    result = rt_sem_trytake(&(cond->sem));
-    if (result != RT_EOK)
+    if (!rt_list_isempty(&cond->sem.parent.suspend_thread))
+    {
         return EBUSY;
+    }
+__retry:
+    result = rt_sem_trytake(&(cond->sem));
+    if (result == EBUSY)
+    {
+        pthread_cond_broadcast(cond);
+        goto __retry;
+    }
 
     /* clean condition */
     rt_memset(cond, 0, sizeof(pthread_cond_t));
@@ -130,7 +151,6 @@ int pthread_cond_broadcast(pthread_cond_t *cond)
     if (cond->attr == -1)
         pthread_cond_init(cond, RT_NULL);
 
-    rt_enter_critical();
     while (1)
     {
         /* try to take condition semaphore */
@@ -148,12 +168,9 @@ int pthread_cond_broadcast(pthread_cond_t *cond)
         }
         else
         {
-            rt_exit_critical();
-
             return EINVAL;
         }
     }
-    rt_exit_critical();
 
     return 0;
 }
@@ -161,6 +178,7 @@ RTM_EXPORT(pthread_cond_broadcast);
 
 int pthread_cond_signal(pthread_cond_t *cond)
 {
+    rt_base_t temp;
     rt_err_t result;
 
     if (cond == RT_NULL)
@@ -168,36 +186,141 @@ int pthread_cond_signal(pthread_cond_t *cond)
     if (cond->attr == -1)
         pthread_cond_init(cond, RT_NULL);
 
-    result = rt_sem_release(&(cond->sem));
-    if (result == RT_EOK)
+    /* disable interrupt */
+    temp = rt_hw_interrupt_disable();
+    if (rt_list_isempty(&cond->sem.parent.suspend_thread))
+    {
+        /* enable interrupt */
+        rt_hw_interrupt_enable(temp);
         return 0;
+    }
+    else
+    {
+        /* enable interrupt */
+        rt_hw_interrupt_enable(temp);
+        result = rt_sem_release(&(cond->sem));
+        if (result == RT_EOK)
+        {
+            return 0;
+        }
 
-    return 0;
+        return 0;
+    }
 }
 RTM_EXPORT(pthread_cond_signal);
 
-rt_err_t _pthread_cond_timedwait(pthread_cond_t  *cond,
+rt_err_t _pthread_cond_timedwait(pthread_cond_t *cond,
                                  pthread_mutex_t *mutex,
-                                 rt_int32_t       timeout)
+                                 rt_int32_t timeout)
 {
-    rt_err_t result;
+    rt_err_t result = RT_EOK;
+    rt_sem_t sem;
+    rt_int32_t time;
+
+    sem = &(cond->sem);
+    if (sem == RT_NULL)
+    {
+        return -RT_ERROR;
+    }
+    time = timeout;
 
     if (!cond || !mutex)
+    {
         return -RT_ERROR;
+    }
     /* check whether initialized */
     if (cond->attr == -1)
+    {
         pthread_cond_init(cond, RT_NULL);
+    }
 
     /* The mutex was not owned by the current thread at the time of the call. */
     if (mutex->lock.owner != rt_thread_self())
+    {
         return -RT_ERROR;
-    /* unlock a mutex failed */
-    if (pthread_mutex_unlock(mutex) != 0)
-        return -RT_ERROR;
+    }
 
-    result = rt_sem_take(&(cond->sem), timeout);
-    /* lock mutex again */
-    pthread_mutex_lock(mutex);
+    {
+        register rt_base_t temp;
+        struct rt_thread *thread;
+
+        /* parameter check */
+        RT_ASSERT(sem != RT_NULL);
+        RT_ASSERT(rt_object_get_type(&sem->parent.parent) == RT_Object_Class_Semaphore);
+
+        /* disable interrupt */
+        temp = rt_hw_interrupt_disable();
+
+        if (sem->value > 0)
+        {
+            /* semaphore is available */
+            sem->value--;
+
+            /* enable interrupt */
+            rt_hw_interrupt_enable(temp);
+        }
+        else
+        {
+            /* no waiting, return with timeout */
+            if (time == 0)
+            {
+                rt_hw_interrupt_enable(temp);
+
+                return -RT_ETIMEOUT;
+            }
+            else
+            {
+                /* current context checking */
+                RT_DEBUG_IN_THREAD_CONTEXT;
+
+                /* semaphore is unavailable, push to suspend list */
+                /* get current thread */
+                thread = rt_thread_self();
+
+                /* reset thread error number */
+                thread->error = RT_EOK;
+
+                /* suspend thread */
+                rt_thread_suspend(thread);
+
+                /* Only support FIFO */
+                rt_list_insert_before(&(sem->parent.suspend_thread), &(thread->tlist));
+
+                /**
+                rt_ipc_list_suspend(&(sem->parent.suspend_thread),
+                                    thread,
+                                    sem->parent.parent.flag);
+                */
+
+                /* has waiting time, start thread timer */
+                if (time > 0)
+                {
+                    /* reset the timeout of thread timer and start it */
+                    rt_timer_control(&(thread->thread_timer),
+                                     RT_TIMER_CTRL_SET_TIME,
+                                     &time);
+                    rt_timer_start(&(thread->thread_timer));
+                }
+
+                /* to avoid the lost of singal< cond->sem > */
+                if (pthread_mutex_unlock(mutex) != 0)
+                {
+                    return -RT_ERROR;
+                }
+
+                /* enable interrupt */
+                rt_hw_interrupt_enable(temp);
+
+                /* do schedule */
+                rt_schedule();
+
+                result = thread->error;
+
+                /* lock mutex again */
+                pthread_mutex_lock(mutex);
+            }
+        }
+    }
 
     return result;
 }
@@ -207,16 +330,26 @@ int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
 {
     rt_err_t result;
 
+__retry:
     result = _pthread_cond_timedwait(cond, mutex, RT_WAITING_FOREVER);
     if (result == RT_EOK)
+    {
         return 0;
+    }
+    else if (result == -RT_EINTR)
+    {
+        /* https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_cond_wait.html
+         * These functions shall not return an error code of [EINTR].
+         */
+        goto __retry;
+    }
 
     return EINVAL;
 }
 RTM_EXPORT(pthread_cond_wait);
 
-int pthread_cond_timedwait(pthread_cond_t        *cond,
-                           pthread_mutex_t       *mutex,
+int pthread_cond_timedwait(pthread_cond_t *cond,
+                           pthread_mutex_t *mutex,
                            const struct timespec *abstime)
 {
     int timeout;
@@ -225,11 +358,14 @@ int pthread_cond_timedwait(pthread_cond_t        *cond,
     timeout = rt_timespec_to_tick(abstime);
     result = _pthread_cond_timedwait(cond, mutex, timeout);
     if (result == RT_EOK)
+    {
         return 0;
+    }
     if (result == -RT_ETIMEOUT)
+    {
         return ETIMEDOUT;
+    }
 
     return EINVAL;
 }
 RTM_EXPORT(pthread_cond_timedwait);
-


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
 * have tested on real project.
 
-----

原 _pthread_cond_timewait 接口使用信号量来使线程处于挂起状态。

在通过 rt_mutex_release<pthread_mutex_unlock> 释放互斥锁时，在 rt_mutex_release 中，如果没有待唤醒的线程则跳过 rt_schedule；因此在 ```_pthread_cond_timedwait`` 中会紧接着获取释放掉的互斥锁，并同时被挂起。   
导致的现象就是尝试获取互斥锁的另一个线程被挂起，两个线程死锁无法执行。


而先释放互斥锁再挂起线程这个操作在 pthread_cond_timewait 里面是不允许存在的，在 pthread_cond_timewait 的挂起操作与互斥量的释放操作是不可被打断的。这个操作是一个原子操作，使用 rt_mutex_release 与 rt_sem_take 的组合操作不能做到这一点，所以需要将信号量挂起的逻辑移到 pthread_cond_timewait 中来解决这个问题。

----

 * 经过压力测试 48 小时后仍然正常

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
