### PR TITLE
[compoenets][driver][usb] fix usbhost hid issues.

### DIFF
--- a/components/drivers/usb/usbhost/class/hid.c
+++ b/components/drivers/usb/usbhost/class/hid.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/components/drivers/usb/usbhost/class/hid.c
+++ b/components/drivers/usb/usbhost/class/hid.c
@@ -47,9 +47,10 @@ rt_err_t rt_usbh_hid_set_idle(struct uhintf* intf, int duration, int report_id)
     setup.wValue = (duration << 8 )| report_id;
 
     if (rt_usb_hcd_setup_xfer(device->hcd, device->pipe_ep0_out, &setup, timeout) == 8)
-        return RT_EOK;
-    else
-        return -RT_FALSE;
+        if (rt_usb_hcd_pipe_xfer(device->hcd, device->pipe_ep0_in, RT_NULL, 0, timeout) == 0)
+            return RT_EOK;
+
+    return -RT_FALSE;
 }
 
 /**
@@ -341,7 +342,7 @@ static rt_err_t rt_usbh_hid_enable(void* arg)
         if(!(ep_desc->bEndpointAddress & USB_DIR_IN)) continue;
 
         ret = rt_usb_hcd_alloc_pipe(intf->device->hcd, &hid->pipe_in,
-            intf, ep_desc);
+            intf->device, ep_desc);
         if(ret != RT_EOK) return ret;
     }
 


### PR DESCRIPTION
1.Set idle function should receive an empty package.
2.Fix uinst_t reference error in hid enable function.

Signed-off-by: dengguiling <greens9@163.com>

## 拉取/合并请求描述：(PR description)

[
近日在RT-Thread上调试USB鼠标时，发现以下问题：
1.通过USB抓包PC连接鼠标，以及查询USB HID相关资料，发现HID set idle时，发送setup之后，Host需要接收一个空包。
[HID协议SET_IDLE请求的解释说明](http://www.usbzh.com/article/detail-825.html)

2.rt_usbh_hid_enable()函数里面，调用rt_usb_hcd_alloc_pipe()的传参存在错误，应为intf->device。
在mass.c中发现有正确使用，猜测为以前重构遗留问题。[mass.c#L572](https://github.com/RT-Thread/rt-thread/blob/2a8e92b8ee8bfe3b6984603cd8a2c444dc4d3039/components/drivers/usb/usbhost/class/mass.c#L572)

测试：在与STM32F4相同USB IP的开发板上测试，且修改问题比较简单，相关资料和抓包也佐证了修改。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
