### PR TITLE
[bsp] 修改 bsp touch 支持包,增加修改 touch address 选项，支持 ft6206 和 ft6336g 两种触摸IC选择

### DIFF
--- a/bsp/stm32/stm32f469-st-disco/board/Kconfig
+++ b/bsp/stm32/stm32f469-st-disco/board/Kconfig
@@ -72,6 +72,10 @@ menu "Onboard Peripheral Drivers"
             config BSP_TOUCH_INT_PIN
                 int "Touch interrupt pin"
                 default 149
+			comment "Notice: ft6206 is 42  , ft6336G is 56"
+			config BSP_TOUCH_ADDR
+				int "Touch I2C address"
+				default 42
             config BSP_I2C_NAME
                 string "I2C Bus Name"
                 default "i2c1"

--- a/bsp/stm32/stm32f469-st-disco/board/ports/touch/drv_touch_ft.c
+++ b/bsp/stm32/stm32f469-st-disco/board/ports/touch/drv_touch_ft.c
@@ -203,7 +203,7 @@ int ft_driver_register(void)
     /* TouchScreen FT6206 Slave I2C address is 0x54
      * 0x54 << 1 = 0x2A
      */
-    ft_driver.address = 0x2A;
+    ft_driver.address = BSP_TOUCH_ADDR;
     ft_driver.probe = ft_probe;
     ft_driver.ops = &ft_ops;
     ft_driver.user_data = RT_NULL;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修改 stm32f469-discovery bsp 包中触摸IC驱动 ,menuconfig 中增加修改 touch address 选项，支持 ft6206 和 ft6336g 两种触摸IC

之前的BSP中触摸驱动只支持 ft6206 触摸IC,由于 stm32f469-discovery 开发板有一部分使用的是FT6336G 触摸IC，因此需要修改 BSP 相关驱动，增加对 FT6336G支持。

新增的 Kconfig 部分主要用于配置触摸IC的IIC总线地址，并做了不同驱动IC的IIC地址的说明。

已经在 STM32F469-Discovery 开发板上面验证 FT6336-G工作正常
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
