### PR TITLE
Revert "解决将RT_NULL当做数字0使用的问题"

### DIFF
--- a/components/finsh/msh_file.c
+++ b/components/finsh/msh_file.c
@@ -608,7 +608,7 @@ MSH_CMD_EXPORT_ALIAS(cmd_echo, echo, echo string to file);
 static int cmd_tail(int argc, char **argv)
 {
     int fd;
-    char c = '\0';
+    char c = RT_NULL;
     char *file_name = RT_NULL;
     rt_uint32_t total_lines = 0;
     rt_uint32_t target_line = 0;

--- a/components/libc/compilers/common/ctime.c
+++ b/components/libc/compilers/common/ctime.c
@@ -180,7 +180,7 @@ struct tm *gmtime_r(const time_t *timep, struct tm *r)
         return RT_NULL;
     }
 
-    rt_memset(r, 0, sizeof(struct tm));
+    rt_memset(r, RT_NULL, sizeof(struct tm));
 
     r->tm_sec = work % 60;
     work /= 60;
@@ -258,7 +258,7 @@ char* asctime_r(const struct tm *t, char *buf)
         return RT_NULL;
     }
 
-    rt_memset(buf, 0, 26);
+    rt_memset(buf, RT_NULL, 26);
 
     /* Checking input validity */
     if ((int)rt_strlen(days) <= (t->tm_wday << 2) || (int)rt_strlen(months) <= (t->tm_mon << 2))

--- a/components/libc/posix/pthreads/pthread.c
+++ b/components/libc/posix/pthreads/pthread.c
@@ -136,7 +136,7 @@ void _pthread_data_destroy(_pthread_data_t *ptd)
         ptd->magic = 0x0;
 
         /* clear the "ptd->tid->user_data" */
-        ptd->tid->user_data = 0;
+        ptd->tid->user_data = RT_NULL;
 
         /* free ptd */
         rt_free(ptd);

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -123,11 +123,7 @@ typedef rt_base_t                       rt_off_t;       /**< Type for offset */
 #define RT_FALSE                        0               /**< boolean fails */
 
 /* null pointer definition */
-#ifdef RT_USING_LIBC
-#define RT_NULL                         NULL            /**< null pointer */
-#else
-#define RT_NULL                         (0)             /**< null pointer */
-#endif /* RT_USING_LIBC */
+#define RT_NULL                         0
 
 /**@}*/
 


### PR DESCRIPTION
This reverts commit 6a05ddf63d1202456a37e970e5a9ab58370ed093.

## 拉取/合并请求描述：(PR description)

[

#6123

这个地方过分区分0指针或者0值，会在GCC编译器出现大面积警告。经过进一步研究，Keil IAR对NULL的定义是数值0，但是GCC对此处要求比较严格，是指针0，会潜在导致大面积使用RT_NULL的程序报警。

查找其他资料，发现NULL定义成0也比较普遍，因此revert对此处的修改。

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
