### PR TITLE
[phy] fix the PHY_FULL_DUPLEX conflicts

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_eth.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_eth.c
@@ -30,6 +30,11 @@
 
 #define MAX_ADDR_LEN 6
 
+#undef PHY_FULL_DUPLEX
+#define PHY_LINK         (1 << 0)
+#define PHY_100M         (1 << 1)
+#define PHY_FULL_DUPLEX  (1 << 2)
+
 struct rt_stm32_eth
 {
     /* inherit from ethernet device */
@@ -400,12 +405,6 @@ void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth)
 {
     LOG_E("eth err");
 }
-
-enum {
-    PHY_LINK        = (1 << 0),
-    PHY_100M        = (1 << 1),
-    PHY_FULL_DUPLEX = (1 << 2),
-};
 
 static void phy_linkchange()
 {

--- a/bsp/stm32/stm32mp157a-st-discovery/board/ports/drv_eth.c
+++ b/bsp/stm32/stm32mp157a-st-discovery/board/ports/drv_eth.c
@@ -22,6 +22,15 @@
 #define LOG_TAG             "drv.emac"
 #include <drv_log.h>
 
+#undef PHY_FULL_DUPLEX
+#undef PHY_HALF_DUPLEX
+#define PHY_LINK        (1 << 0)
+#define PHY_10M         (1 << 1)
+#define PHY_100M        (1 << 2)
+#define PHY_1000M       (1 << 3)
+#define PHY_FULL_DUPLEX (1 << 4)
+#define PHY_HALF_DUPLEX (1 << 5)
+
 #define MAX_ADDR_LEN 6
 rt_base_t level;
 

--- a/bsp/stm32/stm32mp157a-st-discovery/board/ports/drv_eth.h
+++ b/bsp/stm32/stm32mp157a-st-discovery/board/ports/drv_eth.h
@@ -50,16 +50,6 @@ typedef struct
    uint32_t rdes3;
 } RxDmaDesc;
 
-enum {
-    PHY_LINK        = (1 << 0),
-    PHY_10M         = (1 << 1),
-    PHY_100M        = (1 << 2),
-    PHY_1000M       = (1 << 3),
-    PHY_FULL_DUPLEX = (1 << 4),
-    PHY_HALF_DUPLEX = (1 << 5)
-};
-
-
 #define RTL8211F_PHY_ADDR       1           /* PHY address */
 
 #define ETH_TXBUFNB             4           /* 4 Tx buffers of size ETH_TX_BUF_SIZE */

--- a/bsp/stm32/stm32mp157a-st-ev1/board/ports/eth/drv_eth.c
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/ports/eth/drv_eth.c
@@ -30,6 +30,15 @@ rt_base_t level;
 #define TX_DMA_ADD_BASE     0x2FFC7000
 #define RX_DMA_ADD_BASE     0x2FFC7100
 
+#undef PHY_FULL_DUPLEX
+#undef PHY_HALF_DUPLEX
+#define PHY_LINK        (1 << 0)
+#define PHY_10M         (1 << 1)
+#define PHY_100M        (1 << 2)
+#define PHY_1000M       (1 << 3)
+#define PHY_FULL_DUPLEX (1 << 4)
+#define PHY_HALF_DUPLEX (1 << 5)
+
 #if defined(__ICCARM__)
 /* transmit buffer */
 #pragma location = TX_ADD_BASE

--- a/bsp/stm32/stm32mp157a-st-ev1/board/ports/eth/drv_eth.h
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/ports/eth/drv_eth.h
@@ -42,15 +42,6 @@ typedef struct
     uint32_t rdes3;
 } RxDmaDesc;
 
-enum {
-    PHY_LINK        = (1 << 0),
-    PHY_10M         = (1 << 1),
-    PHY_100M        = (1 << 2),
-    PHY_1000M       = (1 << 3),
-    PHY_FULL_DUPLEX = (1 << 4),
-    PHY_HALF_DUPLEX = (1 << 5)
-};
-
 #define RTL8211E_PHY_ADDR       7           /* PHY address */
 
 #define ETH_TXBUFNB             4           /* 4 Tx buffers of size ETH_TX_BUF_SIZE */

--- a/components/drivers/include/drivers/phy.h
+++ b/components/drivers/include/drivers/phy.h
@@ -19,52 +19,34 @@ extern "C"
 #endif
 
 /* Defines the PHY link speed. This is align with the speed for MAC. */
-enum phy_speed
-{
-    PHY_SPEED_10M = 0U, /* PHY 10M speed. */
-    PHY_SPEED_100M      /* PHY 100M speed. */
-};
+#define PHY_SPEED_10M   0U     /* PHY 10M speed. */
+#define PHY_SPEED_100M  1U     /* PHY 100M speed. */
 
 /* Defines the PHY link duplex. */
-enum phy_duplex
-{
-    PHY_HALF_DUPLEX = 0U, /* PHY half duplex. */
-    PHY_FULL_DUPLEX       /* PHY full duplex. */
-};
+#define PHY_HALF_DUPLEX 0U     /* PHY half duplex. */
+#define PHY_FULL_DUPLEX 1U     /* PHY full duplex. */
 
 /*! @brief Defines the PHY loopback mode. */
-enum phy_loop
-{
-    PHY_LOCAL_LOOP = 0U, /* PHY local loopback. */
-    PHY_REMOTE_LOOP      /* PHY remote loopback. */
-};
+#define PHY_LOCAL_LOOP  0U     /* PHY local loopback. */
+#define PHY_REMOTE_LOOP 1U     /* PHY remote loopback. */
 
+#define PHY_STATUS_OK      0U
+#define PHY_STATUS_FAIL    1U
+#define PHY_STATUS_TIMEOUT 2U
 
-struct rt_phy_msg
+typedef struct rt_phy_msg
 {
     rt_uint32_t reg;
     rt_uint32_t value;
-};
+}rt_phy_msg_t;
 
-typedef struct rt_phy_msg rt_phy_msg_t;
-
-
-struct rt_phy_device
+typedef struct rt_phy_device
 {
     struct rt_device parent;
     struct rt_mdio_bus *bus;
     rt_uint32_t addr;
     struct rt_phy_ops *ops;
-};
-
-typedef struct rt_phy_device rt_phy_t;
-
-
-enum {
-    PHY_STATUS_OK = 0,
-    PHY_STATUS_FAIL,
-    PHY_STATUS_TIMEOUT,
-};
+}rt_phy_t;
 
 typedef rt_int32_t rt_phy_status;
 

--- a/components/drivers/phy/phy.c
+++ b/components/drivers/phy/phy.c
@@ -31,8 +31,6 @@ static rt_size_t phy_device_write(rt_device_t dev, rt_off_t pos, const void *buf
     return phy->bus->ops->write(phy->bus, phy->addr, msg->reg, &(msg->value), 4);
 }
 
-
-
 #ifdef RT_USING_DEVICE_OPS
 const static struct rt_device_ops phy_ops =
 {


### PR DESCRIPTION
https://github.com/RT-Thread/rt-thread/issues/6021
https://github.com/RT-Thread/rt-thread/issues/5700
报告

将枚举体转为宏定义的方式，通过#undef来防止冲突，.c内部使用自己重定义的PHY_FULL_DUPLEX 
冲突的问题目前只发生在stm32身上，因为stm32 的PHY_FULL_DUPLEX 使用的是自己定义的一套，没有用phy框架的