### PR TITLE
Added LCD Touch Int pin to ioconfig. During testing GT911 would not c…

### DIFF
--- a/bsp/imxrt/imxrt1060-nxp-evk/board/board.c
+++ b/bsp/imxrt/imxrt1060-nxp-evk/board/board.c
@@ -450,6 +450,9 @@ static void imxrt_lcd_pins_init(void)
         IOMUXC_GPIO_AD_B0_02_GPIO1_IO02, /* GPIO_AD_B0_02 is configured as GPIO1_IO02 */
         0U);                             /* Software Input On Field: Input Path is determined by functionality */
     IOMUXC_SetPinMux(
+        IOMUXC_GPIO_AD_B0_11_GPIO1_IO11, /* GPIO_AD_B0_11 is configured as GPIO1_IO11 */
+        0U);                             /* Software Input On Field: Input Path is determined by functionality */
+    IOMUXC_SetPinMux(
         IOMUXC_GPIO_B1_15_GPIO2_IO31, /* GPIO_B1_15 is configured as GPIO2_IO31 */
         0U);                          /* Software Input On Field: Input Path is determined by functionality */
     IOMUXC_SetPinMux(
@@ -514,6 +517,16 @@ static void imxrt_lcd_pins_init(void)
         0U);                          /* Software Input On Field: Input Path is determined by functionality */
     IOMUXC_SetPinConfig(
         IOMUXC_GPIO_AD_B0_02_GPIO1_IO02, /* GPIO_AD_B0_02 PAD functional properties : */
+        0x10B0u);                        /* Slew Rate Field: Slow Slew Rate
+                                                 Drive Strength Field: R0/6
+                                                 Speed Field: medium(100MHz)
+                                                 Open Drain Enable Field: Open Drain Disabled
+                                                 Pull / Keep Enable Field: Pull/Keeper Enabled
+                                                 Pull / Keep Select Field: Keeper
+                                                 Pull Up / Down Config. Field: 100K Ohm Pull Down
+                                                 Hyst. Enable Field: Hysteresis Disabled */
+    IOMUXC_SetPinConfig(
+        IOMUXC_GPIO_AD_B0_11_GPIO1_IO11, /* GPIO_AD_B0_11 PAD functional properties : */
         0x10B0u);                        /* Slew Rate Field: Slow Slew Rate
                                                  Drive Strength Field: R0/6
                                                  Speed Field: medium(100MHz)


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

[
During power-up sequence the Interrupt pin tied to the touch controller on the MIMXRT1060-EVKB floats and does not properly reset the GT911 controller. Failure of the touch controller to complete initialization prevents the LCD and subsequently LVGL from loading and executing.

The issue is that the INT pin is not configured during the initialization sequence. This PR corrects that issue and configures the INT pin.

This was tested on the MIMXRT1060-EVKB eval board with a Rocktech RK043FN66HS-CTG. The unit correctly exists reset and the display shows the expected code. This was confirmed using a logic analyzer and the timing of the signals matches that of the MCUXpresso IDE demo project.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
