### PR TITLE
Fix armclang error when enable LTO

### DIFF
--- a/libcpu/arm/cortex-m3/cpuport.c
+++ b/libcpu/arm/cortex-m3/cpuport.c
@@ -389,12 +389,12 @@ exit
 int __rt_ffs(int value)
 {
     __asm volatile(
-        "CMP     r0, #0x00            \n"
+        "CMP     %1, #0x00            \n"
         "BEQ     1f                   \n"
 
-        "RBIT    r0, r0               \n"
-        "CLZ     r0, r0               \n"
-        "ADDS    r0, r0, #0x01        \n"
+        "RBIT    %1, %1               \n"
+        "CLZ     %0, %1               \n"
+        "ADDS    %0, %0, #0x01        \n"
 
         "1:                           \n"
 

--- a/libcpu/arm/cortex-m4/cpuport.c
+++ b/libcpu/arm/cortex-m4/cpuport.c
@@ -474,11 +474,11 @@ exit
 int __rt_ffs(int value)
 {
     __asm volatile(
-        "CMP     %0, #0x00            \n"
+        "CMP     %1, #0x00            \n"
         "BEQ     1f                   \n"
 
-        "RBIT    %0, %0               \n"
-        "CLZ     %0, %0               \n"
+        "RBIT    %1, %1               \n"
+        "CLZ     %0, %1               \n"
         "ADDS    %0, %0, #0x01        \n"
 
         "1:                           \n"

--- a/libcpu/arm/cortex-m7/cpuport.c
+++ b/libcpu/arm/cortex-m7/cpuport.c
@@ -473,12 +473,12 @@ exit
 int __rt_ffs(int value)
 {
     __asm volatile(
-        "CMP     r0, #0x00            \n"
+        "CMP     %1, #0x00            \n"
         "BEQ     1f                   \n"
 
-        "RBIT    r0, r0               \n"
-        "CLZ     r0, r0               \n"
-        "ADDS    r0, r0, #0x01        \n"
+        "RBIT    %1, %1               \n"
+        "CLZ     %0, %1               \n"
+        "ADDS    %0, %0, #0x01        \n"
 
         "1:                           \n"
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
当 armclang 开启 LTO 时，`__rt_ffs()`  会被内联，导致不一定会从 `r0` 中获取返回值。当在 C 语言中嵌入汇编时，应使用 `%[value]` 进行输入和输出操作数的替换。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
