### PR TITLE
[completion]fix completion init flag to RT_COMPLETED.

### DIFF
--- a/components/drivers/ipc/completion.c
+++ b/components/drivers/ipc/completion.c
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2012-09-30     Bernard      first version.
  * 2021-08-18     chenyingchun add comments
+ * 2022-08-04     zjh          fix completion init flag to RT_COMPLETED.
  */
 
 #include <rthw.h>
@@ -27,7 +28,7 @@ void rt_completion_init(struct rt_completion *completion)
     RT_ASSERT(completion != RT_NULL);
 
     level = rt_hw_interrupt_disable();
-    completion->flag = RT_UNCOMPLETED;
+    completion->flag = RT_COMPLETED;
     rt_list_init(&completion->suspended_list);
     rt_hw_interrupt_enable(level);
 }
@@ -64,11 +65,12 @@ rt_err_t rt_completion_wait(struct rt_completion *completion,
     thread = rt_thread_self();
 
     level = rt_hw_interrupt_disable();
-    if (completion->flag != RT_COMPLETED)
+    if (completion->flag != RT_UNCOMPLETED)
     {
         /* only one thread can suspend on complete */
         RT_ASSERT(rt_list_isempty(&(completion->suspended_list)));
-
+		/* clean completed flag */
+		completion->flag = RT_UNCOMPLETED;
         if (timeout == 0)
         {
             result = -RT_ETIMEOUT;
@@ -106,8 +108,6 @@ rt_err_t rt_completion_wait(struct rt_completion *completion,
             level = rt_hw_interrupt_disable();
         }
     }
-    /* clean completed flag */
-    completion->flag = RT_UNCOMPLETED;
 
 __exit:
     rt_hw_interrupt_enable(level);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
问题：在用can发送时，如果人为让can断路或者短路再恢复，超过4次时，在发送时，虽然接收端有收到，但是，发送端提示失败。
查找：在单步调试时，发现can发送后，在rt_completion_wait函数里直接返回，而没有等待can中断内的rt_completion_done完成。导致can发送标志没有更新而产生错误。
处理：修改rt_completion_init函数内completion->flag = RT_COMPLETED并且在rt_completion_wait内修改只有在completion->flag！=RT_UNCOMPLETED才清completion->flag = RT_UNCOMPLETED;
在芯片AT32F403A测试通过。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
