### PR TITLE
[armclang] 使用__clang__代替__CLANG_ARM

### DIFF
--- a/bsp/Vango/v85xxp/drivers/board.h
+++ b/bsp/Vango/v85xxp/drivers/board.h
@@ -19,7 +19,7 @@
 #define V85XX_SRAM_END          (0x20000000 + V85XX_SRAM_SIZE * 1024)
 
 
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
+#if defined(__ARMCC_VERSION)
 extern int Image$$RW_IRAM1$$ZI$$Limit;
 #define HEAP_BEGIN  (&Image$$RW_IRAM1$$ZI$$Limit)
 #elif __ICCARM__

--- a/bsp/imxrt/imxrt1021-nxp-evk/board/board.h
+++ b/bsp/imxrt/imxrt1021-nxp-evk/board/board.h
@@ -15,7 +15,7 @@
 #include "fsl_common.h"
 #include "clock_config.h"
 #define SOC_IMXRT1020_SERIES
-#if defined(__CC_ARM) || defined (__CLANG_ARM) || defined (__CLANG_ARM)
+#if defined(__ARMCC_VERSION)
 extern int Image$$RTT_HEAP$$ZI$$Base;
 extern int Image$$RTT_HEAP$$ZI$$Limit;
 #define HEAP_BEGIN          (&Image$$RTT_HEAP$$ZI$$Base)

--- a/bsp/microchip/samc21/board/board.c
+++ b/bsp/microchip/samc21/board/board.c
@@ -73,7 +73,7 @@ void rt_hw_board_init(void)
     NVIC_SetPriority(PendSV_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
 
 #ifdef RT_USING_HEAP
-    #if defined(__CC_ARM) || defined(__CLANG_ARM)
+    #if defined(__ARMCC_VERSION)
         rt_system_heap_init((void*)&Image$$RW_IRAM1$$ZI$$Limit, (void*)HEAP_END);
     #elif __ICCARM__
         rt_system_heap_init((void*)HEAP_BEGIN, (void*)HEAP_END);

--- a/bsp/microchip/samc21/board/board.h
+++ b/bsp/microchip/samc21/board/board.h
@@ -46,7 +46,7 @@
 
 #define SAMC21_SRAM_END        (0x20000000 + SAMC21_SRAM_SIZE * 1024)
 
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
+#if defined(__ARMCC_VERSION)
 extern int Image$$RW_IRAM1$$ZI$$Limit;
 #define HEAP_BEGIN    (&Image$$RW_IRAM1$$ZI$$Limit)
 #elif __ICCARM__

--- a/bsp/microchip/same54/board/board.c
+++ b/bsp/microchip/same54/board/board.c
@@ -75,7 +75,7 @@ void rt_hw_board_init(void)
     NVIC_SetPriority(PendSV_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
 
 #ifdef RT_USING_HEAP
-    #if defined(__CC_ARM) || defined(__CLANG_ARM)
+    #if defined(__ARMCC_VERSION)
         rt_system_heap_init((void*)&Image$$RW_IRAM1$$ZI$$Limit, (void*)HEAP_END);
     #elif __ICCARM__
         rt_system_heap_init((void*)HEAP_BEGIN, (void*)HEAP_END);

--- a/bsp/microchip/same54/board/board.h
+++ b/bsp/microchip/same54/board/board.h
@@ -60,7 +60,7 @@
 
 #define SAME5x_SRAM_END      (0x20000000 + SAME5x_SRAM_SIZE * 1024)
 
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
+#if defined(__ARMCC_VERSION)
 extern int Image$$RW_IRAM1$$ZI$$Limit;
 #define HEAP_BEGIN    (&Image$$RW_IRAM1$$ZI$$Limit)
 #elif __ICCARM__

--- a/bsp/microchip/same70/board/board.c
+++ b/bsp/microchip/same70/board/board.c
@@ -78,7 +78,7 @@ void rt_hw_board_init(void)
     NVIC_SetPriority(PendSV_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
 
 #ifdef RT_USING_HEAP
-    #if defined(__CC_ARM) || defined(__CLANG_ARM)
+    #if defined(__ARMCC_VERSION)
         rt_system_heap_init((void*)&Image$$RW_IRAM1$$ZI$$Limit, (void*)HEAP_END);
     #elif __ICCARM__
         rt_system_heap_init((void*)HEAP_BEGIN, (void*)HEAP_END);

--- a/bsp/microchip/same70/board/board.h
+++ b/bsp/microchip/same70/board/board.h
@@ -92,7 +92,7 @@
 
 #define SAME70_SRAM_END    (0x20400000 + SAME70_SRAM_SIZE * 1024)
 
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
+#if defined(__ARMCC_VERSION)
 extern int Image$$RW_IRAM1$$ZI$$Limit;
 #define HEAP_BEGIN    (&Image$$RW_IRAM1$$ZI$$Limit)
 #elif __ICCARM__

--- a/bsp/microchip/saml10/board/board.c
+++ b/bsp/microchip/saml10/board/board.c
@@ -73,7 +73,7 @@ void rt_hw_board_init(void)
     NVIC_SetPriority(PendSV_IRQn, (1 << __NVIC_PRIO_BITS) - 1);
 
 #ifdef RT_USING_HEAP
-    #if defined(__CC_ARM) || defined(__CLANG_ARM)
+    #if defined(__ARMCC_VERSION)
         rt_system_heap_init((void*)&Image$$RW_IRAM1$$ZI$$Limit, (void*)HEAP_END);
     #elif __ICCARM__
         rt_system_heap_init((void*)HEAP_BEGIN, (void*)HEAP_END);

--- a/bsp/microchip/saml10/board/board.h
+++ b/bsp/microchip/saml10/board/board.h
@@ -30,7 +30,7 @@
 
 #define SAML10_SRAM_END        (0x20000000 + SAML10_SRAM_SIZE * 1024)
 
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
+#if defined(__ARMCC_VERSION)
 extern int Image$$RW_IRAM1$$ZI$$Limit;
 #define HEAP_BEGIN    (&Image$$RW_IRAM1$$ZI$$Limit)
 #elif __ICCARM__

--- a/bsp/wch/arm/ch579m/board/board.h
+++ b/bsp/wch/arm/ch579m/board/board.h
@@ -21,7 +21,7 @@
 #define CH579M_SRAM_SIZE      32
 #define CH579M_SRAM_END       (0x20000000 + CH579M_SRAM_SIZE * 1024)
 
-#if defined(__CC_ARM) || defined(__CLANG_ARM)
+#if defined(__ARMCC_VERSION)
 extern int Image$$RW_IRAM1$$ZI$$Limit;
 #define HEAP_BEGIN      ((void *)&Image$$RW_IRAM1$$ZI$$Limit)
 #elif __ICCARM__


### PR DESCRIPTION
attach https://github.com/RT-Thread/rt-thread/pull/5451

## 拉取/合并请求描述：(PR description)

[
这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
