### PR TITLE
[armlibc] 解决fflush失效的问题

### DIFF
--- a/components/libc/compilers/armlibc/syscalls.c
+++ b/components/libc/compilers/armlibc/syscalls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -226,6 +226,11 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
         size = write(fh, buf, len);
         if (size >= 0)
         {
+            /*
+            fflush doesn't have a good solution in Keil-MDK,
+            so it has to sync/flush when for each writen.
+            */
+            fsync(fh);
             return len - size; /* success */
         }
         else
@@ -237,6 +242,18 @@ int _sys_write(FILEHANDLE fh, const unsigned char *buf, unsigned len, int mode)
         return 0; /* error */
 #endif /* DFS_USING_POSIX */
     }
+}
+
+/*
+ * Flush any OS buffers associated with fh, ensuring that the file
+ * is up to date on disk. Result is >=0 if OK, negative for an
+ * error.
+ * This function is deprecated. It is never called by any other library function,
+ * and you are not required to re-implement it if you are retargeting standard I/O (stdio).
+ */
+int _sys_ensure(FILEHANDLE fh)
+{
+    return fsync(fh);
 }
 
 /*


### PR DESCRIPTION
该问题在Keil-MDK中没有一个太好的解决方案。本PR为权衡利弊之后得到的一套解决方案。Keil曾经提供了底层桩函数_sys_ensure，但是目前已经被废弃。因此唯一的解决方案就是每写完一句，就调用fsync去同步一次。
该问题在mbedos社区也进行过讨论，他们也面临和我们相同的两个问题：
1. Keil-MDK无有效的fflush解决方案，mbedos依然在使用淘汰的_sys_ensure桩函数。
2. Keil-MDK没有fileno函数，我方少部分软件包因此而无法使用Keil平台编译。
参考：https://github.com/ARMmbed/mbed-os/issues/1601

issue: https://github.com/RT-Thread/rt-thread/issues/4928


经过进一步测试发现，Keil-MDK中的fflush函数已经退化成服务于STDOUT的函数，Keil-MDK内部有一个buffer可以存放fputc(stdout) 发过来的数据，如果调用fflush，这些数据是可以flush出去的。但是如果是真正的文件数据，fflush函数并没有提供任何桩函数接口可以让文件flush数据出去。

## 拉取/合并请求描述：(PR description)

[
这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
