### PR TITLE
解决控制台无法输入bug

### DIFF
--- a/src/kservice.c
+++ b/src/kservice.c
@@ -1175,7 +1175,7 @@ void rt_kputs(const char *str)
 
         _console_device->open_flag |= RT_DEVICE_FLAG_STREAM;
         rt_device_write(_console_device, 0, str, rt_strlen(str));
-        _console_device->open_flag = old_flag;
+        _console_device->open_flag ^= (~old_flag & RT_DEVICE_FLAG_STREAM);
     }
 #else
     rt_hw_console_output(str);
@@ -1213,7 +1213,7 @@ void rt_kprintf(const char *fmt, ...)
 
         _console_device->open_flag |= RT_DEVICE_FLAG_STREAM;
         rt_device_write(_console_device, 0, rt_log_buf, length);
-        _console_device->open_flag = old_flag;
+        _console_device->open_flag ^= (~old_flag & RT_DEVICE_FLAG_STREAM);
     }
 #else
     rt_hw_console_output(rt_log_buf);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
```
        rt_uint16_t old_flag = _console_device->open_flag;

        _console_device->open_flag |= RT_DEVICE_FLAG_STREAM;
        rt_device_write(_console_device, 0, str, rt_strlen(str));
        _console_device->open_flag = old_flag;
```

当一个线程正在执行 rt_device_write(_console_device, 0, str, rt_strlen(str));函数时，一个高优先级线程抢占当前线程并修改 _console_device->open_flag（修改为RT_DEVICE_FLAG_INT_RX，之前不是中断接收），高优先级线程执行完后，继续执行以前线程，此时old_flag与_console_device->open_flag不一致，执行_console_device->open_flag = old_flag;后_console_device->open_flag新的值被覆盖。控制台串口实际配置成硬件中断接收，因为_console_device->open_flag值被修改为不是中断，最后导致控制台串口无法接收任何数据输入。


]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
