### PR TITLE
Update kservice.c

### DIFF
--- a/src/kservice.c
+++ b/src/kservice.c
@@ -154,6 +154,8 @@ RT_WEAK void *rt_memset(void *s, int c, rt_ubase_t count)
 #define UNALIGNED(X)    ((long)X & (LBLOCKSIZE - 1))
 #define TOO_SMALL(LEN)  ((LEN) < LBLOCKSIZE)
 
+    RT_ASSERT(LBLOCKSIZE == 2 || LBLOCKSIZE == 4 || LBLOCKSIZE == 8);
+
     char *m = (char *)s;
     unsigned long buffer;
     unsigned long *aligned_addr;

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -168,7 +168,18 @@ RT_WEAK void *rt_memset(void *s, int c, rt_ubase_t count)
         /* Store d into each char sized location in buffer so that
          * we can set large blocks quickly.
          */
-        if (LBLOCKSIZE == 4)
+        if (LBLOCKSIZE == 8)
+        {
+            *(((unsigned char *)&buffer)+0) = d;
+            *(((unsigned char *)&buffer)+1) = d;
+            *(((unsigned char *)&buffer)+2) = d;
+            *(((unsigned char *)&buffer)+3) = d;
+            *(((unsigned char *)&buffer)+4) = d;
+            *(((unsigned char *)&buffer)+5) = d;
+            *(((unsigned char *)&buffer)+6) = d;
+            *(((unsigned char *)&buffer)+7) = d;
+        }
+        else if (LBLOCKSIZE == 4)
         {
             *(((unsigned char *)&buffer)+0) = d;
             *(((unsigned char *)&buffer)+1) = d;
@@ -611,7 +622,7 @@ void rt_show_version(void)
     rt_kprintf("\n \\ | /\n");
     rt_kprintf("- RT -     Thread Operating System\n");
     rt_kprintf(" / | \\     %d.%d.%d build %s %s\n",
-               RT_VERSION, RT_SUBVERSION, RT_REVISION, __DATE__, __TIME__);
+               (rt_int32_t)RT_VERSION, (rt_int32_t)RT_SUBVERSION, (rt_int32_t)RT_REVISION, __DATE__, __TIME__);
     rt_kprintf(" 2006 - 2022 Copyright by RT-Thread team\n");
 }
 RTM_EXPORT(rt_show_version);

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -21,8 +21,7 @@
  * 2021-12-20     Meco Man     implement rt_strcpy()
  * 2022-01-07     Gabriel      add __on_rt_assert_hook
  * 2022-06-04     Meco Man     remove strnlen
- * 2022-06-21     Yunjie       make rt_memset word-independent to adapt to 16bit addressing
- * 2022-08-11     Yunjie       rt_vsnprintf fix argument passing for 16bit, and remove redundant sign conversion
+ * 2022-08-24     Yunjie       make rt_memset word-independent to adapt to ti c28x (16bit word)
  */
 
 #include <rtthread.h>
@@ -150,7 +149,7 @@ RT_WEAK void *rt_memset(void *s, int c, rt_ubase_t count)
 
     return s;
 #else
-#define LBLOCKSIZE      (sizeof(long))
+#define LBLOCKSIZE      (sizeof(rt_ubase_t))
 #define UNALIGNED(X)    ((long)X & (LBLOCKSIZE - 1))
 #define TOO_SMALL(LEN)  ((LEN) < LBLOCKSIZE)
 
@@ -1074,21 +1073,17 @@ RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list arg
 #endif /* RT_KPRINTF_USING_LONGLONG */
         {
             num = va_arg(args, rt_uint32_t);
+            if (flags & SIGN) num = (rt_int32_t)num;
         }
         else if (qualifier == 'h')
         {
-            /*for arm gcc, args are aligned to 32bit.
-              for Ti C28x, args are aligned to 16bit.
-              Therefore we use int here to adapt to both archs. */
-
-            if (flags & SIGN)
-                num = (rt_int32_t)va_arg(args, int);
-            else
-                num = (rt_uint32_t)va_arg(args, unsigned int);
+            num = (rt_uint16_t)va_arg(args, rt_int32_t);
+            if (flags & SIGN) num = (rt_int16_t)num;
         }
         else
         {
             num = va_arg(args, rt_uint32_t);
+            if (flags & SIGN) num = (rt_int32_t)num;
         }
 #ifdef RT_PRINTF_PRECISION
         str = print_number(str, end, num, base, field_width, precision, flags);

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -154,13 +154,14 @@ RT_WEAK void *rt_memset(void *s, int c, rt_ubase_t count)
 #define UNALIGNED(X)    ((long)X & (LBLOCKSIZE - 1))
 #define TOO_SMALL(LEN)  ((LEN) < LBLOCKSIZE)
 
-    RT_ASSERT(LBLOCKSIZE == 2 || LBLOCKSIZE == 4 || LBLOCKSIZE == 8);
-
+    unsigned int i;
     char *m = (char *)s;
     unsigned long buffer;
     unsigned long *aligned_addr;
     unsigned char d = (unsigned int)c & (unsigned char)(-1);  /* To avoid sign extension, copy C to an
                                 unsigned variable. (unsigned)((char)(-1))=0xFF for 8bit and =0xFFFF for 16bit: word independent */
+
+    RT_ASSERT(LBLOCKSIZE == 2 || LBLOCKSIZE == 4 || LBLOCKSIZE == 8);
 
     if (!TOO_SMALL(count) && !UNALIGNED(s))
     {
@@ -170,28 +171,9 @@ RT_WEAK void *rt_memset(void *s, int c, rt_ubase_t count)
         /* Store d into each char sized location in buffer so that
          * we can set large blocks quickly.
          */
-        if (LBLOCKSIZE == 8)
+        for (i = 0; i < LBLOCKSIZE; i++)
         {
-            *(((unsigned char *)&buffer)+0) = d;
-            *(((unsigned char *)&buffer)+1) = d;
-            *(((unsigned char *)&buffer)+2) = d;
-            *(((unsigned char *)&buffer)+3) = d;
-            *(((unsigned char *)&buffer)+4) = d;
-            *(((unsigned char *)&buffer)+5) = d;
-            *(((unsigned char *)&buffer)+6) = d;
-            *(((unsigned char *)&buffer)+7) = d;
-        }
-        else if (LBLOCKSIZE == 4)
-        {
-            *(((unsigned char *)&buffer)+0) = d;
-            *(((unsigned char *)&buffer)+1) = d;
-            *(((unsigned char *)&buffer)+2) = d;
-            *(((unsigned char *)&buffer)+3) = d;
-        }
-        else if (LBLOCKSIZE == 2)
-        {
-            *(((unsigned char *)&buffer)+0) = d;
-            *(((unsigned char *)&buffer)+1) = d;
+            *(((unsigned char *)&buffer)+i) = d;
         }
 
         while (count >= LBLOCKSIZE * 4)

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -21,6 +21,8 @@
  * 2021-12-20     Meco Man     implement rt_strcpy()
  * 2022-01-07     Gabriel      add __on_rt_assert_hook
  * 2022-06-04     Meco Man     remove strnlen
+ * 2022-06-21     Yunjie       make rt_memset word-independent to adapt to 16bit addressing
+ * 2022-08-11     Yunjie       rt_vsnprintf fix argument passing for 16bit, and remove redundant sign conversion
  */
 
 #include <rtthread.h>
@@ -152,12 +154,11 @@ RT_WEAK void *rt_memset(void *s, int c, rt_ubase_t count)
 #define UNALIGNED(X)    ((long)X & (LBLOCKSIZE - 1))
 #define TOO_SMALL(LEN)  ((LEN) < LBLOCKSIZE)
 
-    unsigned int i;
     char *m = (char *)s;
     unsigned long buffer;
     unsigned long *aligned_addr;
-    unsigned int d = c & 0xff;  /* To avoid sign extension, copy C to an
-                                unsigned variable.  */
+    unsigned char d = (unsigned int)c & (unsigned char)(-1);  /* To avoid sign extension, copy C to an
+                                unsigned variable. (unsigned)((char)(-1))=0xFF for 8bit and =0xFFFF for 16bit: word independent */
 
     if (!TOO_SMALL(count) && !UNALIGNED(s))
     {
@@ -169,14 +170,15 @@ RT_WEAK void *rt_memset(void *s, int c, rt_ubase_t count)
          */
         if (LBLOCKSIZE == 4)
         {
-            buffer = (d << 8) | d;
-            buffer |= (buffer << 16);
+            *(((unsigned char *)&buffer)+0) = d;
+            *(((unsigned char *)&buffer)+1) = d;
+            *(((unsigned char *)&buffer)+2) = d;
+            *(((unsigned char *)&buffer)+3) = d;
         }
-        else
+        else if (LBLOCKSIZE == 2)
         {
-            buffer = 0;
-            for (i = 0; i < LBLOCKSIZE; i ++)
-                buffer = (buffer << 8) | d;
+            *(((unsigned char *)&buffer)+0) = d;
+            *(((unsigned char *)&buffer)+1) = d;
         }
 
         while (count >= LBLOCKSIZE * 4)
@@ -1077,17 +1079,21 @@ RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list arg
 #endif /* RT_KPRINTF_USING_LONGLONG */
         {
             num = va_arg(args, rt_uint32_t);
-            if (flags & SIGN) num = (rt_int32_t)num;
         }
         else if (qualifier == 'h')
         {
-            num = (rt_uint16_t)va_arg(args, rt_int32_t);
-            if (flags & SIGN) num = (rt_int16_t)num;
+            /*for arm gcc, args are aligned to 32bit.
+              for Ti C28x, args are aligned to 16bit.
+              Therefore we use int here to adapt to both archs. */
+
+            if (flags & SIGN)
+                num = (rt_int32_t)va_arg(args, int);
+            else
+                num = (rt_uint32_t)va_arg(args, unsigned int);
         }
         else
         {
             num = va_arg(args, rt_uint32_t);
-            if (flags & SIGN) num = (rt_int32_t)num;
         }
 #ifdef RT_PRINTF_PRECISION
         str = print_number(str, end, num, base, field_width, precision, flags);


### PR DESCRIPTION
For compatibility with 16bit addressing 32bit CPU (e.g. Ti C28x).

## 拉取/合并请求描述：(PR description)

[
1. 修改了rt_memset 使其 word size independent.
2. 修改了rt_vsnprintf 使其适应于 16bit 和 32bit stack alignment. This is a bit tricking by using "va_arg(args, int)".
3. Further discussion is needed on whether or nor shall we create separate memory-related service functions for 16-bit addressing CPUs. From my point of view, I think rt_memset can be kept like this (independent of addressing mode), but rt_vsnprintf should be dealt with carefully since va_arg(args, int) may corrupt the argument passing mechanism if the size of int is not the default stack alignment size.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
