### PR TITLE
[rt_drv_pwm]完善PWM框架互补输出部分代码

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -383,14 +383,8 @@ static rt_err_t drv_pwm_control(struct rt_device_pwm *device, int cmd, void *arg
 
     switch (cmd)
     {
-    case PWMN_CMD_ENABLE:
-        configuration->complementary = RT_TRUE;
-        return RT_EOK;
     case PWM_CMD_ENABLE:
         return drv_pwm_enable(htim, configuration, RT_TRUE);
-    case PWMN_CMD_DISABLE:
-        configuration->complementary = RT_FALSE;
-        return RT_EOK;
     case PWM_CMD_DISABLE:
         return drv_pwm_enable(htim, configuration, RT_FALSE);
     case PWM_CMD_SET:

--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -385,10 +385,12 @@ static rt_err_t drv_pwm_control(struct rt_device_pwm *device, int cmd, void *arg
     {
     case PWMN_CMD_ENABLE:
         configuration->complementary = RT_TRUE;
+        return RT_EOK;
     case PWM_CMD_ENABLE:
         return drv_pwm_enable(htim, configuration, RT_TRUE);
     case PWMN_CMD_DISABLE:
         configuration->complementary = RT_FALSE;
+        return RT_EOK;
     case PWM_CMD_DISABLE:
         return drv_pwm_enable(htim, configuration, RT_FALSE);
     case PWM_CMD_SET:

--- a/components/drivers/include/drivers/rt_drv_pwm.h
+++ b/components/drivers/include/drivers/rt_drv_pwm.h
@@ -24,7 +24,7 @@
 
 struct rt_pwm_configuration
 {
-    rt_uint32_t channel; /* 1-n or 0-n, which depends on specific MCU requirements */
+    rt_uint32_t channel; /* 0 ~ n or 0 ~ -n, which depends on specific MCU requirements */
     rt_uint32_t period;  /* unit:ns 1ns~4.29s:1Ghz~0.23hz */
     rt_uint32_t pulse;   /* unit:ns (pulse<=period) */
 

--- a/components/drivers/misc/rt_drv_pwm.c
+++ b/components/drivers/misc/rt_drv_pwm.c
@@ -8,6 +8,7 @@
  * 2018-05-07     aozima       the first version
  * 2022-05-14     Stanley Lwin add pwm function
  * 2022-07-25     liYony       fix complementary outputs and add usage information in finsh
+ * 2022-08-31     liYony       Add complementary output section to framework for management
  */
 
 #include <rtdevice.h>

--- a/components/drivers/misc/rt_drv_pwm.c
+++ b/components/drivers/misc/rt_drv_pwm.c
@@ -136,8 +136,20 @@ rt_err_t rt_pwm_enable(struct rt_device_pwm *device, int channel)
         return -RT_EIO;
     }
 
-    configuration.channel = (channel > 0) ? (channel) : (-channel);         /* Make it is positive num forever */
-    configuration.complementary = (channel > 0) ? (RT_FALSE) : (RT_TRUE);   /* If nagetive, it's complementary */
+    /* Make it is positive num forever */
+    configuration.channel = (channel > 0) ? (channel) : (-channel);
+
+    /* If channel is a positive number (0 ~ n), it means using normal output pin.
+     * If channel is a negative number (0 ~ -n), it means using complementary output pin. */
+    if(channel > 0)
+    {
+        result = rt_device_control(&device->parent, PWMN_CMD_DISABLE, &configuration);
+    }
+    else
+    {
+        result = rt_device_control(&device->parent, PWMN_CMD_ENABLE, &configuration);
+    }
+
     result = rt_device_control(&device->parent, PWM_CMD_ENABLE, &configuration);
 
     return result;
@@ -153,8 +165,20 @@ rt_err_t rt_pwm_disable(struct rt_device_pwm *device, int channel)
         return -RT_EIO;
     }
 
-    configuration.channel = (channel > 0) ? (channel) : (-channel);         /* Make it is positive num forever */
-    configuration.complementary = (channel > 0) ? (RT_FALSE) : (RT_TRUE);   /* If nagetive, it's complementary */
+    /* Make it is positive num forever */
+    configuration.channel = (channel > 0) ? (channel) : (-channel);
+
+    /* If channel is a positive number (0 ~ n), it means using normal output pin.
+     * If channel is a negative number (0 ~ -n), it means using complementary output pin. */
+    if(channel > 0)
+    {
+        result = rt_device_control(&device->parent, PWMN_CMD_DISABLE, &configuration);
+    }
+    else
+    {
+        result = rt_device_control(&device->parent, PWMN_CMD_ENABLE, &configuration);
+    }
+
     result = rt_device_control(&device->parent, PWM_CMD_DISABLE, &configuration);
 
     return result;

--- a/components/drivers/misc/rt_drv_pwm.c
+++ b/components/drivers/misc/rt_drv_pwm.c
@@ -16,10 +16,20 @@ static rt_err_t _pwm_control(rt_device_t dev, int cmd, void *args)
 {
     rt_err_t result = RT_EOK;
     struct rt_device_pwm *pwm = (struct rt_device_pwm *)dev;
+    struct rt_pwm_configuration *configuration = (struct rt_pwm_configuration *)args;
 
-    if (pwm->ops->control)
+    switch (cmd)
     {
-        result = pwm->ops->control(pwm, cmd, args);
+        case PWMN_CMD_ENABLE:
+            configuration->complementary = RT_TRUE;
+            break;
+        case PWMN_CMD_DISABLE:
+            configuration->complementary = RT_FALSE;
+            break;
+        default:
+            if(pwm->ops->control)
+                result = pwm->ops->control(pwm, cmd, args);
+            break;
     }
 
     return result;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
# 1、完善rt_drv_pwm中互补输出

原先PWM设备框架中是提供命令去设置PWM的互补输出的。如图：

![image](https://user-images.githubusercontent.com/64183082/187108711-ca97eb85-43c9-4ae6-8f4c-303c05e74533.png)

所以，在框架中，建议使用提供好的命令去设置互补输出模式，而不是直接修改configuration.complementary的值。

![image](https://user-images.githubusercontent.com/64183082/187108526-674b6030-a57e-401d-9431-83afeb0a473f.png)

# 2、drv_pwm中互补输出部分bug

当我们使用PWMN_CMD_ENABLE和PWMN_CMD_DISABLE命令的时候，代码没有返回值，而且这个swicth case语句没有break，那么会执行到 return RT_EINVAL 我们希望返回的是RT_EOK。

![image](https://user-images.githubusercontent.com/64183082/187109154-ac63a95e-c2d1-4020-a086-cdff0c27725c.png)

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
