### PR TITLE
[kservice][ti c28x]rt_vsnprintf

### DIFF
--- a/src/kservice.c
+++ b/src/kservice.c
@@ -22,7 +22,7 @@
  * 2022-01-07     Gabriel      add __on_rt_assert_hook
  * 2022-06-04     Meco Man     remove strnlen
  * 2022-08-24     Yunjie       make rt_memset word-independent to adapt to ti c28x (16bit word)
- * 2022-08-30     Yunjie       change rt_vsnprintf for compliance with ti c28x (16bit stack alignment)
+ * 2022-08-30     Yunjie       make rt_vsnprintf adapt to ti c28x (16bit int)
  */
 
 #include <rtthread.h>
@@ -882,8 +882,6 @@ static char *print_number(char *buf,
  */
 RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list args)
 {
-#define LBLOCKSIZE      (sizeof(rt_ubase_t))
-
 #ifdef RT_KPRINTF_USING_LONGLONG
     unsigned long long num;
 #else
@@ -901,8 +899,6 @@ RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list arg
 #ifdef RT_PRINTF_PRECISION
     int precision;      /* min. # of digits for integers and max for a string */
 #endif /* RT_PRINTF_PRECISION */
-
-    RT_ASSERT(LBLOCKSIZE == 2 || LBLOCKSIZE == 4 || LBLOCKSIZE == 8);
 
     str = buf;
     end = buf + size;
@@ -1116,14 +1112,7 @@ RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list arg
         }
         else if (qualifier == 'h')
         {
-            if(LBLOCKSIZE == 2)  /* for ti c28x: 16bit stack alignment */
-            {
-                num = (rt_uint16_t)va_arg(args, rt_uint16_t);
-            }
-            else /* for 32bit and 64bit cpus */
-            {
-                num = (rt_uint16_t)va_arg(args, rt_uint32_t);
-            }
+            num = (rt_uint16_t)va_arg(args, int);
             if (flags & SIGN) num = (rt_int16_t)num;
         }
         else

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -22,6 +22,7 @@
  * 2022-01-07     Gabriel      add __on_rt_assert_hook
  * 2022-06-04     Meco Man     remove strnlen
  * 2022-08-24     Yunjie       make rt_memset word-independent to adapt to ti c28x (16bit word)
+ * 2022-08-30     Yunjie       change rt_vsnprintf for compliance with ti c28x (16bit stack alignment)
  */
 
 #include <rtthread.h>
@@ -1111,7 +1112,14 @@ RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list arg
         }
         else if (qualifier == 'h')
         {
-            num = (rt_uint16_t)va_arg(args, rt_int32_t);
+            if(sizeof(rt_ubase_t) == 4)       /* for normal 32bit cpus */
+            {
+                num = (rt_uint16_t)va_arg(args, rt_uint32_t);
+            }
+            else if(sizeof(rt_ubase_t) == 2)  /* for ti c28x: 16bit stack alignment */
+            {
+                num = (rt_uint16_t)va_arg(args, rt_uint16_t);
+            }
             if (flags & SIGN) num = (rt_int16_t)num;
         }
         else

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -882,6 +882,8 @@ static char *print_number(char *buf,
  */
 RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list args)
 {
+#define LBLOCKSIZE      (sizeof(rt_ubase_t))
+
 #ifdef RT_KPRINTF_USING_LONGLONG
     unsigned long long num;
 #else
@@ -899,6 +901,8 @@ RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list arg
 #ifdef RT_PRINTF_PRECISION
     int precision;      /* min. # of digits for integers and max for a string */
 #endif /* RT_PRINTF_PRECISION */
+
+    RT_ASSERT(LBLOCKSIZE == 2 || LBLOCKSIZE == 4 || LBLOCKSIZE == 8);
 
     str = buf;
     end = buf + size;
@@ -1112,13 +1116,13 @@ RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list arg
         }
         else if (qualifier == 'h')
         {
-            if(sizeof(rt_ubase_t) == 4)       /* for normal 32bit cpus */
-            {
-                num = (rt_uint16_t)va_arg(args, rt_uint32_t);
-            }
-            else if(sizeof(rt_ubase_t) == 2)  /* for ti c28x: 16bit stack alignment */
+            if(LBLOCKSIZE == 2)  /* for ti c28x: 16bit stack alignment */
             {
                 num = (rt_uint16_t)va_arg(args, rt_uint16_t);
+            }
+            else /* for 32bit and 64bit cpus */
+            {
+                num = (rt_uint16_t)va_arg(args, rt_uint32_t);
             }
             if (flags & SIGN) num = (rt_int16_t)num;
         }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
update rt_vsnprintf for compliance with ti c28x cpus.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
