### PR TITLE
[kservice] 增加printf格式2进制和8进制，RT_KPRINTF_USING_LONGLONG 和 RT_PRINTF_SPECIAL 做了相应处理

### DIFF
--- a/src/kservice.c
+++ b/src/kservice.c
@@ -796,7 +796,7 @@ static char *print_number(char *buf,
 #ifdef RT_PRINTF_SPECIAL
     if (type & SPECIAL)
     {
-		if (base == 2)
+        if (base == 2)
         {
             if (buf < end)
                 *buf = '0';
@@ -1067,7 +1067,7 @@ RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list arg
         case 'b':
             base = 2;
             break;
-		case 'o':
+        case 'o':
             base = 8;
             break;
 

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -666,26 +666,13 @@ rt_inline int divide(long *n, int base)
     int res;
 
     /* optimized for processor which does not support divide instructions. */
-    if (base == 10)
-    {
 #ifdef RT_KPRINTF_USING_LONGLONG
-        res = (int)(((unsigned long long)*n) % 10U);
-        *n = (long long)(((unsigned long long)*n) / 10U);
+    res = (int)(((unsigned long long)*n) % base);
+    *n = (long long)(((unsigned long long)*n) / base);
 #else
-        res = (int)(((unsigned long)*n) % 10U);
-        *n = (long)(((unsigned long)*n) / 10U);
+    res = (int)(((unsigned long)*n) % base);
+    *n = (long)(((unsigned long)*n) / base);
 #endif
-    }
-    else
-    {
-#ifdef RT_KPRINTF_USING_LONGLONG
-        res = (int)(((unsigned long long)*n) % 16U);
-        *n = (long long)(((unsigned long long)*n) / 16U);
-#else
-        res = (int)(((unsigned long)*n) % 16U);
-        *n = (long)(((unsigned long)*n) / 16U);
-#endif
-    }
 
     return res;
 }
@@ -723,9 +710,9 @@ static char *print_number(char *buf,
 {
     char c, sign;
 #ifdef RT_KPRINTF_USING_LONGLONG
-    char tmp[32];
+    char tmp[64];
 #else
-    char tmp[16];
+    char tmp[32];
 #endif /* RT_KPRINTF_USING_LONGLONG */
     int precision_bak = precision;
     const char *digits;
@@ -759,7 +746,7 @@ static char *print_number(char *buf,
 #ifdef RT_PRINTF_SPECIAL
     if (type & SPECIAL)
     {
-        if (base == 16)
+        if (base == 2 || base == 16)
             size -= 2;
         else if (base == 8)
             size--;
@@ -809,7 +796,16 @@ static char *print_number(char *buf,
 #ifdef RT_PRINTF_SPECIAL
     if (type & SPECIAL)
     {
-        if (base == 8)
+		if (base == 2)
+        {
+            if (buf < end)
+                *buf = '0';
+            ++ buf;
+            if (buf < end)
+                *buf = 'b';
+            ++ buf;
+        }
+        else if (base == 8)
         {
             if (buf < end)
                 *buf = '0';
@@ -1068,7 +1064,10 @@ RT_WEAK int rt_vsnprintf(char *buf, rt_size_t size, const char *fmt, va_list arg
             continue;
 
         /* integer number formats - set up the flags and "break" */
-        case 'o':
+        case 'b':
+            base = 2;
+            break;
+		case 'o':
             base = 8;
             break;
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
增加printf格式2进制和8进制，RT_KPRINTF_USING_LONGLONG 和 RT_PRINTF_SPECIAL 做了相应处理
增加了%b支持2进制输出；
函数rt_inline int divide(long long *n, int base) 函数用变量base获取逐位字符；
函数static char *print_number 中 局部数组tmp[]做了相应的增加，SPECIAL选项对二进制做了处理，显示为0bxxxx

stm32h747-st-discovery bsp 测试通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
