### PR TITLE
Ch32 v307 kconfig fix

### DIFF
--- a/bsp/wch/risc-v/ch32v307v-r1/board/Kconfig
+++ b/bsp/wch/risc-v/ch32v307v-r1/board/Kconfig
@@ -44,7 +44,7 @@ menu "On-chip Peripheral Drivers"
             default n
 
             config BSP_USING_UART8
-            bool "Enable UART7"
+            bool "Enable UART8"
             default n
         endif
 

--- a/bsp/wch/risc-v/ch32v307v-r1/board/Kconfig
+++ b/bsp/wch/risc-v/ch32v307v-r1/board/Kconfig
@@ -18,6 +18,34 @@ menu "On-chip Peripheral Drivers"
             config BSP_USING_UART1
             bool "Enable UART1"
             default n
+
+            config BSP_USING_UART2
+            bool "Enable UART2"
+            default n
+
+            config BSP_USING_UART3
+            bool "Enable UART3"
+            default n
+
+            config BSP_USING_UART4
+            bool "Enable UART4"
+            default n
+
+            config BSP_USING_UART5
+            bool "Enable UART5"
+            default n
+
+            config BSP_USING_UART6
+            bool "Enable UART6"
+            default n
+
+            config BSP_USING_UART7
+            bool "Enable UART7"
+            default n
+
+            config BSP_USING_UART8
+            bool "Enable UART7"
+            default n
         endif
 
 endmenu


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
解决了ch32v307使用ENV工具中  Hardware Drivers Config → On-chip Peripheral Drivers 中usart配置只有usart1开关的问题，添加了usart2-usart8
但是由于drv_usart.c的时钟配置bug并未修改，故即使开启了usart2-usart8，usart2-usart8仍不可正常使用
已使用env工具测试
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
