### PR TITLE
[stm32][RTduino]删除一些不必要的代码

### DIFF
--- a/bsp/stm32/stm32f103-blue-pill/applications/arduino_pinout/pins_arduino.c
+++ b/bsp/stm32/stm32f103-blue-pill/applications/arduino_pinout/pins_arduino.c
@@ -42,12 +42,3 @@ const pin_map_t pin_map_table[]=
     {A5, RT_NULL, "adc1", 17}, /* ADC, On-Chip: internal reference voltage, ADC_CHANNEL_VREFINT */
     {A6, RT_NULL, "adc1", 16} /* ADC, On-Chip: internal temperature sensor, ADC_CHANNEL_TEMPSENSOR */
 };
-/* 
- * Before RTdunio is used, you can do some necessary initialization through this function
- */
-void initVariant()
-{
-    /* JTAG-DP Disabled and SW-DP enabled */
-    __HAL_RCC_AFIO_CLK_ENABLE();
-    __HAL_AFIO_REMAP_SWJ_NOJTAG(); 
-}


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
关于SWD和JTAG调试选择，其实CubeMX已经做了处理，我们不用重复的在实现了！

![image](https://user-images.githubusercontent.com/64183082/189093149-13491ed3-22ad-416c-9789-3340ab5d1370.png)

我们在CubeMX配置的时候，需要选择调试方式，这时候CubeMX会根据我们的选择，自动生成SWD和JTAG调试选择的代码。为了不干扰用户，建议还是将本段代码删除。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
