### PR TITLE
[components] sdio

### DIFF
--- a/components/drivers/sdio/mmcsd_core.c
+++ b/components/drivers/sdio/mmcsd_core.c
@@ -667,6 +667,7 @@ void mmcsd_detect(void *param)
                     continue;
                 }
                 mmcsd_host_unlock(host);
+                rt_mb_send(&mmcsd_hotpluge_mb, (rt_ubase_t)host);
             }
             else
             {


### PR DESCRIPTION
mmcsd_detect 函数在检测 sdio设备不成功时，也需要向 mmcsd_hotpluge_mb这个 mailbox反信。

■需求
代码实现是：
SD卡的插拔检测有一个thread，thread会loop 读取SD卡探测用的gpio，如果gpio值为1，则认为插入SD卡了，紧接着
调用 mmcsd_change 函数通知mmcsd_core，进行SD初始化。

■bug现象
插入SD卡后，
执行流: mmcsd_change(driver中调用) → mmcsd_detect（组件 sdio）
当执行到：mmcsd_detect的mmcsd_send_app_op_cond 函数时**拔卡的话**， 会造成此此函数执行错误，此时mmcsd_detect函数就不会发rt_mb_send 导致**mmcsd_change 卡住** 。
这样的话，在插入SD卡时，就无法执行mmcsd_change 了。
