### PR TITLE
[tools/link-order] Sort objects so that compilation can be done in a fixed link order.

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -775,8 +775,16 @@ def DoBuilding(target, objects):
                             objects.remove(obj)
 
         # re-add the source files to the objects
+
+        objects_in_group = []
         for group in Projects:
-            local_group(group, objects)
+            local_group(group, objects_in_group)
+
+        # sort seperately, because the data type of
+        # the members of the two lists are different
+        objects_in_group = sorted(objects_in_group)
+        objects = sorted(objects)
+        objects.append(objects_in_group)
 
         program = Env.Program(target, objects)
 


### PR DESCRIPTION
…fixed link order.

## 拉取/合并请求描述：(PR description)

**Reason for submission:**

The map file, BIN file, and link order generated by RT-Thread Scons compiled from the same source code are different.
This introduces uncontrollable variables for embedded debugging to trace back the source code from the lr or pc register address.

Experiments show that the BIN files generated by different link sequences are different,
and their operating phenomena are also different.

Running differences in BIN files are easy to observe on some software versions, but not so easy on others.
We have encountered such situations in our practice:
(1) Some versions of the software work fine (and seem to work fine) in all linking orders,
(2) while some versions of the software work fine in some link sequences and stuck in others.

Random link order increases uncertainty.

**Problem solved:**
Fixed the link order. The map file, BIN file, and link order generated by RT-Thread Scons compiled from the same source code are different

**Solution:**
Modify the building.py file to sort objects before each target is generated by objects.

**Self-test description:**
The problem is a compilation problem, no need to test on the board.
1. Download [RT-Thread v4.1.0](https://github.com/RT-Thread/rt-thread/releases/tag/v4.1.0)
2. cd ..\rt-thread-4.1.0\bsp\stm32\stm32h750-armfly-h7-tool
3. Consecutively compile scons twice in the above directory and use the file comparison tool to compare the map files generated before and after.
4. It can be seen that the map files generated before sort objects are very different, and the map files after sort objects are the same.

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
