### PR TITLE
RTC STM32F1 Enable PWR and BKP clocks in the same time

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_rtc.c
@@ -128,7 +128,6 @@ static void rt_rtc_f1_bkp_update(void)
     RTC_DateTypeDef RTC_DateStruct = {0};
 
     HAL_PWR_EnableBkUpAccess();
-    __HAL_RCC_BKP_CLK_ENABLE();
 
     RTC_DateStruct.Year    = HAL_RTCEx_BKUPRead(&RTC_Handler, RTC_BKP_DR2);
     RTC_DateStruct.Month   = HAL_RTCEx_BKUPRead(&RTC_Handler, RTC_BKP_DR3);
@@ -232,6 +231,9 @@ static rt_err_t stm32_rtc_init(void)
 {
 #if !defined(SOC_SERIES_STM32H7) && !defined(SOC_SERIES_STM32WL) && !defined(SOC_SERIES_STM32WB)
     __HAL_RCC_PWR_CLK_ENABLE();
+#ifdef SOC_SERIES_STM32F1
+    __HAL_RCC_BKP_CLK_ENABLE();
+#endif
 #endif
 
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};


### PR DESCRIPTION

转移自：https://gitee.com/rtthread/rt-thread/pulls/567


## 拉取/合并请求描述：(PR description)

[
bsp\stm32\libraries\HAL_Drivers\drv_rtc.c在STM32F10x上有一个“RTC首次上电时BKP时钟没使能”的问题。

STM32F10x要求：
写RTC Domain and RTC registers之前需要__HAL_RCC_BKP_CLK_ENABLE（详见：stm32f1xx_hal_rtc.c里面的##### Backup Domain Access #####）

问题分析：
1、RTC首次上电时：由于HAL_RTC_Init初始化之前没有使能BKP时钟，所以对RTC registers的初始化无效。 2、然后用date命令设置时间，调用到set_rtc_time_stamp也没有__HAL_RCC_BKP_CLK_ENABLE，所以HAL_RTCEx_BKUPWrite写的值无法真正永存于BKP，重启后就丢失。 最终导致：对于RTC首次上电的情况，每次重启后RTC_BKP_DR1里的值都不是BKUP_REG_DATA，导致永远无法调用到rt_rtc_f1_bkp_update()去使能BKP时钟。

解决办法：
参考STM32F10x_StdPeriph_Lib_V3.5.0\Project\STM32F10x_StdPeriph_Examples\RTC\Calendar\main.c里面的RTC_Configuration()同时打开RCC_APB1Periph_PWR和RCC_APB1Periph_BKP
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
