### PR TITLE
build: EndBuilding need_exit after GenTargetProject

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -871,7 +871,6 @@ def GenTargetProject(program = None):
     if GetOption('target') == 'esp-idf':
         from esp_idf import ESPIDFProject
         ESPIDFProject(Env, Projects)
-        exit(0)
 
 def EndBuilding(target, program = None):
 
@@ -895,6 +894,7 @@ def EndBuilding(target, program = None):
 
     if GetOption('target'):
         GenTargetProject(program)
+        need_exit = True
 
     BSP_ROOT = Dir('#').abspath
     if GetOption('make-dist') and program != None:


### PR DESCRIPTION
User choice IDE build, after GenTargetProject there's no need to do the rest. 并且，既然用户指定了IDE，接下来的命令行编译却仍然是使用arm-none-eabi-gcc，为什么不是用IDE的编译器呢？（也许是个bug）

## 拉取/合并请求描述：(PR description)

以下是旧的编译过程：
> $ scons --target=iar --verbose
> scons: Reading SConscript files ...
> IAR Version: 9.30.1.335
> scons: done reading SConscript files.
> scons: Building targets ...
> scons: building associated VariantDir targets: build
> arm-none-eabi-gcc -o build\applications\main.o -c -mcpu=cortex-m3 -mthumb ...

通过 --verbose 可以看到，生成完 IAR 工程后，还进行了编译，且编译器用的是 GCC ，而不是 IAR 。

加上 need_exit 后， rtconfig.py 里面的IDE部分就可以写的很简单了（不用再关心那些 CFLAGS AFLAGS LFLAGS 等），如下：
> ...
> elif PLATFORM == 'iccarm':
>     EXEC_PATH = EXEC_PATH + '/arm/bin/'

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
