### PR TITLE
Modified   bsp/stm32/libraries/HAL_Drivers/config/f4/dma_config.h

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/config/f4/dma_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f4/dma_config.h
@@ -25,6 +25,12 @@ extern "C" {
 #define SPI3_RX_DMA_INSTANCE             DMA1_Stream0
 #define SPI3_RX_DMA_CHANNEL              DMA_CHANNEL_0
 #define SPI3_RX_DMA_IRQ                  DMA1_Stream0_IRQn
+#elif defined(BSP_I2C1_RX_USING_DMA) && !defined(I2C1_RX_DMA_INSTANCE)
+#define I2C1_DMA_RX_IRQHandler          DMA1_Stream0_IRQHandler
+#define I2C1_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define I2C1_RX_DMA_INSTANCE            DMA1_Stream0
+#define I2C1_RX_DMA_CHANNEL             DMA_CHANNEL_1
+#define I2C1_RX_DMA_IRQ                 DMA1_Stream0_IRQn
 #elif defined(BSP_UART5_RX_USING_DMA) && !defined(UART5_RX_DMA_INSTANCE)
 #define UART5_DMA_RX_IRQHandler          DMA1_Stream0_IRQHandler
 #define UART5_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
@@ -46,12 +52,12 @@ extern "C" {
 #define UART3_RX_DMA_INSTANCE            DMA1_Stream1
 #define UART3_RX_DMA_CHANNEL             DMA_CHANNEL_4
 #define UART3_RX_DMA_IRQ                 DMA1_Stream1_IRQn
-#elif defined(BSP_UART7_RX_USING_DMA) && !defined(UART7_RX_DMA_INSTANCE)
-#define UART7_DMA_RX_IRQHandler          DMA1_Stream1_IRQHandler
-#define UART7_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
-#define UART7_RX_DMA_INSTANCE            DMA1_Stream1
-#define UART7_RX_DMA_CHANNEL             DMA_CHANNEL_5
-#define UART7_RX_DMA_IRQ                 DMA1_Stream1_IRQn
+#elif defined(BSP_UART7_TX_USING_DMA) && !defined(UART7_TX_DMA_INSTANCE)
+#define UART7_DMA_TX_IRQHandler          DMA1_Stream1_IRQHandler
+#define UART7_TX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define UART7_TX_DMA_INSTANCE            DMA1_Stream1
+#define UART7_TX_DMA_CHANNEL             DMA_CHANNEL_5
+#define UART7_TX_DMA_IRQ                 DMA1_Stream1_IRQn
 #endif
 
 /* DMA1 stream2 */
@@ -61,12 +67,24 @@ extern "C" {
 #define SPI3_RX_DMA_INSTANCE             DMA1_Stream2
 #define SPI3_RX_DMA_CHANNEL              DMA_CHANNEL_0
 #define SPI3_RX_DMA_IRQ                  DMA1_Stream2_IRQn
+#elif defined(BSP_I2C3_RX_USING_DMA) && !defined(I2C3_RX_DMA_INSTANCE)
+#define I2C3_DMA_RX_IRQHandler          DMA1_Stream2_IRQHandler
+#define I2C3_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define I2C3_RX_DMA_INSTANCE            DMA1_Stream2
+#define I2C3_RX_DMA_CHANNEL             DMA_CHANNEL_3
+#define I2C3_RX_DMA_IRQ                 DMA1_Stream2_IRQn
 #elif defined(BSP_UART4_RX_USING_DMA) && !defined(UART4_RX_DMA_INSTANCE)
 #define UART4_DMA_RX_IRQHandler          DMA1_Stream2_IRQHandler
 #define UART4_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
 #define UART4_RX_DMA_INSTANCE            DMA1_Stream2
 #define UART4_RX_DMA_CHANNEL             DMA_CHANNEL_4
 #define UART4_RX_DMA_IRQ                 DMA1_Stream2_IRQn
+#elif defined(BSP_I2C2_RX_USING_DMA) && !defined(I2C2_RX_DMA_INSTANCE)
+#define I2C2_DMA_RX_IRQHandler          DMA1_Stream2_IRQHandler
+#define I2C2_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define I2C2_RX_DMA_INSTANCE            DMA1_Stream2
+#define I2C2_RX_DMA_CHANNEL             DMA_CHANNEL_7
+#define I2C2_RX_DMA_IRQ                 DMA1_Stream2_IRQn
 #endif
 
 /* DMA1 stream3 */
@@ -82,12 +100,18 @@ extern "C" {
 #define UART3_TX_DMA_INSTANCE            DMA1_Stream3
 #define UART3_TX_DMA_CHANNEL             DMA_CHANNEL_4
 #define UART3_TX_DMA_IRQ                 DMA1_Stream3_IRQn
-#elif defined(BSP_UART7_TX_USING_DMA) && !defined(UART7_TX_DMA_INSTANCE)
+#elif defined(BSP_UART7_RX_USING_DMA) && !defined(UART7_RX_DMA_INSTANCE)
 #define UART7_DMA_RX_IRQHandler          DMA1_Stream3_IRQHandler
 #define UART7_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
 #define UART7_RX_DMA_INSTANCE            DMA1_Stream3
 #define UART7_RX_DMA_CHANNEL             DMA_CHANNEL_5
 #define UART7_RX_DMA_IRQ                 DMA1_Stream3_IRQn
+#elif defined(BSP_I2C2_RX_USING_DMA) && !defined(I2C2_RX_DMA_INSTANCE)
+#define I2C2_DMA_RX_IRQHandler          DMA1_Stream3_IRQHandler
+#define I2C2_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define I2C2_RX_DMA_INSTANCE            DMA1_Stream3
+#define I2C2_RX_DMA_CHANNEL             DMA_CHANNEL_7
+#define I2C2_RX_DMA_IRQ                 DMA1_Stream3_IRQn
 #endif
 
 /* DMA1 stream4 */
@@ -97,12 +121,24 @@ extern "C" {
 #define SPI2_TX_DMA_INSTANCE             DMA1_Stream4
 #define SPI2_TX_DMA_CHANNEL              DMA_CHANNEL_0
 #define SPI2_TX_DMA_IRQ                  DMA1_Stream4_IRQn
+#elif defined(BSP_I2C3_TX_USING_DMA) && !defined(I2C3_TX_DMA_INSTANCE)
+#define I2C3_DMA_TX_IRQHandler          DMA1_Stream4_IRQHandler
+#define I2C3_TX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define I2C3_TX_DMA_INSTANCE            DMA1_Stream4
+#define I2C3_TX_DMA_CHANNEL             DMA_CHANNEL_3
+#define I2C3_TX_DMA_IRQ                 DMA1_Stream4_IRQn
 #elif defined(BSP_UART4_TX_USING_DMA) && !defined(UART4_TX_DMA_INSTANCE)
 #define UART4_DMA_TX_IRQHandler          DMA1_Stream4_IRQHandler
 #define UART4_TX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
 #define UART4_TX_DMA_INSTANCE            DMA1_Stream4
 #define UART4_TX_DMA_CHANNEL             DMA_CHANNEL_4
 #define UART4_TX_DMA_IRQ                 DMA1_Stream4_IRQn
+#elif defined(BSP_UART3_TX_USING_DMA) && !defined(UART3_TX_DMA_INSTANCE)
+#define UART3_DMA_TX_IRQHandler          DMA1_Stream4_IRQHandler
+#define UART3_TX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define UART3_TX_DMA_INSTANCE            DMA1_Stream4
+#define UART3_TX_DMA_CHANNEL             DMA_CHANNEL_7
+#define UART3_TX_DMA_IRQ                 DMA1_Stream4_IRQn
 #endif
 
 /* DMA1 stream5 */
@@ -112,6 +148,12 @@ extern "C" {
 #define SPI3_TX_DMA_INSTANCE             DMA1_Stream5
 #define SPI3_TX_DMA_CHANNEL              DMA_CHANNEL_0
 #define SPI3_TX_DMA_IRQ                  DMA1_Stream5_IRQn
+#elif defined(BSP_I2C1_RX_USING_DMA) && !defined(I2C1_RX_DMA_INSTANCE)
+#define I2C1_DMA_RX_IRQHandler          DMA1_Stream5_IRQHandler
+#define I2C1_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define I2C1_RX_DMA_INSTANCE            DMA1_Stream5
+#define I2C1_RX_DMA_CHANNEL             DMA_CHANNEL_1
+#define I2C1_RX_DMA_IRQ                 DMA1_Stream5_IRQn
 #elif defined(BSP_UART2_RX_USING_DMA) && !defined(UART2_RX_DMA_INSTANCE)
 #define UART2_DMA_RX_IRQHandler          DMA1_Stream5_IRQHandler
 #define UART2_RX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
@@ -121,7 +163,13 @@ extern "C" {
 #endif
 
 /* DMA1 stream6 */
-#if defined(BSP_UART2_TX_USING_DMA) && !defined(UART2_TX_DMA_INSTANCE)
+#if defined(BSP_I2C1_TX_USING_DMA) && !defined(I2C1_TX_DMA_INSTANCE)
+#define I2C1_DMA_TX_IRQHandler          DMA1_Stream6_IRQHandler
+#define I2C1_TX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define I2C1_TX_DMA_INSTANCE            DMA1_Stream6
+#define I2C1_TX_DMA_CHANNEL             DMA_CHANNEL_1
+#define I2C1_TX_DMA_IRQ                 DMA1_Stream6_IRQn
+#elif defined(BSP_UART2_TX_USING_DMA) && !defined(UART2_TX_DMA_INSTANCE)
 #define UART2_DMA_TX_IRQHandler          DMA1_Stream6_IRQHandler
 #define UART2_TX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
 #define UART2_TX_DMA_INSTANCE            DMA1_Stream6
@@ -142,16 +190,40 @@ extern "C" {
 #define SPI3_TX_DMA_INSTANCE             DMA1_Stream7
 #define SPI3_TX_DMA_CHANNEL              DMA_CHANNEL_0
 #define SPI3_TX_DMA_IRQ                  DMA1_Stream7_IRQn
+#elif defined(BSP_I2C1_TX_USING_DMA) && !defined(I2C1_TX_DMA_INSTANCE)
+#define I2C1_DMA_TX_IRQHandler          DMA1_Stream7_IRQHandler
+#define I2C1_TX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define I2C1_TX_DMA_INSTANCE            DMA1_Stream7
+#define I2C1_TX_DMA_CHANNEL             DMA_CHANNEL_1
+#define I2C1_TX_DMA_IRQ                 DMA1_Stream7_IRQn
 #elif defined(BSP_UART5_TX_USING_DMA) && !defined(UART5_TX_DMA_INSTANCE)
 #define UART5_DMA_TX_IRQHandler          DMA1_Stream7_IRQHandler
 #define UART5_TX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
 #define UART5_TX_DMA_INSTANCE            DMA1_Stream7
 #define UART5_TX_DMA_CHANNEL             DMA_CHANNEL_4
 #define UART5_TX_DMA_IRQ                 DMA1_Stream7_IRQn
+#elif defined(BSP_I2C2_TX_USING_DMA) && !defined(I2C2_TX_DMA_INSTANCE)
+#define I2C2_DMA_TX_IRQHandler          DMA1_Stream7_IRQHandler
+#define I2C2_TX_DMA_RCC                 RCC_AHB1ENR_DMA1EN
+#define I2C2_TX_DMA_INSTANCE            DMA1_Stream7
+#define I2C2_TX_DMA_CHANNEL             DMA_CHANNEL_7
+#define I2C2_TX_DMA_IRQ                 DMA1_Stream7_IRQn
 #endif
 
 /* DMA2 stream0 */
-#if defined(BSP_SPI1_RX_USING_DMA) && !defined(SPI1_RX_DMA_INSTANCE)
+#if defined(BSP_ADC1_USING_DMA) && !defined(ADC1_DMA_INSTANCE)
+#define ADC1_DMA_IRQHandler           DMA2_Stream0_IRQHandler
+#define ADC1_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define ADC1_DMA_INSTANCE             DMA2_Stream0
+#define ADC1_DMA_CHANNEL              DMA_CHANNEL_0
+#define ADC1_DMA_IRQ                  DMA2_Stream0_IRQn
+#elif defined(BSP_ADC3_USING_DMA) && !defined(ADC3_DMA_INSTANCE)
+#define ADC3_DMA_IRQHandler           DMA2_Stream0_IRQHandler
+#define ADC3_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define ADC3_DMA_INSTANCE             DMA2_Stream0
+#define ADC3_DMA_CHANNEL              DMA_CHANNEL_2
+#define ADC3_DMA_IRQ                  DMA2_Stream0_IRQn
+#elif defined(BSP_SPI1_RX_USING_DMA) && !defined(SPI1_RX_DMA_INSTANCE)
 #define SPI1_DMA_RX_IRQHandler           DMA2_Stream0_IRQHandler
 #define SPI1_RX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
 #define SPI1_RX_DMA_INSTANCE             DMA2_Stream0
@@ -163,10 +235,28 @@ extern "C" {
 #define SPI4_RX_DMA_INSTANCE             DMA2_Stream0
 #define SPI4_RX_DMA_CHANNEL              DMA_CHANNEL_4
 #define SPI4_RX_DMA_IRQ                  DMA2_Stream0_IRQn
+#elif defined(BSP_MEMTOMEM0_USING_DMA) && !defined(MEMTOMEM0_DMA_INSTANCE)
+#define MEMTOMEM0_DMA_IRQHandler           DMA2_Stream0_IRQHandler
+#define MEMTOMEM0_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define MEMTOMEM0_DMA_INSTANCE             DMA2_Stream0
+#define MEMTOMEM0_DMA_CHANNEL              DMA_CHANNEL_7
+#define MEMTOMEM0_DMA_IRQ                  DMA2_Stream0_IRQn
 #endif
 
 /* DMA2 stream1 */
-#if defined(BSP_SPI4_TX_USING_DMA) && !defined(SPI4_TX_DMA_INSTANCE)
+#if defined(BSP_ADC3_USING_DMA) && !defined(ADC3_DMA_INSTANCE)
+#define ADC3_DMA_IRQHandler           DMA2_Stream1_IRQHandler
+#define ADC3_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define ADC3_DMA_INSTANCE             DMA2_Stream1
+#define ADC3_DMA_CHANNEL              DMA_CHANNEL_2
+#define ADC3_DMA_IRQ                  DMA2_Stream1_IRQn
+#elif defined(BSP_MEMTOMEM1_USING_DMA) && !defined(MEMTOMEM1_DMA_INSTANCE)
+#define MEMTOMEM1_DMA_IRQHandler           DMA2_Stream1_IRQHandler
+#define MEMTOMEM1_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define MEMTOMEM1_DMA_INSTANCE             DMA2_Stream1
+#define MEMTOMEM1_DMA_CHANNEL              DMA_CHANNEL_3
+#define MEMTOMEM1_DMA_IRQ                  DMA2_Stream1_IRQn
+#elif defined(BSP_SPI4_TX_USING_DMA) && !defined(SPI4_TX_DMA_INSTANCE)
 #define SPI4_DMA_TX_IRQHandler           DMA2_Stream1_IRQHandler
 #define SPI4_TX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
 #define SPI4_TX_DMA_INSTANCE             DMA2_Stream1
@@ -181,7 +271,19 @@ extern "C" {
 #endif
 
 /* DMA2 stream2 */
-#if defined(BSP_SPI1_RX_USING_DMA) && !defined(SPI1_RX_DMA_INSTANCE)
+#if defined(BSP_ADC2_USING_DMA) && !defined(ADC2_DMA_INSTANCE)
+#define ADC2_DMA_IRQHandler           DMA2_Stream2_IRQHandler
+#define ADC2_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define ADC2_DMA_INSTANCE             DMA2_Stream2
+#define ADC2_DMA_CHANNEL              DMA_CHANNEL_1
+#define ADC2_DMA_IRQ                  DMA2_Stream2_IRQn
+#elif defined(BSP_MEMTOMEM2_USING_DMA) && !defined(MEMTOMEM2_DMA_INSTANCE)
+#define MEMTOMEM2_DMA_IRQHandler           DMA2_Stream2_IRQHandler
+#define MEMTOMEM2_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define MEMTOMEM2_DMA_INSTANCE             DMA2_Stream2
+#define MEMTOMEM2_DMA_CHANNEL              DMA_CHANNEL_2
+#define MEMTOMEM2_DMA_IRQ                  DMA2_Stream2_IRQn
+#elif defined(BSP_SPI1_RX_USING_DMA) && !defined(SPI1_RX_DMA_INSTANCE)
 #define SPI1_DMA_RX_IRQHandler           DMA2_Stream2_IRQHandler
 #define SPI1_RX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
 #define SPI1_RX_DMA_INSTANCE             DMA2_Stream2
@@ -193,10 +295,28 @@ extern "C" {
 #define UART1_RX_DMA_INSTANCE           DMA2_Stream2
 #define UART1_RX_DMA_CHANNEL            DMA_CHANNEL_4
 #define UART1_RX_DMA_IRQ                DMA2_Stream2_IRQn
+#elif defined(BSP_UART6_RX_USING_DMA) && !defined(UART6_RX_DMA_INSTANCE)
+#define UART6_DMA_RX_IRQHandler         DMA2_Stream2_IRQHandler
+#define UART6_RX_DMA_RCC                RCC_AHB1ENR_DMA2EN
+#define UART6_RX_DMA_INSTANCE           DMA2_Stream2
+#define UART6_RX_DMA_CHANNEL            DMA_CHANNEL_5
+#define UART6_RX_DMA_IRQ                DMA2_Stream2_IRQn
 #endif
 
 /* DMA2 stream3 */
-#if defined(BSP_SPI5_RX_USING_DMA) && !defined(SPI5_RX_DMA_INSTANCE)
+#if defined(BSP_MEMTOMEM3_USING_DMA) && !defined(MEMTOMEM3_DMA_INSTANCE)
+#define MEMTOMEM3_DMA_IRQHandler           DMA2_Stream3_IRQHandler
+#define MEMTOMEM3_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define MEMTOMEM3_DMA_INSTANCE             DMA2_Stream3
+#define MEMTOMEM3_DMA_CHANNEL              DMA_CHANNEL_0
+#define MEMTOMEM3_DMA_IRQ                  DMA2_Stream3_IRQn
+#elif defined(BSP_ADC2_USING_DMA) && !defined(ADC2_DMA_INSTANCE)
+#define ADC2_DMA_IRQHandler           DMA2_Stream3_IRQHandler
+#define ADC2_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define ADC2_DMA_INSTANCE             DMA2_Stream3
+#define ADC2_DMA_CHANNEL              DMA_CHANNEL_1
+#define ADC2_DMA_IRQ                  DMA2_Stream3_IRQn
+#elif defined(BSP_SPI5_RX_USING_DMA) && !defined(SPI5_RX_DMA_INSTANCE)
 #define SPI5_DMA_RX_IRQHandler           DMA2_Stream3_IRQHandler
 #define SPI5_RX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
 #define SPI5_RX_DMA_INSTANCE             DMA2_Stream3
@@ -208,6 +328,12 @@ extern "C" {
 #define SPI1_TX_DMA_INSTANCE             DMA2_Stream3
 #define SPI1_TX_DMA_CHANNEL              DMA_CHANNEL_3
 #define SPI1_TX_DMA_IRQ                  DMA2_Stream3_IRQn
+#elif defined(BSP_SDIO_RX_USING_DMA) && !defined(SDIO_RX_DMA_INSTANCE)
+#define SDIO_DMA_RX_IRQHandler           DMA2_Stream3_IRQHandler
+#define SDIO_RX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define SDIO_RX_DMA_INSTANCE             DMA2_Stream3
+#define SDIO_RX_DMA_CHANNEL              DMA_CHANNEL_4
+#define SDIO_RX_DMA_IRQ                  DMA2_Stream3_IRQn
 #elif defined(BSP_SPI4_RX_USING_DMA) && !defined(SPI4_RX_DMA_INSTANCE)
 #define SPI4_DMA_RX_IRQHandler           DMA2_Stream3_IRQHandler
 #define SPI4_RX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
@@ -217,12 +343,24 @@ extern "C" {
 #endif
 
 /* DMA2 stream4 */
-#if defined(BSP_SPI5_TX_USING_DMA) && !defined(SPI5_TX_DMA_INSTANCE)
+#if defined(BSP_ADC1_USING_DMA) && !defined(ADC1_DMA_INSTANCE)
+#define ADC1_DMA_IRQHandler           DMA2_Stream4_IRQHandler
+#define ADC1_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define ADC1_DMA_INSTANCE             DMA2_Stream4
+#define ADC1_DMA_CHANNEL              DMA_CHANNEL_0
+#define ADC1_DMA_IRQ                  DMA2_Stream4_IRQn
+#elif defined(BSP_SPI5_TX_USING_DMA) && !defined(SPI5_TX_DMA_INSTANCE)
 #define SPI5_DMA_TX_IRQHandler           DMA2_Stream4_IRQHandler
 #define SPI5_TX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
 #define SPI5_TX_DMA_INSTANCE             DMA2_Stream4
 #define SPI5_TX_DMA_CHANNEL              DMA_CHANNEL_2
 #define SPI5_TX_DMA_IRQ                  DMA2_Stream4_IRQn
+#elif defined(BSP_MEMTOMEM4_USING_DMA) && !defined(MEMTOMEM4_DMA_INSTANCE)
+#define MEMTOMEM4_DMA_IRQHandler           DMA2_Stream4_IRQHandler
+#define MEMTOMEM4_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define MEMTOMEM4_DMA_INSTANCE             DMA2_Stream4
+#define MEMTOMEM4_DMA_CHANNEL              DMA_CHANNEL_4
+#define MEMTOMEM4_DMA_IRQ                  DMA2_Stream4_IRQn
 #elif defined(BSP_SPI4_TX_USING_DMA) && !defined(SPI4_TX_DMA_INSTANCE)
 #define SPI4_DMA_TX_IRQHandler           DMA2_Stream4_IRQHandler
 #define SPI4_TX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
@@ -232,7 +370,13 @@ extern "C" {
 #endif
 
 /* DMA2 stream5 */
-#if defined(BSP_SPI1_TX_USING_DMA) && !defined(SPI1_TX_DMA_INSTANCE)
+#if defined(BSP_SPI6_TX_USING_DMA) && !defined(SPI6_TX_DMA_INSTANCE)
+#define SPI6_DMA_TX_IRQHandler           DMA2_Stream5_IRQHandler
+#define SPI6_TX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define SPI6_TX_DMA_INSTANCE             DMA2_Stream5
+#define SPI6_TX_DMA_CHANNEL              DMA_CHANNEL_1
+#define SPI6_TX_DMA_IRQ                  DMA2_Stream5_IRQn
+#elif defined(BSP_SPI1_TX_USING_DMA) && !defined(SPI1_TX_DMA_INSTANCE)
 #define SPI1_DMA_TX_IRQHandler           DMA2_Stream5_IRQHandler
 #define SPI1_TX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
 #define SPI1_TX_DMA_INSTANCE             DMA2_Stream5
@@ -244,6 +388,12 @@ extern "C" {
 #define UART1_RX_DMA_INSTANCE           DMA2_Stream5
 #define UART1_RX_DMA_CHANNEL            DMA_CHANNEL_4
 #define UART1_RX_DMA_IRQ                DMA2_Stream5_IRQn
+#elif defined(BSP_MEMTOMEM5_USING_DMA) && !defined(MEMTOMEM5_DMA_INSTANCE)
+#define MEMTOMEM5_DMA_IRQHandler           DMA2_Stream5_IRQHandler
+#define MEMTOMEM5_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define MEMTOMEM5_DMA_INSTANCE             DMA2_Stream5
+#define MEMTOMEM5_DMA_CHANNEL              DMA_CHANNEL_5
+#define MEMTOMEM5_DMA_IRQ                  DMA2_Stream5_IRQn
 #elif defined(BSP_SPI5_RX_USING_DMA) && !defined(SPI5_RX_DMA_INSTANCE)
 #define SPI5_DMA_RX_IRQHandler           DMA2_Stream5_IRQHandler
 #define SPI5_RX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
@@ -253,18 +403,36 @@ extern "C" {
 #endif
 
 /* DMA2 stream6 */
-#if defined(BSP_SPI5_TX_USING_DMA) && !defined(SPI5_TX_DMA_INSTANCE)
-#define SPI5_DMA_TX_IRQHandler           DMA2_Stream6_IRQHandler
-#define SPI5_TX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
-#define SPI5_TX_DMA_INSTANCE             DMA2_Stream6
-#define SPI5_TX_DMA_CHANNEL              DMA_CHANNEL_7
-#define SPI5_TX_DMA_IRQ                  DMA2_Stream6_IRQn
-#elif defined(BSP_UART6_TX_USING_DMA) && !defined(BSP_USING_SDIO) && !defined(UART6_TX_DMA_INSTANCE)
+#if defined(BSP_SPI6_RX_USING_DMA) && !defined(SPI6_RX_DMA_INSTANCE)
+#define SPI6_DMA_RX_IRQHandler           DMA2_Stream6_IRQHandler
+#define SPI6_RX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define SPI6_RX_DMA_INSTANCE             DMA2_Stream6
+#define SPI6_RX_DMA_CHANNEL              DMA_CHANNEL_1
+#define SPI6_RX_DMA_IRQ                  DMA2_Stream6_IRQn
+#elif defined(BSP_MEMTOMEM6_USING_DMA) && !defined(MEMTOMEM6_DMA_INSTANCE)
+#define MEMTOMEM6_DMA_IRQHandler         DMA2_Stream6_IRQHandler
+#define MEMTOMEM6_DMA_RCC                RCC_AHB1ENR_DMA2EN
+#define MEMTOMEM6_DMA_INSTANCE           DMA2_Stream6
+#define MEMTOMEM6_DMA_CHANNEL            DMA_CHANNEL_3
+#define MEMTOMEM6_DMA_IRQ                DMA2_Stream6_IRQn
+#elif defined(BSP_SDIO_TX_USING_DMA) && !defined(SDIO_TX_DMA_INSTANCE)
+#define SDIO_DMA_TX_IRQHandler         DMA2_Stream6_IRQHandler
+#define SDIO_TX_DMA_RCC                RCC_AHB1ENR_DMA2EN
+#define SDIO_TX_DMA_INSTANCE           DMA2_Stream6
+#define SDIO_TX_DMA_CHANNEL            DMA_CHANNEL_4
+#define SDIO_TX_DMA_IRQ                DMA2_Stream6_IRQn
+#elif defined(BSP_UART6_TX_USING_DMA) && !defined(UART6_TX_DMA_INSTANCE)
 #define UART6_DMA_TX_IRQHandler         DMA2_Stream6_IRQHandler
 #define UART6_TX_DMA_RCC                RCC_AHB1ENR_DMA2EN
 #define UART6_TX_DMA_INSTANCE           DMA2_Stream6
 #define UART6_TX_DMA_CHANNEL            DMA_CHANNEL_5
 #define UART6_TX_DMA_IRQ                DMA2_Stream6_IRQn
+#elif defined(BSP_SPI5_TX_USING_DMA) && !defined(SPI5_TX_DMA_INSTANCE)
+#define SPI5_DMA_TX_IRQHandler           DMA2_Stream6_IRQHandler
+#define SPI5_TX_DMA_RCC                  RCC_AHB1ENR_DMA2EN
+#define SPI5_TX_DMA_INSTANCE             DMA2_Stream6
+#define SPI5_TX_DMA_CHANNEL              DMA_CHANNEL_7
+#define SPI5_TX_DMA_IRQ                  DMA2_Stream6_IRQn
 #endif
 
 /* DMA2 stream7 */
@@ -280,6 +448,12 @@ extern "C" {
 #define UART6_TX_DMA_INSTANCE           DMA2_Stream7
 #define UART6_TX_DMA_CHANNEL            DMA_CHANNEL_5
 #define UART6_TX_DMA_IRQ                DMA2_Stream7_IRQn
+#elif defined(BSP_MEMTOMEM7_USING_DMA) && !defined(MEMTOMEM7_DMA_INSTANCE)
+#define MEMTOMEM7_DMA_IRQHandler         DMA2_Stream7_IRQHandler
+#define MEMTOMEM7_DMA_RCC                RCC_AHB1ENR_DMA2EN
+#define MEMTOMEM7_DMA_INSTANCE           DMA2_Stream7
+#define MEMTOMEM7_DMA_CHANNEL            DMA_CHANNEL_6
+#define MEMTOMEM7_DMA_IRQ                DMA2_Stream7_IRQn
 #endif
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
@@ -311,7 +311,7 @@ static int stm32_putc(struct rt_serial_device *serial, char c)
 
 rt_uint32_t stm32_uart_get_mask(rt_uint32_t word_length, rt_uint32_t parity)
 {
-    rt_uint32_t mask;
+    rt_uint32_t mask = 0;
     if (word_length == UART_WORDLENGTH_8B)
     {
         if (parity == UART_PARITY_NONE)
@@ -935,6 +935,7 @@ static void stm32_uart_get_config(void)
     static struct dma_config uart4_dma_tx = UART4_DMA_TX_CONFIG;
     uart_config[UART4_INDEX].dma_tx = &uart4_dma_tx;
 #endif
+#endif
 
 #ifdef BSP_USING_UART5
     uart_obj[UART5_INDEX].serial.config = config;
@@ -956,6 +957,64 @@ static void stm32_uart_get_config(void)
 #endif
 #endif
 
+#ifdef BSP_USING_UART6
+    uart_obj[UART6_INDEX].serial.config = config;
+    uart_obj[UART6_INDEX].uart_dma_flag = 0;
+
+    uart_obj[UART6_INDEX].serial.config.rx_bufsz = BSP_UART6_RX_BUFSIZE;
+    uart_obj[UART6_INDEX].serial.config.tx_bufsz = BSP_UART6_TX_BUFSIZE;
+
+#ifdef BSP_UART6_RX_USING_DMA
+    uart_obj[UART6_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
+    static struct dma_config uart6_dma_rx = UART6_DMA_RX_CONFIG;
+    uart_config[UART6_INDEX].dma_rx = &uart6_dma_rx;
+#endif
+
+#ifdef BSP_UART6_TX_USING_DMA
+    uart_obj[UART6_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
+    static struct dma_config uart6_dma_tx = UART6_DMA_TX_CONFIG;
+    uart_config[UART6_INDEX].dma_tx = &uart6_dma_tx;
+#endif
+#endif
+
+#ifdef BSP_USING_UART7
+    uart_obj[UART7_INDEX].serial.config = config;
+    uart_obj[UART7_INDEX].uart_dma_flag = 0;
+
+    uart_obj[UART7_INDEX].serial.config.rx_bufsz = BSP_UART7_RX_BUFSIZE;
+    uart_obj[UART7_INDEX].serial.config.tx_bufsz = BSP_UART7_TX_BUFSIZE;
+
+#ifdef BSP_UART7_RX_USING_DMA
+    uart_obj[UART7_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
+    static struct dma_config uart7_dma_rx = UART7_DMA_RX_CONFIG;
+    uart_config[UART7_INDEX].dma_rx = &uart7_dma_rx;
+#endif
+
+#ifdef BSP_UART7_TX_USING_DMA
+    uart_obj[UART7_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
+    static struct dma_config uart7_dma_tx = UART7_DMA_TX_CONFIG;
+    uart_config[UART7_INDEX].dma_tx = &uart7_dma_tx;
+#endif
+#endif
+
+#ifdef BSP_USING_UART8
+    uart_obj[UART8_INDEX].serial.config = config;
+    uart_obj[UART8_INDEX].uart_dma_flag = 0;
+
+    uart_obj[UART8_INDEX].serial.config.rx_bufsz = BSP_UART8_RX_BUFSIZE;
+    uart_obj[UART8_INDEX].serial.config.tx_bufsz = BSP_UART8_TX_BUFSIZE;
+
+#ifdef BSP_UART8_RX_USING_DMA
+    uart_obj[UART8_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
+    static struct dma_config uart8_dma_rx = UART8_DMA_RX_CONFIG;
+    uart_config[UART8_INDEX].dma_rx = &uart8_dma_rx;
+#endif
+
+#ifdef BSP_UART8_TX_USING_DMA
+    uart_obj[UART8_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
+    static struct dma_config uart8_dma_tx = UART8_DMA_TX_CONFIG;
+    uart_config[UART8_INDEX].dma_tx = &uart8_dma_tx;
+#endif
 #endif
 }
 


### PR DESCRIPTION
Modified   bsp/stm32/libraries/HAL_Drivers/config/f4/dma_config.h
Modified   bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
修复f4的dma配置，修改v2串口驱动dma接收不响应半满和全满


## 拉取/合并请求描述：(PR description)

[
解决的问题：
串口接收数据错误，应用层接收的数据被截断成两个。

解决方案：
按照stm32f4的数据手册修改dma_config.h，drv_usart_v2.c中stm32_uart_get_config添加缺失的串口，屏蔽dma接收的半满和全满的处理，不然应用层触发时那一帧数据会被截取成两段。
![image](https://user-images.githubusercontent.com/28536570/192188681-35011f6a-c6d9-4217-be27-c2507b315fab.png)
![image](https://user-images.githubusercontent.com/28536570/192188600-ffd114d7-0813-48cc-b326-b078bcb28626.png)

测试环境：
f429系列的开发板
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
