### PR TITLE
[menuconfig] Fix pyconfig running errors

### DIFF
--- a/tools/menuconfig.py
+++ b/tools/menuconfig.py
@@ -249,8 +249,8 @@ def menuconfig(RTT_ROOT):
 
     touch_env()
     env_dir = get_env_dir()
-
-    os.environ['PKGS_ROOT'] = os.path.join(env_dir, 'packages')
+    if isinstance(env_dir, str):
+        os.environ['PKGS_ROOT'] = os.path.join(env_dir, 'packages')
 
     fn = '.config'
     fn_old = '.config.old'
@@ -282,8 +282,8 @@ def guiconfig(RTT_ROOT):
         touch_env()
 
     env_dir = get_env_dir()
-
-    os.environ['PKGS_ROOT'] = os.path.join(env_dir, 'packages')
+    if isinstance(env_dir, str):
+        os.environ['PKGS_ROOT'] = os.path.join(env_dir, 'packages')
 
     fn = '.config'
     fn_old = '.config.old'
@@ -316,8 +316,8 @@ def guiconfig_silent(RTT_ROOT):
         touch_env()
 
     env_dir = get_env_dir()
-
-    os.environ['PKGS_ROOT'] = os.path.join(env_dir, 'packages')
+    if isinstance(env_dir, str):
+        os.environ['PKGS_ROOT'] = os.path.join(env_dir, 'packages')
 
     fn = '.config'
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修复 pyconfig 运行错误

当前 pyconfig 强制依赖 `ENV_ROOT` 环境变量，使用 `ENV_ROOT` 来设置 `PKGS_ROOT` 环境变量。当 `ENV_ROOT` 环境变量没有设置时，就会抛异常。

在某些工程中，不需要通过 `PKGS_ROOT` 获取软件包的根路径，也就不依赖  `ENV_ROOT` 环境变量

此改动之后，如果 Kconfig 中依赖  `PKGS_ROOT` 环境变量，则会打印如下日志，提示用户

```
Kconfig:19: 'packages/Kconfig' not found (in 'source "$PKGS_DIR/Kconfig"'). Check that environment variables are set correctly (e.g. $srctree, which is unset or blank). Also note that unset environment variables expand to the empty string.
```
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
