### PR TITLE
FIX: [bsp][stm32] pulse_encoder driver did not handle TIM overflow

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_pulse_encoder.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pulse_encoder.c
@@ -157,10 +157,12 @@ rt_err_t pulse_encoder_control(struct rt_pulse_encoder_device *pulse_encoder, rt
     switch (cmd)
     {
     case PULSE_ENCODER_CMD_ENABLE:
+        __HAL_TIM_ENABLE_IT(&stm32_device->tim_handler, TIM_IT_UPDATE);
         HAL_TIM_Encoder_Start(&stm32_device->tim_handler, TIM_CHANNEL_ALL);
         HAL_TIM_Encoder_Start_IT(&stm32_device->tim_handler, TIM_CHANNEL_ALL);
         break;
     case PULSE_ENCODER_CMD_DISABLE:
+        __HAL_TIM_DISABLE_IT(&stm32_device->tim_handler, TIM_IT_UPDATE);
         HAL_TIM_Encoder_Stop(&stm32_device->tim_handler, TIM_CHANNEL_ALL);
         HAL_TIM_Encoder_Stop_IT(&stm32_device->tim_handler, TIM_CHANNEL_ALL);
         break;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
问题：
正交编码器从 0 反方向转动时跳变到 0x7fff，驱动预期变为负数
原因：
stm32 bsp pulse encoder 中未开启定时器更新中断导致驱动中的溢出处理不生效
解决方案：
添加定时器溢出中断使能

测试：
stm32f103rc 测试霍尔正交编码器读数，测试通过
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
