### PR TITLE
提交stm32 bsp drv_pwm.c里面的一个小建议

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/config/f0/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f0/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \
-       .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM2,         \   /* TIM1/2/3... */
+       .name                    = "pwm2",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f0/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f0/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \   /* TIM1/2/3... */
-       .name                    = "pwm2",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM2,         \
+       .name                    = "pwm2",       \
+       .channel                 = 0             \
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f1/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \   /* TIM1/2/3... */
-       .name                    = "pwm1",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM1,         \
+       .name                    = "pwm1",       \
+       .channel                 = 0             \
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f1/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \
-       .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM1,         \   /* TIM1/2/3... */
+       .name                    = "pwm1",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f2/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f2/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
-       .name                    = "pwm2",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM2,         \
+       .name                    = "pwm2",       \
+       .channel                 = 0             \
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f2/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f2/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \
-       .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
+       .name                    = "pwm2",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f3/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f3/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \
-       .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
+       .name                    = "pwm1",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f3/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f3/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
-       .name                    = "pwm1",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM1,         \
+       .name                    = "pwm1",       \
+       .channel                 = 0             \
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f4/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \   // TIM1/2/3...
-       .name                    = "pwm1",       \   // your pwm device name
-       .channel                 = 0             \   // range: 1--4
+       .tim_handle.Instance     = TIM1,         \   /* TIM1/2/3... */
+       .name                    = "pwm1",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f4/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \   /* TIM1/2/3... */
-       .name                    = "pwm1",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM1,         \
+       .name                    = "pwm1",       \
+       .channel                 = 0             \
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f4/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \
-       .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM1,         \   // TIM1/2/3...
+       .name                    = "pwm1",       \   // your pwm device name
+       .channel                 = 0             \   // range: 1--4
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f7/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f7/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
-       .name                    = "pwm2",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM2,         \
+       .name                    = "pwm2",       \
+       .channel                 = 0             \
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/f7/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f7/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \
-       .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
+       .name                    = "pwm2",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/g0/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/g0/pwm_config.h
@@ -18,13 +18,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
-       .name                    = "pwm2",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM2,         \
+       .name                    = "pwm2",       \
+       .channel                 = 0             \
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/g0/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/g0/pwm_config.h
@@ -22,9 +22,9 @@ extern "C" {
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \
-       .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
+       .name                    = "pwm2",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/g4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/g4/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
-       .name                    = "pwm2",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM2,         \
+       .name                    = "pwm2",       \
+       .channel                 = 0             \
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/g4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/g4/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \
-       .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
+       .name                    = "pwm2",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/h7/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/h7/pwm_config.h
@@ -22,9 +22,9 @@ extern "C" {
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \
-       .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
+       .name                    = "pwm1",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/h7/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/h7/pwm_config.h
@@ -18,13 +18,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
-       .name                    = "pwm1",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM1,         \
+       .name                    = "pwm1",       \
+       .channel                 = 0             \
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/l1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l1/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
-       .name                    = "pwm2",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM2,         \
+       .name                    = "pwm2",       \
+       .channel                 = 0             \
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/l1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l1/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \
-       .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
+       .name                    = "pwm2",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/l4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l4/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \
-       .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
+       .name                    = "pwm1",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/l4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l4/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
-       .name                    = "pwm1",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM1,         \
+       .name                    = "pwm1",       \
+       .channel                 = 0             \
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/l5/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l5/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \
-       .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
+       .name                    = "pwm1",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/l5/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l5/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
-       .name                    = "pwm1",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM1,         \
+       .name                    = "pwm1",       \
+       .channel                 = 0             \
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/mp1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/mp1/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
-       .name                    = "pwm2",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM2,         \
+       .name                    = "pwm2",       \
+       .channel                 = 0             \
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/mp1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/mp1/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM2,         \
-       .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM2,         \	/* TIM1/2/3... */
+       .name                    = "pwm2",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/u5/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/u5/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \
-       .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
+       .name                    = "pwm1",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/u5/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/u5/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
-       .name                    = "pwm1",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM1,         \
+       .name                    = "pwm1",       \
+       .channel                 = 0             \
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/wb/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/wb/pwm_config.h
@@ -21,9 +21,9 @@ extern "C" {
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \
-       .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
+       .name                    = "pwm1",       \   /* your pwm device name */
+       .channel                 = 0             \   /* range: 1--4 */
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/config/wb/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/wb/pwm_config.h
@@ -17,13 +17,19 @@
 extern "C" {
 #endif
 
+/*
+ * .tim_handle.Instance     = TIM1/2/3...,
+ * .name					= "your pwm device name",
+ * .channel					= 1/2/3/4
+ */
+
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
-       .tim_handle.Instance     = TIM1,         \	/* TIM1/2/3... */
-       .name                    = "pwm1",       \   /* your pwm device name */
-       .channel                 = 0             \   /* range: 1--4 */
+       .tim_handle.Instance     = TIM1,         \
+       .name                    = "pwm1",       \
+       .channel                 = 0             \
     }
 #endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */

--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -234,7 +234,13 @@ static struct rt_pwm_ops drv_ops =
 static rt_err_t drv_pwm_enable(TIM_HandleTypeDef *htim, struct rt_pwm_configuration *configuration, rt_bool_t enable)
 {
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = 0x04 * (configuration->channel - 1);
+    rt_uint32_t channel = configuration->channel；
+    if(channel<1 || channel >4)	
+    {
+		LOG_E("pwm channel %d is invalid, failed to enable", configuration->channel);
+		return -RT_ERROR;
+	}
+    channel = 0x04 * (configuration->channel - 1);
 
     if (!configuration->complementary)
     {
@@ -265,7 +271,13 @@ static rt_err_t drv_pwm_enable(TIM_HandleTypeDef *htim, struct rt_pwm_configurat
 static rt_err_t drv_pwm_get(TIM_HandleTypeDef *htim, struct rt_pwm_configuration *configuration)
 {
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = 0x04 * (configuration->channel - 1);
+    rt_uint32_t channel = configuration->channel；
+    if(channel<1 || channel >4)	
+    {
+		LOG_E("pwm channel %d is invalid, failed to get", configuration->channel);
+		return -RT_ERROR;
+	}
+    channel = 0x04 * (configuration->channel - 1);
     rt_uint64_t tim_clock;
 
     tim_clock = tim_clock_get(htim);
@@ -291,7 +303,13 @@ static rt_err_t drv_pwm_set(TIM_HandleTypeDef *htim, struct rt_pwm_configuration
     rt_uint32_t period, pulse;
     rt_uint64_t tim_clock, psc;
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = 0x04 * (configuration->channel - 1);
+    rt_uint32_t channel = configuration->channel；
+    if(channel<1 || channel >4)	
+    {
+		LOG_E("pwm channel %d is invalid, failed to set", configuration->channel);
+		return -RT_ERROR;
+	}
+    channel = 0x04 * (configuration->channel - 1);
 
     tim_clock = tim_clock_get(htim);
     /* Convert nanosecond to frequency and duty cycle. 1s = 1 * 1000 * 1000 * 1000 ns */
@@ -354,7 +372,13 @@ static rt_err_t drv_pwm_set_pulse(TIM_HandleTypeDef *htim, struct rt_pwm_configu
     rt_uint32_t period, pulse;
     rt_uint64_t tim_clock;
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = 0x04 * (configuration->channel - 1);
+    rt_uint32_t channel = configuration->channel；
+    if(channel<1 || channel >4)	
+    {
+		LOG_E("pwm channel %d is invalid, failed to set pulse", configuration->channel);
+		return -RT_ERROR;
+	}
+    channel = 0x04 * (configuration->channel - 1);
 
     tim_clock = tim_clock_get(htim);
     /* Convert nanosecond to frequency and duty cycle. 1s = 1 * 1000 * 1000 * 1000 ns */
@@ -407,7 +431,14 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     TIM_OC_InitTypeDef oc_config = {0};
     TIM_MasterConfigTypeDef master_config = {0};
     TIM_ClockConfigTypeDef clock_config = {0};
-    rt_uint32_t channel = 0x04 * (device->channel - 1);
+    
+    rt_uint32_t channel = device->channel；
+    if(channel<1 || channel >4)	
+    {
+		LOG_E("%s pwm channel %d is invalid, failed to init", device->name, device->channel);
+		return -RT_ERROR;
+	}
+    channel = 0x04 * (device->channel - 1);
 
     RT_ASSERT(device != RT_NULL);
 

--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -458,8 +458,8 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     oc_config.OCFastMode = TIM_OCFAST_DISABLE;
     oc_config.OCNIdleState = TIM_OCNIDLESTATE_RESET;
     oc_config.OCIdleState  = TIM_OCIDLESTATE_RESET;
-	
-	if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, channel) != HAL_OK)
+
+    if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, channel) != HAL_OK)
     {
         LOG_E("%s %d config failed", device->name, device->channel);
         result = -RT_ERROR;

--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -234,12 +234,12 @@ static struct rt_pwm_ops drv_ops =
 static rt_err_t drv_pwm_enable(TIM_HandleTypeDef *htim, struct rt_pwm_configuration *configuration, rt_bool_t enable)
 {
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = configuration->channel；
-    if(channel<1 || channel >4)	
+    rt_uint32_t channel = configuration->channel;
+    if(channel<1 || channel >4)
     {
-		LOG_E("pwm channel %d is invalid, failed to enable", configuration->channel);
-		return -RT_ERROR;
-	}
+        LOG_E("pwm channel %d is invalid, failed to enable", configuration->channel);
+        return -RT_ERROR;
+    }
     channel = 0x04 * (configuration->channel - 1);
 
     if (!configuration->complementary)
@@ -271,12 +271,12 @@ static rt_err_t drv_pwm_enable(TIM_HandleTypeDef *htim, struct rt_pwm_configurat
 static rt_err_t drv_pwm_get(TIM_HandleTypeDef *htim, struct rt_pwm_configuration *configuration)
 {
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = configuration->channel；
-    if(channel<1 || channel >4)	
+    rt_uint32_t channel = configuration->channel;
+    if(channel<1 || channel >4)
     {
-		LOG_E("pwm channel %d is invalid, failed to get", configuration->channel);
-		return -RT_ERROR;
-	}
+        LOG_E("pwm channel %d is invalid, failed to get", configuration->channel);
+        return -RT_ERROR;
+    }
     channel = 0x04 * (configuration->channel - 1);
     rt_uint64_t tim_clock;
 
@@ -303,12 +303,12 @@ static rt_err_t drv_pwm_set(TIM_HandleTypeDef *htim, struct rt_pwm_configuration
     rt_uint32_t period, pulse;
     rt_uint64_t tim_clock, psc;
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = configuration->channel；
-    if(channel<1 || channel >4)	
+    rt_uint32_t channel = configuration->channel;
+    if(channel<1 || channel >4)
     {
-		LOG_E("pwm channel %d is invalid, failed to set", configuration->channel);
-		return -RT_ERROR;
-	}
+        LOG_E("pwm channel %d is invalid, failed to set", configuration->channel);
+        return -RT_ERROR;
+    }
     channel = 0x04 * (configuration->channel - 1);
 
     tim_clock = tim_clock_get(htim);
@@ -372,12 +372,12 @@ static rt_err_t drv_pwm_set_pulse(TIM_HandleTypeDef *htim, struct rt_pwm_configu
     rt_uint32_t period, pulse;
     rt_uint64_t tim_clock;
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = configuration->channel；
-    if(channel<1 || channel >4)	
+    rt_uint32_t channel = configuration->channel;
+    if(channel<1 || channel >4)
     {
-		LOG_E("pwm channel %d is invalid, failed to set pulse", configuration->channel);
-		return -RT_ERROR;
-	}
+        LOG_E("pwm channel %d is invalid, failed to set pulse", configuration->channel);
+        return -RT_ERROR;
+    }
     channel = 0x04 * (configuration->channel - 1);
 
     tim_clock = tim_clock_get(htim);
@@ -431,13 +431,13 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     TIM_OC_InitTypeDef oc_config = {0};
     TIM_MasterConfigTypeDef master_config = {0};
     TIM_ClockConfigTypeDef clock_config = {0};
-    
-    rt_uint32_t channel = device->channel；
-    if(channel<1 || channel >4)	
+
+    rt_uint32_t channel = device->channel;
+    if(channel<1 || channel >4)
     {
-		LOG_E("%s pwm channel %d is invalid, failed to init", device->name, device->channel);
-		return -RT_ERROR;
-	}
+        LOG_E("%s pwm channel %d is invalid, failed to init", device->name, device->channel);
+        return -RT_ERROR;
+    }
     channel = 0x04 * (device->channel - 1);
 
     RT_ASSERT(device != RT_NULL);

--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -235,7 +235,7 @@ static rt_err_t drv_pwm_enable(TIM_HandleTypeDef *htim, struct rt_pwm_configurat
 {
     /* Converts the channel number to the channel number of Hal library */
     rt_uint32_t channel = configuration->channel;
-    if(channel<1 || channel >4)
+    if(channel < 1 || channel > 4)
     {
         LOG_E("pwm channel %d is invalid, failed to enable", configuration->channel);
         return -RT_ERROR;
@@ -272,7 +272,7 @@ static rt_err_t drv_pwm_get(TIM_HandleTypeDef *htim, struct rt_pwm_configuration
 {
     /* Converts the channel number to the channel number of Hal library */
     rt_uint32_t channel = configuration->channel;
-    if(channel<1 || channel >4)
+    if(channel < 1 || channel > 4)
     {
         LOG_E("pwm channel %d is invalid, failed to get", configuration->channel);
         return -RT_ERROR;
@@ -304,7 +304,7 @@ static rt_err_t drv_pwm_set(TIM_HandleTypeDef *htim, struct rt_pwm_configuration
     rt_uint64_t tim_clock, psc;
     /* Converts the channel number to the channel number of Hal library */
     rt_uint32_t channel = configuration->channel;
-    if(channel<1 || channel >4)
+    if(channel < 1 || channel > 4)
     {
         LOG_E("pwm channel %d is invalid, failed to set", configuration->channel);
         return -RT_ERROR;
@@ -373,7 +373,7 @@ static rt_err_t drv_pwm_set_pulse(TIM_HandleTypeDef *htim, struct rt_pwm_configu
     rt_uint64_t tim_clock;
     /* Converts the channel number to the channel number of Hal library */
     rt_uint32_t channel = configuration->channel;
-    if(channel<1 || channel >4)
+    if(channel < 1 || channel > 4)
     {
         LOG_E("pwm channel %d is invalid, failed to set pulse", configuration->channel);
         return -RT_ERROR;
@@ -433,7 +433,7 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     TIM_ClockConfigTypeDef clock_config = {0};
 
     rt_uint32_t channel = device->channel;
-    if(channel<1 || channel >4)
+    if(channel < 1 || channel > 4)
     {
         LOG_E("%s pwm channel %d is invalid, failed to init", device->name, device->channel);
         return -RT_ERROR;

--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -407,6 +407,7 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     TIM_OC_InitTypeDef oc_config = {0};
     TIM_MasterConfigTypeDef master_config = {0};
     TIM_ClockConfigTypeDef clock_config = {0};
+    rt_uint32_t channel = 0x04 * (device->channel - 1);
 
     RT_ASSERT(device != RT_NULL);
 
@@ -457,46 +458,12 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     oc_config.OCFastMode = TIM_OCFAST_DISABLE;
     oc_config.OCNIdleState = TIM_OCNIDLESTATE_RESET;
     oc_config.OCIdleState  = TIM_OCIDLESTATE_RESET;
-
-    /* config pwm channel */
-    if (device->channel & 0x01)
+	
+	if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, channel) != HAL_OK)
     {
-        if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, TIM_CHANNEL_1) != HAL_OK)
-        {
-            LOG_E("%s channel1 config failed", device->name);
-            result = -RT_ERROR;
-            goto __exit;
-        }
-    }
-
-    if (device->channel & 0x02)
-    {
-        if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, TIM_CHANNEL_2) != HAL_OK)
-        {
-            LOG_E("%s channel2 config failed", device->name);
-            result = -RT_ERROR;
-            goto __exit;
-        }
-    }
-
-    if (device->channel & 0x04)
-    {
-        if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, TIM_CHANNEL_3) != HAL_OK)
-        {
-            LOG_E("%s channel3 config failed", device->name);
-            result = -RT_ERROR;
-            goto __exit;
-        }
-    }
-
-    if (device->channel & 0x08)
-    {
-        if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, TIM_CHANNEL_4) != HAL_OK)
-        {
-            LOG_E("%s channel4 config failed", device->name);
-            result = -RT_ERROR;
-            goto __exit;
-        }
+        LOG_E("%s %d config failed", device->name, device->channel);
+        result = -RT_ERROR;
+        goto __exit;
     }
 
     /* pwm pin configuration */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
 在使用stm32的pwm驱动时，发现其初始化channel的时候是根据device->channel这个值去初始化的，device->channel这个值是在pwm_configh.h里面定义设置的，又根据rtt的pwm例程，和常规习惯，应该大多数人会更喜欢设置channel=1/2/3/4，而不是在pwm_configh.h中将channel设置为TIM_CHANNEL_1/2/3/4，因此建议drv_pwm.c做出PR中的修改。

在实际开发中，因pwm_configh.h的示例均是.channel=0，又没有做出解释说明要让.channel=TIM_CHANNEL_1/2/3/4的值，容易误操作导致没有成功输出PWM，这是我在实际开发中遇到的现实问题，因而提出此建议。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](../documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](../documentation/contribution_guide/coding_style_en.txt) 
