### PR TITLE
修复  RTT 串口DMA接受 开头丢失一整包的问题

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart.c
@@ -170,7 +170,7 @@ static rt_err_t stm32_configure(struct rt_serial_device *serial, struct serial_c
 
 #ifdef RT_SERIAL_USING_DMA
     if (!(serial->parent.open_flag & RT_DEVICE_OFLAG_OPEN)) {
-        uart->dma_rx.remaining_cnt = 0;
+        uart->dma_rx.remaining_cnt = cfg->bufsz;
     }
 #endif
 


### PR DESCRIPTION
修复RX DMA 第一包收不到的bug

## 拉取/合并请求描述：(PR description)

[
出现的问题: 

使用RT框架串口DMA接收的时候,如果上位机发送的第一包大小超过缓冲区大小(设置的NDRT寄存器大小,或者说是buffsize大小),则会丢失一整个包(包长为buffsize)。

定位问题:

问题被定位到,是[uart->dma_rx.remaining_cnt]参数初始化的值不对, 导致第一次DMA半接受中断没有做事情, 等待DMA满中断过来的时候[因为是串口循环],数据已经被覆盖了.

解决方案:

正确初始化[uart->dma_rx.remaining_cnt]为(buffsize)的值.

测试:

已经在STMF405的板卡进行测试了,可以正确接受第一包.

]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
