### PR TITLE
[env] add scons --strict

### DIFF
--- a/bsp/stm32/stm32f411-st-nucleo/rtconfig.py
+++ b/bsp/stm32/stm32f411-st-nucleo/rtconfig.py
@@ -44,7 +44,7 @@ if PLATFORM == 'gcc':
     OBJCPY = PREFIX + 'objcopy'
 
     DEVICE = ' -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard -ffunction-sections -fdata-sections'
-    CFLAGS = DEVICE + ' -Dgcc' + ' -Wall -Werror'
+    CFLAGS = DEVICE + ' -Dgcc' + ' -Wall'
     AFLAGS = ' -c' + DEVICE + ' -x assembler-with-cpp -Wa,-mimplicit-it=thumb '
     LFLAGS = DEVICE + ' -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,Reset_Handler -T board/linker_scripts/link.lds'
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -223,7 +223,7 @@ def PrepareBuilding(env, root_directory, has_libcpu=False, remove_components = [
 
     utils.ReloadModule(rtconfig) # update environment variables to rtconfig.py
 
-    # some env variables have loaded in SConsctruct Environment() before re-load rtconfig.py;
+    # some env variables have loaded in Environment() of SConstruct before re-load rtconfig.py;
     # after update rtconfig.py's variables, those env variables need to synchronize
     if exec_prefix:
         env['CC'] = rtconfig.CC
@@ -233,6 +233,12 @@ def PrepareBuilding(env, root_directory, has_libcpu=False, remove_components = [
         env['LINK'] = rtconfig.LINK
     if exec_path:
         env.PrependENVPath('PATH', rtconfig.EXEC_PATH)
+
+    if GetOption('strict-compiling'):
+        STRICT_FLAGS = ''
+        if rtconfig.PLATFORM in ['gcc']:
+            STRICT_FLAGS += ' -Werror' #-Wextra
+            env.Append(CFLAGS=STRICT_FLAGS, CXXFLAGS=STRICT_FLAGS)
 
     # add compability with Keil MDK 4.6 which changes the directory of armcc.exe
     if rtconfig.PLATFORM in ['armcc', 'armclang']:

--- a/tools/options.py
+++ b/tools/options.py
@@ -85,6 +85,11 @@ def AddOptions():
                       dest = 'target',
                       type = 'string',
                       help = 'set target project: mdk/mdk4/mdk5/iar/vs/vsc/ua/cdk/ses/makefile/eclipse/codelite/cmake')
+    AddOption('--strict',
+                dest='strict-compiling',
+                help='Compiling project with strict mode and ALL warning will be errors',
+                action='store_true',
+                default=False)
     AddOption('--cc-prefix', '--exec-prefix',
                 dest = 'exec-prefix',
                 type = 'string',


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
此PR意图在脚本中增加 scons --strict命令，使用该命令编译工程时，会自动将CFLAGS CXXFLAGS设置为 Werrors，即较为严格的编译模式，任何警告都会当做错误来处理。

该命令主要用于CI，在CI执行bsp编译时，可以使用 scons --strict命令。现在QEMU的rtconfig.py 为了CI检查，直接将CFLAGS加上了Werrors，导致正常编译过程中也把警告当做了错误，对日常使用该bsp造成了影响。
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
