### PR TITLE
replaced the judgement of RT_USING_XXX  with  BSP_USING, and add some…

### DIFF
--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_gpio.c
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_gpio.c
@@ -11,7 +11,7 @@
 #include <board.h>
 #include "drv_gpio.h"
 
-#ifdef RT_USING_PIN
+#ifdef BSP_USING_GPIO
 #define PIN_NUM(port, no) (((((port) & 0xFu) << 4) | ((no) & 0xFu)))
 #define PIN_PORT(pin) ((uint8_t)(((pin) >> 4) & 0xFu))
 #define PIN_NO(pin) ((uint8_t)((pin) & 0xFu))

--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_gpio.c
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_gpio.c
@@ -569,4 +569,4 @@ int rt_hw_pin_init(void)
 }
 INIT_BOARD_EXPORT(rt_hw_pin_init);
 
-#endif /* RT_USING_PIN */
+#endif /* BSP_USING_GPIO */

--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_soft_spi.c
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_soft_spi.c
@@ -11,7 +11,7 @@
 #include <board.h>
 #include "drv_soft_spi.h"
 
-#if defined(BSP_USING_I2C1) || defined(BSP_USING_I2C2)
+#if defined(BSP_USING_SOFT_I2C)
 
 #define LOG_TAG             "drv.soft_spi"
 #include <drv_log.h>
@@ -225,4 +225,4 @@ int rt_soft_spi_init(void)
 }
 INIT_BOARD_EXPORT(rt_soft_spi_init);
 
-#endif /* defined(BSP_USING_I2C1) || defined(BSP_USING_I2C2) */
+#endif /* defined(BSP_USING_SOFT_I2C) */

--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_soft_spi.c
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_soft_spi.c
@@ -11,7 +11,7 @@
 #include <board.h>
 #include "drv_soft_spi.h"
 
-#if defined(BSP_USING_SOFT_I2C)
+#ifdef BSP_USING_SOFT_I2C
 
 #define LOG_TAG             "drv.soft_spi"
 #include <drv_log.h>
@@ -225,4 +225,4 @@ int rt_soft_spi_init(void)
 }
 INIT_BOARD_EXPORT(rt_soft_spi_init);
 
-#endif /* defined(BSP_USING_SOFT_I2C) */
+#endif /* BSP_USING_SOFT_I2C */

--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_soft_spi.c
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_soft_spi.c
@@ -11,7 +11,7 @@
 #include <board.h>
 #include "drv_soft_spi.h"
 
-#if defined(RT_USING_SPI) && defined(RT_USING_SPI_BITOPS) && defined(RT_USING_PIN)
+#if defined(BSP_USING_I2C1) || defined(BSP_USING_I2C2)
 
 #define LOG_TAG             "drv.soft_spi"
 #include <drv_log.h>

--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_soft_spi.c
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_soft_spi.c
@@ -225,4 +225,4 @@ int rt_soft_spi_init(void)
 }
 INIT_BOARD_EXPORT(rt_soft_spi_init);
 
-#endif /* defined(RT_USING_SPI) && defined(RT_USING_SPI_BITOPS) && defined(RT_USING_PIN) */
+#endif /* defined(BSP_USING_I2C1) || defined(BSP_USING_I2C2) */

--- a/bsp/wch/risc-v/ch32v307v-r1/board/Kconfig
+++ b/bsp/wch/risc-v/ch32v307v-r1/board/Kconfig
@@ -98,7 +98,7 @@ menu "On-chip Peripheral Drivers"
 
         if BSP_USING_SOFT_I2C
             config BSP_USING_I2C1
-                bool "Enable I2C1 Bus"
+                bool "Enable I2C1 Bus (software simulation)"
                 default n
 
                 if BSP_USING_I2C1
@@ -115,7 +115,7 @@ menu "On-chip Peripheral Drivers"
                 endif
 
             config BSP_USING_I2C2
-                bool "Enable I2C2 Bus"
+                bool "Enable I2C2 Bus (software simulation)"
                 default n
 
                 if BSP_USING_I2C2


### PR DESCRIPTION
… tips in Konfig about soft_i2c

## 拉取/合并请求描述：(PR description)

[
在驱动文件随后被包含，使用BSP_USING进行判断，替换掉了原来的RT_USING判断，并且修改了Kconfig文件，使得在menuconfig的BSP_USING_I2C1配置名称由Enable I2C1 Bus变为Enable I2C1 Bus (software simulation)，并且BSP_USING_I2C2也是如此，已测试过使用此配置能够正常添加驱动文件
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
