### PR TITLE
fix test_thread_yield fail bug in multiple utest loop case.

### DIFF
--- a/examples/utest/testcases/kernel/thread_tc.c
+++ b/examples/utest/testcases/kernel/thread_tc.c
@@ -259,6 +259,7 @@ static void thread6_entry(void *parameter)
 static void test_thread_yield(void)
 {
     rt_err_t ret_startup = -RT_ERROR;
+    thread5_source = 0;
     tid5 = rt_thread_create("thread5",
                             thread5_entry,
                             RT_NULL,


### PR DESCRIPTION
Signed-off-by: fan.ji <fan.ji@weiheng-tech.com>

## 拉取/合并请求描述：(PR description)

[
a counter in test_thread_yield  is not reset to zero.
if we run test_thread_yield in utest framework for multiple times, uassert_true(thread5_source == 10) will case a fail, but this is wrong.

I have already tested it on a stm32f103rct6 core board and this finally fix the problem.
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [*] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [*] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [*] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [*] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [*] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [*] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [*] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [*] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
