### PR TITLE
Revert "提交stm32 bsp drv_pwm.c里面的一个小建议"

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/config/f0/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f0/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/f1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f1/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/f2/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f2/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/f3/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f3/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/f4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f4/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/f7/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f7/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/g0/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/g0/pwm_config.h
@@ -18,12 +18,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/g4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/g4/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/h7/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/h7/pwm_config.h
@@ -18,12 +18,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/l1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l1/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/l4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l4/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/l5/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l5/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/mp1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/mp1/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM2
 #ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/u5/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/u5/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/config/wb/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/wb/pwm_config.h
@@ -17,12 +17,6 @@
 extern "C" {
 #endif
 
-/*
- * .tim_handle.Instance     = TIM1/2/3...,
- * .name					= "your pwm device name",
- * .channel					= 1/2/3/4
- */
-
 #ifdef BSP_USING_PWM1
 #ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \

--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -234,13 +234,7 @@ static struct rt_pwm_ops drv_ops =
 static rt_err_t drv_pwm_enable(TIM_HandleTypeDef *htim, struct rt_pwm_configuration *configuration, rt_bool_t enable)
 {
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = configuration->channel;
-    if(channel < 1 || channel > 4)
-    {
-        LOG_E("pwm channel %d is invalid, failed to enable", configuration->channel);
-        return -RT_ERROR;
-    }
-    channel = 0x04 * (configuration->channel - 1);
+    rt_uint32_t channel = 0x04 * (configuration->channel - 1);
 
     if (!configuration->complementary)
     {
@@ -271,13 +265,7 @@ static rt_err_t drv_pwm_enable(TIM_HandleTypeDef *htim, struct rt_pwm_configurat
 static rt_err_t drv_pwm_get(TIM_HandleTypeDef *htim, struct rt_pwm_configuration *configuration)
 {
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = configuration->channel;
-    if(channel < 1 || channel > 4)
-    {
-        LOG_E("pwm channel %d is invalid, failed to get", configuration->channel);
-        return -RT_ERROR;
-    }
-    channel = 0x04 * (configuration->channel - 1);
+    rt_uint32_t channel = 0x04 * (configuration->channel - 1);
     rt_uint64_t tim_clock;
 
     tim_clock = tim_clock_get(htim);
@@ -303,13 +291,7 @@ static rt_err_t drv_pwm_set(TIM_HandleTypeDef *htim, struct rt_pwm_configuration
     rt_uint32_t period, pulse;
     rt_uint64_t tim_clock, psc;
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = configuration->channel;
-    if(channel < 1 || channel > 4)
-    {
-        LOG_E("pwm channel %d is invalid, failed to set", configuration->channel);
-        return -RT_ERROR;
-    }
-    channel = 0x04 * (configuration->channel - 1);
+    rt_uint32_t channel = 0x04 * (configuration->channel - 1);
 
     tim_clock = tim_clock_get(htim);
     /* Convert nanosecond to frequency and duty cycle. 1s = 1 * 1000 * 1000 * 1000 ns */
@@ -372,13 +354,7 @@ static rt_err_t drv_pwm_set_pulse(TIM_HandleTypeDef *htim, struct rt_pwm_configu
     rt_uint32_t period, pulse;
     rt_uint64_t tim_clock;
     /* Converts the channel number to the channel number of Hal library */
-    rt_uint32_t channel = configuration->channel;
-    if(channel < 1 || channel > 4)
-    {
-        LOG_E("pwm channel %d is invalid, failed to set pulse", configuration->channel);
-        return -RT_ERROR;
-    }
-    channel = 0x04 * (configuration->channel - 1);
+    rt_uint32_t channel = 0x04 * (configuration->channel - 1);
 
     tim_clock = tim_clock_get(htim);
     /* Convert nanosecond to frequency and duty cycle. 1s = 1 * 1000 * 1000 * 1000 ns */
@@ -432,14 +408,6 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     TIM_MasterConfigTypeDef master_config = {0};
     TIM_ClockConfigTypeDef clock_config = {0};
 
-    rt_uint32_t channel = device->channel;
-    if(channel < 1 || channel > 4)
-    {
-        LOG_E("%s pwm channel %d is invalid, failed to init", device->name, device->channel);
-        return -RT_ERROR;
-    }
-    channel = 0x04 * (device->channel - 1);
-
     RT_ASSERT(device != RT_NULL);
 
     tim = (TIM_HandleTypeDef *)&device->tim_handle;
@@ -490,11 +458,45 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     oc_config.OCNIdleState = TIM_OCNIDLESTATE_RESET;
     oc_config.OCIdleState  = TIM_OCIDLESTATE_RESET;
 
-    if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, channel) != HAL_OK)
+    /* config pwm channel */
+    if (device->channel & 0x01)
     {
-        LOG_E("%s %d config failed", device->name, device->channel);
-        result = -RT_ERROR;
-        goto __exit;
+        if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, TIM_CHANNEL_1) != HAL_OK)
+        {
+            LOG_E("%s channel1 config failed", device->name);
+            result = -RT_ERROR;
+            goto __exit;
+        }
+    }
+
+    if (device->channel & 0x02)
+    {
+        if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, TIM_CHANNEL_2) != HAL_OK)
+        {
+            LOG_E("%s channel2 config failed", device->name);
+            result = -RT_ERROR;
+            goto __exit;
+        }
+    }
+
+    if (device->channel & 0x04)
+    {
+        if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, TIM_CHANNEL_3) != HAL_OK)
+        {
+            LOG_E("%s channel3 config failed", device->name);
+            result = -RT_ERROR;
+            goto __exit;
+        }
+    }
+
+    if (device->channel & 0x08)
+    {
+        if (HAL_TIM_PWM_ConfigChannel(tim, &oc_config, TIM_CHANNEL_4) != HAL_OK)
+        {
+            LOG_E("%s channel4 config failed", device->name);
+            result = -RT_ERROR;
+            goto __exit;
+        }
     }
 
     /* pwm pin configuration */


### PR DESCRIPTION
Reverts RT-Thread/rt-thread#6517

![7ac37b51b46ce09a571965e62c0adcf](https://user-images.githubusercontent.com/34888354/198749991-fba382c2-3967-4796-a2cf-137234a36f12.png)
PR里描述的有问题，channel的定义实际上只需要在pwm_get_channel补充缺的channel即可，不需要单独拉出来定义

经确认目前源码没有问题，是缺文档说明，导致用户不知道如何正确的增加缺少的pwm通道号导致的。应当补充教程。