### PR TITLE
[bsp]  修改了stm32中pwm的部分选择编译选项，并使pwm channel初始化为RT_NULL

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/config/f0/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f0/pwm_config.h
@@ -18,69 +18,57 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef BSP_USING_PWM16
-#ifndef PWM16_CONFIG
-#define PWM16_CONFIG                             \
+#define PWM16_CONFIG                            \
     {                                           \
-       .tim_handle.Instance     = TIM16,         \
-       .name                    = "pwm16",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM16,        \
+       .name                    = "pwm16",      \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM16_CONFIG */
 #endif /* BSP_USING_PWM16 */
 
 #ifdef BSP_USING_PWM17
-#ifndef PWM17_CONFIG
-#define PWM17_CONFIG                             \
+#define PWM17_CONFIG                            \
     {                                           \
-       .tim_handle.Instance     = TIM17,         \
-       .name                    = "pwm17",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM17,        \
+       .name                    = "pwm17",      \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM17_CONFIG */
 #endif /* BSP_USING_PWM17 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/f1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f1/pwm_config.h
@@ -18,146 +18,121 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM1
-#ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM1,         \
        .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM1_CONFIG */
+
 #endif /* BSP_USING_PWM1 */
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef BSP_USING_PWM6
-#ifndef PWM6_CONFIG
 #define PWM6_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM6,         \
        .name                    = "pwm6",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM6_CONFIG */
 #endif /* BSP_USING_PWM6 */
 
 #ifdef BSP_USING_PWM7
-#ifndef PWM7_CONFIG
 #define PWM7_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM7,         \
        .name                    = "pwm7",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM7_CONFIG */
 #endif /* BSP_USING_PWM7 */
 
 #ifdef BSP_USING_PWM8
-#ifndef PWM8_CONFIG
 #define PWM8_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM8,         \
        .name                    = "pwm8",       \
-       .channel                 = 12             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM8_CONFIG */
 #endif /* BSP_USING_PWM8 */
 
 #ifdef BSP_USING_PWM9
-#ifndef PWM9_CONFIG
 #define PWM9_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM9,         \
        .name                    = "pwm9",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM9_CONFIG */
 #endif /* BSP_USING_PWM9 */
 
 #ifdef BSP_USING_PWM10
-#ifndef PWM10_CONFIG
-#define PWM10_CONFIG                             \
+#define PWM10_CONFIG                            \
     {                                           \
-       .tim_handle.Instance     = TIM10,         \
-       .name                    = "pwm10",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM10,        \
+       .name                    = "pwm10",      \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM10_CONFIG */
 #endif /* BSP_USING_PWM10 */
 
 #ifdef BSP_USING_PWM11
-#ifndef PWM11_CONFIG
-#define PWM11_CONFIG                             \
+#define PWM11_CONFIG                            \
     {                                           \
-       .tim_handle.Instance     = TIM11,         \
-       .name                    = "pwm11",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM11,        \
+       .name                    = "pwm11",      \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM11_CONFIG */
 #endif /* BSP_USING_PWM11 */
 
 #ifdef BSP_USING_PWM12
-#ifndef PWM12_CONFIG
-#define PWM12_CONFIG                             \
+#define PWM12_CONFIG                            \
     {                                           \
-       .tim_handle.Instance     = TIM12,         \
-       .name                    = "pwm12",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM12,        \
+       .name                    = "pwm12",      \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM12_CONFIG */
 #endif /* BSP_USING_PWM12 */
 
 #ifdef BSP_USING_PWM13
-#ifndef PWM13_CONFIG
-#define PWM13_CONFIG                             \
+#define PWM13_CONFIG                            \
     {                                           \
-       .tim_handle.Instance     = TIM13,         \
-       .name                    = "pwm13",       \
-       .channel                 = 0             \
+       .tim_handle.Instance     = TIM13,        \
+       .name                    = "pwm13",      \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM13_CONFIG */
 #endif /* BSP_USING_PWM13 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/f2/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f2/pwm_config.h
@@ -18,47 +18,39 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/f3/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f3/pwm_config.h
@@ -18,14 +18,12 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM1
-#ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM1,         \
        .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/f4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f4/pwm_config.h
@@ -18,157 +18,129 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM1
-#ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM1,         \
        .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef BSP_USING_PWM6
-#ifndef PWM6_CONFIG
 #define PWM6_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM6,         \
        .name                    = "pwm6",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM6_CONFIG */
 #endif /* BSP_USING_PWM6 */
 
 #ifdef BSP_USING_PWM7
-#ifndef PWM7_CONFIG
 #define PWM7_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM7,         \
        .name                    = "pwm7",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM7_CONFIG */
 #endif /* BSP_USING_PWM7 */
 
 #ifdef BSP_USING_PWM8
-#ifndef PWM8_CONFIG
 #define PWM8_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM8,         \
        .name                    = "pwm8",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM8_CONFIG */
 #endif /* BSP_USING_PWM8 */
 
 #ifdef BSP_USING_PWM9
-#ifndef PWM9_CONFIG
 #define PWM9_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM9,         \
        .name                    = "pwm9",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM9_CONFIG */
 #endif /* BSP_USING_PWM9 */
 
 #ifdef BSP_USING_PWM10
-#ifndef PWM10_CONFIG
 #define PWM10_CONFIG                            \
     {                                           \
        .tim_handle.Instance     = TIM10,        \
        .name                    = "pwm10",      \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM10_CONFIG */
 #endif /* BSP_USING_PWM10 */
 
 #ifdef BSP_USING_PWM11
-#ifndef PWM11_CONFIG
 #define PWM11_CONFIG                            \
     {                                           \
        .tim_handle.Instance     = TIM11,        \
        .name                    = "pwm11",      \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM11_CONFIG */
 #endif /* BSP_USING_PWM11 */
 
 #ifdef BSP_USING_PWM12
-#ifndef PWM12_CONFIG
 #define PWM12_CONFIG                            \
     {                                           \
        .tim_handle.Instance     = TIM12,        \
        .name                    = "pwm12",      \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM12_CONFIG */
 #endif /* BSP_USING_PWM12 */
 
 #ifdef BSP_USING_PWM13
-#ifndef PWM13_CONFIG
 #define PWM13_CONFIG                            \
     {                                           \
        .tim_handle.Instance     = TIM13,        \
        .name                    = "pwm13",      \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM13_CONFIG */
 #endif /* BSP_USING_PWM13 */
 
 #ifdef BSP_USING_PWM14
-#ifndef PWM14_CONFIG
 #define PWM14_CONFIG                            \
     {                                           \
        .tim_handle.Instance     = TIM14,        \
        .name                    = "pwm14",      \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM14_CONFIG */
 #endif /* BSP_USING_PWM14 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/f7/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/f7/pwm_config.h
@@ -18,47 +18,39 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/g0/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/g0/pwm_config.h
@@ -19,25 +19,21 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/g4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/g4/pwm_config.h
@@ -18,58 +18,48 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef BSP_USING_PWM12
-#ifndef PWM12_CONFIG
 #define PWM12_CONFIG                            \
     {                                           \
        .tim_handle.Instance     = TIM12,        \
        .name                    = "pwm12",      \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM12_CONFIG */
 #endif /* BSP_USING_PWM12 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/h7/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/h7/pwm_config.h
@@ -19,58 +19,48 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM1
-#ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM1,         \
        .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/l1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l1/pwm_config.h
@@ -18,47 +18,39 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/l4/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l4/pwm_config.h
@@ -18,58 +18,48 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM1
-#ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM1,         \
        .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/l5/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/l5/pwm_config.h
@@ -18,58 +18,48 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM1
-#ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM1,         \
        .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/mp1/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/mp1/pwm_config.h
@@ -18,47 +18,39 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/u5/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/u5/pwm_config.h
@@ -18,58 +18,48 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM1
-#ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM1,         \
        .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/config/wb/pwm_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/config/wb/pwm_config.h
@@ -18,58 +18,48 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_PWM1
-#ifndef PWM1_CONFIG
 #define PWM1_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM1,         \
        .name                    = "pwm1",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM1_CONFIG */
 #endif /* BSP_USING_PWM1 */
 
 #ifdef BSP_USING_PWM2
-#ifndef PWM2_CONFIG
 #define PWM2_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM2,         \
        .name                    = "pwm2",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM2_CONFIG */
 #endif /* BSP_USING_PWM2 */
 
 #ifdef BSP_USING_PWM3
-#ifndef PWM3_CONFIG
 #define PWM3_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM3,         \
        .name                    = "pwm3",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM3_CONFIG */
 #endif /* BSP_USING_PWM3 */
 
 #ifdef BSP_USING_PWM4
-#ifndef PWM4_CONFIG
 #define PWM4_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM4,         \
        .name                    = "pwm4",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM4_CONFIG */
 #endif /* BSP_USING_PWM4 */
 
 #ifdef BSP_USING_PWM5
-#ifndef PWM5_CONFIG
 #define PWM5_CONFIG                             \
     {                                           \
        .tim_handle.Instance     = TIM5,         \
        .name                    = "pwm5",       \
-       .channel                 = 0             \
+       .channel                 = RT_NULL       \
     }
-#endif /* PWM5_CONFIG */
 #endif /* BSP_USING_PWM5 */
 
 #ifdef __cplusplus


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
删除pwm_config.h中对pwm_config的判断，并初始化channel 为RT_NULL，仅仅测试语法无错误，未进行编译测试
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [ ] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
