### PR TITLE
 [components][ulog]添加控制台滤波函数

### DIFF
--- a/components/utilities/ulog/backend/console_be.c
+++ b/components/utilities/ulog/backend/console_be.c
@@ -84,4 +84,6 @@ static void ulog_console_backend_filter_set(uint8_t argc, char **argv)
     }
 }
 MSH_CMD_EXPORT_ALIAS(ulog_console_backend_filter_set,console_filter,console filter [option] optino:enable or disable);
+#endif
+
 #endif /* ULOG_BACKEND_USING_CONSOLE */

--- a/components/utilities/ulog/backend/console_be.c
+++ b/components/utilities/ulog/backend/console_be.c
@@ -39,7 +39,7 @@ void ulog_console_backend_output(struct ulog_backend *backend, rt_uint32_t level
 
 }
 
-RT_WEAK rt_bool_t ulog_console_backend_filter(struct ulog_backend *backend, rt_uint32_t level, const char *tag, 
+RT_WEAK rt_bool_t ulog_console_backend_filter(struct ulog_backend *backend, rt_uint32_t level, const char *tag,
                                              rt_bool_t is_raw,const char *log, rt_size_t len)
 {
   return RT_TRUE;

--- a/components/utilities/ulog/backend/console_be.c
+++ b/components/utilities/ulog/backend/console_be.c
@@ -56,4 +56,32 @@ int ulog_console_backend_init(void)
 }
 INIT_PREV_EXPORT(ulog_console_backend_init);
 
+#ifdef RT_USING_MSH
+static void ulog_console_backend_filter_set(uint8_t argc, char **argv)
+{
+    if (argc < 2)
+    {
+        rt_kprintf("Usage:\n");
+        rt_kprintf("console filter [option] optino:enable or disable\n");
+        return;
+    }
+    else
+    {
+        const char *operator = argv[1];
+        if (!rt_strcmp(operator, "enable"))
+        {
+            ulog_backend_set_filter(&console,ulog_console_backend_filter);
+        }
+        else if (!rt_strcmp(operator, "disable"))
+        {
+            ulog_backend_set_filter(&console,RT_NULL);
+        }
+        else
+        {
+            rt_kprintf("Usage:\n");
+            rt_kprintf("console filter [option] optino:enable or disable\n");
+        }
+    }
+}
+MSH_CMD_EXPORT_ALIAS(ulog_console_backend_filter_set,console_filter,console filter [option] optino:enable or disable);
 #endif /* ULOG_BACKEND_USING_CONSOLE */

--- a/components/utilities/ulog/backend/console_be.c
+++ b/components/utilities/ulog/backend/console_be.c
@@ -39,13 +39,19 @@ void ulog_console_backend_output(struct ulog_backend *backend, rt_uint32_t level
 
 }
 
+RT_WEAK rt_bool_t ulog_console_backend_filter(struct ulog_backend *backend, rt_uint32_t level, const char *tag, 
+                                             rt_bool_t is_raw,const char *log, rt_size_t len)
+{
+  return RT_TRUE;
+}
+
 int ulog_console_backend_init(void)
 {
     ulog_init();
     console.output = ulog_console_backend_output;
 
     ulog_backend_register(&console, "console", RT_TRUE);
-
+    ulog_backend_set_filter(&console,ulog_console_backend_filter);
     return 0;
 }
 INIT_PREV_EXPORT(ulog_console_backend_init);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
### 为什么提交这份PR；
- ULOG中有文件后端的滤波设置函数，而控制台后端中没有调用
- 控制台后端无法单独设置显示特定内容或者单独不显示特定内容。
- MSH命令的滤波函数只能设置全部的过滤等级。
  没有一个MSH命令用来控制控制台可以显示什么内容或者不显示什么内容。
  一旦设置不显示，另一个文件后端中也不会保存
 
### 解决的问题是什么
- 添加弱定义的控制台滤波函数以供用户自定义实现
  让用户自己实现需要滤波与不过滤内容
- 添加MSH命令用来启用控制台滤波或者禁用控制台滤波
  让不需要时，特定内容不显示在控制台。保证调试信息干净。
  需要时，使用命令，查看日志输出内容

### 并确认并列出已经在什么情况或板卡上进行了测试。
- STM32F429IGT6
- RTT V4.1.1
- 文章中有详细测试
> https://club.rt-thread.org/ask/article/73cedec4f1707abf.html
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
