### PR TITLE
[fix][dfs]修复list_fd导致系统卡死问题

### DIFF
--- a/components/dfs/src/dfs.c
+++ b/components/dfs/src/dfs.c
@@ -526,43 +526,46 @@ int list_fd(void)
     int index;
     struct dfs_fdtable *fd_table;
 
+    char *buff = rt_malloc(1024);
+    char *buff_start = buff;
+
     fd_table = dfs_fdtable_get();
     if (!fd_table) return -1;
 
     rt_enter_critical();
-
-    rt_kprintf("fd type    ref magic  path\n");
-    rt_kprintf("-- ------  --- ----- ------\n");
+    buff += rt_sprintf(buff, "fd type    ref magic  path\n");
+    buff += rt_sprintf(buff, "-- ------  --- ----- ------\n");
     for (index = 0; index < (int)fd_table->maxfd; index ++)
     {
         struct dfs_fd *fd = fd_table->fds[index];
 
         if (fd && fd->fops)
         {
-            rt_kprintf("%2d ", index + DFS_FD_OFFSET);
-            if (fd->type == FT_DIRECTORY)    rt_kprintf("%-7.7s ", "dir");
-            else if (fd->type == FT_REGULAR) rt_kprintf("%-7.7s ", "file");
-            else if (fd->type == FT_SOCKET)  rt_kprintf("%-7.7s ", "socket");
-            else if (fd->type == FT_USER)    rt_kprintf("%-7.7s ", "user");
-            else if (fd->type == FT_DEVICE)   rt_kprintf("%-7.7s ", "device");
+            buff += rt_sprintf(buff,"%2d ", index + DFS_FD_OFFSET);
+            if (fd->type == FT_DIRECTORY)    buff += rt_sprintf(buff,"%-7.7s ", "dir");
+            else if (fd->type == FT_REGULAR) buff += rt_sprintf(buff,"%-7.7s ", "file");
+            else if (fd->type == FT_SOCKET)  buff += rt_sprintf(buff,"%-7.7s ", "socket");
+            else if (fd->type == FT_USER)    buff += rt_sprintf(buff,"%-7.7s ", "user");
+            else if (fd->type == FT_DEVICE)   buff += rt_sprintf(buff,"%-7.7s ", "device");
             else rt_kprintf("%-8.8s ", "unknown");
-            rt_kprintf("%3d ", fd->ref_count);
-            rt_kprintf("%04x  ", fd->magic);
+            buff += rt_sprintf(buff,"%3d ", fd->ref_count);
+            buff += rt_sprintf(buff,"%04x  ", fd->magic);
             if (fd->fs && fd->fs->path && rt_strlen(fd->fs->path) > 1)
             {
-                rt_kprintf("%s", fd->fs->path);
+                buff += rt_sprintf(buff,"%s", fd->fs->path);
             }
             if (fd->path)
             {
-                rt_kprintf("%s\n", fd->path);
+                buff += rt_sprintf(buff,"%s\n", fd->path);
             }
             else
             {
-                rt_kprintf("\n");
+                buff += rt_sprintf(buff,"\n");
             }
         }
     }
     rt_exit_critical();
+    rt_kprintf(buff_start);
 
     return 0;
 }

--- a/components/dfs/src/dfs.c
+++ b/components/dfs/src/dfs.c
@@ -541,32 +541,32 @@ int list_fd(void)
 
         if (fd && fd->fops)
         {
-            buff += rt_sprintf(buff,"%2d ", index + DFS_FD_OFFSET);
-            if (fd->type == FT_DIRECTORY)    buff += rt_sprintf(buff,"%-7.7s ", "dir");
-            else if (fd->type == FT_REGULAR) buff += rt_sprintf(buff,"%-7.7s ", "file");
-            else if (fd->type == FT_SOCKET)  buff += rt_sprintf(buff,"%-7.7s ", "socket");
-            else if (fd->type == FT_USER)    buff += rt_sprintf(buff,"%-7.7s ", "user");
-            else if (fd->type == FT_DEVICE)   buff += rt_sprintf(buff,"%-7.7s ", "device");
-            else rt_kprintf("%-8.8s ", "unknown");
-            buff += rt_sprintf(buff,"%3d ", fd->ref_count);
-            buff += rt_sprintf(buff,"%04x  ", fd->magic);
+            buff += rt_sprintf(buff, "%2d ", index + DFS_FD_OFFSET);
+            if (fd->type == FT_DIRECTORY)    buff += rt_sprintf(buff, "%-7.7s ", "dir");
+            else if (fd->type == FT_REGULAR) buff += rt_sprintf(buff, "%-7.7s ", "file");
+            else if (fd->type == FT_SOCKET)  buff += rt_sprintf(buff, "%-7.7s ", "socket");
+            else if (fd->type == FT_USER)    buff += rt_sprintf(buff, "%-7.7s ", "user");
+            else if (fd->type == FT_DEVICE)  buff += rt_sprintf(buff, "%-7.7s ", "device");
+            else buff += rt_sprintf(buff, "%-8.8s ", "unknown");
+            buff += rt_sprintf(buff, "%3d ", fd->ref_count);
+            buff += rt_sprintf(buff, "%04x  ", fd->magic);
             if (fd->fs && fd->fs->path && rt_strlen(fd->fs->path) > 1)
             {
-                buff += rt_sprintf(buff,"%s", fd->fs->path);
+                buff += rt_sprintf(buff, "%s", fd->fs->path);
             }
             if (fd->path)
             {
-                buff += rt_sprintf(buff,"%s\n", fd->path);
+                buff += rt_sprintf(buff, "%s\n", fd->path);
             }
             else
             {
-                buff += rt_sprintf(buff,"\n");
+                buff += rt_sprintf(buff, "\n");
             }
         }
     }
     rt_exit_critical();
     rt_kprintf(buff_start);
-
+    rt_free(buff_start);
     return 0;
 }
 MSH_CMD_EXPORT(list_fd, list file descriptor);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
### 为什么提交这份PR；
- list_fd导致系统卡死问题
> https://club.rt-thread.org/ask/question/74e15e3e942102fc.html
> https://club.rt-thread.org/ask/question/97ed3d005d24ecc7.html
### 你的解决方案是什么；
- 进入临界段后, 先将信息打印到buff, 退出临界段后, 将buff中的信息进行进行rt_kprintf. 
### 并确认并列出已经在什么情况或板卡上进行了测试。
- STM32F429IGT6
- RTT V4.1.1
![image](https://user-images.githubusercontent.com/66928464/199150137-41efb5e5-ba96-4a61-8b86-6d86111cc447.png)
]

以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 本拉取/合并请求代码是高质量的 Code in this PR is of high quality
- [x] 本拉取/合并使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
