### PR TITLE
[components/sdio] bugfix: remove sdcard block dev may cause a infinite loop.

### DIFF
--- a/components/drivers/sdio/block_dev.c
+++ b/components/drivers/sdio/block_dev.c
@@ -505,6 +505,18 @@ void rt_mmcsd_blk_remove(struct rt_mmcsd_card *card)
     rt_list_t *l, *n;
     struct mmcsd_blk_device *blk_dev;
 
+    if(card == RT_NULL)
+    {
+        LOG_E("card is null!");
+        return;
+    }
+
+    if(rt_list_isempty(&card->blk_devices))
+    {
+        LOG_E("card blk_devices is empty!");
+        return;
+    }
+
     for (l = (&card->blk_devices)->next, n = l->next; l != &card->blk_devices; l = n, n=n->next)
     {
         blk_dev = (struct mmcsd_blk_device *)rt_list_entry(l, struct mmcsd_blk_device, list);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

■bug现象
SD卡快速抽拔，导致死机.

■bug原因
①  插入SD卡，检卡流程: init_sd->rt_mmcsd_blk_probe .
②  检卡执行流到rt_mmcsd_blk_probe 时突然拔卡的话，可能会导致rt_mmcsd_blk_probe 中的rt_mmcsd_req_blk 函数执行失败（read mmcsd first sector failed）。
③ rt_mmcsd_blk_probe 出错后，会 goto 到 remove_card分支，  调用rt_mmcsd_blk_remove函数释放块设备.
④ rt_mmcsd_blk_remove会释放 挂载 card->blk_devices上的块设备，但是由于 ②步骤中读取分区失败，所以 card->blk_devices没有挂任何设备，导致之后的处理出现问题(for循环刚开始 l 变量被赋值为null)。

■解决方法
在rt_mmcsd_blk_remove函数刚开始的地方判断 card->blk_devices 是否为空表, 如果为空，则直接返回

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
