### PR TITLE
[update]添加优先网卡配置选项

### DIFF
--- a/components/net/netdev/Kconfig
+++ b/components/net/netdev/Kconfig
@@ -20,6 +20,10 @@ if RT_USING_NETDEV
         bool "Enable default netdev automatic change features"
         default y
 
+    config NETDEV_USING_PRIORITY
+        bool "Enable priority netdev automatic change features"
+        default n
+
     config NETDEV_USING_IPV6
         bool "Enable IPV6 protocol support"
         default n

--- a/components/net/netdev/include/netdev.h
+++ b/components/net/netdev/include/netdev.h
@@ -140,6 +140,10 @@ struct netdev_ops
 
     /* set default network interface device in current network stack*/
     int (*set_default)(struct netdev *netdev);
+#ifdef NETDEV_USING_PRIORITY
+    /* set priority network interface device in current network stack*/
+    int (*set_priority)(struct netdev *netdev);
+#endif
 };
 
 /* The network interface device registered and unregistered*/
@@ -157,7 +161,10 @@ int netdev_family_get(struct netdev *netdev);
 
 /* Set default network interface device in list */
 void netdev_set_default(struct netdev *netdev);
-
+#ifdef NETDEV_USING_PRIORITY
+/* Set priority network interface device in list */
+void netdev_set_priority(struct netdev *netdev);
+#endif
 /*  Set network interface device status */
 int netdev_set_up(struct netdev *netdev);
 int netdev_set_down(struct netdev *netdev);


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

[
- 添加优先网卡配置选项，在网卡自动切换时可以实现：
  - 1.当优先网卡 linkup 时把优先网卡配置为默认网卡用于上网
  - 2.当优先网卡 linkdown 时自动切换其他能上网的网卡。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
