### PR TITLE
proposal: `replace `rt_enter_critical` with `dfs_lock` for list_fd

### DIFF
--- a/components/dfs/src/dfs.c
+++ b/components/dfs/src/dfs.c
@@ -529,7 +529,7 @@ int list_fd(void)
     fd_table = dfs_fdtable_get();
     if (!fd_table) return -1;
 
-    rt_enter_critical();
+    dfs_lock();
 
     rt_kprintf("fd type    ref magic  path\n");
     rt_kprintf("-- ------  --- ----- ------\n");
@@ -562,7 +562,7 @@ int list_fd(void)
             }
         }
     }
-    rt_exit_critical();
+    dfs_unlock();
 
     return 0;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
最近发现，使用 [rt_kprintf_threadsafe](https://packages.rt-thread.org/detail.html?package=rt_kprintf_threadsafe)
软件包后, 无法 List_fd, 检查后发现，是由于 list_fd 使用了 `rt_enter_critical` 做临界区保护，导致无法使用 mutex.
仔细检查后，发现list_fd 过程中唯一使用到的共享资源是 `fd_table`, 而在其它读写 fd_table 的位置均使用了 `dfs_lock`,
所以，个人认为此处使用 dfs_lock 就足够了。一点个人见解, 如有错误，还望见谅, 谢谢哈 :)
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
