### PR TITLE
[device]添加中断优先级设置与查看命令

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_tim.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_tim.c
@@ -370,6 +370,14 @@ static rt_err_t timer_ctrl(rt_hwtimer_t *timer, rt_uint32_t cmd, void *arg)
         result = RT_EOK;
     }
     break;
+    case RT_DEVICE_CTRL_SET_INT_PRIORITY:
+    {
+        struct stm32_hwtimer *tim_device = RT_NULL;
+        tim_device = (struct stm32_hwtimer *)timer;
+        rt_ubase_t ctrl_arg = (rt_ubase_t)arg;
+        HAL_NVIC_SetPriority(tim_device->tim_irqn,ctrl_arg, 0);
+    }
+    break;
     default:
     {
         result = -RT_EINVAL;

--- a/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_usart_v2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -291,7 +291,9 @@ static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *ar
             RT_ASSERT(0)
         }
         break;
-
+    case RT_DEVICE_CTRL_SET_INT_PRIORITY:
+        HAL_NVIC_SetPriority(uart->config->irq_type,ctrl_arg, 0);
+        break;
     }
     return RT_EOK;
 }

--- a/components/drivers/hwtimer/hwtimer.c
+++ b/components/drivers/hwtimer/hwtimer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -294,6 +294,24 @@ static rt_err_t rt_hwtimer_control(struct rt_device *dev, int cmd, void *args)
         level = rt_hw_interrupt_disable();
         timer->mode = *m;
         rt_hw_interrupt_enable(level);
+    }
+    break;
+    case RT_DEVICE_CTRL_SET_INT_PRIORITY:
+    {
+        if (args == RT_NULL)
+        {
+            result = -RT_EEMPTY;
+            break;
+        }
+
+        if (timer->ops->control != RT_NULL)
+        {
+            result = timer->ops->control(timer, cmd, args);
+        }
+        else
+        {
+            result = -RT_ENOSYS;
+        }
     }
     break;
     default:

--- a/components/drivers/hwtimer/hwtimer.c
+++ b/components/drivers/hwtimer/hwtimer.c
@@ -296,25 +296,13 @@ static rt_err_t rt_hwtimer_control(struct rt_device *dev, int cmd, void *args)
         rt_hw_interrupt_enable(level);
     }
     break;
-    case RT_DEVICE_CTRL_SET_INT_PRIORITY:
-    {
-        if (args == RT_NULL)
-        {
-            result = -RT_EEMPTY;
-            break;
-        }
-
-        if (timer->ops->control != RT_NULL)
-        {
-            result = timer->ops->control(timer, cmd, args);
-        }
-        else
-        {
-            result = -RT_ENOSYS;
-        }
-    }
-    break;
     default:
+    /* control device */
+    if (timer->ops->control != RT_NULL)
+    {
+        result = timer->ops->control(timer, cmd, args);
+    }
+    else
     {
         result = -RT_ENOSYS;
     }

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -1041,7 +1041,8 @@ enum rt_device_class_type
 #define RT_DEVICE_CTRL_SET_INT          0x10            /**< set interrupt */
 #define RT_DEVICE_CTRL_CLR_INT          0x11            /**< clear interrupt */
 #define RT_DEVICE_CTRL_GET_INT          0x12            /**< get interrupt status */
-
+#define RT_DEVICE_CTRL_SET_INT_PRIORITY 0x13            /**< set interrupt Priority*/
+#define RT_DEVICE_CTRL_GET_INT_PRIORITY 0x14            /**< get interrupt Priority*/
 /**
  * device control
  */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
- 目前设备驱动没有关于中断优先级设置的函数
- 有些时候设备驱动默认的中断优先级设置不适合使用场景，需要修改
- 已之前的方式，只能修改源码中优先级的设置。
- 或者如下方式，有些驱动不像串口把结构体开放处理，还得重新定义一遍结构体。
```c
/**
  * @brief  设置FINSH串口中断优先级
  * @param  None
  * @retval None
  */
static int Set_FINSH_IRQ(void)
{
  rt_err_t ret = RT_EOK;
  /* 串口设备句柄 */
  rt_device_t serial;
  /* 查找串口设备 */
  serial = rt_device_find(RT_CONSOLE_DEVICE_NAME);
  if (!serial)
  {
      LOG_E("find %s failed!", RT_CONSOLE_DEVICE_NAME);
      ret = -RT_ERROR;
  }
  struct stm32_uart *uart;

  uart = rt_container_of(serial, struct stm32_uart, serial);
  /* parameter check */
  RT_ASSERT(uart != RT_NULL);
  HAL_NVIC_SetPriority(uart->config->irq_type,FINSH_IRQ_PRIORITY, 0);
  return ret;
}
INIT_COMPONENT_EXPORT(Set_FINSH_IRQ);
```

#### 你的解决方案是什么 (what is your solution)
- 在rtdef.h中添加设置中断优先级与查看中断优先级命令
```c
#define RT_DEVICE_CTRL_SET_INT_PRIORITY 0x13            /**< set interrupt Priority*/
#define RT_DEVICE_CTRL_GET_INT_PRIORITY 0x14            /**< get interrupt Priority*/
```
- 在对应驱动中的control函数中添加实现
- 目前仅在STM串口V2中对中断优先级设置进行处理，其余没有用到驱动，没有进行设置。
- 硬件定时器添加设置中断优先级接口，stm32硬件定时器添加设置优先级代码
- 查看中断优先级可能得在添加一个结构体才能读取抢占优先级与子优先级。没有编写。
```c
static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *arg)
{
  ...
    case RT_DEVICE_CTRL_SET_INT_PRIORITY:
        HAL_NVIC_SetPriority(uart->config->irq_type,ctrl_arg, 0);
        break;
    }
  ...
}
```
#### 在什么测试环境下测试通过 (what is the test environment)
- STM32F429芯片
- RTT 5.0.0
- 测试串口可正常设置优先级,串口1~3从默认优先级1设置为3

![image](https://user-images.githubusercontent.com/66928464/202838171-c3a020e5-eadf-4e4d-b946-cae53ace925e.png)

- 测试硬件定时器可正常设置优先级,定时器14从默认优先级3设置为1

![image](https://user-images.githubusercontent.com/66928464/202839013-d0633cad-1e1a-4faa-95a4-fc1418ec1428.png)

#### 其他
- 像STM32有抢占优先级与子优先级说法，有不同配置可选。但是默认都是只用抢占优先级配置。而有些芯片就只有一种优先级的设置。如果需要两种优先级都可以设置，就得增加一个结构体，用户使用时，得创建一个结构体变量，不够方便，没有实现。
- 有些驱动，比如CAN驱动，可能有着CAN_RX1\CAN_RX2\can_tx1\can_sce等多个优先级设置。这种就更没办法啦。
- 只能说，要都支持到，那么得针对不同的驱动来进行不同的实现，创建不同的结构体去传参配置
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
