### PR TITLE
Revert "[kernel] 修正复制name字段时潜在的内存踩踏问题"

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -366,8 +366,7 @@ void rt_object_init(struct rt_object         *object,
     /* set object type to static */
     object->type = type | RT_Object_Class_Static;
     /* copy name */
-    rt_strncpy(object->name, name, RT_NAME_MAX - 1);
-    object->name[RT_NAME_MAX - 1] = '\0';
+    rt_strncpy(object->name, name, RT_NAME_MAX);
 
     RT_OBJECT_HOOK_CALL(rt_object_attach_hook, (object));
 


### PR DESCRIPTION
Reverts RT-Thread/rt-thread#6605

目前的解决方案不彻底，重新讨论一种新的解决方案可以完美解决此问题。