### PR TITLE
[BSP][STM32]修改PWM驱动APBx外设时钟选择方案

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -173,11 +173,11 @@ static rt_uint64_t tim_clock_get(TIM_HandleTypeDef *htim)
 #elif defined(APB1PERIPH_BASE) || defined(APB2PERIPH_BASE)
     if ((rt_uint32_t)htim->Instance >= APB2PERIPH_BASE)
     {
-        tim_clock = (rt_uint32_t)(HAL_RCC_GetPCLK2Freq() * pclk1_doubler);
+        tim_clock = (rt_uint32_t)(HAL_RCC_GetPCLK2Freq() * pclk2_doubler);
     }
     else
     {
-        tim_clock = (rt_uint32_t)(HAL_RCC_GetPCLK1Freq() * pclk2_doubler);
+        tim_clock = (rt_uint32_t)(HAL_RCC_GetPCLK1Freq() * pclk1_doubler);
     }
 #endif
 

--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -167,26 +167,19 @@ static rt_uint64_t tim_clock_get(TIM_HandleTypeDef *htim)
 
     stm32_tim_pclkx_doubler_get(&pclk1_doubler, &pclk2_doubler);
 
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-    if (htim->Instance == TIM9 || htim->Instance == TIM10 || htim->Instance == TIM11)
-#elif defined(SOC_SERIES_STM32F3) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32H7)
-    if (htim->Instance == TIM15 || htim->Instance == TIM16 || htim->Instance == TIM17)
-#elif defined(SOC_SERIES_STM32MP1)
-    if (htim->Instance == TIM4)
-#elif defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32G0)
-    if (0)
-#else
-#error "This driver has not supported this series yet!"
-#endif
+/* Some series may only have APBPERIPH_BASE, don't have HAL_RCC_GetPCLK2Freq */
+#if defined(APBPERIPH_BASE)
+    tim_clock = (rt_uint32_t)(HAL_RCC_GetPCLK1Freq() * pclk1_doubler);
+#elif defined(APB1PERIPH_BASE) || defined(APB2PERIPH_BASE)
+    if ((rt_uint32_t)htim->Instance >= APB2PERIPH_BASE)
     {
-#if !(defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32G0)) /* don't have HAL_RCC_GetPCLK2Freq */
-        tim_clock = (rt_uint32_t)(HAL_RCC_GetPCLK2Freq() * pclk2_doubler);
-#endif
+        tim_clock = (rt_uint32_t)(HAL_RCC_GetPCLK2Freq() * pclk1_doubler);
     }
     else
     {
-        tim_clock = (rt_uint32_t)(HAL_RCC_GetPCLK1Freq() * pclk1_doubler);
+        tim_clock = (rt_uint32_t)(HAL_RCC_GetPCLK1Freq() * pclk2_doubler);
     }
+#endif
 
     return tim_clock;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
解决 tim_clock_get 函数中关于不同stm32芯片的tim时钟配置相关代码。

未修改代码前：

![图片](https://user-images.githubusercontent.com/64183082/205277540-b64d2108-3e84-43f1-a5b8-a5fdc69a301c.png)

我在编译stm32l431系列的芯片的时候，报了以下错误：

![图片](https://user-images.githubusercontent.com/64183082/205277808-dafe7b47-a42e-4612-a0c5-29251796dfa4.png)

就是说目前的这种实现方式太笼统了，这里的stm32l431系列单片机其实是没有TIM17的，所以这个TIM17这个宏定义根本不存在。

![图片](https://user-images.githubusercontent.com/64183082/205278251-c54e735b-3b99-4afb-a241-e39e97195a2a.png)

发现这段代码也就是判断TIM是在APB1，还是APB2外设总线上。

原先的方法是根据芯片的系列去判断，但是这里就出现了一个问题，子系列可能会有所不同，就比如我上面出现的那个问题，这里我建议通过库文件的外设宏定义去做判断会更好！

### 原理补充

在stm32的库文件中，一般来说大部分外设都是挂在APBx总线上的，比如定时器，我们直接根据内存映射去处理，因为无论如何定时器总会在这两条总线上，考虑到部分系列单片机只有一条APB总线，所以我做了区分。

![图片](https://user-images.githubusercontent.com/64183082/205792784-51e3ee7d-9ec8-4e3d-98be-ed7151f6cb85.png)
![图片](https://user-images.githubusercontent.com/64183082/205793846-4d63f4ff-7f54-48a9-a291-6d36e9c816ba.png)
基本所有系列单片机的库文件都有这样的宏定义。

![图片](https://user-images.githubusercontent.com/64183082/205793540-d2f80797-438e-41e4-96b6-3f076f73a4eb.png)
比如这样，我们直接根据内存映射，就可以知道TIM5，TIM9到底在哪个总线上了。
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
