### PR TITLE
[rt-smart][Kconfig] Fix Kconfig issue for rt-smart

### DIFF
--- a/bsp/qemu-virt64-aarch64/Kconfig
+++ b/bsp/qemu-virt64-aarch64/Kconfig
@@ -28,3 +28,17 @@ config SOC_VIRT64_AARCH64
     default y
 
 source "$BSP_DIR/driver/Kconfig"
+
+config BOARD_USING_SMART:
+    bool "Enable rt-smart features"
+    select RT_USING_SMART
+    select RT_USING_SIGNALS
+    default n
+
+if BOARD_USING_SMART
+    config KERNEL_VADDR_START
+        default 0xffff000000000000
+
+    config PV_OFFSET
+        default 0x1000040000000
+endif

--- a/bsp/qemu-virt64-aarch64/Kconfig
+++ b/bsp/qemu-virt64-aarch64/Kconfig
@@ -35,7 +35,7 @@ config BOARD_USING_SMART:
     select RT_USING_SIGNALS
     default n
 
-if BOARD_USING_SMART
+if RT_USING_SMART
     config KERNEL_VADDR_START
         default 0xffff000000000000
 

--- a/components/lwp/Kconfig
+++ b/components/lwp/Kconfig
@@ -8,7 +8,7 @@ menuconfig RT_USING_LWP
     select RT_USING_ZERO
     select RT_USING_RANDOM
     select RT_USING_RTC
-    depends on ARCH_ARM_CORTEX_M || ARCH_ARM_ARM9 || ARCH_ARM_CORTEX_A || ARCH_RISCV64
+    depends on ARCH_ARM_CORTEX_M || ARCH_ARM_ARM9 || ARCH_ARM_CORTEX_A || ARCH_ARMV8 || ARCH_RISCV64
     default n
     help
         The lwP is a light weight process running in user mode.

--- a/components/lwp/arch/aarch64/common/reloc.c
+++ b/components/lwp/arch/aarch64/common/reloc.c
@@ -10,7 +10,8 @@
 #define Elf_Word Elf64_Word
 #define Elf_Addr Elf64_Addr
 #define Elf_Half Elf64_Half
-#define Elf_Ehdr Elf64_Ehdr                                                   #define Elf_Phdr Elf64_Phdr
+#define Elf_Ehdr Elf64_Ehdr
+#define Elf_Phdr Elf64_Phdr
 #define Elf_Shdr Elf64_Shdr
 
 typedef struct

--- a/libcpu/Kconfig
+++ b/libcpu/Kconfig
@@ -80,8 +80,8 @@ config ARCH_ARM_MMU
     depends on ARCH_ARM
 
 config RT_USING_USERSPACE
-    bool "Isolated user space"
-    default n
+    bool
+    default y
     depends on ARCH_MM_MMU
 
 config KERNEL_VADDR_START
@@ -162,6 +162,7 @@ config RT_BACKTRACE_FUNCTION_NAME
 config ARCH_ARMV8
     bool
     select ARCH_ARM
+    select ARCH_ARM_MMU
 
 config ARCH_MIPS
     bool

--- a/libcpu/Kconfig
+++ b/libcpu/Kconfig
@@ -79,10 +79,12 @@ config ARCH_ARM_MMU
     select ARCH_MM_MMU
     depends on ARCH_ARM
 
+if RT_USING_SMART
 config RT_USING_USERSPACE
     bool
     default y
     depends on ARCH_MM_MMU
+endif
 
 config KERNEL_VADDR_START
     hex "The virtural address of kernel start"


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

fix Kconfig issue for AArch64 in rt-smart.

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
