### PR TITLE
[STM32][SPI]在H7芯片下修复时钟频率获取错误问题并添加DMA驱动

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
@@ -351,7 +351,7 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
             state = HAL_SPI_TransmitReceive_DMA(spi_handle, (uint8_t *)dma_buf, (uint8_t *)dma_buf, send_length);
         }
         else
-#endif /* SOC_SERIES_STM32H7 || SOC_SERIES_STM32F7 */        
+#endif /* SOC_SERIES_STM32H7 || SOC_SERIES_STM32F7 */
         /* start once data exchange in DMA mode */
         if (message->send_buf && message->recv_buf)
         {

--- a/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
@@ -351,8 +351,7 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
             state = HAL_SPI_TransmitReceive_DMA(spi_handle, (uint8_t *)dma_buf, (uint8_t *)dma_buf, send_length);
         }
         else
-#endif /* SOC_SERIES_STM32H7 || SOC_SERIES_STM32F7 */
-        
+#endif /* SOC_SERIES_STM32H7 || SOC_SERIES_STM32F7 */        
         /* start once data exchange in DMA mode */
         if (message->send_buf && message->recv_buf)
         {

--- a/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
@@ -140,47 +140,55 @@ static rt_err_t stm32_spi_init(struct stm32_spi *spi_drv, struct rt_spi_configur
 
     spi_handle->Init.NSS = SPI_NSS_SOFT;
 
-    uint32_t SPI_APB_CLOCK;
+    uint32_t SPI_CLOCK;
 
 /* Some series may only have APBPERIPH_BASE, but don't have HAL_RCC_GetPCLK2Freq */
 #if defined(APBPERIPH_BASE)
-    SPI_APB_CLOCK = HAL_RCC_GetPCLK1Freq();
+    SPI_CLOCK = HAL_RCC_GetPCLK1Freq();
 #elif defined(APB1PERIPH_BASE) || defined(APB2PERIPH_BASE)
+    /*The SPI clock for H7 cannot be configured with a peripheral bus clock, so it needs to be written separately*/
+#if defined(SOC_SERIES_STM32H7)
+    /*When the configuration is generated using CUBEMX, the configuration for the SPI clock is placed in the HAL_SPI_Init function. 
+    Therefore, it is necessary to initialize and configure the SPI clock to automatically configure the frequency division*/
+    HAL_SPI_Init(spi_handle);
+    SPI_CLOCK = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI123);
+#else
     if ((rt_uint32_t)spi_drv->config->Instance >= APB2PERIPH_BASE)
     {
-        SPI_APB_CLOCK = HAL_RCC_GetPCLK2Freq();
+        SPI_CLOCK = HAL_RCC_GetPCLK2Freq();
     }
     else
     {
-        SPI_APB_CLOCK = HAL_RCC_GetPCLK1Freq();
+        SPI_CLOCK = HAL_RCC_GetPCLK1Freq();
     }
-#endif
+#endif /*SOC_SERIES_STM32H7)*/
+#endif /*APBPERIPH_BASE*/
 
-    if (cfg->max_hz >= SPI_APB_CLOCK / 2)
+    if (cfg->max_hz >= SPI_CLOCK / 2)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2;
     }
-    else if (cfg->max_hz >= SPI_APB_CLOCK / 4)
+    else if (cfg->max_hz >= SPI_CLOCK / 4)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_4;
     }
-    else if (cfg->max_hz >= SPI_APB_CLOCK / 8)
+    else if (cfg->max_hz >= SPI_CLOCK / 8)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_8;
     }
-    else if (cfg->max_hz >= SPI_APB_CLOCK / 16)
+    else if (cfg->max_hz >= SPI_CLOCK / 16)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16;
     }
-    else if (cfg->max_hz >= SPI_APB_CLOCK / 32)
+    else if (cfg->max_hz >= SPI_CLOCK / 32)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32;
     }
-    else if (cfg->max_hz >= SPI_APB_CLOCK / 64)
+    else if (cfg->max_hz >= SPI_CLOCK / 64)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_64;
     }
-    else if (cfg->max_hz >= SPI_APB_CLOCK / 128)
+    else if (cfg->max_hz >= SPI_CLOCK / 128)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128;
     }
@@ -190,15 +198,15 @@ static rt_err_t stm32_spi_init(struct stm32_spi *spi_drv, struct rt_spi_configur
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256;
     }
 
-    LOG_D("sys freq: %d, pclk2 freq: %d, SPI limiting freq: %d, BaudRatePrescaler: %d",
+    LOG_D("sys freq: %d, pclk freq: %d, SPI limiting freq: %d, SPI usage freq: %d",
 #if defined(SOC_SERIES_STM32MP1)
           HAL_RCC_GetSystemCoreClockFreq(),
 #else
           HAL_RCC_GetSysClockFreq(),
 #endif
-          SPI_APB_CLOCK,
+          SPI_CLOCK,
           cfg->max_hz,
-          spi_handle->Init.BaudRatePrescaler);
+          SPI_CLOCK / (rt_size_t)pow(2,(spi_handle->Init.BaudRatePrescaler >> 28) + 1));
 
     if (cfg->mode & RT_SPI_MSB)
     {
@@ -326,6 +334,25 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
         send_buf = (rt_uint8_t *)message->send_buf + already_send_length;
         recv_buf = (rt_uint8_t *)message->recv_buf + already_send_length;
 
+#if defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32F7)
+        rt_uint32_t* dma_buf = RT_NULL;
+        if ((spi_drv->spi_dma_flag & SPI_USING_TX_DMA_FLAG) && (spi_drv->spi_dma_flag & SPI_USING_RX_DMA_FLAG))
+        {
+            dma_buf = (rt_uint32_t *)rt_malloc_align(send_length,32);
+            if(send_buf)
+            {
+                rt_memcpy(dma_buf, send_buf, send_length);
+            }
+            else
+            {
+                rt_memset(dma_buf, 0xFF, send_length);
+            }
+            SCB_CleanDCache_by_Addr(dma_buf, send_length);
+            state = HAL_SPI_TransmitReceive_DMA(spi_handle, (uint8_t *)dma_buf, (uint8_t *)dma_buf, send_length);
+        }
+        else
+#endif /*SOC_SERIES_STM32H7 || SOC_SERIES_STM32F7*/
+        
         /* start once data exchange in DMA mode */
         if (message->send_buf && message->recv_buf)
         {
@@ -393,6 +420,17 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
         {
             while (HAL_SPI_GetState(spi_handle) != HAL_SPI_STATE_READY);
         }
+#if defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32F7)
+        if(dma_buf)
+        {
+            if(recv_buf)
+            {
+                SCB_InvalidateDCache_by_Addr(dma_buf, send_length);
+                rt_memcpy(recv_buf, dma_buf,send_length);
+            }
+            rt_free_align(dma_buf);
+        }
+#endif /*SOC_SERIES_STM32H7 || SOC_SERIES_STM32F7*/
     }
 
     if (message->cs_release && !(device->config.mode & RT_SPI_NO_CS))

--- a/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
@@ -146,10 +146,10 @@ static rt_err_t stm32_spi_init(struct stm32_spi *spi_drv, struct rt_spi_configur
 #if defined(APBPERIPH_BASE)
     SPI_CLOCK = HAL_RCC_GetPCLK1Freq();
 #elif defined(APB1PERIPH_BASE) || defined(APB2PERIPH_BASE)
-    /*The SPI clock for H7 cannot be configured with a peripheral bus clock, so it needs to be written separately*/
+    /* The SPI clock for H7 cannot be configured with a peripheral bus clock, so it needs to be written separately */
 #if defined(SOC_SERIES_STM32H7)
-    /*When the configuration is generated using CUBEMX, the configuration for the SPI clock is placed in the HAL_SPI_Init function. 
-    Therefore, it is necessary to initialize and configure the SPI clock to automatically configure the frequency division*/
+    /* When the configuration is generated using CUBEMX, the configuration for the SPI clock is placed in the HAL_SPI_Init function.
+    Therefore, it is necessary to initialize and configure the SPI clock to automatically configure the frequency division */
     HAL_SPI_Init(spi_handle);
     SPI_CLOCK = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI123);
 #else
@@ -161,8 +161,8 @@ static rt_err_t stm32_spi_init(struct stm32_spi *spi_drv, struct rt_spi_configur
     {
         SPI_CLOCK = HAL_RCC_GetPCLK1Freq();
     }
-#endif /*SOC_SERIES_STM32H7)*/
-#endif /*APBPERIPH_BASE*/
+#endif /* SOC_SERIES_STM32H7) */
+#endif /* APBPERIPH_BASE */
 
     if (cfg->max_hz >= SPI_CLOCK / 2)
     {
@@ -351,7 +351,7 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
             state = HAL_SPI_TransmitReceive_DMA(spi_handle, (uint8_t *)dma_buf, (uint8_t *)dma_buf, send_length);
         }
         else
-#endif /*SOC_SERIES_STM32H7 || SOC_SERIES_STM32F7*/
+#endif /* SOC_SERIES_STM32H7 || SOC_SERIES_STM32F7 */
         
         /* start once data exchange in DMA mode */
         if (message->send_buf && message->recv_buf)
@@ -430,7 +430,7 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
             }
             rt_free_align(dma_buf);
         }
-#endif /*SOC_SERIES_STM32H7 || SOC_SERIES_STM32F7*/
+#endif /* SOC_SERIES_STM32H7 || SOC_SERIES_STM32F7 */
     }
 
     if (message->cs_release && !(device->config.mode & RT_SPI_NO_CS))


### PR DESCRIPTION
* H7下SPI时钟不再为外设总线时钟频率
* H7和F7下DMA驱动需要进行CacheLine对齐
* 打印SPI时钟配置信息进行修改
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
在H7芯片下修复时钟频率获取错误问题并添加DMA驱动

#### 你的解决方案是什么 (what is your solution)
- H7下SPI时钟不再为外设总线时钟频率
- 里面我进行了说明
> https://github.com/RT-Thread/rt-thread/pull/6698#issuecomment-1350548069


其中调用HAL SPI_Init是因为CUBEMX生成的对于SPI的时钟配置放在HAL SPI_Init里.如果不先调用一遍,获取的时钟频率是错误的.
![image](https://user-images.githubusercontent.com/66928464/207558558-e7c13a8a-47c0-4f04-8a40-103506590a9d.png)


单独为H7编写查询代码
- H7和F7下DMA驱动需要进行CacheLine对齐
- 根据如下帖子
> https://club.rt-thread.org/ask/question/b5049fff129ff608.html
单独为H7和F7编写DMA驱动
- 打印SPI时钟配置信息进行修改
可以打印出实际的SPI时钟频率
#### 在什么测试环境下测试通过 (what is the test environment)
- ART-PI
- SPI FLASH W25Q128
- 具体测试情况
> https://club.rt-thread.org/ask/question/67709922b1d2022b.html
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
