### PR TITLE
[STM32][SPI]使用rt_hw_cpu_dcache_ops函数替换HAL库函数

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
@@ -347,7 +347,7 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
             {
                 rt_memset(dma_buf, 0xFF, send_length);
             }
-            rt_hw_cpu_dcache_ops(RT_HW_CACHE_FLUSH,dma_buf, send_length);
+            rt_hw_cpu_dcache_ops(RT_HW_CACHE_FLUSH, dma_buf, send_length);
             state = HAL_SPI_TransmitReceive_DMA(spi_handle, (uint8_t *)dma_buf, (uint8_t *)dma_buf, send_length);
         }
         else
@@ -424,7 +424,7 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
         {
             if(recv_buf)
             {
-                rt_hw_cpu_dcache_ops(RT_HW_CACHE_INVALIDATE,dma_buf, send_length);
+                rt_hw_cpu_dcache_ops(RT_HW_CACHE_INVALIDATE, dma_buf, send_length);
                 rt_memcpy(recv_buf, dma_buf,send_length);
             }
             rt_free_align(dma_buf);

--- a/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_spi.c
@@ -347,7 +347,7 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
             {
                 rt_memset(dma_buf, 0xFF, send_length);
             }
-            SCB_CleanDCache_by_Addr(dma_buf, send_length);
+            rt_hw_cpu_dcache_ops(RT_HW_CACHE_FLUSH,dma_buf, send_length);
             state = HAL_SPI_TransmitReceive_DMA(spi_handle, (uint8_t *)dma_buf, (uint8_t *)dma_buf, send_length);
         }
         else
@@ -424,7 +424,7 @@ static rt_uint32_t spixfer(struct rt_spi_device *device, struct rt_spi_message *
         {
             if(recv_buf)
             {
-                SCB_InvalidateDCache_by_Addr(dma_buf, send_length);
+                rt_hw_cpu_dcache_ops(RT_HW_CACHE_INVALIDATE,dma_buf, send_length);
                 rt_memcpy(recv_buf, dma_buf,send_length);
             }
             rt_free_align(dma_buf);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
