### PR TITLE
[components][libc] 在rv32下编译时cstring.c中的strtok_r函数与libc.a中的strtok_r重定义

### DIFF
--- a/components/libc/compilers/common/cstring.c
+++ b/components/libc/compilers/common/cstring.c
@@ -182,7 +182,7 @@ char *strndup(const char *s, size_t size)
     return news;
 }
 
-char *strtok_r(char *str, const char *delim, char **saveptr)
+rt_weak char *strtok_r(char *str, const char *delim, char **saveptr)
 {
     char *pbegin;
     char *pend = NULL;


### PR DESCRIPTION
问题：在rv32下编译时cstring.c中的strtok_r函数与libc.a中的strtok_r重定义
修改：在strtok_r前添加rt_weak
工具链：riscv32-unknown-elf-gcc.exe
工具链本地相对路径：RT-ThreadStudio\repo\Extract\ToolChain_Support_Packages\RISC-V\RISC-V-GCC-RV32\2022-04-12\bin
libc.a相对路径:RT-ThreadStudio\repo\Extract\ToolChain_Support_Packages\RISC-V\RISC-V-GCC-RV32\2022-04-12\riscv32-unknown-elf\lib
![f15775d812521dac9264da1d966702b](https://user-images.githubusercontent.com/34888354/208349090-bde3e258-a802-4ea0-9714-761dc71a1994.png)

