### PR TITLE
[stm32][adc]更改配置通道与校准函数顺序

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -287,8 +287,24 @@ static rt_uint32_t stm32_adc_get_channel(rt_uint32_t channel)
 
 static rt_int16_t stm32_adc_get_vref (struct rt_adc_device *device)
 {
-    RT_ASSERT(device);
-    return 3300;
+static rt_int16_t stm32_adc_get_vref (struct rt_adc_device *device)
+{
+    if(device == RT_NULL)
+      return RT_ERROR;
+    
+    rt_err_t ret = RT_EOK;
+    rt_uint32_t vref_value;
+    rt_uint16_t vref_mv; 
+    ADC_HandleTypeDef *stm32_adc_handler = device->parent.user_data;
+    
+    ret = rt_adc_enable(device, ADC_CHANNEL_VREFINT - ADC_CHANNEL_0);
+    vref_value = rt_adc_read(device, ADC_CHANNEL_VREFINT - ADC_CHANNEL_0);
+    ret = rt_adc_disable(device, ADC_CHANNEL_VREFINT - ADC_CHANNEL_0);
+    
+    vref_mv = __HAL_ADC_CALC_VREFANALOG_VOLTAGE(vref_value, stm32_adc_handler->Init.Resolution);
+    
+    return vref_mv;
+}
 }
 
 static rt_err_t stm32_adc_get_value(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value)

--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -287,8 +287,6 @@ static rt_uint32_t stm32_adc_get_channel(rt_uint32_t channel)
 
 static rt_int16_t stm32_adc_get_vref (struct rt_adc_device *device)
 {
-static rt_int16_t stm32_adc_get_vref (struct rt_adc_device *device)
-{
     if(device == RT_NULL)
       return RT_ERROR;
     

--- a/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_adc.c
@@ -289,20 +289,19 @@ static rt_int16_t stm32_adc_get_vref (struct rt_adc_device *device)
 {
     if(device == RT_NULL)
       return RT_ERROR;
-    
+
     rt_err_t ret = RT_EOK;
     rt_uint32_t vref_value;
-    rt_uint16_t vref_mv; 
+    rt_uint16_t vref_mv;
     ADC_HandleTypeDef *stm32_adc_handler = device->parent.user_data;
-    
+
     ret = rt_adc_enable(device, ADC_CHANNEL_VREFINT - ADC_CHANNEL_0);
     vref_value = rt_adc_read(device, ADC_CHANNEL_VREFINT - ADC_CHANNEL_0);
     ret = rt_adc_disable(device, ADC_CHANNEL_VREFINT - ADC_CHANNEL_0);
-    
+
     vref_mv = __HAL_ADC_CALC_VREFANALOG_VOLTAGE(vref_value, stm32_adc_handler->Init.Resolution);
-    
+
     return vref_mv;
-}
 }
 
 static rt_err_t stm32_adc_get_value(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value)


### PR DESCRIPTION
* 添加16位与14位分辨率配置
* 添加内部参考电压与温度,电池电压通道配置

## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
- 更改配置通道与校准函数顺序
在使能函数中配置通道更为合适
- 添加16位与14位分辨率配置
H7芯片支持16位与14位分辨率
- 添加内部参考电压与温度,电池电压通道配置
在H7芯片中,使用17~19通道去读取上述信息值错误.
需要单独配置通道,才可读取正常

#### 你的解决方案是什么 (what is your solution)
- 进行修改

#### 在什么测试环境下测试通过 (what is the test environment)
- ART-PI H750

![image](https://user-images.githubusercontent.com/66928464/208592451-d245a525-dd23-41f0-9bd3-929c52bf5673.png)

- 测试代码如下
```c
#include <rtthread.h>
#include <rtdevice.h>
#include <main.h>

#define ADC_DEV_NAME        "adc3"      /* ADC 设备名称 */
#define ADC_VREF_CHANNEL     ADC_CHANNEL_VREFINT - ADC_CHANNEL_0    /* ADC Vref 通道 */
#define ADC_TEMP_CHANNEL     ADC_CHANNEL_TEMPSENSOR - ADC_CHANNEL_0 /* ADC Temp 通道 */

static int adc_vol_sample(void)
{
    rt_uint32_t vref_value,temp_value;
    rt_uint16_t vref_mv,temp_mv; 

    rt_adc_device_t adc_dev;
    rt_err_t ret = RT_EOK;
    
    /* 查找设备 */
    adc_dev = (rt_adc_device_t)rt_device_find(ADC_DEV_NAME);
    if (adc_dev == RT_NULL)
    {
        rt_kprintf("adc sample run failed! can't find %s device!\n", ADC_DEV_NAME);
        return RT_ERROR;
    }

    /* 使能设备 */
    ret = rt_adc_enable(adc_dev, ADC_VREF_CHANNEL);
    /* 读取采样值 */
    vref_value = rt_adc_read(adc_dev, ADC_VREF_CHANNEL);
    /* 关闭通道 */
    ret = rt_adc_disable(adc_dev, ADC_VREF_CHANNEL);

    /* 使能设备 */
    ret = rt_adc_enable(adc_dev, ADC_TEMP_CHANNEL);
    /* 读取采样值 */
    temp_value = rt_adc_read(adc_dev, ADC_TEMP_CHANNEL);
    /* 关闭通道 */
    ret = rt_adc_disable(adc_dev, ADC_TEMP_CHANNEL);
  
    rt_kprintf("Vref  is %u.\n", vref_value);
    rt_kprintf("Temp is %u.\n" , temp_value);
    
    // Calculating Vref voltage
    vref_mv = __HAL_ADC_CALC_VREFANALOG_VOLTAGE(vref_value, ADC_RESOLUTION_16B);
    rt_kprintf("Vref voltage is %u mV.\n", vref_mv);
    // Calculate Temperature
    rt_kprintf("%d are Temperature in Degree C.\n",
    __HAL_ADC_CALC_TEMPERATURE(vref_mv, temp_value, ADC_RESOLUTION_16B));
    return RT_EOK;
}
/* 导出到 msh 命令列表中 */
MSH_CMD_EXPORT(adc_vol_sample, adc voltage convert sample);
```
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
