### PR TITLE
[drivers][serial_v2]修复DMA+TX阻塞模式异常

### DIFF
--- a/components/drivers/serial/serial_v2.c
+++ b/components/drivers/serial/serial_v2.c
@@ -694,7 +694,7 @@ static rt_err_t rt_serial_tx_enable(struct rt_device        *dev,
 
         tx_fifo->activated = RT_FALSE;
         tx_fifo->put_size = 0;
-        rt_memset(&tx_fifo->rb, 0, sizeof(tx_fifo->rb));
+        rt_memset(&tx_fifo->rb, RT_NULL, sizeof(tx_fifo->rb));
         rt_completion_init(&(tx_fifo->tx_cpt));
         dev->open_flag |= RT_SERIAL_TX_BLOCKING;
 

--- a/components/drivers/serial/serial_v2.c
+++ b/components/drivers/serial/serial_v2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -694,6 +694,7 @@ static rt_err_t rt_serial_tx_enable(struct rt_device        *dev,
 
         tx_fifo->activated = RT_FALSE;
         tx_fifo->put_size = 0;
+        rt_memset(&tx_fifo->rb,0,sizeof(tx_fifo->rb));
         rt_completion_init(&(tx_fifo->tx_cpt));
         dev->open_flag |= RT_SERIAL_TX_BLOCKING;
 

--- a/components/drivers/serial/serial_v2.c
+++ b/components/drivers/serial/serial_v2.c
@@ -694,7 +694,7 @@ static rt_err_t rt_serial_tx_enable(struct rt_device        *dev,
 
         tx_fifo->activated = RT_FALSE;
         tx_fifo->put_size = 0;
-        rt_memset(&tx_fifo->rb,0,sizeof(tx_fifo->rb));
+        rt_memset(&tx_fifo->rb, 0, sizeof(tx_fifo->rb));
         rt_completion_init(&(tx_fifo->tx_cpt));
         dev->open_flag |= RT_SERIAL_TX_BLOCKING;
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
- 修复DMA+TX阻塞模式异常
- 使用例程代码去配,运行错误
> https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/programming-manual/device/uart/uart_v2/uart?id=%e4%b8%b2%e5%8f%a3%e8%ae%be%e5%a4%87%e4%bd%bf%e7%94%a8%e7%a4%ba%e4%be%8b
```shell
msh />uart_dma_sample
.................................................................................
固件名称：rt-thread，硬件版本号：1.0，软件版本号：1.0
在线程(tshell)中发生错误异常
发生总线错误，原因：不精确的数据总线错误
```
- 应该说我运气比较差吧,malloc分配的空间刚好是被用完的.....
- 正常来说分配的是空的空间的话,就不会有问题
#### 原因分析
- 初始化时进入rt_serial_tx_enable函数
1.在If not use RT_SERIAL_TX_BLOCKING_BUFFER判断中未对tx_fifo->rb进行清零.
2.导致tx_fifo->rb.buffer_ptr不为空指针
![image](https://user-images.githubusercontent.com/66928464/209526721-15d4485d-1621-446a-b8ff-a6374e99eb0e.png)
- 在串口发送时,进入rt_serial_write函数,tx_fifo->rb.buffer_ptr不为空指针,导致进入_serial_fifo_tx_blocking_buf函数
![image](https://user-images.githubusercontent.com/66928464/209527272-5e52535d-e7ec-4110-b49e-47e4102ee715.png)
- 按照DMA+TX阻塞方式来说,应该进入nbuf函数的
![image](https://user-images.githubusercontent.com/66928464/209596681-1515e0be-3b4c-421c-8a9a-b776d29477ac.png)
- 从而发生错误,不发生错误也无法正常串口发送
![image](https://user-images.githubusercontent.com/66928464/209527410-320c5a15-c29f-4dec-9211-afde6983f6c2.png)
#### 你的解决方案是什么 (what is your solution)
- 清零rb空间
rt_memset(&tx_fifo->rb,0,sizeof(tx_fifo->rb));

#### 在什么测试环境下测试通过 (what is the test environment)
- ART-PI
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
