### PR TITLE
fix the syntax error of drv_spi.c in lpc55sxx.

### DIFF
--- a/bsp/lpc55sxx/Libraries/drivers/drv_spi.c
+++ b/bsp/lpc55sxx/Libraries/drivers/drv_spi.c
@@ -29,7 +29,7 @@
 #endif
 
 struct lpc_spi
-{iteopuywqt[riouqwyyyyyyyyyyyy
+{
     SPI_Type *base;
     struct rt_spi_configuration *cfg;
     SYSCON_RSTn_t spi_rst;


### PR DESCRIPTION
修复lpc55sxx中的drv_spi.c语法错误。