### PR TITLE
[rt-smart] handling kernel from accessing unmapped user stack

### DIFF
--- a/components/lwp/arch/risc-v/rv64/lwp_gcc.S
+++ b/components/lwp/arch/risc-v/rv64/lwp_gcc.S
@@ -125,6 +125,15 @@ user_do_signal:
     addi t0, sp, CTX_REG_NR * REGBYTES
     csrw sscratch, t0
 
+    LOAD t0, FRAME_OFF_SP(sp)
+    addi t1, t0, -CTX_REG_NR * REGBYTES
+    LOAD t2, (t0)
+    li t3, 0x1000
+1:
+    add t0, t0, t3
+    LOAD t2, (t0)
+    bgt t0, t1, 1b
+
     RESTORE_ALL
     SAVE_ALL
 

--- a/components/lwp/arch/risc-v/rv64/lwp_gcc.S
+++ b/components/lwp/arch/risc-v/rv64/lwp_gcc.S
@@ -121,18 +121,19 @@ arch_signal_quit:
  * routine in user stack
  */
 user_do_signal:
-    /** restore and backup kernel sp carefully to avoid leaking */
-    addi t0, sp, CTX_REG_NR * REGBYTES
-    csrw sscratch, t0
-
+    /* prefetch ustack to avoid corrupted status in RESTORE/STORE pair below */
     LOAD t0, FRAME_OFF_SP(sp)
     addi t1, t0, -CTX_REG_NR * REGBYTES
     LOAD t2, (t0)
-    li t3, 0x1000
+    li t3, -0x1000
 1:
     add t0, t0, t3
     LOAD t2, (t0)
     bgt t0, t1, 1b
+
+    /** restore and backup kernel sp carefully to avoid leaking */
+    addi t0, sp, CTX_REG_NR * REGBYTES
+    csrw sscratch, t0
 
     RESTORE_ALL
     SAVE_ALL

--- a/components/lwp/lwp_user_mm.c
+++ b/components/lwp/lwp_user_mm.c
@@ -560,10 +560,12 @@ int lwp_user_accessable(void *addr, size_t size)
             len = size;
         }
         tmp_addr = lwp_v2p(lwp, addr_start);
-        if (tmp_addr == ARCH_MAP_FAILED && (
-            ((rt_ubase_t)addr_start < USER_STACK_VSTART || (rt_ubase_t)addr_start > USER_STACK_VEND)))
+        if (tmp_addr == ARCH_MAP_FAILED)
         {
-            return 0;
+            if ((rt_ubase_t)addr_start >= USER_STACK_VSTART && (rt_ubase_t)addr_start < USER_STACK_VEND)
+                tmp_addr = *(void **)addr_start;
+            else
+                return 0;
         }
         addr_start = (void *)((char *)addr_start + len);
         size -= len;
@@ -637,8 +639,7 @@ size_t lwp_data_put(struct rt_lwp *lwp, void *dst, void *src, size_t size)
             len = size;
         }
         tmp_dst = lwp_v2p(lwp, addr_start);
-        if (tmp_dst == ARCH_MAP_FAILED && (
-            ((rt_ubase_t)addr_start < USER_STACK_VSTART || (rt_ubase_t)addr_start > USER_STACK_VEND)))
+        if (tmp_dst == ARCH_MAP_FAILED)
         {
             break;
         }

--- a/components/lwp/lwp_user_mm.c
+++ b/components/lwp/lwp_user_mm.c
@@ -560,7 +560,8 @@ int lwp_user_accessable(void *addr, size_t size)
             len = size;
         }
         tmp_addr = lwp_v2p(lwp, addr_start);
-        if (!tmp_addr)
+        if (tmp_addr == ARCH_MAP_FAILED && (
+            ((rt_ubase_t)addr_start < USER_STACK_VSTART || (rt_ubase_t)addr_start > USER_STACK_VEND)))
         {
             return 0;
         }
@@ -596,7 +597,7 @@ size_t lwp_data_get(struct rt_lwp *lwp, void *dst, void *src, size_t size)
             len = size;
         }
         tmp_src = lwp_v2p(lwp, addr_start);
-        if (!tmp_src)
+        if (tmp_src == ARCH_MAP_FAILED)
         {
             break;
         }
@@ -636,7 +637,8 @@ size_t lwp_data_put(struct rt_lwp *lwp, void *dst, void *src, size_t size)
             len = size;
         }
         tmp_dst = lwp_v2p(lwp, addr_start);
-        if (!tmp_dst)
+        if (tmp_dst == ARCH_MAP_FAILED && (
+            ((rt_ubase_t)addr_start < USER_STACK_VSTART || (rt_ubase_t)addr_start > USER_STACK_VEND)))
         {
             break;
         }

--- a/libcpu/risc-v/t-head/c906/stackframe.h
+++ b/libcpu/risc-v/t-head/c906/stackframe.h
@@ -13,6 +13,10 @@
 #ifndef __STACKFRAME_H__
 #define __STACKFRAME_H__
 
+#define BYTES(idx)          ((idx) * REGBYTES)
+#define FRAME_OFF_SSTATUS   BYTES(2)
+#define FRAME_OFF_SP        BYTES(32)
+
 #include "cpuport.h"
 #include "encoding.h"
 

--- a/libcpu/risc-v/t-head/c906/stackframe.h
+++ b/libcpu/risc-v/t-head/c906/stackframe.h
@@ -58,7 +58,7 @@
 /**
  * The register `tp` always save/restore when context switch,
  * we call `lwp_user_setting_save` when syscall enter,
- * call `lwp_user_setting_restore` when syscall exit 
+ * call `lwp_user_setting_restore` when syscall exit
  * and modify context stack after `lwp_user_setting_restore` called
  * so that the `tp` can be the correct thread area value.
  */

--- a/libcpu/risc-v/t-head/c906/trap.c
+++ b/libcpu/risc-v/t-head/c906/trap.c
@@ -305,39 +305,39 @@ void handle_trap(rt_size_t scause, rt_size_t stval, rt_size_t sepc, struct rt_hw
     else if (SCAUSE_INTERRUPT & scause)
     {
         if(id < sizeof(Interrupt_Name) / sizeof(const char *))
-            {
-                msg = Interrupt_Name[id];
-            }
-            else
-            {
-                msg = "Unknown Interrupt";
-            }
-        LOG_E("Unhandled Interrupt %ld:%s\n",id,msg);
+        {
+            msg = Interrupt_Name[id];
         }
         else
         {
+            msg = "Unknown Interrupt";
+        }
+        LOG_E("Unhandled Interrupt %ld:%s\n",id,msg);
+    }
+    else
+    {
 #ifdef RT_USING_SMART
-            if (!(sp->sstatus & 0x100) || (PAGE_FAULT && IN_USER_SPACE))
-            {
-                handle_user(scause, stval, sepc, sp);
-                // if handle_user() return here, jump to u mode then
+        if (!(sp->sstatus & 0x100) || (PAGE_FAULT && IN_USER_SPACE))
+        {
+            handle_user(scause, stval, sepc, sp);
+            // if handle_user() return here, jump to u mode then
             return ;
-            }
+        }
 #endif
 
-            // handle kernel exception:
-            rt_kprintf("Unhandled Exception %ld:%s\n", id, get_exception_msg(id));
-        }
+        // handle kernel exception:
+        rt_kprintf("Unhandled Exception %ld:%s\n", id, get_exception_msg(id));
+    }
 
-        rt_kprintf("scause:0x%p,stval:0x%p,sepc:0x%p\n", scause, stval, sepc);
-        dump_regs(sp);
-        rt_kprintf("--------------Thread list--------------\n");
-        rt_kprintf("current thread: %s\n", rt_thread_self()->name);
+    rt_kprintf("scause:0x%p,stval:0x%p,sepc:0x%p\n", scause, stval, sepc);
+    dump_regs(sp);
+    rt_kprintf("--------------Thread list--------------\n");
+    rt_kprintf("current thread: %s\n", rt_thread_self()->name);
 
-        extern struct rt_thread *rt_current_thread;
-        rt_kprintf("--------------Backtrace--------------\n");
-        rt_hw_backtrace((uint32_t *)sp->s0_fp, sepc);
+    extern struct rt_thread *rt_current_thread;
+    rt_kprintf("--------------Backtrace--------------\n");
+    rt_hw_backtrace((uint32_t *)sp->s0_fp, sepc);
 
-        while (1)
-            ;
+    while (1)
+        ;
 }

--- a/libcpu/risc-v/t-head/c906/trap.c
+++ b/libcpu/risc-v/t-head/c906/trap.c
@@ -277,6 +277,9 @@ static void handle_nested_trap_panic(
     rt_hw_cpu_shutdown();
 }
 
+#define IN_USER_SPACE (stval >= USER_VADDR_START && stval < USER_VADDR_TOP)
+#define PAGE_FAULT (id == EP_LOAD_PAGE_FAULT || id == EP_STORE_PAGE_FAULT)
+
 /* Trap entry */
 void handle_trap(rt_size_t scause, rt_size_t stval, rt_size_t sepc, struct rt_hw_stack_frame *sp)
 {
@@ -302,39 +305,39 @@ void handle_trap(rt_size_t scause, rt_size_t stval, rt_size_t sepc, struct rt_hw
     else if (SCAUSE_INTERRUPT & scause)
     {
         if(id < sizeof(Interrupt_Name) / sizeof(const char *))
-        {
-            msg = Interrupt_Name[id];
+            {
+                msg = Interrupt_Name[id];
+            }
+            else
+            {
+                msg = "Unknown Interrupt";
+            }
+        LOG_E("Unhandled Interrupt %ld:%s\n",id,msg);
         }
         else
         {
-            msg = "Unknown Interrupt";
-        }
-        LOG_E("Unhandled Interrupt %ld:%s\n",id,msg);
-    }
-    else
-    {
 #ifdef RT_USING_SMART
-        if (!(sp->sstatus & 0x100))
-        {
-            handle_user(scause, stval, sepc, sp);
-            // if handle_user() return here, jump to u mode then
+            if (!(sp->sstatus & 0x100) || (PAGE_FAULT && IN_USER_SPACE))
+            {
+                handle_user(scause, stval, sepc, sp);
+                // if handle_user() return here, jump to u mode then
             return ;
-        }
+            }
 #endif
 
-        // handle kernel exception:
-        rt_kprintf("Unhandled Exception %ld:%s\n", id, get_exception_msg(id));
-    }
+            // handle kernel exception:
+            rt_kprintf("Unhandled Exception %ld:%s\n", id, get_exception_msg(id));
+        }
 
-    rt_kprintf("scause:0x%p,stval:0x%p,sepc:0x%p\n", scause, stval, sepc);
-    dump_regs(sp);
-    rt_kprintf("--------------Thread list--------------\n");
-    rt_kprintf("current thread: %s\n", rt_thread_self()->name);
+        rt_kprintf("scause:0x%p,stval:0x%p,sepc:0x%p\n", scause, stval, sepc);
+        dump_regs(sp);
+        rt_kprintf("--------------Thread list--------------\n");
+        rt_kprintf("current thread: %s\n", rt_thread_self()->name);
 
-    extern struct rt_thread *rt_current_thread;
-    rt_kprintf("--------------Backtrace--------------\n");
-    rt_hw_backtrace((uint32_t *)sp->s0_fp, sepc);
+        extern struct rt_thread *rt_current_thread;
+        rt_kprintf("--------------Backtrace--------------\n");
+        rt_hw_backtrace((uint32_t *)sp->s0_fp, sepc);
 
-    while (1)
-        ;
+        while (1)
+            ;
 }

--- a/libcpu/risc-v/virt64/stackframe.h
+++ b/libcpu/risc-v/virt64/stackframe.h
@@ -141,7 +141,7 @@
 
 /**
  * @brief Restore All General Registers, for interrupt handling
- * 
+ *
  */
 .macro RESTORE_ALL
 

--- a/libcpu/risc-v/virt64/stackframe.h
+++ b/libcpu/risc-v/virt64/stackframe.h
@@ -18,8 +18,9 @@
 #include "encoding.h"
 #include "ext_context.h"
 
-#define BYTES(idx) ((idx) * REGBYTES)
-#define FRAME_OFF_SSTATUS BYTES(2)
+#define BYTES(idx)          ((idx) * REGBYTES)
+#define FRAME_OFF_SSTATUS   BYTES(2)
+#define FRAME_OFF_SP        BYTES(32)
 
 #ifdef __ASSEMBLY__
 

--- a/libcpu/risc-v/virt64/trap.c
+++ b/libcpu/risc-v/virt64/trap.c
@@ -274,6 +274,9 @@ static void handle_nested_trap_panic(
     rt_hw_cpu_shutdown();
 }
 
+#define IN_USER_SPACE (stval >= USER_VADDR_START && stval < USER_VADDR_TOP)
+#define PAGE_FAULT (id == EP_LOAD_PAGE_FAULT || id == EP_STORE_PAGE_FAULT)
+
 /* Trap entry */
 void handle_trap(rt_size_t scause, rt_size_t stval, rt_size_t sepc, struct rt_hw_stack_frame *sp)
 {
@@ -326,7 +329,7 @@ void handle_trap(rt_size_t scause, rt_size_t stval, rt_size_t sepc, struct rt_hw
             }
 #endif /* ENABLE_VECTOR */
 #ifdef RT_USING_SMART
-            if (!(sp->sstatus & 0x100))
+            if (!(sp->sstatus & 0x100) || (PAGE_FAULT && IN_USER_SPACE))
             {
                 handle_user(scause, stval, sepc, sp);
                 // if handle_user() return here, jump to u mode then


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

Kernel exploits `accessible()` to protect itself from panic of accessing corrupted user pointer. But stack is a special case that may be unmapped by still a legal address. These commits enable kernel to access legal but unmapped user stack by prefetching and loading user stack region in `accessible()` routine.

Tested on:

* allwinner D1s
* qemu-virt64-riscv
* qemu-virt64-aarch64
* qemu-vexpress-a9

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
