### PR TITLE
[rt-smart] use virtual address in shm struct

### DIFF
--- a/components/lwp/lwp_shm.c
+++ b/components/lwp/lwp_shm.c
@@ -101,7 +101,7 @@ static int _lwp_shmget(size_t key, size_t size, int create)
     int id = -1;
     struct lwp_avl_struct *node_key = 0;
     struct lwp_avl_struct *node_pa = 0;
-    void *page_addr = 0, *page_addr_p = RT_NULL;
+    void *page_addr = 0;
     uint32_t bit = 0;
 
     /* try to locate the item with the key in the binary tree */
@@ -134,11 +134,10 @@ static int _lwp_shmget(size_t key, size_t size, int create)
         {
             goto err;
         }
-        page_addr_p = (void *)((char *)page_addr + PV_OFFSET);    /* physical address */
 
         /* initialize the shared memory structure */
         p = _shm_ary + id;
-        p->addr = (size_t)page_addr_p;
+        p->addr = (size_t)page_addr;
         p->size = (1UL << (bit + ARCH_PAGE_SHIFT));
         p->ref = 0;
         p->key = key;
@@ -236,7 +235,7 @@ static int _lwp_shmrm(int id)
         return 0;
     }
     bit = rt_page_bits(p->size);
-    rt_pages_free((void *)((char *)p->addr - PV_OFFSET), bit);
+    rt_pages_free((void *)p->addr, bit);
     lwp_avl_remove(node_key, &shm_tree_key);
     node_pa = node_key + 1;
     lwp_avl_remove(node_pa, &shm_tree_pa);

--- a/libcpu/aarch64/common/mmu.c
+++ b/libcpu/aarch64/common/mmu.c
@@ -109,6 +109,10 @@ static void _kenrel_unmap_4K(unsigned long *lv0_tbl, void *v_addr)
             }
             rt_pages_free(cur_page, 0);
         }
+        else
+        {
+            break;
+        }
         level--;
     }
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

* [fix][lwp/shm] use virtual address in shm struct to establish a mapping in user space
* [fix][libcpu/aarch64] unmapping should stop if pos is NULL

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
