### PR TITLE
[libcpu/riscv/virt64] fix (#5979) 修复 qemu-riscv-virt64 smode 下无法启动

### DIFF
--- a/libcpu/risc-v/virt64/startup_gcc.S
+++ b/libcpu/risc-v/virt64/startup_gcc.S
@@ -13,8 +13,10 @@
 #include <encoding.h>
 #include <cpuport.h>
 
-boot_hartid: .int
-    .global         boot_hartid
+    .data
+    .global boot_hartid    /* global varible rt_boot_hartid in .data section */
+boot_hartid:                          
+    .word 0xdeadbeef
 
     .global         _start
     .section ".start", "ax"


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[


#### 为什么提交这份PR (why to submit this PR)
在当前 master 分支中，qemu-riscv-virt64 smode 启动有问题，只有在使用 [Sifive 工具链](https://www.sifive.com/software) 的情况下才能进入系统，使用其他工具链则会报 `Illegal Instruction`  异常。

经过排查，最终确定是在 `startup_gcc.S` 没有为 `boot_hartid` 分配空间，在后续的指令中，发生了错误的修改。

```
boot_hartid: .int
.global boot_hartid
.global _start
.section ".start", "ax"
_start:
```

```c
/* save hartid */
la t0, boot_hartid /* global varible rt_boot_hartid */
mv t1, a0 /* get hartid in S-mode frome a0 register */
// 由于没有为 boot_hartid 分配空间，修改 boot_hartid 导致了其他指令的改动
sw t1, (t0) /* store t1 register low 4 bits in memory address which is stored in t0 */
```
对应的汇编语句如下，`boot_hartid` 与 `memset` 地址相同
```c
    8020001c:   44828293                addi    t0,t0,1096 # 80200460 <memset>
    80200020:   00050313                mv      t1,a0                                                       
    80200024:   0062a023                sw      t1,0(t0)
```
`map` 文件如下，可以明显看到 `boot_hartid` 的空间为 0x0，地址信息与 `memset` 相同。
```
 .text          0x0000000080200460        0x0 build/kernel/libcpu/risc-v/virt64/startup_gcc.o
                0x0000000080200460                boot_hartid
 .text          0x0000000080200460       0xdc /opt/riscv/lib/gcc/riscv64-unknown-elf/12.2.0/../../../../riscv64-unknown-elf/lib/libc.a(lib_a-memset.o)
                0x0000000080200460                memset
```

在 `80200024:   0062a023                sw      t1,0(t0)` 中修改了 `memset` 的第一条指令，导致后续调用 `memset` 时，指令发生错误。

使用不同工具链的情况下， 与 `boot_hartid` 地址相同的函数会有变化，在使用[Sifive 工具链](https://www.sifive.com/software) 时，地址信息如下
```
 .text          0x00000000802002ce        0x0 build/kernel/libcpu/risc-v/virt64/startup_gcc.o
                0x00000000802002ce                boot_hartid
 .text          0x00000000802002ce       0x28 /home/leesum/Downloads/riscv64-unknown-elf-toolchain-10.2.0-2020.12.8-x86_64-linux-ubuntu14/bin/../lib/gcc/riscv64-unknown-elf/10.2.0/../../../../riscv64-unknown-elf/lib/rv64imac/lp64/libc.a(lib_a-atoi.o)
                0x00000000802002ce                atoi
```

```asm
    80200018:   00000297                auipc   t0,0x0
    8020001c:   2b628293                addi    t0,t0,694 # 802002ce <atoi>
    80200020:   832a                    mv      t1,a0
```
与 `atoi` 函数地址相同，而 `atoi` 不是很常用的函数，所以没有在一开始启动的时候就报错。
本次提交能够修复上述 bug。


#### 你的解决方案是什么 (what is your solution)
原来的 `boot_hartid` 位于 `.start` 段，作为全局变量。修改后放在了 `.data` 段，并分配了 4byte 空间，不会与其他符号冲突
```asm
.data
.global boot_hartid   /* global varible rt_boot_hartid in .data section */
boot_hartid:
	.word 0xdeadbeef
```


#### 在什么测试环境下测试通过 (what is the test environment)
❯ qemu-system-riscv64 --help  
QEMU emulator version 7.2.0

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
