### PR TITLE
[mutex] mutex may suspend a thread already suspended & fix ceilingprio

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -127,12 +127,15 @@ rt_inline rt_err_t _ipc_list_suspend(rt_list_t        *list,
                                        rt_uint8_t        flag,
                                        int suspend_flag)
 {
-    rt_err_t ret = rt_thread_suspend_with_flag(thread, suspend_flag);
-
-    /* suspend thread */
-    if (ret != RT_EOK)
+    if ((thread->stat & RT_THREAD_SUSPEND_MASK) != RT_THREAD_SUSPEND_MASK)
     {
-        return ret;
+        rt_err_t ret = rt_thread_suspend_with_flag(thread, suspend_flag);
+
+        /* suspend thread */
+        if (ret != RT_EOK)
+        {
+            return ret;
+        }
     }
 
     switch (flag)
@@ -1218,6 +1221,7 @@ static rt_err_t _rt_mutex_take(rt_mutex_t mutex, rt_int32_t timeout, int suspend
             }
             else
             {
+                /* mutex already taken, suspend current thread */
                 rt_uint8_t priority = thread->current_priority;
 
                 /* mutex is unavailable, push to suspend list */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

When trying to update the priority of a thread in the scene of taking a mutex, there's a chance to update a suspended thread. And in the routine to update priority of a target thread, it reinsert the target thread to the suspended list of the waiting object (mutex in this case). The reinsertion is implemented by `_ipc_list_suspend`. Then it turns out that `_ipc_list_suspend` should not call `rt_thread_suspend_with_flag` directly because the suspended thread is suspended already.

In the end you will see error like this:

```text
(thread == rt_thread_self()) assertion failed at function:rt_thread_suspend_with_flag, line number:984
```

Following codes describe the scene above:

```c
struct rt_mutex _test_mutex1;
struct rt_mutex _test_mutex2;
struct rt_mutex _test_ceiling;
rt_thread_t tid1, tid2, tid3;

void _threadA(void *param)
{
    rt_mutex_take(&_test_mutex1, -1);
    /* prio A must be 15 since it take mutex 1, and its init prio is 15 */
    RT_ASSERT(rt_thread_self()->current_priority == 15);

    rt_mutex_take(&_test_ceiling, -1);
    /* prio A must be 10 since it take mutex ceiling */
    RT_ASSERT(rt_thread_self()->current_priority == 10);

    rt_thread_startup(tid2);

    rt_thread_mdelay(1000);

    rt_mutex_release(&_test_mutex1);
    /* recalculation of prio right ? */
    RT_ASSERT(rt_thread_self()->current_priority == 10);

    rt_mutex_release(&_test_ceiling);
    rt_mutex_detach(&_test_ceiling);

    rt_kprintf("A exit\n");
    return ;
}

void _threadB(void *param)
{
    rt_mutex_take(&_test_mutex2, -1);
    rt_kprintf("B get mutex 2\n");
    rt_thread_startup(tid3);

    /* suspended */
    rt_mutex_take(&_test_mutex1, -1);
    RT_ASSERT(rt_thread_self()->current_priority == 15);

    rt_kprintf("B get mutex 1\n");

    rt_mutex_release(&_test_mutex1);
    /* after release prio restore to 15 (because threadC) */
    RT_ASSERT(rt_thread_self()->current_priority == 15);

    rt_mutex_detach(&_test_mutex1);

    rt_mutex_setprioceiling(&_test_mutex2, 10);
    RT_ASSERT(rt_thread_self()->current_priority == 10);

    rt_mutex_release(&_test_mutex2);
    rt_kprintf("B exit\n");
    return;
}

void _threadC(void *param)
{
    rt_mutex_take(&_test_mutex2, -1);
    RT_ASSERT(rt_thread_self()->current_priority == 10);

    rt_mutex_release(&_test_mutex2);
    RT_ASSERT(rt_thread_self()->current_priority == 15);

    rt_mutex_detach(&_test_mutex2);
    rt_kprintf("C exit\n");

    return ;
}

void test_mutex_update_prio(void)
{
    rt_mutex_init(&_test_mutex1, "test_thread_mutex1", RT_IPC_FLAG_FIFO);
    rt_mutex_init(&_test_mutex2, "test_thread_mutex2", RT_IPC_FLAG_FIFO);
    rt_mutex_init(&_test_ceiling, "test_thread_mutex2", RT_IPC_FLAG_FIFO);

    tid1 = rt_thread_create("threadA", _threadA, NULL, 4096, 20, 20);
    tid2 = rt_thread_create("threadB", _threadB, NULL, 4096, 20, 20);
    tid3 = rt_thread_create("threadC", _threadC, NULL, 4096, 15, 20);
    rt_mutex_setprioceiling(&_test_mutex1, 15);
    rt_mutex_setprioceiling(&_test_ceiling, 10);

    rt_thread_startup(tid1);
}
MSH_CMD_EXPORT(test_mutex_update_prio, test mutex through priority update);
```

![image](https://user-images.githubusercontent.com/65584760/224664874-494f7730-841e-426c-a762-0f157f776ea5.png)

### Fix

* fix call to `rt_thread_control` in `_ipc_list_suspend`
* fix set proceiling failed to maintain thread priority in its semantic

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
