### PR TITLE
fix the bug with PendSV_Handler of arm-m33

### DIFF
--- a/libcpu/arm/cortex-m33/context_rvds.S
+++ b/libcpu/arm/cortex-m33/context_rvds.S
@@ -113,7 +113,7 @@ schedule
     ; skip register save at the first time
     LDR     r0, =rt_interrupt_from_thread           ; r0 = &rt_interrupt_from_thread
     LDR     r1, [r0]                                ; r1 = *r0
-    CBZ     r1, switch_to_thread                    ; if r1 == 0, goto switch_to_thread
+    CBZ     r1, first_to_thread                     ; if r1 == 0, first_to_thread
 
     ; Whether TrustZone thread stack exists
     LDR     r1,  =rt_trustzone_current_context      ; r1 = &rt_secure_current_context
@@ -162,7 +162,30 @@ contex_ns_store
 
     LDR     r0, [r0]
     STR     r1, [r0]                                ; update from thread stack pointer
+first_to_thread
+	LDR     r1, =rt_interrupt_to_thread
+    LDR     r1, [r1]
+    LDR     r1, [r1]                                ; load thread stack pointer
 
+    ; update current TrustZone context
+    LDMFD   r1!, {r2-r5}                            ; pop thread stack
+    MSR     psplim, r4                              ; psplim = r4
+    MSR     control, r5                             ; control = r5
+    ORR     lr, lr, #0x04                           ; first return
+    
+	LDR     r6,  =rt_trustzone_current_context      ; r6 = &rt_secure_current_context
+    STR     r2, [r6]                                ; *r6 = r2
+    MOV     r0, r2                                  ; r0 = r2
+
+    ; Whether TrustZone thread stack exists
+    CBZ     r0, contex_ns_load                      ; if r0 == 0, goto contex_ns_load
+    PUSH    {r1, r3}                                ; push lr, thread_stack
+    BL rt_trustzone_context_load                    ; call TrustZone load fun
+    POP     {r1, r3}                                ; pop lr, thread_stack
+    MOV     lr, r3                                  ; lr = r1
+    TST     r3, #0x40                               ; if EXC_RETURN[6] is 1, TrustZone stack was used
+    BEQ     contex_ns_load                          ; if r1 & 0x40 == 0, goto contex_ns_load
+    B pendsv_exit
 switch_to_thread
     LDR     r1, =rt_interrupt_to_thread
     LDR     r1, [r1]


### PR DESCRIPTION
There is no special handling for the first thread switch，so I added the "first_to_thread" label.

## 拉取/合并请求描述：

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
移植到M33平台上首次调度线程返回裸机main失败，发现是首次调度并未特殊处理，应该是把lr寄存器置为0xFFFF_FFFD

#### 你的解决方案是什么 (what is your solution)
在PendSV_handle里加入首次调度的代码，其实就是复制了switch_to_thread，修改了写入lr的那行代码

#### 在什么测试环境下测试通过 (what is the test environment)
arm-M33
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR



- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
