### PR TITLE
[stm32][pwm] fix the timer clock enable problem

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pwm.c
@@ -24,8 +24,6 @@
 #define MIN_PERIOD 3
 #define MIN_PULSE 2
 
-extern void HAL_TIM_MspPostInit(TIM_HandleTypeDef *htim);
-
 enum
 {
 #ifdef BSP_USING_PWM1
@@ -380,24 +378,26 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
 #if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32L4)
     tim->Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
 #endif
-
     if (HAL_TIM_Base_Init(tim) != HAL_OK)
     {
         LOG_E("%s pwm init failed", device->name);
         result = -RT_ERROR;
         goto __exit;
     }
-    if (HAL_TIM_PWM_Init(tim) != HAL_OK)
-    {
-        LOG_E("%s pwm init failed", device->name);
-        result = -RT_ERROR;
-        goto __exit;
-    }
+
+    stm32_tim_enable_clock(tim);
 
     clock_config.ClockSource = TIM_CLOCKSOURCE_INTERNAL;
     if (HAL_TIM_ConfigClockSource(tim, &clock_config) != HAL_OK)
     {
         LOG_E("%s clock init failed", device->name);
+        result = -RT_ERROR;
+        goto __exit;
+    }
+
+    if (HAL_TIM_PWM_Init(tim) != HAL_OK)
+    {
+        LOG_E("%s pwm init failed", device->name);
         result = -RT_ERROR;
         goto __exit;
     }
@@ -463,6 +463,7 @@ static rt_err_t stm32_hw_pwm_init(struct stm32_pwm *device)
     }
 
     /* pwm pin configuration */
+    void HAL_TIM_MspPostInit(TIM_HandleTypeDef *htim);
     HAL_TIM_MspPostInit(tim);
 
     /* enable update request source */
@@ -472,7 +473,7 @@ __exit:
     return result;
 }
 
-static void pwm_get_channel(void)
+static void stm32_pwm_get_channel(void)
 {
 #ifdef BSP_USING_PWM1_CH1
     stm32_pwm_obj[PWM1_INDEX].channel |= 1 << 0;
@@ -616,7 +617,7 @@ static int stm32_pwm_init(void)
     int i = 0;
     int result = RT_EOK;
 
-    pwm_get_channel();
+    stm32_pwm_get_channel();
 
     for (i = 0; i < sizeof(stm32_pwm_obj) / sizeof(stm32_pwm_obj[0]); i++)
     {

--- a/bsp/stm32/libraries/HAL_Drivers/drv_tim.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_tim.c
@@ -366,21 +366,13 @@ static void timer_init(struct rt_hwtimer_device *timer, rt_uint32_t state)
             LOG_E("%s init failed", tim_device->name);
             return;
         }
-        else
-        {
-            /* set the TIMx priority */
-            HAL_NVIC_SetPriority(tim_device->tim_irqn, 3, 0);
 
-            /* enable the TIMx global Interrupt */
-            HAL_NVIC_EnableIRQ(tim_device->tim_irqn);
-
-            /* clear update flag */
-            __HAL_TIM_CLEAR_FLAG(tim, TIM_FLAG_UPDATE);
-            /* enable update request source */
-            __HAL_TIM_URS_ENABLE(tim);
-
-            LOG_D("%s init success", tim_device->name);
-        }
+        stm32_tim_enable_clock(tim);
+        HAL_NVIC_SetPriority(tim_device->tim_irqn, 3, 0); /* set the TIMx priority */
+        HAL_NVIC_EnableIRQ(tim_device->tim_irqn); /* enable the TIMx global Interrupt */
+        __HAL_TIM_CLEAR_FLAG(tim, TIM_FLAG_UPDATE); /* clear update flag */
+        __HAL_TIM_URS_ENABLE(tim); /* enable update request source */
+        LOG_D("%s init success", tim_device->name);
     }
 }
 
@@ -463,7 +455,7 @@ static rt_err_t timer_ctrl(rt_hwtimer_t *timer, rt_uint32_t cmd, void *arg)
 #elif defined(SOC_SERIES_STM32WB)
         if (tim->Instance == TIM16 || tim->Instance == TIM17)
 #elif defined(SOC_SERIES_STM32MP1)
-       if(tim->Instance == TIM14 || tim->Instance == TIM16 || tim->Instance == TIM17)
+        if(tim->Instance == TIM14 || tim->Instance == TIM16 || tim->Instance == TIM17)
 #elif defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32H7)
         if (0)
 #else

--- a/bsp/stm32/libraries/HAL_Drivers/drv_tim.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_tim.c
@@ -52,8 +52,133 @@ void stm32_tim_pclkx_doubler_get(rt_uint32_t *pclk1_doubler, rt_uint32_t *pclk2_
     {
          *pclk2_doubler = 2;
     }
-#endif
-#endif
+#endif /* !(defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32G0)) */
+#endif /* defined(SOC_SERIES_STM32MP1) */
+}
+
+void stm32_tim_enable_clock(TIM_HandleTypeDef* htim_base)
+{
+    RT_ASSERT(htim_base != RT_NULL);
+
+    if(RT_FALSE);
+#ifdef TIM1
+    else if(htim_base->Instance==TIM1)
+    {
+        __HAL_RCC_TIM1_CLK_ENABLE();
+    }
+#endif /* TIM1 */
+#ifdef TIM2
+    else if(htim_base->Instance==TIM2)
+    {
+        __HAL_RCC_TIM2_CLK_ENABLE();
+    }
+#endif /* TIM2 */
+#ifdef TIM3
+    else if(htim_base->Instance==TIM3)
+    {
+        __HAL_RCC_TIM3_CLK_ENABLE();
+    }
+#endif /* TIM3 */
+#ifdef TIM4
+    else if(htim_base->Instance==TIM4)
+    {
+        __HAL_RCC_TIM4_CLK_ENABLE();
+    }
+#endif /* TIM4 */
+#ifdef TIM5
+    else if(htim_base->Instance==TIM5)
+    {
+        __HAL_RCC_TIM5_CLK_ENABLE();
+    }
+#endif /* TIM5 */
+#ifdef TIM6
+    else if(htim_base->Instance==TIM6)
+    {
+        __HAL_RCC_TIM6_CLK_ENABLE();
+    }
+#endif /* TIM6 */
+#ifdef TIM7
+    else if(htim_base->Instance==TIM7)
+    {
+        __HAL_RCC_TIM7_CLK_ENABLE();
+    }
+#endif /* TIM7 */
+#ifdef TIM8
+    else if(htim_base->Instance==TIM8)
+    {
+        __HAL_RCC_TIM8_CLK_ENABLE();
+    }
+#endif /* TIM8 */
+#ifdef TIM9
+    else if(htim_base->Instance==TIM9)
+    {
+        __HAL_RCC_TIM9_CLK_ENABLE();
+    }
+#endif /* TIM9 */
+#ifdef TIM10
+    else if(htim_base->Instance==TIM10)
+    {
+        __HAL_RCC_TIM10_CLK_ENABLE();
+    }
+#endif /* TIM10 */
+#ifdef TIM11
+    else if(htim_base->Instance==TIM11)
+    {
+        __HAL_RCC_TIM11_CLK_ENABLE();
+    }
+#endif /* TIM11 */
+#ifdef TIM12
+    else if(htim_base->Instance==TIM12)
+    {
+        __HAL_RCC_TIM12_CLK_ENABLE();
+    }
+#endif /* TIM12 */
+#ifdef TIM13
+    else if(htim_base->Instance==TIM13)
+    {
+        __HAL_RCC_TIM13_CLK_ENABLE();
+    }
+#endif /* TIM13 */
+#ifdef TIM14
+    else if(htim_base->Instance==TIM14)
+    {
+        __HAL_RCC_TIM14_CLK_ENABLE();
+    }
+#endif /* TIM14 */
+#ifdef TIM15
+    else if(htim_base->Instance==TIM15)
+    {
+        __HAL_RCC_TIM15_CLK_ENABLE();
+    }
+#endif /* TIM15 */
+#ifdef TIM16
+    else if(htim_base->Instance==TIM16)
+    {
+        __HAL_RCC_TIM16_CLK_ENABLE();
+    }
+#endif /* TIM16 */
+#ifdef TIM17
+    else if(htim_base->Instance==TIM17)
+    {
+        __HAL_RCC_TIM17_CLK_ENABLE();
+    }
+#endif /* TIM17 */
+#ifdef TIM18
+    else if(htim_base->Instance==TIM18)
+    {
+        __HAL_RCC_TIM18_CLK_ENABLE();
+    }
+#endif /* TIM18 */
+#ifdef TIM19
+    else if(htim_base->Instance==TIM19)
+    {
+        __HAL_RCC_TIM19_CLK_ENABLE();
+    }
+#endif /* TIM19 */
+    else
+    {
+        RT_ASSERT(RT_TRUE);
+    }
 }
 
 #ifdef BSP_USING_TIM

--- a/bsp/stm32/libraries/HAL_Drivers/drv_tim.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_tim.h
@@ -12,7 +12,9 @@
 #define __DRV_TIM_H__
 
 #include <rtdef.h>
+#include <board.h>
 
 void stm32_tim_pclkx_doubler_get(rt_uint32_t *pclk1_doubler, rt_uint32_t *pclk2_doubler);
+void stm32_tim_enable_clock(TIM_HandleTypeDef* htim_base);
 
 #endif /* __DRV_TIM_H__ */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
这个问题已经在过去四年间反复折腾，主要问题就是集中在HAL_TIM_Base_Init和HAL_TIM_PWM_Init这两个函数的初始化顺序上。四年依赖，有很多小伙伴曾经在论坛上反馈过这个问题，并且也有很多PR。但是所有PR都是在这两个函数的调用顺序上扯大锯拉大锯，上一个PR换过去，下一个PR换回来.....

https://github.com/RT-Thread/rt-thread/pull/3155
https://github.com/RT-Thread/rt-thread/pull/3337
https://github.com/RT-Thread/rt-thread/pull/4254
https://github.com/RT-Thread/rt-thread/pull/5241
https://github.com/RT-Thread/rt-thread/pull/7030

论坛上的相关问题
https://club.rt-thread.org/ask/question/a8b1487fde9f0e77.html
https://club.rt-thread.org/ask/question/6ce57376be3021bd.html
https://club.rt-thread.org/ask/article/e611b91ad2e31ae8.html
https://club.rt-thread.org/ask/article/aae3a83f0bfe9857.html


本PR:
1. HAL_TIM_Base_Init 和 HAL_TIM_PWM_Init按照CubeMX生成的顺序，即先调用HAL_TIM_Base_Init再调用HAL_TIM_PWM_Init
2. 由于HAL_TIM_Base_Init 和 HAL_TIM_PWM_Init在TIM时钟初始化上存在一定可能的互斥，导致定时器时钟没有使能的问题。本PR增加了stm32_tim_enable_clock函数，确保tim时钟可以正常被使能。

此后无需在选择internal source，直接不用管这个即可
![image](https://user-images.githubusercontent.com/34888354/225182326-beab6a51-c3ea-43eb-9467-8bec1c295e7d.png)


问题回顾可以参见此PR，https://github.com/RT-Thread/rt-thread/pull/4254


另外，除了时钟使能的自身问题之外，本问题也暴露了我们没有针对如何正确开启STM32 PWM功能出一份详细的文档，导致用户针对PWM功能使能的方式理解不同，进而导致甲认为正确的初始化流程乙不认可，乙认为正确的初始化流程甲不认可。导致反复扯大锯。因此需要补充在RT-Thread下如何正确开启STM32 PWM的文档，统一并明确一个规范的开启范例。

<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)


#### 你的解决方案是什么 (what is your solution)


#### 在什么测试环境下测试通过 (what is the test environment)

已经在潘多拉测试通过，通过复现之前PR/论坛报告的现象，增加本PR代码之后，问题解决。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
