### PR TITLE
[rt-smart] fix competition on aspace

### DIFF
--- a/components/lwp/lwp_user_mm.c
+++ b/components/lwp/lwp_user_mm.c
@@ -362,8 +362,12 @@ void *lwp_map_user_phy(struct rt_lwp *lwp, void *map_va, void *map_pa,
         va = RT_NULL;
         LOG_W("%s", __func__);
     }
+    else
+    {
+        va += offset;
+    }
 
-    return va + offset;
+    return va;
 }
 
 rt_base_t lwp_brk(void *addr)

--- a/components/mm/mm_aspace.c
+++ b/components/mm/mm_aspace.c
@@ -75,12 +75,12 @@ static inline void _varea_uninstall(rt_varea_t varea)
 
     rt_varea_free_pages(varea);
 
+    rt_hw_mmu_unmap(aspace, varea->start, varea->size);
+    rt_hw_tlb_invalidate_range(aspace, varea->start, varea->size, ARCH_PAGE_SIZE);
+
     WR_LOCK(aspace);
     _aspace_bst_remove(aspace, varea);
     WR_UNLOCK(aspace);
-
-    rt_hw_mmu_unmap(aspace, varea->start, varea->size);
-    rt_hw_tlb_invalidate_range(aspace, varea->start, varea->size, ARCH_PAGE_SIZE);
 }
 
 int _init_lock(rt_aspace_t aspace)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

* [mm] mmu operations should be wrapped by _aspace_bst_insert & _aspace_bst_remove to avoid competition on page table
* [lwp] may not return null on failed

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
