### PR TITLE
fix stime set time error

### DIFF
--- a/components/libc/compilers/common/ctime.c
+++ b/components/libc/compilers/common/ctime.c
@@ -109,8 +109,7 @@ static rt_err_t get_timeval(struct timeval *tv)
     {
         if (rt_device_open(device, 0) == RT_EOK)
         {
-            rst = rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIME, &tv->tv_sec);
-            rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIMEVAL, tv);
+            rst = rt_device_control(device, RT_DEVICE_CTRL_RTC_GET_TIMEVAL, tv);
             rt_device_close(device);
         }
     }
@@ -153,8 +152,7 @@ static int set_timeval(struct timeval *tv)
     {
         if (rt_device_open(device, 0) == RT_EOK)
         {
-            rst = rt_device_control(device, RT_DEVICE_CTRL_RTC_SET_TIME, &tv->tv_sec);
-            rt_device_control(device, RT_DEVICE_CTRL_RTC_SET_TIMEVAL, tv);
+            rst = rt_device_control(device, RT_DEVICE_CTRL_RTC_SET_TIMEVAL, tv);
             rt_device_close(device);
         }
     }
@@ -383,6 +381,7 @@ int stime(const time_t *t)
     }
 
     tv.tv_sec = *t;
+    tv.tv_usec = 0;
     if (set_timeval(&tv) == RT_EOK)
     {
         return 0;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[
when i use stime to set my rtc device, the time always wrong, because t get value from time_t var, so t.tv_sec == var, but t.tv_usec must be 0, if t.tv_usec not set to 0,it always be 0xdeadbeef,
and i2c read/write is slow,i think set_timeval/get_timeval do same action twice, i think this just waste time,and make mcu read/write time slowly, so i delete one, i test this in my device , mcu mxrt1020 and rtc sd3078, just work well,
]
<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
