### PR TITLE
【HUST CSE IoTS&P Lab】[bsp] fix Force TypeCast to pointer dereference

### DIFF
--- a/bsp/at32/libraries/rt_drivers/drv_can.c
+++ b/bsp/at32/libraries/rt_drivers/drv_can.c
@@ -259,7 +259,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
     switch (cmd)
     {
     case RT_DEVICE_CTRL_CLR_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             if (CAN1 == can_instance->config.can_x)
@@ -317,7 +317,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
 
         break;
     case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             can_interrupt_enable(can_instance->config.can_x, CAN_RF0MIEN_INT, TRUE);
@@ -456,7 +456,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         break;
     }
     case RT_CAN_CMD_SET_MODE:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_NORMAL &&
             argval != RT_CAN_MODE_LISTEN &&
             argval != RT_CAN_MODE_LOOPBACK &&
@@ -471,7 +471,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_BAUD:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != CAN1MBaud   &&
             argval != CAN800kBaud &&
             argval != CAN500kBaud &&
@@ -491,7 +491,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_PRIV:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_PRIV &&
             argval != RT_CAN_MODE_NOPRIV)
         {

--- a/bsp/essemi/es32f0654/drivers/drv_can.c
+++ b/bsp/essemi/es32f0654/drivers/drv_can.c
@@ -159,7 +159,7 @@ static rt_err_t _can_control(struct rt_can_device *can_device, int cmd, void *ar
     switch (cmd)
     {
     case RT_DEVICE_CTRL_CLR_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             ald_can_interrupt_config(&drv_can->CanHandle, CAN_IT_FP0, DISABLE);
@@ -183,7 +183,7 @@ static rt_err_t _can_control(struct rt_can_device *can_device, int cmd, void *ar
         }
         break;
     case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             NVIC_SetPriority(CAN0_IRQn, 1);
@@ -293,7 +293,7 @@ static rt_err_t _can_control(struct rt_can_device *can_device, int cmd, void *ar
 
 #endif
     case RT_CAN_CMD_SET_MODE:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_NORMAL &&
                 argval != RT_CAN_MODE_LISTEN &&
                 argval != RT_CAN_MODE_LOOPBACK &&
@@ -308,7 +308,7 @@ static rt_err_t _can_control(struct rt_can_device *can_device, int cmd, void *ar
         }
         break;
     case RT_CAN_CMD_SET_BAUD:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
 
         if (argval != drv_can->device.config.baud_rate)
         {
@@ -317,7 +317,7 @@ static rt_err_t _can_control(struct rt_can_device *can_device, int cmd, void *ar
         }
         break;
     case RT_CAN_CMD_SET_PRIV:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_PRIV &&
                 argval != RT_CAN_MODE_NOPRIV)
         {

--- a/bsp/essemi/es32f369x/drivers/drv_can.c
+++ b/bsp/essemi/es32f369x/drivers/drv_can.c
@@ -152,7 +152,7 @@ static rt_err_t _can_control(struct rt_can_device *can_device, int cmd, void *ar
     switch (cmd)
     {
     case RT_DEVICE_CTRL_CLR_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             ald_can_interrupt_config(&drv_can->CanHandle, CAN_IT_FP0, DISABLE);
@@ -176,7 +176,7 @@ static rt_err_t _can_control(struct rt_can_device *can_device, int cmd, void *ar
         }
         break;
     case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             NVIC_SetPriority(CAN0_RX0_IRQn, 1);
@@ -287,7 +287,7 @@ static rt_err_t _can_control(struct rt_can_device *can_device, int cmd, void *ar
 
 #endif
     case RT_CAN_CMD_SET_MODE:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_NORMAL &&
                 argval != RT_CAN_MODE_LISTEN &&
                 argval != RT_CAN_MODE_LOOPBACK &&
@@ -302,7 +302,7 @@ static rt_err_t _can_control(struct rt_can_device *can_device, int cmd, void *ar
         }
         break;
     case RT_CAN_CMD_SET_BAUD:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
 
         if (argval != drv_can->device.config.baud_rate)
         {
@@ -311,7 +311,7 @@ static rt_err_t _can_control(struct rt_can_device *can_device, int cmd, void *ar
         }
         break;
     case RT_CAN_CMD_SET_PRIV:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_PRIV &&
                 argval != RT_CAN_MODE_NOPRIV)
         {

--- a/bsp/hc32/libraries/hc32_drivers/drv_can.c
+++ b/bsp/hc32/libraries/hc32_drivers/drv_can.c
@@ -210,7 +210,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
     switch (cmd)
     {
     case RT_DEVICE_CTRL_CLR_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         switch (argval)
         {
         case RT_DEVICE_FLAG_INT_RX:
@@ -234,7 +234,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         switch (argval)
         {
         case RT_DEVICE_FLAG_INT_RX:
@@ -296,7 +296,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
             break;
         }
     case RT_CAN_CMD_SET_MODE:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_NORMAL &&
                 argval != RT_CAN_MODE_LISTEN &&
                 argval != RT_CAN_MODE_LOOPBACK &&
@@ -311,7 +311,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_BAUD:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != CAN1MBaud &&
                 argval != CAN800kBaud &&
                 argval != CAN500kBaud &&
@@ -331,7 +331,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_PRIV:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_PRIV &&
                 argval != RT_CAN_MODE_NOPRIV)
         {

--- a/bsp/imxrt/libraries/drivers/drv_can.c
+++ b/bsp/imxrt/libraries/drivers/drv_can.c
@@ -234,7 +234,7 @@ static rt_err_t can_control(struct rt_can_device *can_dev, int cmd, void *arg)
     switch (cmd)
     {
     case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             mask = kFLEXCAN_RxWarningInterruptEnable;

--- a/bsp/loongson/ls1cdev/drivers/drv_can.c
+++ b/bsp/loongson/ls1cdev/drivers/drv_can.c
@@ -270,7 +270,7 @@ static rt_err_t control(struct rt_can_device *can, int cmd, void *arg)
           return setfilter(pbxcan, (struct rt_can_filter_config *) arg);
         break;
     case RT_CAN_CMD_SET_MODE:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_NORMAL ||
                 argval != RT_CAN_MODE_LISTEN ||
                 argval != RT_CAN_MODE_LOOPBACK ||
@@ -285,7 +285,7 @@ static rt_err_t control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_BAUD:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != CAN1MBaud &&
                 argval != CAN800kBaud &&
                 argval != CAN500kBaud &&

--- a/bsp/n32/libraries/n32_drivers/drv_can.c
+++ b/bsp/n32/libraries/n32_drivers/drv_can.c
@@ -331,7 +331,7 @@ static rt_err_t control(struct rt_can_device *can, int cmd, void *arg)
     switch (cmd)
     {
         case RT_DEVICE_CTRL_CLR_INT:
-            argval = (rt_uint32_t) arg;
+            argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
 #if defined(SOC_N32G45X) || defined(SOC_N32WB452) || defined(SOC_N32G4FR)
@@ -410,7 +410,7 @@ static rt_err_t control(struct rt_can_device *can, int cmd, void *arg)
         break;
 
         case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             CAN_INTConfig(drv_can->CANx, CAN_INT_FMP0, ENABLE); /* DATFIFO 0 message pending Interrupt */
@@ -570,7 +570,7 @@ static rt_err_t control(struct rt_can_device *can, int cmd, void *arg)
         }
 
         case RT_CAN_CMD_SET_MODE:
-            argval = (rt_uint32_t) arg;
+            argval = *(rt_uint32_t *) arg;
             if (argval != RT_CAN_MODE_NORMAL &&
                 argval != RT_CAN_MODE_LISTEN &&
                 argval != RT_CAN_MODE_LOOPBACK &&
@@ -586,7 +586,7 @@ static rt_err_t control(struct rt_can_device *can, int cmd, void *arg)
         break;
 
         case RT_CAN_CMD_SET_BAUD:
-            argval = (rt_uint32_t) arg;
+            argval = *(rt_uint32_t *) arg;
             if (argval != CAN1MBaud &&
                 argval != CAN800kBaud &&
                 argval != CAN500kBaud &&
@@ -607,7 +607,7 @@ static rt_err_t control(struct rt_can_device *can, int cmd, void *arg)
             break;
 
         case RT_CAN_CMD_SET_PRIV:
-            argval = (rt_uint32_t) arg;
+            argval = *(rt_uint32_t *) arg;
             if (argval != RT_CAN_MODE_PRIV &&
                 argval != RT_CAN_MODE_NOPRIV)
             {

--- a/bsp/n32g452xx/Libraries/rt_drivers/drv_can.c
+++ b/bsp/n32g452xx/Libraries/rt_drivers/drv_can.c
@@ -232,7 +232,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
     switch (cmd)
     {
     case RT_DEVICE_CTRL_CLR_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             if (CAN1 == drv_can->can_base)
@@ -282,7 +282,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             CAN_INTConfig(drv_can->can_base, CAN_INT_FMP0, ENABLE);   /*!< DATFIFO 0 message pending Interrupt*/
@@ -412,7 +412,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         break;
     }
     case RT_CAN_CMD_SET_MODE:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_NORMAL &&
                 argval != RT_CAN_MODE_LISEN &&
                 argval != RT_CAN_MODE_LOOPBACK &&
@@ -427,7 +427,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_BAUD:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != CAN1MBaud &&
                 argval != CAN800kBaud &&
                 argval != CAN500kBaud &&
@@ -447,7 +447,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_PRIV:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_PRIV &&
                 argval != RT_CAN_MODE_NOPRIV)
         {

--- a/bsp/nuvoton/libraries/m2354/rtt_port/drv_can.c
+++ b/bsp/nuvoton/libraries/m2354/rtt_port/drv_can.c
@@ -283,7 +283,7 @@ exit_nu_can_configure:
 
 static rt_err_t nu_can_control(struct rt_can_device *can, int cmd, void *arg)
 {
-    rt_uint32_t argval = (rt_uint32_t)arg;
+    rt_uint32_t argval = *(rt_uint32_t *) arg;
     nu_can_t psNuCAN = (nu_can_t)can;
 
     RT_ASSERT(can);

--- a/bsp/nuvoton/libraries/m460/rtt_port/drv_canfd.c
+++ b/bsp/nuvoton/libraries/m460/rtt_port/drv_canfd.c
@@ -458,7 +458,7 @@ exit_nu_canfd_configure:
 
 static rt_err_t nu_canfd_control(struct rt_can_device *can, int cmd, void *arg)
 {
-    rt_uint32_t argval = (rt_uint32_t)arg;
+    rt_uint32_t argval = *(rt_uint32_t *)arg;
     nu_canfd_t psNuCANFD = (nu_canfd_t)can;
 
     RT_ASSERT(can);

--- a/bsp/nuvoton/libraries/m480/rtt_port/drv_can.c
+++ b/bsp/nuvoton/libraries/m480/rtt_port/drv_can.c
@@ -334,7 +334,7 @@ exit_nu_can_configure:
 
 static rt_err_t nu_can_control(struct rt_can_device *can, int cmd, void *arg)
 {
-    rt_uint32_t argval = (rt_uint32_t)arg;
+    rt_uint32_t argval = *(rt_uint32_t *) arg;
     nu_can_t psNuCAN = (nu_can_t)can;
 
     RT_ASSERT(can);

--- a/bsp/nuvoton/libraries/ma35/rtt_port/drv_canfd.c
+++ b/bsp/nuvoton/libraries/ma35/rtt_port/drv_canfd.c
@@ -366,7 +366,7 @@ exit_nu_canfd_configure:
 
 static rt_err_t nu_canfd_control(struct rt_can_device *can, int cmd, void *arg)
 {
-    rt_uint32_t argval = (rt_uint32_t)arg;
+    rt_uint32_t argval = *(rt_uint32_t *)arg;
     nu_canfd_t psNuCANFD = (nu_canfd_t)can;
 
     RT_ASSERT(can);

--- a/bsp/nuvoton/libraries/n9h30/rtt_port/drv_can.c
+++ b/bsp/nuvoton/libraries/n9h30/rtt_port/drv_can.c
@@ -283,7 +283,7 @@ exit_nu_can_configure:
 
 static rt_err_t nu_can_control(struct rt_can_device *can, int cmd, void *arg)
 {
-    rt_uint32_t argval = (rt_uint32_t)arg;
+    rt_uint32_t argval = *(rt_uint32_t *)arg;
     nu_can_t psNuCAN = (nu_can_t)can;
 
     RT_ASSERT(can);

--- a/bsp/nuvoton/libraries/nuc980/rtt_port/drv_can.c
+++ b/bsp/nuvoton/libraries/nuc980/rtt_port/drv_can.c
@@ -307,7 +307,7 @@ exit_nu_can_configure:
 
 static rt_err_t nu_can_control(struct rt_can_device *can, int cmd, void *arg)
 {
-    rt_uint32_t argval = (rt_uint32_t)arg;
+    rt_uint32_t argval = *(rt_uint32_t *)arg;
     nu_can_t psNuCAN = (nu_can_t)can;
 
     RT_ASSERT(can);

--- a/bsp/renesas/libraries/HAL_Drivers/drv_can.c
+++ b/bsp/renesas/libraries/HAL_Drivers/drv_can.c
@@ -107,7 +107,7 @@ rt_err_t ra_can_control(struct rt_can_device *can_dev, int cmd, void *arg)
         R_BSP_IrqStatusClear((IRQn_Type)arg);
         break;
     case RT_CAN_CMD_SET_BAUD:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != CAN1MBaud &&
                 argval != CAN800kBaud &&
                 argval != CAN500kBaud &&
@@ -132,7 +132,7 @@ rt_err_t ra_can_control(struct rt_can_device *can_dev, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_MODE:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_NORMAL &&
                 argval != RT_CAN_MODE_LISTEN &&
                 argval != RT_CAN_MODE_LOOPBACK)

--- a/bsp/stm32/libraries/HAL_Drivers/drv_can.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_can.c
@@ -192,7 +192,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
     switch (cmd)
     {
     case RT_DEVICE_CTRL_CLR_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             if (CAN1 == drv_can->CanHandle.Instance)
@@ -248,7 +248,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             __HAL_CAN_ENABLE_IT(&drv_can->CanHandle, CAN_IT_RX_FIFO0_MSG_PENDING);
@@ -409,7 +409,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         break;
     }
     case RT_CAN_CMD_SET_MODE:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_NORMAL &&
                 argval != RT_CAN_MODE_LISTEN &&
                 argval != RT_CAN_MODE_LOOPBACK &&
@@ -424,7 +424,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_BAUD:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != CAN1MBaud &&
                 argval != CAN800kBaud &&
                 argval != CAN500kBaud &&
@@ -444,7 +444,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_PRIV:
-        argval = (rt_uint32_t) arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_PRIV &&
                 argval != RT_CAN_MODE_NOPRIV)
         {

--- a/bsp/synwit/swm341/drivers/drv_can.c
+++ b/bsp/synwit/swm341/drivers/drv_can.c
@@ -183,7 +183,7 @@ static rt_err_t swm_can_control(struct rt_can_device *can_device, int cmd, void 
     switch (cmd)
     {
     case RT_DEVICE_CTRL_CLR_INT:
-        argval = (rt_uint32_t)arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             can_dev->can_cfg->CANx->IE &= ~(CAN_IE_RXDA_Msk | CAN_IE_RXOV_Msk);
@@ -198,7 +198,7 @@ static rt_err_t swm_can_control(struct rt_can_device *can_device, int cmd, void 
         }
         break;
     case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t)arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             can_dev->can_cfg->CANx->IE |= (CAN_IE_RXDA_Msk | CAN_IE_RXOV_Msk);
@@ -258,7 +258,7 @@ static rt_err_t swm_can_control(struct rt_can_device *can_device, int cmd, void 
         break;
     }
     case RT_CAN_CMD_SET_MODE:
-        argval = (rt_uint32_t)arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_NORMAL &&
             argval != RT_CAN_MODE_LISTEN &&
             argval != RT_CAN_MODE_LOOPBACK &&
@@ -273,7 +273,7 @@ static rt_err_t swm_can_control(struct rt_can_device *can_device, int cmd, void 
         }
         break;
     case RT_CAN_CMD_SET_BAUD:
-        argval = (rt_uint32_t)arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != CAN1MBaud &&
             argval != CAN800kBaud &&
             argval != CAN500kBaud &&
@@ -293,7 +293,7 @@ static rt_err_t swm_can_control(struct rt_can_device *can_device, int cmd, void 
         }
         break;
     case RT_CAN_CMD_SET_PRIV:
-        argval = (rt_uint32_t)arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_PRIV &&
             argval != RT_CAN_MODE_NOPRIV)
         {

--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_can.c
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_can.c
@@ -292,7 +292,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
     switch (cmd)
     {
     case RT_DEVICE_CTRL_CLR_INT:
-        argval = (rt_uint32_t)arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             if (CAN1 == drv_can_obj->can_base)
@@ -355,7 +355,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t)arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval == RT_DEVICE_FLAG_INT_RX)
         {
             CAN_ClearITPendingBit( drv_can_obj->can_base, CAN_IT_FMP0 );
@@ -493,7 +493,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         break;
     }
     case RT_CAN_CMD_SET_MODE:
-        argval = (rt_uint32_t)arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_NORMAL &&
             argval != RT_CAN_MODE_LISTEN &&
             argval != RT_CAN_MODE_LOOPBACK &&
@@ -508,7 +508,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_BAUD:
-        argval = (rt_uint32_t)arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != CAN1MBaud &&
             argval != CAN800kBaud &&
             argval != CAN500kBaud &&
@@ -528,7 +528,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
         }
         break;
     case RT_CAN_CMD_SET_PRIV:
-        argval = (rt_uint32_t)arg;
+        argval = *(rt_uint32_t *) arg;
         if (argval != RT_CAN_MODE_PRIV &&
             argval != RT_CAN_MODE_NOPRIV)
         {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[


#### 为什么提交这份PR (why to submit this PR)

在通过 arg 作为参数传输数据时，直接把地址赋值给了一个 uint32_t 的变量，不合理，

#### 你的解决方案是什么 (what is your solution)

应该改为转换为对应类型的指针，在进行解引用，获得其中包含的数据

#### 在什么测试环境下测试通过 (what is the test environment)

* CAN es32f0654

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
