### PR TITLE
add macro of dfs_fd to get the attribute.

### DIFF
--- a/components/dfs/include/dfs_file.h
+++ b/components/dfs/include/dfs_file.h
@@ -64,6 +64,10 @@ struct dfs_fd
     void *data;                  /* Specific fd data */
 };
 
+#define DFS_FD_GET_TYPE(fd)         ((fd)->vnode == RT_NULL ? 0       : (fd)->vnode->type)
+#define DFS_FD_GET_PATH(fd)         ((fd)->vnode == RT_NULL ? RT_NULL : (fd)->vnode->path)
+#define DFS_FD_GET_SIZE(fd)         ((fd)->vnode == RT_NULL ? 0       : (fd)->vnode->size)
+
 struct dfs_mmap2_args
 {
     void *addr;


### PR DESCRIPTION
在dfs_file中增加对dfs_fd的属性访问的宏定义，用于子类统一访问接口及考虑对之间的兼容。