### PR TITLE
[HUST CSE][bsp] fix mismatched function types in rt_pin_ops

### DIFF
--- a/bsp/at32/libraries/rt_drivers/drv_gpio.c
+++ b/bsp/at32/libraries/rt_drivers/drv_gpio.c
@@ -163,7 +163,7 @@ static rt_base_t at32_pin_get(const char *name)
     return pin;
 }
 
-static void at32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void at32_pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
 {
     gpio_type *gpio_port;
 
@@ -180,7 +180,7 @@ static void at32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     gpio_bits_write(gpio_port, gpio_pin, (confirm_state)value);
 }
 
-static int at32_pin_read(rt_device_t dev, rt_base_t pin)
+static rt_int8_t at32_pin_read(rt_device_t dev, rt_base_t pin)
 {
     gpio_type *gpio_port;
     uint16_t gpio_pin;
@@ -197,7 +197,7 @@ static int at32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-static void at32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void at32_pin_mode(rt_device_t dev, rt_base_t pin, rt_uint8_t mode)
 {
     gpio_init_type gpio_init_struct;
     gpio_type *gpio_port;
@@ -279,8 +279,8 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
     return &pin_irq_map[mapindex];
 };
 
-static rt_err_t at32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                                    rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t at32_pin_attach_irq(struct rt_device *device, rt_base_t pin,
+                                    rt_uint8_t mode, void (*hdr)(void *args), void *args)
 {
     uint16_t gpio_pin;
     rt_base_t level;
@@ -324,7 +324,7 @@ static rt_err_t at32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-static rt_err_t at32_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t at32_pin_dettach_irq(struct rt_device *device, rt_base_t pin)
 {
     uint16_t gpio_pin;
     rt_base_t level;
@@ -360,7 +360,7 @@ static rt_err_t at32_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
 }
 
 static rt_err_t at32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                                    rt_uint32_t enabled)
+                                    rt_uint8_t enabled)
 {
     gpio_init_type gpio_init_struct;
     exint_init_type exint_init_struct;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
在AT32F437-START开发板上使用IAR编译project工程会报“结构体类型不匹配的问题”，定位原因到drv_gpio.c与pin.h文件中。
在此给出文件的详细路径：
1.  bsp/at32/libraries/rt_drivers/drv_gpio.c
2. components/drivers/include/drivers/pin.h

查看pin.h文件中struct rt_pin_ops 原型：
```
struct rt_pin_ops
{
    void (*pin_mode)(struct rt_device *device, rt_base_t pin, rt_uint8_t mode);
    void (*pin_write)(struct rt_device *device, rt_base_t pin, rt_uint8_t value);
    rt_int8_t  (*pin_read)(struct rt_device *device, rt_base_t pin);
    rt_err_t (*pin_attach_irq)(struct rt_device *device, rt_base_t pin,
            rt_uint8_t mode, void (*hdr)(void *args), void *args);
    rt_err_t (*pin_detach_irq)(struct rt_device *device, rt_base_t pin);
    rt_err_t (*pin_irq_enable)(struct rt_device *device, rt_base_t pin, rt_uint8_t enabled);
    rt_base_t (*pin_get)(const char *name);
};
```

发现两部分类型并**不匹配**！

#### 你的解决方案是什么 (what is your solution)
把**不匹配的参数类型修改成正确的类型**。具体来说把drv_gpio.c中下列函数的形参或返回值修改为跟rt_pin_ops操作方法中的成员形参与返回值一致。重新修改之后的drv_gpio.c中函数原型如下：
```
static void at32_pin_mode(rt_device_t dev, rt_base_t pin, rt_uint8_t mode)
static void at32_pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
static rt_int8_t at32_pin_read(rt_device_t dev, rt_base_t pin)
static rt_err_t at32_pin_attach_irq(struct rt_device *device, rt_base_t pin,
                                    rt_uint8_t mode, void (*hdr)(void *args), void *args)
static rt_err_t at32_pin_dettach_irq(struct rt_device *device, rt_base_t pin)
static rt_err_t at32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
                                    rt_uint8_t enabled)
static rt_base_t at32_pin_get(const char *name)
```


#### 在什么测试环境下测试通过 (what is the test environment)
在 AT32F437-START开发板上测试并通过！

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
