### PR TITLE
[HUST CSE][components] Fix null pointer problems caused by the function rt_slist_entry()

### DIFF
--- a/components/net/at/at_socket/at_socket.c
+++ b/components/net/at/at_socket/at_socket.c
@@ -70,9 +70,9 @@ struct at_socket *at_get_socket(int socket)
     rt_slist_for_each(node, &_socket_list)
     {
         at_sock = rt_slist_entry(node, struct at_socket, list);
-        if (socket == at_sock->socket)
+        if (at_sock && socket == at_sock->socket)
         {
-            if (at_sock && at_sock->magic == AT_SOCKET_MAGIC)
+            if (at_sock->magic == AT_SOCKET_MAGIC)
             {
                 rt_hw_interrupt_enable(level);
                 return at_sock;
@@ -97,9 +97,9 @@ struct at_socket *at_get_base_socket(int base_socket)
     rt_slist_for_each(node, &_socket_list)
     {
         at_sock = rt_slist_entry(node, struct at_socket, list);
-        if (base_socket == (int)at_sock->user_data && at_sock->state != AT_SOCKET_LISTEN)
+        if (at_sock && base_socket == (int)at_sock->user_data && at_sock->state != AT_SOCKET_LISTEN)
         {
-            if (at_sock && at_sock->magic == AT_SOCKET_MAGIC)
+            if (at_sock->magic == AT_SOCKET_MAGIC)
             {
                 rt_hw_interrupt_enable(level);
                 return at_sock;
@@ -149,7 +149,7 @@ static int at_recvpkt_all_delete(rt_slist_t *rlist)
     {
         pkt = rt_slist_entry(node, struct at_recv_pkt, list);
         node = rt_slist_next(node);
-        if (pkt->buff)
+        if (pkt && pkt->buff)
         {
             rt_free(pkt->buff);
         }
@@ -176,7 +176,7 @@ static int at_recvpkt_node_delete(rt_slist_t *rlist, rt_slist_t *node)
     rt_slist_remove(rlist, node);
 
     pkt = rt_slist_entry(node, struct at_recv_pkt, list);
-    if (pkt->buff)
+    if (pkt && pkt->buff)
     {
         rt_free(pkt->buff);
     }
@@ -208,6 +208,8 @@ static size_t at_recvpkt_get(rt_slist_t *rlist, char *mem, size_t len)
 
         free_node = node;
         node = rt_slist_next(node);
+
+        if (!pkt) continue;
 
         page_pos = pkt->bfsz_totle - pkt->bfsz_index;
 
@@ -330,7 +332,7 @@ static int alloc_empty_socket(rt_slist_t *l)
     rt_slist_for_each(node, &_socket_list)
     {
         at_sock = rt_slist_entry(node, struct at_socket, list);
-        if(at_sock->socket != idx)
+        if(at_sock && at_sock->socket != idx)
             break;
         idx++;
         pre_node = node;
@@ -527,9 +529,9 @@ static int free_socket(struct at_socket *sock)
         rt_slist_for_each(node, &_socket_list)
         {
             at_sock = rt_slist_entry(node, struct at_socket, list);
-            if (sock->socket == at_sock->socket)
+            if (at_sock && sock->socket == at_sock->socket)
             {
-                if (at_sock && at_sock->magic == AT_SOCKET_MAGIC)
+                if (at_sock->magic == AT_SOCKET_MAGIC)
                 {
                     rt_slist_remove(&_socket_list, &at_sock->list);
                     break;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
在at_socket.c文件中，检查出（警告）指针变量“at_sock”存在可能的空指针解引用。问题定位到了文件at_socket.c和rtservice.h中。在此给出文件的详细路径如下：

1. rt-thread\components\net\at\at_socket.c
2. rt-thread\include\rtservice.h

该空指针隐患在at_socket.c文件中多处存在，容易导致代码崩溃，主要导致该问题的原因在于如下代码，即在引用之前未判断pkt != RT_NULL：

``` 
pkt = rt_slist_entry(node, struct at_recv_pkt, list);
    if (pkt->buff)
    {
        rt_free(pkt->buff);
    }
```

查看rtservice.h文件中关于宏函数rt_slist_entry的描述：
```
#define rt_slist_entry(node, type, member) \
    rt_container_of(node, type, member)
#define rt_container_of(ptr, type, member) \
    ((type *)((char *)(ptr) - (unsigned long)(&((type *)0)->member)))
```
综上所述，笔者发现可能存在空指针引用问题，所以提出了该问题并尝试解决。
#### 你的解决方案是什么 (what is your solution)
在可能存在空指针引用的代码段内，添加一层空指针判断的步骤。由于存在多处空指针引用错误，所以举例一处如下：

未修改前的代码如下（将空指针判断错误地放到了内层判断中）：
```
rt_slist_for_each(node, &_socket_list)
    {
        at_sock = rt_slist_entry(node, struct at_socket, list);
        if (socket == at_sock->socket)
        {
            if (at_sock && at_sock->magic == AT_SOCKET_MAGIC)
            {
                rt_hw_interrupt_enable(level);
                return at_sock;
            }
        }
    }
```
修改后的代码如下：
```
rt_slist_for_each(node, &_socket_list)
    {
        at_sock = rt_slist_entry(node, struct at_socket, list);
        if (at_sock && socket == at_sock->socket)
        {
            if (at_sock->magic == AT_SOCKET_MAGIC)
            {
                rt_hw_interrupt_enable(level);
                return at_sock;
            }
        }
    }
```

#### 在什么测试环境下测试通过 (what is the test environment)
all

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
