### PR TITLE
fix RTT file system identifier bit

### DIFF
--- a/components/libc/compilers/common/extension/fcntl/msvc/fcntl.h
+++ b/components/libc/compilers/common/extension/fcntl/msvc/fcntl.h
@@ -18,9 +18,9 @@ extern "C" {
 #endif
 
 /* VS fcntl.h interent */
-#define O_RDONLY        0x0000  /* open for reading only */
-#define O_WRONLY        0x0001  /* open for writing only */
-#define O_RDWR          0x0002  /* open for reading and writing */
+#define O_RDONLY        0x0001  /* open for reading only */
+#define O_WRONLY        0x0002  /* open for writing only */
+#define O_RDWR          0x0003  /* open for reading and writing */
 #define O_APPEND        0x0008  /* writes done at eof */
 
 #define O_CREAT         0x0100  /* create and open file */

--- a/components/libc/compilers/common/extension/fcntl/octal/fcntl.h
+++ b/components/libc/compilers/common/extension/fcntl/octal/fcntl.h
@@ -17,9 +17,9 @@
 extern "C" {
 #endif
 
-#define O_RDONLY         00
-#define O_WRONLY         01
-#define O_RDWR           02
+#define O_RDONLY         01
+#define O_WRONLY         02
+#define O_RDWR           03
 
 #define O_CREAT        0100
 #define O_EXCL         0200


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
RTT文件系统标识位和littefs的不一样，导致写入文件时提示错误的问题

#### 你的解决方案是什么 (what is your solution)
修正了RTT文件系统的标识位

]
### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
