### PR TITLE
[HUST CSE][bsp] 修复潜在的未初始化变量参与运算的问题并格式化不规范的部分文档

### DIFF
--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7.h
@@ -8,7 +8,7 @@
  * @version  V1.0
  * @date     5. January 2015
  *
- * @note     Generated with SVDConv V2.75 
+ * @note     Generated with SVDConv V2.75
  *           from CMSIS SVD File 'SVDConv_CME_M7.svd' Version 1.0,
  *******************************************************************************************************/
 
@@ -152,10 +152,10 @@ typedef struct {                                    /*!< UART0 Structure        
   __I  uint16_t  RESERVED1;
   __I  uint16_t  RX_BUF;                            /*!< receive buffer Register                                               */
   __I  uint16_t  RESERVED2;
-  
+
   union {
     __IO uint32_t  CTRL;                            /*!< control Register                                                      */
-    
+
     struct {
       __IO uint32_t  MODE       :  3;               /*!< asc mode control                                                      */
       __IO uint32_t  STOP       :  2;               /*!< number of stop bits selection                                         */
@@ -171,10 +171,10 @@ typedef struct {                                    /*!< UART0 Structure        
       __IO uint32_t  RX_HALF_FULL:  5;              /*!< receive fifi half full level                                          */
     } CTRL_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_MASK;                        /*!< interrupt mask register                                               */
-    
+
     struct {
       __IO uint32_t  RNE        :  1;               /*!< Receive FIFO not empty interrupt                                      */
       __IO uint32_t  TE         :  1;               /*!< Transmitter FIFO empty interrupt                                      */
@@ -189,10 +189,10 @@ typedef struct {                                    /*!< UART0 Structure        
       __IO uint32_t  RX_THRE_REACH:  1;             /*!< Receive threshold reach interrupt                                     */
     } INT_MASK_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  STATUS;                          /*!< status register                                                       */
-    
+
     struct {
       __IO uint32_t  RNE        :  1;               /*!< receiver FIFO not empty                                               */
       __IO uint32_t  TE         :  1;               /*!< Transmitter FIFO empty                                                */
@@ -205,34 +205,34 @@ typedef struct {                                    /*!< UART0 Structure        
   };
   __IO uint8_t   TIMEOUT;                           /*!< timeout Register                                                      */
   __I  uint8_t   RESERVED3[3];
-  
+
   union {
     __IO uint32_t  TX_RESET;                        /*!< transmit reset Register                                               */
-    
+
     struct {
       __IO uint32_t  EN         :  1;               /*!< enable                                                                */
     } TX_RESET_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RX_RESET;                        /*!< receive reset Register                                                */
-    
+
     struct {
       __IO uint32_t  EN         :  1;               /*!< enable                                                                */
     } RX_RESET_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RUN;                             /*!< uart enable register                                                  */
-    
+
     struct {
       __IO uint32_t  EN         :  1;               /*!< enable                                                                */
     } RUN_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_RAW;                         /*!< raw interrupt before mask register                                    */
-    
+
     struct {
       __IO uint32_t  RNE        :  1;               /*!< Receive FIFO not empty interrupt                                      */
       __IO uint32_t  TE         :  1;               /*!< Transmitter FIFO empty interrupt                                      */
@@ -247,10 +247,10 @@ typedef struct {                                    /*!< UART0 Structure        
       __IO uint32_t  RX_THRE_REACH:  1;             /*!< Receive threshold reach interrupt                                     */
     } INT_RAW_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_SEEN;                        /*!< interrupt after mask register                                         */
-    
+
     struct {
       __IO uint32_t  RNE        :  1;               /*!< Receive FIFO not empty interrupt                                      */
       __IO uint32_t  TE         :  1;               /*!< Transmitter FIFO empty interrupt                                      */
@@ -278,37 +278,37 @@ typedef struct {                                    /*!< UART0 Structure        
   */
 
 typedef struct {                                    /*!< WDG Structure                                                         */
-  
+
   union {
     __IO uint32_t  CTRL;                            /*!< control Register                                                      */
-    
+
     struct {
       __IO uint32_t  EN         :  1;               /*!< flag indicates if watchdog is enabled or not                          */
       __IO uint32_t  INT_LEN    :  1;               /*!< watchdog report interrupt when COUNTER is 1/4 or 1/2 of LENGTH        */
     } CTRL_b;                                       /*!< BitSize                                                               */
   };
   __IO uint32_t  LEN;                               /*!< Ticks decrease down to 25% or 50% to trigger an interrupt             */
-  
+
   union {
     __IO uint32_t  INT_CTRL;                        /*!< interrupt control                                                     */
-    
+
     struct {
       __IO uint32_t  MASK       :  1;               /*!< mask register                                                         */
       __IO uint32_t  TRIGGER_MODE:  1;              /*!< trigger mode                                                          */
     } INT_CTRL_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_STA;                         /*!< interrupt status register                                             */
-    
+
     struct {
       __IO uint32_t  STA        :  1;               /*!< interrupt status                                                      */
     } INT_STA_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_RAW;                         /*!< interrupt raw register                                                */
-    
+
     struct {
       __IO uint32_t  STA        :  1;               /*!< interrupt status                                                      */
     } INT_RAW_b;                                    /*!< BitSize                                                               */
@@ -327,43 +327,43 @@ typedef struct {                                    /*!< WDG Structure          
   */
 
 typedef struct {                                    /*!< TIMER0 Structure                                                      */
-  
+
   union {
     __IO uint32_t  CTRL;                            /*!< control Register                                                      */
-    
+
     struct {
       __IO uint32_t  EN         :  1;               /*!< flag indicates if timer is enabled or not                             */
     } CTRL_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  TYPE;                            /*!< type Register                                                         */
-    
+
     struct {
       __IO uint32_t  SIGNLE_SHOT:  1;               /*!< indicate timer generate only one interrupt if not reload              */
     } TYPE_b;                                       /*!< BitSize                                                               */
   };
   __IO uint32_t  LEN;                               /*!< length                                                                */
-  
+
   union {
     __IO uint32_t  INT_EN;                          /*!< interrupt enable                                                      */
-    
+
     struct {
       __IO uint32_t  EN_REVERSE :  1;               /*!< flag indicates if timer is disable or not                             */
     } INT_EN_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_STA;                         /*!< interrupt status                                                      */
-    
+
     struct {
       __IO uint32_t  STA        :  1;               /*!< interrupt status                                                      */
     } INT_STA_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_RAW;                         /*!< interrupt raw register                                                */
-    
+
     struct {
       __IO uint32_t  STA        :  1;               /*!< interrupt status                                                      */
     } INT_RAW_b;                                    /*!< BitSize                                                               */
@@ -382,10 +382,10 @@ typedef struct {                                    /*!< TIMER0 Structure       
   */
 
 typedef struct {                                    /*!< SPI0 Structure                                                        */
-  
+
   union {
     __I  uint32_t  STATUS;                          /*!< status Register                                                       */
-    
+
     struct {
       __I  uint32_t  RFIFO_EMPTY:  1;               /*!< receive fifo is empty                                                 */
       __I  uint32_t  RFIFO_FULL :  1;               /*!< receive fifo is full                                                  */
@@ -398,10 +398,10 @@ typedef struct {                                    /*!< SPI0 Structure         
       __I  uint32_t  BUSY       :  1;               /*!< indecates if SPI is idle or busy                                      */
     } STATUS_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CTRL;                            /*!< control Register                                                      */
-    
+
     struct {
       __IO uint32_t  EN         :  1;               /*!< indicates if SPI is enabled or not                                    */
       __IO uint32_t  RX_EN      :  1;               /*!< indicates if SPI receiver is enabled or not                           */
@@ -412,10 +412,10 @@ typedef struct {                                    /*!< SPI0 Structure         
       __IO uint32_t  RX_BIT_SEQUENCE:  1;           /*!< receive bit sequence. 0: MSB is received first                        */
     } CTRL_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_MASK;                        /*!< interrupt mask Register                                               */
-    
+
     struct {
       __IO uint32_t  RFIFO_UNDERFLOW:  1;           /*!< receive fifo underflow interrupt                                      */
       __IO uint32_t  RFIFO_OVERFLOW:  1;            /*!< receive fifo overflow interrupt                                       */
@@ -426,10 +426,10 @@ typedef struct {                                    /*!< SPI0 Structure         
       __IO uint32_t  DONE       :  1;               /*!< transmit done interrupt                                               */
     } INT_MASK_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_STATUS;                      /*!< interrupt Register                                                    */
-    
+
     struct {
       __IO uint32_t  RFIFO_UNDERFLOW:  1;           /*!< receive fifo underflow interrupt                                      */
       __IO uint32_t  RFIFO_OVERFLOW:  1;            /*!< receive fifo overflow interrupt                                       */
@@ -440,10 +440,10 @@ typedef struct {                                    /*!< SPI0 Structure         
       __IO uint32_t  DONE       :  1;               /*!< transmit done interrupt                                               */
     } INT_STATUS_b;                                 /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_RAW;                         /*!< interrupt raw Register                                                */
-    
+
     struct {
       __IO uint32_t  RFIFO_UNDERFLOW:  1;           /*!< receive fifo underflow interrupt                                      */
       __IO uint32_t  RFIFO_OVERFLOW:  1;            /*!< receive fifo overflow interrupt                                       */
@@ -454,10 +454,10 @@ typedef struct {                                    /*!< SPI0 Structure         
       __IO uint32_t  DONE       :  1;               /*!< transmit done interrupt                                               */
     } INT_RAW_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  BCNT;                            /*!< bit length while transmitting and receiving                           */
-    
+
     struct {
       __IO uint32_t  CNT        :  5;               /*!< bit length while transmitting and receiving, BCNT + 1                 */
     } BCNT_b;                                       /*!< BitSize                                                               */
@@ -467,10 +467,10 @@ typedef struct {                                    /*!< SPI0 Structure         
   __IO uint16_t  DIV;                               /*!< frequency division register, fsck = fclk_io / (DIV + 1) / 2           */
   __I  uint16_t  RESERVED1;
   __IO uint32_t  TRANS_CNT;                         /*!< transmit data length, data number = TRANS_CNT + 1                     */
-  
+
   union {
     __O  uint32_t  TRANS_START;                     /*!< transmit startup register, write 1 to trigger transmision once        */
-    
+
     struct {
       __O  uint32_t  TX_TRIGGER :  1;               /*!< write 1 to trigger transmision once                                   */
     } TRANS_START_b;                                /*!< BitSize                                                               */
@@ -489,39 +489,39 @@ typedef struct {                                    /*!< SPI0 Structure         
   */
 
 typedef struct {                                    /*!< I2C0 Structure                                                        */
-  
+
   union {
     __IO uint32_t  CTRL;                            /*!< control Register                                                      */
-    
+
     struct {
       __IO uint32_t  MODE       :  1;               /*!< master or slave mode                                                  */
       __IO uint32_t  MASTER_ADDR_WIDTH:  1;         /*!< 7- or 10-bits address as a master                                     */
       __IO uint32_t  SLAVE_ADDR_WIDTH:  1;          /*!< 7- or 10-bits address width as a slave                                */
     } CTRL_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint16_t  TAR;                             /*!< target address Register                                               */
-    
+
     struct {
       __IO uint16_t  ADDR10     : 10;               /*!< 7- or 10-bits address                                                 */
       __IO uint16_t  START_BYTE :  1;               /*!< Enable start Byte for each transfer                                   */
     } TAR_b;                                        /*!< BitSize                                                               */
   };
   __I  uint16_t  RESERVED0;
-  
+
   union {
     __IO uint16_t  SAR;                             /*!< slave address Register                                                */
-    
+
     struct {
       __IO uint16_t  ADDR10     : 10;               /*!< 7- or 10-bits address                                                 */
     } SAR_b;                                        /*!< BitSize                                                               */
   };
   __I  uint16_t  RESERVED1;
-  
+
   union {
     __IO uint32_t  DATA_CMD;                        /*!< I2C transfer data/command entry                                       */
-    
+
     struct {
       __IO uint32_t  DATA       :  8;               /*!< 8-bits data                                                           */
       __O  uint32_t  RD_CMD     :  1;               /*!< read command for master mode only, write 0 if slave mode              */
@@ -529,30 +529,30 @@ typedef struct {                                    /*!< I2C0 Structure         
       __O  uint32_t  WR_RD_CMD  :  1;               /*!< write and read command for master mode only                           */
     } DATA_CMD_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  WRITE_READ_CNT;                  /*!< I2C write and read data byte counter Register                         */
-    
+
     struct {
       __IO uint32_t  RD_BYTE_CNT:  9;               /*!< Decide the number of bytes read back as a master-receiver             */
            uint32_t             :  7;
       __IO uint32_t  WR_BYTE_CNT:  9;               /*!< Decide the number of byte to send as a master-transmitter             */
     } WRITE_READ_CNT_b;                             /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  SCL_CNT;                         /*!< I2C clk pulse counter                                                 */
-    
+
     struct {
       __IO uint32_t  HIGH_LEVEL_TICK: 16;           /*!< the SCL clock high-period count                                       */
       __IO uint32_t  LOW_LEVEL_TICK: 16;            /*!< the SCL clock low-period count                                        */
     } SCL_CNT_b;                                    /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED2;
-  
+
   union {
     __I  uint32_t  INT_STATUS;                      /*!< I2C interrupt sources                                                 */
-    
+
     struct {
       __I  uint32_t  RX_UNDER   :  1;               /*!< receiver underflow                                                    */
       __I  uint32_t  RX_OVER    :  1;               /*!< receiver overflow                                                     */
@@ -566,10 +566,10 @@ typedef struct {                                    /*!< I2C0 Structure         
       __I  uint32_t  WR_REQ     :  1;               /*!< write request                                                         */
     } INT_STATUS_b;                                 /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_MASK;                        /*!< I2C interrupt mask register                                           */
-    
+
     struct {
       __I  uint32_t  RX_UNDER   :  1;               /*!< receiver underflow                                                    */
       __I  uint32_t  RX_OVER    :  1;               /*!< receiver overflow                                                     */
@@ -584,88 +584,88 @@ typedef struct {                                    /*!< I2C0 Structure         
     } INT_MASK_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED3;
-  
+
   union {
     __IO uint32_t  RX_TL;                           /*!< I2C receive FIFO threshold                                            */
-    
+
     struct {
       __IO uint32_t  THRESHOLD  :  5;               /*!< FIFO threashold                                                       */
     } RX_TL_b;                                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  TX_TL;                           /*!< I2C transmit FIFO threshold                                           */
-    
+
     struct {
       __IO uint32_t  THRESHOLD  :  5;               /*!< FIFO threashold                                                       */
     } TX_TL_b;                                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  CLR_ALL_INT;                     /*!< I2C clear all interrupt register                                      */
-    
+
     struct {
       __I  uint32_t  CLEAR      :  1;               /*!< Read this register to clear all individual interrupts                 */
     } CLR_ALL_INT_b;                                /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  CLR_RX_UNDER;                    /*!< I2C clear RX_UNDER interrupt                                          */
-    
+
     struct {
       __I  uint32_t  CLEAR      :  1;               /*!< Read this register to clear the RX_UNDER interrupt (bit 19)
                                                          of the I2C_STATUS register                                            */
     } CLR_RX_UNDER_b;                               /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  CLR_RX_OVER;                     /*!< I2C clear RX_OVER interrupt                                           */
-    
+
     struct {
       __I  uint32_t  CLEAR      :  1;               /*!< Read this register to clear the RX_OVER interrupt (bit 20) of
                                                          the I2C_STATUS register                                               */
     } CLR_RX_OVER_b;                                /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  CLR_TX_OVER;                     /*!< I2C clear TX_OVER interrupt                                           */
-    
+
     struct {
       __I  uint32_t  CLEAR      :  1;               /*!< Read this register to clear the TX_OVER interrupt (bit 22) of
                                                          the I2C_STATUS register                                               */
     } CLR_TX_OVER_b;                                /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  CLR_RD_REQ;                      /*!< I2C clear RD_REQ interrupt                                            */
-    
+
     struct {
       __I  uint32_t  CLEAR      :  1;               /*!< Read this register to clear the RD_REQ interrupt (bit 24) of
                                                          the I2C_STATUS register                                               */
     } CLR_RD_REQ_b;                                 /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  CLR_TX_ABRT;                     /*!< I2C clear TX_ABRT interrupt                                           */
-    
+
     struct {
       __I  uint32_t  CLEAR      :  1;               /*!< Read this register to clear the TX_ABRT interrupts (bit 25 ,
                                                          bit 18, bit 17, bit 16 and bit 15) of the I2C_STATUS register.        */
     } CLR_TX_ABRT_b;                                /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  CLR_RX_DONE;                     /*!< I2C clear RX_DONE interrupt                                           */
-    
+
     struct {
       __I  uint32_t  CLEAR      :  1;               /*!< Read this register to clear the RX_DONE interrupt (bit 26) of
                                                          the I2C_STATUS register                                               */
     } CLR_RX_DONE_b;                                /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  ENABLE;                          /*!< I2C enable register                                                   */
-    
+
     struct {
       __IO uint32_t  EN         :  1;               /*!< enable device                                                         */
            uint32_t             : 30;
@@ -673,10 +673,10 @@ typedef struct {                                    /*!< I2C0 Structure         
                                                          interrupts deserted                                                   */
     } ENABLE_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  STATUS;                          /*!< I2C status register                                                   */
-    
+
     struct {
       __I  uint32_t  BUSY       :  1;               /*!< I2C busy Status                                                       */
       __I  uint32_t  TX_FIFO_NOT_FULL:  1;          /*!< transmit FIFO is not full                                             */
@@ -709,36 +709,36 @@ typedef struct {                                    /*!< I2C0 Structure         
       __I  uint32_t  MST_WR_RD_FLAG:  1;            /*!< Master is executing write-read command                                */
     } STATUS_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  TX_FIFO_LEVEL;                   /*!< I2C transmit FIFO level                                               */
-    
+
     struct {
       __I  uint32_t  LEVEL      :  5;               /*!< FIFO level                                                            */
     } TX_FIFO_LEVEL_b;                              /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  RX_FIFO_LEVEL;                   /*!< I2C receive FIFO level                                                */
-    
+
     struct {
       __I  uint32_t  LEVEL      :  5;               /*!< FIFO level                                                            */
     } RX_FIFO_LEVEL_b;                              /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED4;
-  
+
   union {
     __O  uint32_t  SLAVE_NACK;                      /*!< I2C slave send a data NACK                                            */
-    
+
     struct {
       __O  uint32_t  NACK       :  1;               /*!< data NACK                                                             */
     } SLAVE_NACK_b;                                 /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED5;
-  
+
   union {
     __IO uint32_t  SDA_SETUP;                       /*!< I2C SDA setup timer                                                   */
-    
+
     struct {
       __IO uint32_t  TSETUP     : 10;               /*!< This counter defines the max value of the following constrains:THD:STA
                                                          TSU:STO,TSETUP: T / INPUT_CLK_PERIOD                                  */
@@ -746,10 +746,10 @@ typedef struct {                                    /*!< I2C0 Structure         
                                                          / INPUT_CLK_PERIOD                                                    */
     } SDA_SETUP_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  TSU_STA_SETUP;                   /*!< I2C Tsu_sta and Tbuf_free timer                                       */
-    
+
     struct {
       __IO uint32_t  TBUF       : 10;               /*!< This counter defines the constrain of bus free interval: Tbuf,
                                                          Tbuf : Tbus_free / INPUT_CLK_PERIOD                                   */
@@ -761,10 +761,10 @@ typedef struct {                                    /*!< I2C0 Structure         
       __IO uint32_t  SCL_FILTER_EN:  1;             /*!< SCL filter enable bit                                                 */
     } TSU_STA_SETUP_b;                              /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  CLR_TX_DONE;                     /*!< I2C clear TX_DONE interrupt                                           */
-    
+
     struct {
       __I  uint32_t  CLEAR      :  1;               /*!< Read this register to clear the TX_DONE interrupt (bit 27) of
                                                          the I2C_STATUS register                                               */
@@ -783,20 +783,20 @@ typedef struct {                                    /*!< I2C0 Structure         
   */
 
 typedef struct {                                    /*!< RTC Structure                                                         */
-  
+
   union {
     __IO uint32_t  INT_STATUS;                      /*!< interrupt Register                                                    */
-    
+
     struct {
       __IO uint32_t  SECOND     :  1;               /*!< 1s interrupt, write 1 clear 0                                         */
       __IO uint32_t  MILLSECOND :  1;               /*!< 1ms interrupt, write 1 clear 0                                        */
     } INT_STATUS_b;                                 /*!< BitSize                                                               */
   };
   __IO uint32_t  SECOND;                            /*!< current seconds of system time                                        */
-  
+
   union {
     __IO uint16_t  MILLSECOND;                      /*!< current millseconds of system time                                    */
-    
+
     struct {
       __IO uint16_t  MS         : 10;               /*!< micro seconds                                                         */
     } MILLSECOND_b;                                 /*!< BitSize                                                               */
@@ -822,10 +822,10 @@ typedef struct {                                    /*!< GPIO Structure         
   __IO uint32_t  GPIO_INT_STATUS;                   /*!< GPIO input interrupt status                                           */
   __IO uint32_t  GPIO_INT_RAW;                      /*!< GPIO input interrupt raw                                              */
   __IO uint32_t  GPIO_POSITIVE_EDGE_INT_TRIGGER;    /*!< triggers an interrupt while a positive edge, else negitive edge       */
-  
+
   union {
     __IO uint32_t  PWM_OUT_SEL;                     /*!< Select gpio output from PWM                                           */
-    
+
     struct {
       __IO uint32_t  GPIO_31    :  1;               /*!< GPIO[31] is selected to output PWM                                    */
       __IO uint32_t  GPIO_H_9   :  1;               /*!< GPIO_H[9] is selected to output PWM                                   */
@@ -833,46 +833,46 @@ typedef struct {                                    /*!< GPIO Structure         
       __IO uint32_t  GPIO_H_20  :  1;               /*!< GPIO_H[20] is selected to output PWM                                  */
     } PWM_OUT_SEL_b;                                /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  PWM_OUT0_LEN;                    /*!< Pwm channel 0 paramters                                               */
-    
+
     struct {
       __IO uint32_t  LOW_LEVEL_TICK: 16;            /*!< low level width = ticks + 1                                           */
       __IO uint32_t  HIGH_LEVEL_TICK: 16;           /*!< high level width = ticks + 1                                          */
     } PWM_OUT0_LEN_b;                               /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  PWM_OUT1_LEN;                    /*!< Pwm channel 1 paramters                                               */
-    
+
     struct {
       __IO uint32_t  LOW_LEVEL_TICK: 16;            /*!< low level width = ticks + 1                                           */
       __IO uint32_t  HIGH_LEVEL_TICK: 16;           /*!< high level width = ticks + 1                                          */
     } PWM_OUT1_LEN_b;                               /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  PWM_OUT2_LEN;                    /*!< Pwm channel 2 paramters                                               */
-    
+
     struct {
       __IO uint32_t  LOW_LEVEL_TICK: 16;            /*!< low level width = ticks + 1                                           */
       __IO uint32_t  HIGH_LEVEL_TICK: 16;           /*!< high level width = ticks + 1                                          */
     } PWM_OUT2_LEN_b;                               /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  PWM_OUT3_LEN;                    /*!< Pwm channel 3 paramters                                               */
-    
+
     struct {
       __IO uint32_t  LOW_LEVEL_TICK: 16;            /*!< low level width = ticks + 1                                           */
       __IO uint32_t  HIGH_LEVEL_TICK: 16;           /*!< high level width = ticks + 1                                          */
     } PWM_OUT3_LEN_b;                               /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  PWM_OUT_EN;                      /*!< Pwm enable                                                            */
-    
+
     struct {
       __IO uint32_t  GPIO_31    :  1;               /*!< GPIO[31] is selected to output PWM                                    */
       __IO uint32_t  GPIO_H_9   :  1;               /*!< GPIO_H[9] is selected to output PWM                                   */
@@ -909,10 +909,10 @@ typedef struct {                                    /*!< GPIO Structure         
   */
 
 typedef struct {                                    /*!< NOR_FLASH Structure                                                   */
-  
+
   union {
     __IO uint32_t  CTRL0;                           /*!< control Register 0                                                    */
-    
+
     struct {
       __IO uint32_t  DIV        :  8;               /*!< frequency division register, fsck = fclk_io / (DIV + 1) / 2           */
       __IO uint32_t  CS_REVALID_INTERVAL:  8;       /*!< interval from CS invalid to valid, number of half cycle of SCK        */
@@ -920,19 +920,19 @@ typedef struct {                                    /*!< NOR_FLASH Structure    
                                                          contains all in transparent state. 0 is unlimited                     */
     } CTRL0_b;                                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CTRL1;                           /*!< control Register 1                                                    */
-    
+
     struct {
       __IO uint32_t  CMD        :  8;               /*!< operated command                                                      */
       __IO uint32_t  ADDRESS    : 24;               /*!< RW address                                                            */
     } CTRL1_b;                                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  TRIGGER;                         /*!< trigger register                                                      */
-    
+
     struct {
       __O  uint32_t  OP_START   :  1;               /*!< operation start.                                                      */
       __IO uint32_t  OP_CLEAN   :  1;               /*!< operation clean, stop current opration and clean FIFO                 */
@@ -940,10 +940,10 @@ typedef struct {                                    /*!< NOR_FLASH Structure    
       __IO uint32_t  TRSP_EN    :  1;               /*!< enable transparent operation                                          */
     } TRIGGER_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  STATUS;                          /*!< status register                                                       */
-    
+
     struct {
       __I  uint32_t  BUSY       :  1;               /*!< reading or writting                                                   */
       __I  uint32_t  RD_FIFO_ALMOST_FULL:  1;       /*!< read FIFO is almost full                                              */
@@ -956,10 +956,10 @@ typedef struct {                                    /*!< NOR_FLASH Structure    
   };
   __IO uint32_t  DATA;                              /*!< data register. lower bits are significant in read and higher
                                                          bits are significant in writting                                      */
-  
+
   union {
     __IO uint32_t  BYPASS;                          /*!< bypass Register, is used for JTAG connecting FLASH directly           */
-    
+
     struct {
       __IO uint32_t  EN         :  1;               /*!< enable bypass                                                         */
     } BYPASS_b;                                     /*!< BitSize                                                               */
@@ -977,10 +977,10 @@ typedef struct {                                    /*!< NOR_FLASH Structure    
   */
 
 typedef struct {                                    /*!< ADC Structure                                                         */
-  
+
   union {
     __IO uint32_t  POWERDOWN_RESET;                 /*!< power down and reset Register                                         */
-    
+
     struct {
       __IO uint32_t  RESET_ADC2 :  1;               /*!< ADC2, reset, active high                                              */
       __IO uint32_t  RESET_ADC1 :  1;               /*!< ADC1, reset, active high                                              */
@@ -988,19 +988,19 @@ typedef struct {                                    /*!< ADC Structure          
       __IO uint32_t  POWERDOWN_ADC1:  1;            /*!< ADC1, power down, active high                                         */
     } POWERDOWN_RESET_b;                            /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CFG0;                            /*!< config Register                                                       */
-    
+
     struct {
       __IO uint32_t  VSEN       :  3;               /*!< ADC-1 VSEN Selection                                                  */
       __IO uint32_t  PHASE_CTRL :  2;               /*!< ADC-1 and ADC-2 CLK Phase Control                                     */
     } CFG0_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CFG_ADC1;                        /*!< config ADC1 register                                                  */
-    
+
     struct {
       __IO uint32_t  SYSTEM_MODE:  3;               /*!< system mode selection                                                 */
       __IO uint32_t  CHANNEL_SEL:  4;               /*!< channel selection                                                     */
@@ -1008,10 +1008,10 @@ typedef struct {                                    /*!< ADC Structure          
       __IO uint32_t  MULTI_CHANNEL_BIT:  8;         /*!< each bit represents each channel                                      */
     } CFG_ADC1_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CFG_ADC2;                        /*!< config ADC1 register                                                  */
-    
+
     struct {
       __IO uint32_t  SYSTEM_MODE:  3;               /*!< system mode selection                                                 */
       __IO uint32_t  CHANNEL_SEL:  4;               /*!< channel selection                                                     */
@@ -1019,34 +1019,34 @@ typedef struct {                                    /*!< ADC Structure          
       __IO uint32_t  MULTI_CHANNEL_BIT:  8;         /*!< each bit represents each channel                                      */
     } CFG_ADC2_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  ADC1_FIFO_CLEAR;                 /*!< clear adc1 fifo data                                                  */
-    
+
     struct {
       __IO uint32_t  CLEAR      :  1;               /*!< clear fifo data, active high                                          */
     } ADC1_FIFO_CLEAR_b;                            /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  ADC2_FIFO_CLEAR;                 /*!< clear adc2 fifo data                                                  */
-    
+
     struct {
       __IO uint32_t  CLEAR      :  1;               /*!< clear fifo data, active high                                          */
     } ADC2_FIFO_CLEAR_b;                            /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  ALL_ADC_FIFO_CLEAR;              /*!< clear adc1 and adc2 fifo data                                         */
-    
+
     struct {
       __IO uint32_t  CLEAR      :  1;               /*!< clear fifo data, active high                                          */
     } ALL_ADC_FIFO_CLEAR_b;                         /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_MASK;                        /*!< interrupt mask register                                               */
-    
+
     struct {
       __IO uint32_t  ADC1_ALMOST_FULL:  1;          /*!< ADC 1 almost full                                                     */
       __IO uint32_t  ADC1_OVERFLOW:  1;             /*!< ADC 1 is overflow                                                     */
@@ -1056,10 +1056,10 @@ typedef struct {                                    /*!< ADC Structure          
       __IO uint32_t  ADC2_EMPTY_ERR:  1;            /*!< ADC 2 read empty error                                                */
     } INT_MASK_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_RAW;                         /*!< interrupt raw register                                                */
-    
+
     struct {
       __IO uint32_t  ADC1_ALMOST_FULL:  1;          /*!< ADC 1 almost full                                                     */
       __IO uint32_t  ADC1_OVERFLOW:  1;             /*!< ADC 1 is overflow                                                     */
@@ -1069,10 +1069,10 @@ typedef struct {                                    /*!< ADC Structure          
       __IO uint32_t  ADC2_EMPTY_ERR:  1;            /*!< ADC 2 read empty error                                                */
     } INT_RAW_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_STATUS;                      /*!< interrupt status register                                             */
-    
+
     struct {
       __IO uint32_t  ADC1_ALMOST_FULL:  1;          /*!< ADC 1 almost full                                                     */
       __IO uint32_t  ADC1_OVERFLOW:  1;             /*!< ADC 1 is overflow                                                     */
@@ -1090,10 +1090,10 @@ typedef struct {                                    /*!< ADC Structure          
   __I  uint32_t  ADC2_OUT_NEGTIVE_GAIN_CALIBRATION; /*!< ADC-2 Output in gain calibration when Input=-FS, Ideally DAO[11:0]=801h */
   __I  uint32_t  ADC1_OUT_POSITIVE_GAIN_CALIBRATION;/*!< ADC-1 Output in gain calibration when Input=FS, Ideally DAO[11:0]=7FFh */
   __I  uint32_t  ADC2_OUT_POSITIVE_GAIN_CALIBRATION;/*!< ADC-2 Output in gain calibration when Input=FS, Ideally DAO[11:0]=7FFh */
-  
+
   union {
     __I  uint32_t  EOC;                             /*!< Conversion End Indicator                                              */
-    
+
     struct {
       __I  uint32_t  ADC2_EOC_GAIN:  1;             /*!< ADC2 EOC_GAIN signal, conversion is done                              */
       __I  uint32_t  ADC2_EOC_OFF:  1;              /*!< ADC2 EOC_OFF signal, conversion is done                               */
@@ -1103,87 +1103,87 @@ typedef struct {                                    /*!< ADC Structure          
       __I  uint32_t  ADC1_EOC   :  1;               /*!< ADC1 EOC signal, conversion is done                                   */
     } EOC_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  BUSY;                            /*!< ADC is busy                                                           */
-    
+
     struct {
       __I  uint32_t  ADC1_BUSY  :  1;               /*!< ADC1 is busy                                                          */
       __I  uint32_t  ADC2_BUSY  :  1;               /*!< ADC2 is busy                                                          */
     } BUSY_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __O  uint32_t  ADC1_START;                      /*!< ADC1 startup enable                                                   */
-    
+
     struct {
       __O  uint32_t  EN         :  1;               /*!< start                                                                 */
     } ADC1_START_b;                                 /*!< BitSize                                                               */
   };
-  
+
   union {
     __O  uint32_t  ADC1_STOP;                       /*!< ADC1 stop enable                                                      */
-    
+
     struct {
       __O  uint32_t  EN         :  1;               /*!< start                                                                 */
     } ADC1_STOP_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __O  uint16_t  ADC1_FIFO_READ;                  /*!< ADC1 FIFO read data                                                   */
-    
+
     struct {
       __O  uint16_t  DATA       : 12;               /*!< data                                                                  */
       __O  uint16_t  CHANNEL    :  4;               /*!< channel number                                                        */
     } ADC1_FIFO_READ_b;                             /*!< BitSize                                                               */
   };
   __I  uint16_t  RESERVED0;
-  
+
   union {
     __O  uint32_t  ADC2_START;                      /*!< ADC2 startup enable, only for single-conversion                       */
-    
+
     struct {
       __O  uint32_t  EN         :  1;               /*!< start                                                                 */
     } ADC2_START_b;                                 /*!< BitSize                                                               */
   };
-  
+
   union {
     __O  uint32_t  ADC2_STOP;                       /*!< ADC1 stop enable, only for single-conversion                          */
-    
+
     struct {
       __O  uint32_t  EN         :  1;               /*!< start                                                                 */
     } ADC2_STOP_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __O  uint16_t  ADC2_FIFO_READ;                  /*!< ADC2 FIFO read data                                                   */
-    
+
     struct {
       __O  uint16_t  DATA       : 12;               /*!< data                                                                  */
       __O  uint16_t  CHANNEL    :  4;               /*!< channel number                                                        */
     } ADC2_FIFO_READ_b;                             /*!< BitSize                                                               */
   };
   __I  uint16_t  RESERVED1;
-  
+
   union {
     __O  uint32_t  ALL_ADC_START;                   /*!< all ADCs start                                                        */
-    
+
     struct {
       __O  uint32_t  EN         :  1;               /*!< start                                                                 */
     } ALL_ADC_START_b;                              /*!< BitSize                                                               */
   };
-  
+
   union {
     __O  uint32_t  ALL_ADC_STOP;                    /*!< all ADCs stop                                                         */
-    
+
     struct {
       __O  uint32_t  EN         :  1;               /*!< start                                                                 */
     } ALL_ADC_STOP_b;                               /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  ALL_ADC_FIFO_READ;               /*!< all ADCs FIFO read data                                               */
-    
+
     struct {
       __I  uint32_t  ADC1_DATA  : 12;               /*!< ADC1 data                                                             */
       __I  uint32_t  ADC1_CHANNEL:  4;              /*!< ADC1 channel number                                                   */
@@ -1191,10 +1191,10 @@ typedef struct {                                    /*!< ADC Structure          
       __I  uint32_t  ADC2_CHANNEL:  4;              /*!< ADC2 channel number                                                   */
     } ALL_ADC_FIFO_READ_b;                          /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  STATUS;                          /*!< status register                                                       */
-    
+
     struct {
       __I  uint32_t  ADC1_READ_EMPTY:  1;           /*!< ADC1 read empty                                                       */
       __I  uint32_t  ADC2_READ_EMPTY:  1;           /*!< ADC2 read empty                                                       */
@@ -1219,10 +1219,10 @@ typedef struct {                                    /*!< ADC Structure          
   */
 
 typedef struct {                                    /*!< EFUSE Structure                                                       */
-  
+
   union {
     __IO uint32_t  USER_CTRL_LOW;                   /*!< low user region control                                               */
-    
+
     struct {
       __IO uint32_t  WR_EN      :  1;               /*!< write enable. 1 : write data into EFUSE. clear 0 after read           */
       __IO uint32_t  RD_EN      :  1;               /*!< read enable. 1 : write data into EFUSE. clear 0 after read            */
@@ -1234,10 +1234,10 @@ typedef struct {                                    /*!< EFUSE Structure        
       __IO uint32_t  TMRF       :  2;               /*!< Reference resistor select, 1200ohm is recommended                     */
     } USER_CTRL_LOW_b;                              /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  TIMING_0;                        /*!< timing 0                                                              */
-    
+
     struct {
       __IO uint32_t  TPRS       :  7;               /*!< TPRS                                                                  */
       __IO uint32_t  TESR       :  2;               /*!< TESR                                                                  */
@@ -1249,10 +1249,10 @@ typedef struct {                                    /*!< EFUSE Structure        
       __IO uint32_t  TPWPH      :  5;               /*!< TPWPH[6:2]                                                            */
     } TIMING_0_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  TIMING_1;                        /*!< timing 1                                                              */
-    
+
     struct {
       __IO uint32_t  TPWPS      :  7;               /*!< TPWPS                                                                 */
       __IO uint32_t  TEPS       :  4;               /*!< TEPS                                                                  */
@@ -1265,10 +1265,10 @@ typedef struct {                                    /*!< EFUSE Structure        
   __IO uint32_t  USER_DATA1_LOW;                    /*!< user data [63:32]                                                     */
   __IO uint32_t  USER_DATA2_LOW;                    /*!< user data [95:64]                                                     */
   __IO uint32_t  USER_DATA3_LOW;                    /*!< user data [127:96]                                                    */
-  
+
   union {
     __IO uint32_t  USER_DATA4_LOW;                  /*!< crc and lock bit                                                      */
-    
+
     struct {
       __IO uint32_t  LOCK       :  1;               /*!< write protection if true                                              */
            uint32_t             : 23;
@@ -1276,10 +1276,10 @@ typedef struct {                                    /*!< EFUSE Structure        
     } USER_DATA4_LOW_b;                             /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED0[3];
-  
+
   union {
     __IO uint32_t  USER_CTRL_HI;                    /*!< high user region control                                              */
-    
+
     struct {
       __IO uint32_t  WR_EN      :  1;               /*!< write enable. 1 : write data into EFUSE. clear 0 after read           */
       __IO uint32_t  RD_EN      :  1;               /*!< read enable. 1 : write data into EFUSE. clear 0 after read            */
@@ -1295,10 +1295,10 @@ typedef struct {                                    /*!< EFUSE Structure        
   __IO uint32_t  USER_DATA1_HI;                     /*!< user data [191:160]                                                   */
   __IO uint32_t  USER_DATA2_HI;                     /*!< user data [223:192]                                                   */
   __IO uint32_t  USER_DATA3_HI;                     /*!< user data [255:224]                                                   */
-  
+
   union {
     __IO uint32_t  USER_DATA4_HI;                   /*!< crc and lock bit                                                      */
-    
+
     struct {
       __IO uint32_t  LOCK       :  1;               /*!< write protection if true                                              */
            uint32_t             : 23;
@@ -1318,10 +1318,10 @@ typedef struct {                                    /*!< EFUSE Structure        
   */
 
 typedef struct {                                    /*!< CAN0 Structure                                                        */
-  
+
   union {
     __IO uint8_t   MODE;                            /*!< mode Register                                                         */
-    
+
     struct {
       __IO uint8_t   RM         :  1;               /*!< reset mode if 1 or operation mode                                     */
       __IO uint8_t   LOM        :  1;               /*!< Listen only mode                                                      */
@@ -1331,10 +1331,10 @@ typedef struct {                                    /*!< CAN0 Structure         
     } MODE_b;                                       /*!< BitSize                                                               */
   };
   __I  uint8_t   RESERVED0[3];
-  
+
   union {
     __O  uint8_t   CMD;                             /*!< command Register                                                      */
-    
+
     struct {
       __O  uint8_t   TR         :  1;               /*!< Set to 1 when a message is to be transmitted                          */
       __O  uint8_t   AT         :  1;               /*!< Set to 1 to cancel the next transmission request                      */
@@ -1345,10 +1345,10 @@ typedef struct {                                    /*!< CAN0 Structure         
     } CMD_b;                                        /*!< BitSize                                                               */
   };
   __I  uint8_t   RESERVED1[3];
-  
+
   union {
     __I  uint8_t   STATUS;                          /*!< status Register                                                       */
-    
+
     struct {
       __I  uint8_t   RBNE       :  1;               /*!< Receive Buffer not empty                                              */
       __I  uint8_t   DO         :  1;               /*!< Data Overrun Status                                                   */
@@ -1362,10 +1362,10 @@ typedef struct {                                    /*!< CAN0 Structure         
     } STATUS_b;                                     /*!< BitSize                                                               */
   };
   __I  uint8_t   RESERVED2[3];
-  
+
   union {
     __I  uint8_t   INT;                             /*!< interrupt Register                                                    */
-    
+
     struct {
       __I  uint8_t   RBNF       :  1;               /*!< Receive Buffer not empty                                              */
       __I  uint8_t   TB_UNLOCK  :  1;               /*!< Transmit Buffer is unlocked and not in transmitting                   */
@@ -1381,10 +1381,10 @@ typedef struct {                                    /*!< CAN0 Structure         
     } INT_b;                                        /*!< BitSize                                                               */
   };
   __I  uint8_t   RESERVED3[3];
-  
+
   union {
     __IO uint8_t   INT_EN;                          /*!< interrupt enabled Register                                            */
-    
+
     struct {
       __I  uint8_t   RBNF       :  1;               /*!< Receive Buffer not empty                                              */
       __I  uint8_t   TB_UNLOCK  :  1;               /*!< Transmit Buffer is unlocked and not in transmitting                   */
@@ -1400,10 +1400,10 @@ typedef struct {                                    /*!< CAN0 Structure         
     } INT_EN_b;                                     /*!< BitSize                                                               */
   };
   __I  uint8_t   RESERVED4[7];
-  
+
   union {
     __IO uint8_t   BTR0;                            /*!< Bus Timing 0                                                          */
-    
+
     struct {
       __IO uint8_t   BRP        :  6;               /*!< TQ =2 x Txtal1 x (32 x BRP.5 + 16 x BRP.4 + 8 x BRP.3 + 4 x
                                                          BRP.2 + 2 x BRP.1 + BRP.0 + 1)                                        */
@@ -1411,10 +1411,10 @@ typedef struct {                                    /*!< CAN0 Structure         
     } BTR0_b;                                       /*!< BitSize                                                               */
   };
   __I  uint8_t   RESERVED5[3];
-  
+
   union {
     __IO uint8_t   BTR1;                            /*!< Bus Timing 1                                                          */
-    
+
     struct {
       __IO uint8_t   TSEG1      :  4;               /*!< the maximum number of time quanta of propagation and 1st phase
                                                          segment                                                               */
@@ -1423,29 +1423,29 @@ typedef struct {                                    /*!< CAN0 Structure         
     } BTR1_b;                                       /*!< BitSize                                                               */
   };
   __I  uint8_t   RESERVED6[3];
-  
+
   union {
     __IO uint8_t   OCR;                             /*!< Output Control Register                                               */
-    
+
     struct {
       __IO uint8_t   MODE       :  2;               /*!< output control mode                                                   */
     } OCR_b;                                        /*!< BitSize                                                               */
   };
   __I  uint8_t   RESERVED7[11];
-  
+
   union {
     __I  uint8_t   ALC;                             /*!< Arbitration Lost Capture                                              */
-    
+
     struct {
       __I  uint8_t   BIT        :  5;               /*!< the current position of the Bit Processor when bus arbitration
                                                          lost, 1st bit (ID.28) if 0                                            */
     } ALC_b;                                        /*!< BitSize                                                               */
   };
   __I  uint8_t   RESERVED8[3];
-  
+
   union {
     __I  uint8_t   ECC;                             /*!< Error Code Capture                                                    */
-    
+
     struct {
       __I  uint8_t   SEGMENT    :  5;               /*!< segment code                                                          */
       __I  uint8_t   DIRECTION  :  1;               /*!< If 1, the error occurred during reception. If 0, the error occurred
@@ -1460,11 +1460,11 @@ typedef struct {                                    /*!< CAN0 Structure         
   __I  uint8_t   RESERVED11[3];
   __IO uint8_t   TXERR;                             /*!< Transmit Error Counter                                                */
   __I  uint8_t   RESERVED12[3];
-  
+
   union {
     __IO uint8_t   FI_OR_ACR0;                      /*!< Transmit Frame Information if writting or Receive Frame Information
                                                          if reading, ACR[0] if reset mode                                      */
-    
+
     struct {
       __IO uint8_t   DLC        :  4;               /*!< byte number in the data                                               */
            uint8_t              :  2;
@@ -1512,10 +1512,10 @@ typedef struct {                                    /*!< CAN0 Structure         
   __I  uint8_t   RESERVED25[3];
   __IO uint8_t   RMC;                               /*!< Receive Message Counter                                               */
   __I  uint8_t   RESERVED26[7];
-  
+
   union {
     __IO uint8_t   CDR;                             /*!< Clock Divider Register                                                */
-    
+
     struct {
       __IO uint8_t   DIVIDER    :  3;               /*!< divider of XTAL1                                                      */
       __IO uint8_t   OFF        :  1;               /*!< disable XTAL1                                                         */
@@ -1538,10 +1538,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED0;
   __IO uint32_t  DAR0;                              /*!< Current Destination Address of DMA transfer                           */
   __I  uint32_t  RESERVED1;
-  
+
   union {
     __IO uint32_t  LLP0;                            /*!< Linked List Pointer Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  LMS        :  2;               /*!< Identifies the AHB layer/interface where the memory device that
                                                          stores the next linked list item resides.                             */
@@ -1550,10 +1550,10 @@ typedef struct {                                    /*!< DMA Structure          
     } LLP0_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED2;
-  
+
   union {
     __IO uint32_t  CTL_LOW0;                        /*!< Lower 32-bits Control Register for Channel                            */
-    
+
     struct {
       __IO uint32_t  INT_EN     :  1;               /*!< Interrupt Enable Bit                                                  */
       __IO uint32_t  DST_TR_WIDTH:  3;              /*!< Destination Transfer Width                                            */
@@ -1572,10 +1572,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  LLP_SRC_EN :  1;               /*!< Block chaining is enabled on the source side                          */
     } CTL_LOW0_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CTL_HI0;                         /*!< Higher 32-bits Control Register for Channel                           */
-    
+
     struct {
       __IO uint32_t  BLOCK_TS   : 12;               /*!< indicates the total number of single transactions to perform
                                                          for every block transfer                                              */
@@ -1590,10 +1590,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED5;
   __IO uint32_t  DSTATAR0;                          /*!< Destination Status Address Register for Channel                       */
   __I  uint32_t  RESERVED6;
-  
+
   union {
     __IO uint32_t  CFG_LOW0;                        /*!< Lower 32-bit Configuration Register for Channel                       */
-    
+
     struct {
            uint32_t             :  5;
       __IO uint32_t  CH_PRIOR   :  3;               /*!< Channel priority. A priority of 7 is the highest priority             */
@@ -1613,10 +1613,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  RELOAD_DST :  1;               /*!< Automatic Destination Reload                                          */
     } CFG_LOW0_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CFG_HI0;                         /*!< Higher 32-bit Configuration Register for Channel                      */
-    
+
     struct {
       __IO uint32_t  FCMODE     :  1;               /*!< if source transaction requests aren't serviced when the Destination
                                                          Peripheral is the flow controller.                                    */
@@ -1628,20 +1628,20 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  SS_UPD_EN  :  1;               /*!< STATx is only updated from STATARx                                    */
     } CFG_HI0_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  SGR0;                            /*!< Source Gather Register for Channel                                    */
-    
+
     struct {
       __IO uint32_t  SGI        : 20;               /*!< Source gather interval                                                */
       __IO uint32_t  SGC        : 12;               /*!< Specifies the number of contiguous source transfers of CTLx.SRC_TR_WIDTH */
     } SGR0_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED7;
-  
+
   union {
     __IO uint32_t  DSR0;                            /*!< Destination Scatter Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  DSI        : 20;               /*!< Destination scatter interval                                          */
       __IO uint32_t  DSC        : 12;               /*!< Specifies the number of contiguous destination transfers of
@@ -1653,10 +1653,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED9;
   __IO uint32_t  DAR1;                              /*!< Current Destination Address of DMA transfer                           */
   __I  uint32_t  RESERVED10;
-  
+
   union {
     __IO uint32_t  LLP1;                            /*!< Linked List Pointer Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  LMS        :  2;               /*!< Identifies the AHB layer/interface where the memory device that
                                                          stores the next linked list item resides.                             */
@@ -1665,10 +1665,10 @@ typedef struct {                                    /*!< DMA Structure          
     } LLP1_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED11;
-  
+
   union {
     __IO uint32_t  CTL_LOW1;                        /*!< Lower 32-bits Control Register for Channel                            */
-    
+
     struct {
       __IO uint32_t  INT_EN     :  1;               /*!< Interrupt Enable Bit                                                  */
       __IO uint32_t  DST_TR_WIDTH:  3;              /*!< Destination Transfer Width                                            */
@@ -1687,10 +1687,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  LLP_SRC_EN :  1;               /*!< Block chaining is enabled on the source side                          */
     } CTL_LOW1_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CTL_HI1;                         /*!< Higher 32-bits Control Register for Channel                           */
-    
+
     struct {
       __IO uint32_t  BLOCK_TS   : 12;               /*!< indicates the total number of single transactions to perform
                                                          for every block transfer                                              */
@@ -1705,10 +1705,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED14;
   __IO uint32_t  DSTATAR1;                          /*!< Destination Status Address Register for Channel                       */
   __I  uint32_t  RESERVED15;
-  
+
   union {
     __IO uint32_t  CFG_LOW1;                        /*!< Lower 32-bit Configuration Register for Channel                       */
-    
+
     struct {
            uint32_t             :  5;
       __IO uint32_t  CH_PRIOR   :  3;               /*!< Channel priority. A priority of 7 is the highest priority             */
@@ -1728,10 +1728,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  RELOAD_DST :  1;               /*!< Automatic Destination Reload                                          */
     } CFG_LOW1_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CFG_HI1;                         /*!< Higher 32-bit Configuration Register for Channel                      */
-    
+
     struct {
       __IO uint32_t  FCMODE     :  1;               /*!< if source transaction requests aren't serviced when the Destination
                                                          Peripheral is the flow controller.                                    */
@@ -1743,20 +1743,20 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  SS_UPD_EN  :  1;               /*!< STATx is only updated from STATARx                                    */
     } CFG_HI1_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  SGR1;                            /*!< Source Gather Register for Channel                                    */
-    
+
     struct {
       __IO uint32_t  SGI        : 20;               /*!< Source gather interval                                                */
       __IO uint32_t  SGC        : 12;               /*!< Specifies the number of contiguous source transfers of CTLx.SRC_TR_WIDTH */
     } SGR1_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED16;
-  
+
   union {
     __IO uint32_t  DSR1;                            /*!< Destination Scatter Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  DSI        : 20;               /*!< Destination scatter interval                                          */
       __IO uint32_t  DSC        : 12;               /*!< Specifies the number of contiguous destination transfers of
@@ -1768,10 +1768,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED18;
   __IO uint32_t  DAR2;                              /*!< Current Destination Address of DMA transfer                           */
   __I  uint32_t  RESERVED19;
-  
+
   union {
     __IO uint32_t  LLP2;                            /*!< Linked List Pointer Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  LMS        :  2;               /*!< Identifies the AHB layer/interface where the memory device that
                                                          stores the next linked list item resides.                             */
@@ -1780,10 +1780,10 @@ typedef struct {                                    /*!< DMA Structure          
     } LLP2_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED20;
-  
+
   union {
     __IO uint32_t  CTL_LOW2;                        /*!< Lower 32-bits Control Register for Channel                            */
-    
+
     struct {
       __IO uint32_t  INT_EN     :  1;               /*!< Interrupt Enable Bit                                                  */
       __IO uint32_t  DST_TR_WIDTH:  3;              /*!< Destination Transfer Width                                            */
@@ -1802,10 +1802,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  LLP_SRC_EN :  1;               /*!< Block chaining is enabled on the source side                          */
     } CTL_LOW2_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CTL_HI2;                         /*!< Higher 32-bits Control Register for Channel                           */
-    
+
     struct {
       __IO uint32_t  BLOCK_TS   : 12;               /*!< indicates the total number of single transactions to perform
                                                          for every block transfer                                              */
@@ -1820,10 +1820,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED23;
   __IO uint32_t  DSTATAR2;                          /*!< Destination Status Address Register for Channel                       */
   __I  uint32_t  RESERVED24;
-  
+
   union {
     __IO uint32_t  CFG_LOW2;                        /*!< Lower 32-bit Configuration Register for Channel                       */
-    
+
     struct {
            uint32_t             :  5;
       __IO uint32_t  CH_PRIOR   :  3;               /*!< Channel priority. A priority of 7 is the highest priority             */
@@ -1843,10 +1843,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  RELOAD_DST :  1;               /*!< Automatic Destination Reload                                          */
     } CFG_LOW2_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CFG_HI2;                         /*!< Higher 32-bit Configuration Register for Channel                      */
-    
+
     struct {
       __IO uint32_t  FCMODE     :  1;               /*!< if source transaction requests aren't serviced when the Destination
                                                          Peripheral is the flow controller.                                    */
@@ -1858,20 +1858,20 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  SS_UPD_EN  :  1;               /*!< STATx is only updated from STATARx                                    */
     } CFG_HI2_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  SGR2;                            /*!< Source Gather Register for Channel                                    */
-    
+
     struct {
       __IO uint32_t  SGI        : 20;               /*!< Source gather interval                                                */
       __IO uint32_t  SGC        : 12;               /*!< Specifies the number of contiguous source transfers of CTLx.SRC_TR_WIDTH */
     } SGR2_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED25;
-  
+
   union {
     __IO uint32_t  DSR2;                            /*!< Destination Scatter Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  DSI        : 20;               /*!< Destination scatter interval                                          */
       __IO uint32_t  DSC        : 12;               /*!< Specifies the number of contiguous destination transfers of
@@ -1883,10 +1883,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED27;
   __IO uint32_t  DAR3;                              /*!< Current Destination Address of DMA transfer                           */
   __I  uint32_t  RESERVED28;
-  
+
   union {
     __IO uint32_t  LLP3;                            /*!< Linked List Pointer Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  LMS        :  2;               /*!< Identifies the AHB layer/interface where the memory device that
                                                          stores the next linked list item resides.                             */
@@ -1895,10 +1895,10 @@ typedef struct {                                    /*!< DMA Structure          
     } LLP3_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED29;
-  
+
   union {
     __IO uint32_t  CTL_LOW3;                        /*!< Lower 32-bits Control Register for Channel                            */
-    
+
     struct {
       __IO uint32_t  INT_EN     :  1;               /*!< Interrupt Enable Bit                                                  */
       __IO uint32_t  DST_TR_WIDTH:  3;              /*!< Destination Transfer Width                                            */
@@ -1917,10 +1917,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  LLP_SRC_EN :  1;               /*!< Block chaining is enabled on the source side                          */
     } CTL_LOW3_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CTL_HI3;                         /*!< Higher 32-bits Control Register for Channel                           */
-    
+
     struct {
       __IO uint32_t  BLOCK_TS   : 12;               /*!< indicates the total number of single transactions to perform
                                                          for every block transfer                                              */
@@ -1935,10 +1935,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED32;
   __IO uint32_t  DSTATAR3;                          /*!< Destination Status Address Register for Channel                       */
   __I  uint32_t  RESERVED33;
-  
+
   union {
     __IO uint32_t  CFG_LOW3;                        /*!< Lower 32-bit Configuration Register for Channel                       */
-    
+
     struct {
            uint32_t             :  5;
       __IO uint32_t  CH_PRIOR   :  3;               /*!< Channel priority. A priority of 7 is the highest priority             */
@@ -1958,10 +1958,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  RELOAD_DST :  1;               /*!< Automatic Destination Reload                                          */
     } CFG_LOW3_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CFG_HI3;                         /*!< Higher 32-bit Configuration Register for Channel                      */
-    
+
     struct {
       __IO uint32_t  FCMODE     :  1;               /*!< if source transaction requests aren't serviced when the Destination
                                                          Peripheral is the flow controller.                                    */
@@ -1973,20 +1973,20 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  SS_UPD_EN  :  1;               /*!< STATx is only updated from STATARx                                    */
     } CFG_HI3_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  SGR3;                            /*!< Source Gather Register for Channel                                    */
-    
+
     struct {
       __IO uint32_t  SGI        : 20;               /*!< Source gather interval                                                */
       __IO uint32_t  SGC        : 12;               /*!< Specifies the number of contiguous source transfers of CTLx.SRC_TR_WIDTH */
     } SGR3_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED34;
-  
+
   union {
     __IO uint32_t  DSR3;                            /*!< Destination Scatter Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  DSI        : 20;               /*!< Destination scatter interval                                          */
       __IO uint32_t  DSC        : 12;               /*!< Specifies the number of contiguous destination transfers of
@@ -1998,10 +1998,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED36;
   __IO uint32_t  DAR4;                              /*!< Current Destination Address of DMA transfer                           */
   __I  uint32_t  RESERVED37;
-  
+
   union {
     __IO uint32_t  LLP4;                            /*!< Linked List Pointer Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  LMS        :  2;               /*!< Identifies the AHB layer/interface where the memory device that
                                                          stores the next linked list item resides.                             */
@@ -2010,10 +2010,10 @@ typedef struct {                                    /*!< DMA Structure          
     } LLP4_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED38;
-  
+
   union {
     __IO uint32_t  CTL_LOW4;                        /*!< Lower 32-bits Control Register for Channel                            */
-    
+
     struct {
       __IO uint32_t  INT_EN     :  1;               /*!< Interrupt Enable Bit                                                  */
       __IO uint32_t  DST_TR_WIDTH:  3;              /*!< Destination Transfer Width                                            */
@@ -2032,10 +2032,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  LLP_SRC_EN :  1;               /*!< Block chaining is enabled on the source side                          */
     } CTL_LOW4_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CTL_HI4;                         /*!< Higher 32-bits Control Register for Channel                           */
-    
+
     struct {
       __IO uint32_t  BLOCK_TS   : 12;               /*!< indicates the total number of single transactions to perform
                                                          for every block transfer                                              */
@@ -2050,10 +2050,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED41;
   __IO uint32_t  DSTATAR4;                          /*!< Destination Status Address Register for Channel                       */
   __I  uint32_t  RESERVED42;
-  
+
   union {
     __IO uint32_t  CFG_LOW4;                        /*!< Lower 32-bit Configuration Register for Channel                       */
-    
+
     struct {
            uint32_t             :  5;
       __IO uint32_t  CH_PRIOR   :  3;               /*!< Channel priority. A priority of 7 is the highest priority             */
@@ -2073,10 +2073,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  RELOAD_DST :  1;               /*!< Automatic Destination Reload                                          */
     } CFG_LOW4_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CFG_HI4;                         /*!< Higher 32-bit Configuration Register for Channel                      */
-    
+
     struct {
       __IO uint32_t  FCMODE     :  1;               /*!< if source transaction requests aren't serviced when the Destination
                                                          Peripheral is the flow controller.                                    */
@@ -2088,20 +2088,20 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  SS_UPD_EN  :  1;               /*!< STATx is only updated from STATARx                                    */
     } CFG_HI4_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  SGR4;                            /*!< Source Gather Register for Channel                                    */
-    
+
     struct {
       __IO uint32_t  SGI        : 20;               /*!< Source gather interval                                                */
       __IO uint32_t  SGC        : 12;               /*!< Specifies the number of contiguous source transfers of CTLx.SRC_TR_WIDTH */
     } SGR4_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED43;
-  
+
   union {
     __IO uint32_t  DSR4;                            /*!< Destination Scatter Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  DSI        : 20;               /*!< Destination scatter interval                                          */
       __IO uint32_t  DSC        : 12;               /*!< Specifies the number of contiguous destination transfers of
@@ -2113,10 +2113,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED45;
   __IO uint32_t  DAR5;                              /*!< Current Destination Address of DMA transfer                           */
   __I  uint32_t  RESERVED46;
-  
+
   union {
     __IO uint32_t  LLP5;                            /*!< Linked List Pointer Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  LMS        :  2;               /*!< Identifies the AHB layer/interface where the memory device that
                                                          stores the next linked list item resides.                             */
@@ -2125,10 +2125,10 @@ typedef struct {                                    /*!< DMA Structure          
     } LLP5_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED47;
-  
+
   union {
     __IO uint32_t  CTL_LOW5;                        /*!< Lower 32-bits Control Register for Channel                            */
-    
+
     struct {
       __IO uint32_t  INT_EN     :  1;               /*!< Interrupt Enable Bit                                                  */
       __IO uint32_t  DST_TR_WIDTH:  3;              /*!< Destination Transfer Width                                            */
@@ -2147,10 +2147,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  LLP_SRC_EN :  1;               /*!< Block chaining is enabled on the source side                          */
     } CTL_LOW5_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CTL_HI5;                         /*!< Higher 32-bits Control Register for Channel                           */
-    
+
     struct {
       __IO uint32_t  BLOCK_TS   : 12;               /*!< indicates the total number of single transactions to perform
                                                          for every block transfer                                              */
@@ -2165,10 +2165,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED50;
   __IO uint32_t  DSTATAR5;                          /*!< Destination Status Address Register for Channel                       */
   __I  uint32_t  RESERVED51;
-  
+
   union {
     __IO uint32_t  CFG_LOW5;                        /*!< Lower 32-bit Configuration Register for Channel                       */
-    
+
     struct {
            uint32_t             :  5;
       __IO uint32_t  CH_PRIOR   :  3;               /*!< Channel priority. A priority of 7 is the highest priority             */
@@ -2188,10 +2188,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  RELOAD_DST :  1;               /*!< Automatic Destination Reload                                          */
     } CFG_LOW5_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CFG_HI5;                         /*!< Higher 32-bit Configuration Register for Channel                      */
-    
+
     struct {
       __IO uint32_t  FCMODE     :  1;               /*!< if source transaction requests aren't serviced when the Destination
                                                          Peripheral is the flow controller.                                    */
@@ -2203,20 +2203,20 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  SS_UPD_EN  :  1;               /*!< STATx is only updated from STATARx                                    */
     } CFG_HI5_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  SGR5;                            /*!< Source Gather Register for Channel                                    */
-    
+
     struct {
       __IO uint32_t  SGI        : 20;               /*!< Source gather interval                                                */
       __IO uint32_t  SGC        : 12;               /*!< Specifies the number of contiguous source transfers of CTLx.SRC_TR_WIDTH */
     } SGR5_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED52;
-  
+
   union {
     __IO uint32_t  DSR5;                            /*!< Destination Scatter Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  DSI        : 20;               /*!< Destination scatter interval                                          */
       __IO uint32_t  DSC        : 12;               /*!< Specifies the number of contiguous destination transfers of
@@ -2228,10 +2228,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED54;
   __IO uint32_t  DAR6;                              /*!< Current Destination Address of DMA transfer                           */
   __I  uint32_t  RESERVED55;
-  
+
   union {
     __IO uint32_t  LLP6;                            /*!< Linked List Pointer Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  LMS        :  2;               /*!< Identifies the AHB layer/interface where the memory device that
                                                          stores the next linked list item resides.                             */
@@ -2240,10 +2240,10 @@ typedef struct {                                    /*!< DMA Structure          
     } LLP6_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED56;
-  
+
   union {
     __IO uint32_t  CTL_LOW6;                        /*!< Lower 32-bits Control Register for Channel                            */
-    
+
     struct {
       __IO uint32_t  INT_EN     :  1;               /*!< Interrupt Enable Bit                                                  */
       __IO uint32_t  DST_TR_WIDTH:  3;              /*!< Destination Transfer Width                                            */
@@ -2262,10 +2262,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  LLP_SRC_EN :  1;               /*!< Block chaining is enabled on the source side                          */
     } CTL_LOW6_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CTL_HI6;                         /*!< Higher 32-bits Control Register for Channel                           */
-    
+
     struct {
       __IO uint32_t  BLOCK_TS   : 12;               /*!< indicates the total number of single transactions to perform
                                                          for every block transfer                                              */
@@ -2280,10 +2280,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED59;
   __IO uint32_t  DSTATAR6;                          /*!< Destination Status Address Register for Channel                       */
   __I  uint32_t  RESERVED60;
-  
+
   union {
     __IO uint32_t  CFG_LOW6;                        /*!< Lower 32-bit Configuration Register for Channel                       */
-    
+
     struct {
            uint32_t             :  5;
       __IO uint32_t  CH_PRIOR   :  3;               /*!< Channel priority. A priority of 7 is the highest priority             */
@@ -2303,10 +2303,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  RELOAD_DST :  1;               /*!< Automatic Destination Reload                                          */
     } CFG_LOW6_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CFG_HI6;                         /*!< Higher 32-bit Configuration Register for Channel                      */
-    
+
     struct {
       __IO uint32_t  FCMODE     :  1;               /*!< if source transaction requests aren't serviced when the Destination
                                                          Peripheral is the flow controller.                                    */
@@ -2318,20 +2318,20 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  SS_UPD_EN  :  1;               /*!< STATx is only updated from STATARx                                    */
     } CFG_HI6_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  SGR6;                            /*!< Source Gather Register for Channel                                    */
-    
+
     struct {
       __IO uint32_t  SGI        : 20;               /*!< Source gather interval                                                */
       __IO uint32_t  SGC        : 12;               /*!< Specifies the number of contiguous source transfers of CTLx.SRC_TR_WIDTH */
     } SGR6_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED61;
-  
+
   union {
     __IO uint32_t  DSR6;                            /*!< Destination Scatter Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  DSI        : 20;               /*!< Destination scatter interval                                          */
       __IO uint32_t  DSC        : 12;               /*!< Specifies the number of contiguous destination transfers of
@@ -2343,10 +2343,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED63;
   __IO uint32_t  DAR7;                              /*!< Current Destination Address of DMA transfer                           */
   __I  uint32_t  RESERVED64;
-  
+
   union {
     __IO uint32_t  LLP7;                            /*!< Linked List Pointer Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  LMS        :  2;               /*!< Identifies the AHB layer/interface where the memory device that
                                                          stores the next linked list item resides.                             */
@@ -2355,10 +2355,10 @@ typedef struct {                                    /*!< DMA Structure          
     } LLP7_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED65;
-  
+
   union {
     __IO uint32_t  CTL_LOW7;                        /*!< Lower 32-bits Control Register for Channel                            */
-    
+
     struct {
       __IO uint32_t  INT_EN     :  1;               /*!< Interrupt Enable Bit                                                  */
       __IO uint32_t  DST_TR_WIDTH:  3;              /*!< Destination Transfer Width                                            */
@@ -2377,10 +2377,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  LLP_SRC_EN :  1;               /*!< Block chaining is enabled on the source side                          */
     } CTL_LOW7_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CTL_HI7;                         /*!< Higher 32-bits Control Register for Channel                           */
-    
+
     struct {
       __IO uint32_t  BLOCK_TS   : 12;               /*!< indicates the total number of single transactions to perform
                                                          for every block transfer                                              */
@@ -2395,10 +2395,10 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint32_t  RESERVED68;
   __IO uint32_t  DSTATAR7;                          /*!< Destination Status Address Register for Channel                       */
   __I  uint32_t  RESERVED69;
-  
+
   union {
     __IO uint32_t  CFG_LOW7;                        /*!< Lower 32-bit Configuration Register for Channel                       */
-    
+
     struct {
            uint32_t             :  5;
       __IO uint32_t  CH_PRIOR   :  3;               /*!< Channel priority. A priority of 7 is the highest priority             */
@@ -2418,10 +2418,10 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  RELOAD_DST :  1;               /*!< Automatic Destination Reload                                          */
     } CFG_LOW7_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CFG_HI7;                         /*!< Higher 32-bit Configuration Register for Channel                      */
-    
+
     struct {
       __IO uint32_t  FCMODE     :  1;               /*!< if source transaction requests aren't serviced when the Destination
                                                          Peripheral is the flow controller.                                    */
@@ -2433,20 +2433,20 @@ typedef struct {                                    /*!< DMA Structure          
       __IO uint32_t  SS_UPD_EN  :  1;               /*!< STATx is only updated from STATARx                                    */
     } CFG_HI7_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  SGR7;                            /*!< Source Gather Register for Channel                                    */
-    
+
     struct {
       __IO uint32_t  SGI        : 20;               /*!< Source gather interval                                                */
       __IO uint32_t  SGC        : 12;               /*!< Specifies the number of contiguous source transfers of CTLx.SRC_TR_WIDTH */
     } SGR7_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED70;
-  
+
   union {
     __IO uint32_t  DSR7;                            /*!< Destination Scatter Register for Channel                              */
-    
+
     struct {
       __IO uint32_t  DSI        : 20;               /*!< Destination scatter interval                                          */
       __IO uint32_t  DSC        : 12;               /*!< Specifies the number of contiguous destination transfers of
@@ -2464,50 +2464,50 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint8_t   RESERVED75[7];
   __I  uint8_t   INT_ERR;                           /*!< Error                                                                 */
   __I  uint8_t   RESERVED76[7];
-  
+
   union {
     __IO uint16_t  INT_EN_TFR;                      /*!< DMA Transfer Complete                                                 */
-    
+
     struct {
       __IO uint16_t  EN         :  8;               /*!< interrupt enable                                                      */
       __IO uint16_t  WE         :  8;               /*!< interrupt enable write enable                                         */
     } INT_EN_TFR_b;                                 /*!< BitSize                                                               */
   };
   __I  uint16_t  RESERVED77[3];
-  
+
   union {
     __IO uint16_t  INT_EN_BLOCK;                    /*!< Block Transfer Complete                                               */
-    
+
     struct {
       __IO uint16_t  EN         :  8;               /*!< interrupt enable                                                      */
       __IO uint16_t  WE         :  8;               /*!< interrupt enable write enable                                         */
     } INT_EN_BLOCK_b;                               /*!< BitSize                                                               */
   };
   __I  uint16_t  RESERVED78[3];
-  
+
   union {
     __IO uint16_t  INT_EN_SRC_TRAN;                 /*!< Source Transaction Complete                                           */
-    
+
     struct {
       __IO uint16_t  EN         :  8;               /*!< interrupt enable                                                      */
       __IO uint16_t  WE         :  8;               /*!< interrupt enable write enable                                         */
     } INT_EN_SRC_TRAN_b;                            /*!< BitSize                                                               */
   };
   __I  uint16_t  RESERVED79[3];
-  
+
   union {
     __IO uint16_t  INT_EN_DST_TRAN;                 /*!< Destination Transaction Complete                                      */
-    
+
     struct {
       __IO uint16_t  EN         :  8;               /*!< interrupt enable                                                      */
       __IO uint16_t  WE         :  8;               /*!< interrupt enable write enable                                         */
     } INT_EN_DST_TRAN_b;                            /*!< BitSize                                                               */
   };
   __I  uint16_t  RESERVED80[3];
-  
+
   union {
     __IO uint16_t  INT_EN_ERR;                      /*!< Error                                                                 */
-    
+
     struct {
       __IO uint16_t  EN         :  8;               /*!< interrupt enable                                                      */
       __IO uint16_t  WE         :  8;               /*!< interrupt enable write enable                                         */
@@ -2524,29 +2524,29 @@ typedef struct {                                    /*!< DMA Structure          
   __I  uint8_t   RESERVED85[7];
   __O  uint8_t   INT_CLEAR_ERR;                     /*!< Error                                                                 */
   __I  uint8_t   RESERVED86[63];
-  
+
   union {
     __IO uint32_t  DMA_EN;                          /*!< DW_ahb_dmac Configuration Register                                    */
-    
+
     struct {
       __IO uint32_t  EN         :  1;               /*!< enable                                                                */
     } DMA_EN_b;                                     /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED87;
-  
+
   union {
     __IO uint32_t  CH_EN;                           /*!< DW_ahb_dmac Channel Enable Register                                   */
-    
+
     struct {
       __IO uint32_t  EN         :  8;               /*!< enable                                                                */
       __IO uint32_t  WE         :  8;               /*!< enable write enable                                                   */
     } CH_EN_b;                                      /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED88[10];
-  
+
   union {
     __I  uint32_t  DMA_COMP_PARAMS_6_HI;            /*!< Component Parameters for channel 7                                    */
-    
+
     struct {
       __I  uint32_t  DTW        :  3;               /*!< If this is not hardcoded, then software can program the destination
                                                          transfer width.                                                       */
@@ -2569,10 +2569,10 @@ typedef struct {                                    /*!< DMA Structure          
       __I  uint32_t  FIFO_DEPTH :  3;               /*!< FIFO depth in bytes                                                   */
     } DMA_COMP_PARAMS_6_HI_b;                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  DMA_COMP_PARAMS_5_LOW;           /*!< Component Parameters for channel 6                                    */
-    
+
     struct {
       __I  uint32_t  DTW        :  3;               /*!< If this is not hardcoded, then software can program the destination
                                                          transfer width.                                                       */
@@ -2595,10 +2595,10 @@ typedef struct {                                    /*!< DMA Structure          
       __I  uint32_t  FIFO_DEPTH :  3;               /*!< FIFO depth in bytes                                                   */
     } DMA_COMP_PARAMS_5_LOW_b;                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  DMA_COMP_PARAMS_5_HI;            /*!< Component Parameters for channel 5                                    */
-    
+
     struct {
       __I  uint32_t  DTW        :  3;               /*!< If this is not hardcoded, then software can program the destination
                                                          transfer width.                                                       */
@@ -2621,10 +2621,10 @@ typedef struct {                                    /*!< DMA Structure          
       __I  uint32_t  FIFO_DEPTH :  3;               /*!< FIFO depth in bytes                                                   */
     } DMA_COMP_PARAMS_5_HI_b;                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  DMA_COMP_PARAMS_4_LOW;           /*!< Component Parameters for channel 4                                    */
-    
+
     struct {
       __I  uint32_t  DTW        :  3;               /*!< If this is not hardcoded, then software can program the destination
                                                          transfer width.                                                       */
@@ -2647,10 +2647,10 @@ typedef struct {                                    /*!< DMA Structure          
       __I  uint32_t  FIFO_DEPTH :  3;               /*!< FIFO depth in bytes                                                   */
     } DMA_COMP_PARAMS_4_LOW_b;                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  DMA_COMP_PARAMS_4_HI;            /*!< Component Parameters for channel 3                                    */
-    
+
     struct {
       __I  uint32_t  DTW        :  3;               /*!< If this is not hardcoded, then software can program the destination
                                                          transfer width.                                                       */
@@ -2673,10 +2673,10 @@ typedef struct {                                    /*!< DMA Structure          
       __I  uint32_t  FIFO_DEPTH :  3;               /*!< FIFO depth in bytes                                                   */
     } DMA_COMP_PARAMS_4_HI_b;                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  DMA_COMP_PARAMS_3_LOW;           /*!< Component Parameters for channel 2                                    */
-    
+
     struct {
       __I  uint32_t  DTW        :  3;               /*!< If this is not hardcoded, then software can program the destination
                                                          transfer width.                                                       */
@@ -2699,10 +2699,10 @@ typedef struct {                                    /*!< DMA Structure          
       __I  uint32_t  FIFO_DEPTH :  3;               /*!< FIFO depth in bytes                                                   */
     } DMA_COMP_PARAMS_3_LOW_b;                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  DMA_COMP_PARAMS_3_HI;            /*!< Component Parameters for channel 1                                    */
-    
+
     struct {
       __I  uint32_t  DTW        :  3;               /*!< If this is not hardcoded, then software can program the destination
                                                          transfer width.                                                       */
@@ -2725,10 +2725,10 @@ typedef struct {                                    /*!< DMA Structure          
       __I  uint32_t  FIFO_DEPTH :  3;               /*!< FIFO depth in bytes                                                   */
     } DMA_COMP_PARAMS_3_HI_b;                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  DMA_COMP_PARAMS_2_LOW;           /*!< Component Parameters for channel 0                                    */
-    
+
     struct {
       __I  uint32_t  DTW        :  3;               /*!< If this is not hardcoded, then software can program the destination
                                                          transfer width.                                                       */
@@ -2752,10 +2752,10 @@ typedef struct {                                    /*!< DMA Structure          
     } DMA_COMP_PARAMS_2_LOW_b;                      /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED89;
-  
+
   union {
     __I  uint32_t  DMA_COMP_PARAMS_1_LOW;           /*!< Maximum block size for channel                                        */
-    
+
     struct {
       __I  uint32_t  CH0_MAX_BLK_SIZE:  4;          /*!< Maximum block size for channel 0.                                     */
       __I  uint32_t  CH1_MAX_BLK_SIZE:  4;          /*!< Maximum block size for channel 1                                      */
@@ -2780,10 +2780,10 @@ typedef struct {                                    /*!< DMA Structure          
   */
 
 typedef struct {                                    /*!< ETH Structure                                                         */
-  
+
   union {
     __IO uint32_t  CONFIG;                          /*!< MAC Configuration Register                                            */
-    
+
     struct {
       __IO uint32_t  PRELEN     :  2;               /*!< Preamble Length for Transmit frames                                   */
       __IO uint32_t  RX_EN      :  1;               /*!< Receiver Enable                                                       */
@@ -2813,10 +2813,10 @@ typedef struct {                                    /*!< ETH Structure          
       __IO uint32_t  SARC       :  3;               /*!< Source Address Insertion or Replacement Control                       */
     } CONFIG_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  FF;                              /*!< MAC Frame Filter                                                      */
-    
+
     struct {
       __IO uint32_t  PR         :  1;               /*!< Receive all frames in spite of source and destination address         */
       __IO uint32_t  HUC        :  1;               /*!< if 1, don't compare DA field in destination address filtering
@@ -2843,10 +2843,10 @@ typedef struct {                                    /*!< ETH Structure          
   };
   __IO uint32_t  HTH;                               /*!< Hash Table High Register                                              */
   __IO uint32_t  HTL;                               /*!< Hash Table Low Register                                               */
-  
+
   union {
     __IO uint32_t  GMII_ADDR;                       /*!< GMII Address Register                                                 */
-    
+
     struct {
       __IO uint32_t  BUSY       :  1;               /*!< GMII Busy                                                             */
       __IO uint32_t  GW         :  1;               /*!< GMII write or read                                                    */
@@ -2858,10 +2858,10 @@ typedef struct {                                    /*!< ETH Structure          
     } GMII_ADDR_b;                                  /*!< BitSize                                                               */
   };
   __IO uint32_t  GMII_DATA;                         /*!< GMII Data Register                                                    */
-  
+
   union {
     __IO uint32_t  FC;                              /*!< Flow Control Register                                                 */
-    
+
     struct {
       __IO uint32_t  FCB        :  1;               /*!< This bit initiates a Pause frame in the full-duplex mode              */
       __IO uint32_t  TFE        :  1;               /*!< MAC enables the flow control operation to transmit Pause frames       */
@@ -2869,10 +2869,10 @@ typedef struct {                                    /*!< ETH Structure          
       __IO uint32_t  UP         :  1;               /*!< MAC can detect Pause frames with unicast address of the station       */
     } FC_b;                                         /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  VLAN_TAG;                        /*!< VLAN Tag Register                                                     */
-    
+
     struct {
       __IO uint32_t  VL         : 16;               /*!< VLAN Tag Identifier for Receive Frames                                */
       __IO uint32_t  ETV        :  1;               /*!< Enable 12-Bit VLAN Tag Comparison                                     */
@@ -2886,10 +2886,10 @@ typedef struct {                                    /*!< ETH Structure          
   };
   __I  uint32_t  RESERVED0[2];
   __IO uint32_t  RWUFFR;                            /*!< Remote Wake-Up Frame Filter Register                                  */
-  
+
   union {
     __IO uint32_t  PMTCSR;                          /*!< PMT Control and Status Register                                       */
-    
+
     struct {
       __IO uint32_t  PWRDWN     :  1;               /*!< Power Down                                                            */
       __IO uint32_t  MGKPKTEN   :  1;               /*!< Magic Packet Enable                                                   */
@@ -2914,10 +2914,10 @@ typedef struct {                                    /*!< ETH Structure          
   __IO uint16_t  ADDR0_HIGH;                        /*!< MAC Address0 High Register                                            */
   __I  uint16_t  RESERVED2;
   __IO uint32_t  ADDR0_LOW;                         /*!< MAC Address0 LOW Register                                             */
-  
+
   union {
     __IO uint32_t  ADDR1_HIGH;                      /*!< MAC Address0 High Register                                            */
-    
+
     struct {
       __IO uint32_t  ADDR       : 16;               /*!< MAC Address1 [47:32]                                                  */
            uint32_t             : 14;
@@ -2928,10 +2928,10 @@ typedef struct {                                    /*!< ETH Structure          
   };
   __IO uint32_t  ADDR1_LOW;                         /*!< MAC Address1 LOW Register                                             */
   __I  uint32_t  RESERVED3[44];
-  
+
   union {
     __IO uint32_t  MMCCR;                           /*!< MMC Control Register                                                  */
-    
+
     struct {
       __IO uint32_t  CNTRST     :  1;               /*!< Counters Reset                                                        */
       __IO uint32_t  CNTSTOPRO  :  1;               /*!< Counter Stop Rollover                                                 */
@@ -2950,10 +2950,10 @@ typedef struct {                                    /*!< ETH Structure          
   __I  uint32_t  RESERVED4[59];
   __IO uint32_t  MMCIRCOIM;                         /*!< MMC IPC Receive Checksum Offload Interrupt Mask                       */
   __I  uint32_t  RESERVED5[319];
-  
+
   union {
     __IO uint32_t  PTPTSCR;                         /*!< Timestamp Control Register                                            */
-    
+
     struct {
       __IO uint32_t  TSENA      :  1;               /*!< Timestamp Enable                                                      */
       __IO uint32_t  TSCFUPDT   :  1;               /*!< Timestamp Fine or Coarse Update                                       */
@@ -2972,10 +2972,10 @@ typedef struct {                                    /*!< ETH Structure          
   __IO uint32_t  PTPTTHR;                           /*!< Target Time Seconds Register                                          */
   __IO uint32_t  PTPTTLR;                           /*!< Target Time Nanoseconds Register                                      */
   __I  uint32_t  RESERVED6[567];
-  
+
   union {
     __IO uint32_t  BUS_MODE;                        /*!< Flow Control Register                                                 */
-    
+
     struct {
       __IO uint32_t  SWR        :  1;               /*!< Software Reset                                                        */
       __IO uint32_t  DA         :  1;               /*!< This bit specifies the arbitration scheme between the transmit
@@ -3006,10 +3006,10 @@ typedef struct {                                    /*!< ETH Structure          
   __IO uint32_t  RPD;                               /*!< Receive Poll Demand                                                   */
   __IO uint32_t  RDESLA;                            /*!< Receive Descriptor List Address                                       */
   __IO uint32_t  TDESLA;                            /*!< Transmit Descriptor List Address                                      */
-  
+
   union {
     __IO uint32_t  STATUS;                          /*!< Status Register                                                       */
-    
+
     struct {
       __IO uint32_t  TI         :  1;               /*!< This bit indicates that the frame transmission is complete            */
       __IO uint32_t  TPS        :  1;               /*!< Transmit Process Stopped                                              */
@@ -3038,10 +3038,10 @@ typedef struct {                                    /*!< ETH Structure          
       __I  uint32_t  TTI        :  1;               /*!< Timestamp Trigger Interrupt                                           */
     } STATUS_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  OPERATION;                       /*!< Operation Mode Register                                               */
-    
+
     struct {
            uint32_t             :  1;
       __IO uint32_t  SR         :  1;               /*!< Start or Stop Receive                                                 */
@@ -3063,10 +3063,10 @@ typedef struct {                                    /*!< ETH Structure          
                                                          frame has been written to it,                                         */
     } OPERATION_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INT_EN;                          /*!< Interrupt Enable Register                                             */
-    
+
     struct {
       __IO uint32_t  TIE        :  1;               /*!< Transmit Interrupt Enable                                             */
       __IO uint32_t  TSE        :  1;               /*!< Transmit Stopped Enable                                               */
@@ -3087,10 +3087,10 @@ typedef struct {                                    /*!< ETH Structure          
     } INT_EN_b;                                     /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED7[3];
-  
+
   union {
     __IO uint32_t  AHB_STATUS;                      /*!< AHB Status Register                                                   */
-    
+
     struct {
       __IO uint32_t  BUSY       :  1;               /*!< If set, it indicates that the AHB master interface FSMs are
                                                          in the non-idle state                                                 */
@@ -3114,10 +3114,10 @@ typedef struct {                                    /*!< ETH Structure          
   */
 
 typedef struct {                                    /*!< USB Structure                                                         */
-  
+
   union {
     __IO uint32_t  GOTGCTL;                         /*!< Control and Status register                                           */
-    
+
     struct {
       __I  uint32_t  SES_REQ_SCS:  1;               /*!< set when a session request initiation is successful as a device       */
       __IO uint32_t  SES_SEQ    :  1;               /*!< set to initiate a session request on the USB as a device              */
@@ -3146,10 +3146,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  OTG_VER    :  1;               /*!< If 0, OTG Version 1.3. If 1, OTG Version 2.0.                         */
     } GOTGCTL_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  GOTGINT;                         /*!< OTG interrupt Register                                                */
-    
+
     struct {
            uint32_t             :  2;
       __IO uint32_t  SES_END_DET:  1;               /*!< Set when the utmiotg_bvalid signal is deasserted                      */
@@ -3162,10 +3162,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DBNCE_DONE :  1;               /*!< debounce is completed after the device connect as a host              */
     } GOTGINT_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  GAHBCFG;                         /*!< AHB Configuration Register                                            */
-    
+
     struct {
       __IO uint32_t  GLBL_INTR_EN:  1;              /*!< Global Interrupt Enable                                               */
       __IO uint32_t  BST_LEN    :  4;               /*!< Burst Length/Type                                                     */
@@ -3178,10 +3178,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  AHB_SINGLE :  1;               /*!< supports Single transfers for the remaining data in a transfer        */
     } GAHBCFG_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  GUSBCFG;                         /*!< USB Configuration Register                                            */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  PHY_IF     :  1;               /*!< PHY Interface                                                         */
@@ -3203,10 +3203,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  FORCE_DEVICE_MODE:  1;         /*!< Force Device Mode                                                     */
     } GUSBCFG_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  GRSTCTL;                         /*!< Reset Register                                                        */
-    
+
     struct {
       __IO uint32_t  CORE_SOFT_RST:  1;             /*!< Core Soft Reset                                                       */
            uint32_t             :  1;
@@ -3222,10 +3222,10 @@ typedef struct {                                    /*!< USB Structure          
       __I  uint32_t  AHB_IDLE   :  1;               /*!< Indicates that the AHB Master State Machine is in the IDLE condition  */
     } GRSTCTL_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  GINTSTS;                         /*!< Interrupt Register                                                    */
-    
+
     struct {
       __I  uint32_t  CUR_MOD    :  1;               /*!< Current Mode of Operation                                             */
       __IO uint32_t  MODE_MIS   :  1;               /*!< Mode Mismatch Interrupt                                               */
@@ -3264,10 +3264,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  WAKEUP     :  1;               /*!< Resume/Remote Wakeup Detected Interrupt                               */
     } GINTSTS_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  GINTEN;                          /*!< Interrupt enable Register                                             */
-    
+
     struct {
            uint32_t             :  1;
       __IO uint32_t  MODE_MIS   :  1;               /*!< Mode Mismatch                                                         */
@@ -3306,10 +3306,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  WAKEUP     :  1;               /*!< Resume/Remote Wakeup Detected Interrupt                               */
     } GINTEN_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  GRXSTSR;                         /*!< Returns the contents of the top of the Receive FIFO                   */
-    
+
     struct {
       __I  uint32_t  CH_EP_NUM  :  4;               /*!< channel number as a host or EP number as a device                     */
       __I  uint32_t  BCNT       : 11;               /*!< byte count of the received packet                                     */
@@ -3319,10 +3319,10 @@ typedef struct {                                    /*!< USB Structure          
                                                          the packet is received on the USB                                     */
     } GRXSTSR_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  GRXSTSP;                         /*!< Pop the contents of the top of the Receive FIFO                       */
-    
+
     struct {
       __I  uint32_t  CH_EP_NUM  :  4;               /*!< channel number as a host or EP number as a device                     */
       __I  uint32_t  BCNT       : 11;               /*!< byte count of the received packet                                     */
@@ -3335,10 +3335,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  GRXFSIZ;                           /*!< This value is in terms of 32-bit words, 16 is minimize and 32768
                                                          is max                                                                */
   __I  uint16_t  RESERVED0;
-  
+
   union {
     __IO uint32_t  GNPTXFSIZ;                       /*!< Non-Periodic Transmit FIFO Size Register                              */
-    
+
     struct {
       __IO uint32_t  NTRSA_INEF0TRSA: 16;           /*!< start address for Non-periodic Transmit FIFO RAM as a host or
                                                          IN Endpoint FIFO0 Transmit RAM as a device                            */
@@ -3347,10 +3347,10 @@ typedef struct {                                    /*!< USB Structure          
                                                           0 Depth as a device                                                  */
     } GNPTXFSIZ_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  GNPTXSTS;                        /*!< Non-Periodic Transmit FIFO/Queue Status Register                      */
-    
+
     struct {
       __I  uint32_t  NTSA       : 16;               /*!< the amount of free space available in the Non-periodic TxFIFO,
                                                          max is 32768.                                                         */
@@ -3364,10 +3364,10 @@ typedef struct {                                    /*!< USB Structure          
     } GNPTXSTS_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED1[5];
-  
+
   union {
     __I  uint32_t  GHWCFG1;                         /*!< User HW Config1 Register                                              */
-    
+
     struct {
       __I  uint32_t  EP0_DIR    :  2;               /*!< Endpoint 0 direction, always Bidirection                              */
       __I  uint32_t  EP1_DIR    :  2;               /*!< Endpoint 1 direction                                                  */
@@ -3388,18 +3388,18 @@ typedef struct {                                    /*!< USB Structure          
     } GHWCFG1_b;                                    /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED2[3];
-  
+
   union {
     __IO uint32_t  GLPMCFG;                         /*!< Core LPM Configuration Register                                       */
-    
+
     struct {
       __IO uint32_t  EP0_DIR    :  1;               /*!< LPM capability is enabled                                             */
     } GLPMCFG_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  GPWRDN;                          /*!< Global Power Down Register                                            */
-    
+
     struct {
            uint32_t             :  1;
       __IO uint32_t  PMU_ACTIVE :  1;               /*!< PMU Active is enabled                                                 */
@@ -3420,165 +3420,165 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  ADP_INT    :  1;               /*!< set whenever there is a ADP event                                     */
     } GPWRDN_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  GDFIFOCFG;                       /*!< Global DFIFO Software Config Register                                 */
-    
+
     struct {
       __IO uint32_t  GDFIFOCFG  : 16;               /*!< This field is for dynamic programming of the DFIFO Size.              */
       __IO uint32_t  EPIBA      : 16;               /*!< This field provides the start address of the EP info controller       */
     } GDFIFOCFG_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED3[40];
-  
+
   union {
     __IO uint32_t  HPTXFSIZ;                        /*!< Host Periodic Transmit FIFO Size Register                             */
-    
+
     struct {
       __IO uint32_t  HPTSA      : 16;               /*!< start address of the Periodic TxFIFO                                  */
       __IO uint32_t  EPIBA      : 16;               /*!< the size of the Periodic TxFIFO                                       */
     } HPTXFSIZ_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF1;                        /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF1_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF2;                        /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF2_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF3;                        /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF3_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF4;                        /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF4_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF5;                        /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF5_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF6;                        /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF6_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF7;                        /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF7_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF8;                        /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF8_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF9;                        /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF9_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF10;                       /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF10_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF11;                       /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF11_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF12;                       /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF12_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF13;                       /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF13_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF14;                       /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF14_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DIEPTXF15;                       /*!< Device In Endpoint Transmit FIFO Size Register                        */
-    
+
     struct {
       __IO uint32_t  INEFTRSA   : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  INETFD     : 16;               /*!< IN Endpoint TxFIFO Depth                                              */
     } DIEPTXF15_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED4[176];
-  
+
   union {
     __IO uint32_t  HCFG;                            /*!< Host Configuration Register                                           */
-    
+
     struct {
       __IO uint32_t  FS_LS_PCS  :  2;               /*!< FS/LS PHY Clock Select as a host                                      */
       __IO uint32_t  FS_LS_SUPPORT:  1;             /*!< If set, FS/LS-only, even If the connected device can support
@@ -3596,19 +3596,19 @@ typedef struct {                                    /*!< USB Structure          
                                                           00 after Suspend or LPM.                                             */
     } HCFG_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HFIR;                            /*!< Host Frame Interval Register                                          */
-    
+
     struct {
       __IO uint32_t  FI         : 16;               /*!< IN Endpoint FIFOn Transmit RAM Start Address                          */
       __IO uint32_t  RC         :  1;               /*!< The HFIR can be dynamically reloaded during runtime if set            */
     } HFIR_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  HFNUM;                           /*!< Host Frame Number/Frame Time Remaining Register                       */
-    
+
     struct {
       __I  uint32_t  FN         : 16;               /*!< This field increments when a new SOF is transmitted on the USB        */
       __I  uint32_t  FTR        : 16;               /*!< amount of time remaining in the current microframe (HS) or Frame
@@ -3616,10 +3616,10 @@ typedef struct {                                    /*!< USB Structure          
     } HFNUM_b;                                      /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED5;
-  
+
   union {
     __I  uint32_t  HPTXSTS;                         /*!< Host Periodic Transmit FIFO/Queue Status Register                     */
-    
+
     struct {
       __I  uint32_t  PTDFSA     : 16;               /*!< Indicates the number of free locations available to be written
                                                          to in the Periodic TxFIFO, max is 32768                               */
@@ -3633,28 +3633,28 @@ typedef struct {                                    /*!< USB Structure          
       __I  uint32_t  TPTRQ_ODD_FRAME:  1;           /*!< If set, send in odd (micro)Frame                                      */
     } HPTXSTS_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  HAINT;                           /*!< Host All Channels Interrupt Register                                  */
-    
+
     struct {
       __I  uint32_t  INT        : 16;               /*!< Channel Interrupts, from 0 to 15.                                     */
     } HAINT_b;                                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HAINT_EN;                        /*!< Host All Channels Interrupt Enable Register                           */
-    
+
     struct {
       __IO uint32_t  EN         : 16;               /*!< Channel Interrupts Enable, from 0 to 15.                              */
     } HAINT_EN_b;                                   /*!< BitSize                                                               */
   };
   __IO uint32_t  HFLBA;                             /*!< The starting address of the Frame list                                */
   __I  uint32_t  RESERVED6[8];
-  
+
   union {
     __IO uint32_t  __HPRT;                          /*!< Host Port Control and Status Register                                 */
-    
+
     struct {
       __I  uint32_t  PCS        :  1;               /*!< If a device is attached to the port                                   */
       __IO uint32_t  PCD        :  1;               /*!< A device connection is detected                                       */
@@ -3678,10 +3678,10 @@ typedef struct {                                    /*!< USB Structure          
     } __HPRT_b;                                     /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED7[47];
-  
+
   union {
     __IO uint32_t  HCC0;                            /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3700,10 +3700,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC0_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED8;
-  
+
   union {
     __IO uint32_t  HCINT0;                          /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3715,10 +3715,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT0_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN0;                       /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3730,10 +3730,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN0_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ0;                         /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -3744,10 +3744,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ0_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA0;                          /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -3756,10 +3756,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED9;
   __IO uint32_t  HCDMAB0;                           /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC1;                            /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3778,10 +3778,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC1_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED10;
-  
+
   union {
     __IO uint32_t  HCINT1;                          /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3793,10 +3793,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT1_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN1;                       /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3808,10 +3808,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN1_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ1;                         /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -3822,10 +3822,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ1_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA1;                          /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -3834,10 +3834,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED11;
   __IO uint32_t  HCDMAB1;                           /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC2;                            /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3856,10 +3856,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC2_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED12;
-  
+
   union {
     __IO uint32_t  HCINT2;                          /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3871,10 +3871,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT2_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN2;                       /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3886,10 +3886,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN2_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ2;                         /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -3900,10 +3900,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ2_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA2;                          /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -3912,10 +3912,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED13;
   __IO uint32_t  HCDMAB2;                           /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC3;                            /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3934,10 +3934,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC3_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED14;
-  
+
   union {
     __IO uint32_t  HCINT3;                          /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3949,10 +3949,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT3_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN3;                       /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -3964,10 +3964,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN3_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ3;                         /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -3978,10 +3978,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ3_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA3;                          /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -3990,10 +3990,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED15;
   __IO uint32_t  HCDMAB3;                           /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC4;                            /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4012,10 +4012,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC4_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED16;
-  
+
   union {
     __IO uint32_t  HCINT4;                          /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4027,10 +4027,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT4_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN4;                       /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4042,10 +4042,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN4_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ4;                         /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4056,10 +4056,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ4_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA4;                          /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4068,10 +4068,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED17;
   __IO uint32_t  HCDMAB4;                           /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC5;                            /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4090,10 +4090,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC5_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED18;
-  
+
   union {
     __IO uint32_t  HCINT5;                          /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4105,10 +4105,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT5_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN5;                       /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4120,10 +4120,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN5_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ5;                         /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4134,10 +4134,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ5_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA5;                          /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4146,10 +4146,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED19;
   __IO uint32_t  HCDMAB5;                           /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC6;                            /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4168,10 +4168,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC6_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED20;
-  
+
   union {
     __IO uint32_t  HCINT6;                          /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4183,10 +4183,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT6_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN6;                       /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4198,10 +4198,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN6_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ6;                         /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4212,10 +4212,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ6_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA6;                          /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4224,10 +4224,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED21;
   __IO uint32_t  HCDMAB6;                           /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC7;                            /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4246,10 +4246,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC7_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED22;
-  
+
   union {
     __IO uint32_t  HCINT7;                          /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4261,10 +4261,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT7_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN7;                       /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4276,10 +4276,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN7_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ7;                         /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4290,10 +4290,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ7_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA7;                          /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4302,10 +4302,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED23;
   __IO uint32_t  HCDMAB7;                           /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC8;                            /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4324,10 +4324,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC8_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED24;
-  
+
   union {
     __IO uint32_t  HCINT8;                          /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4339,10 +4339,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT8_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN8;                       /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4354,10 +4354,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN8_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ8;                         /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4368,10 +4368,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ8_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA8;                          /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4380,10 +4380,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED25;
   __IO uint32_t  HCDMAB8;                           /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC9;                            /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4402,10 +4402,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC9_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED26;
-  
+
   union {
     __IO uint32_t  HCINT9;                          /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4417,10 +4417,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT9_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN9;                       /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4432,10 +4432,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN9_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ9;                         /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4446,10 +4446,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ9_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA9;                          /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4458,10 +4458,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED27;
   __IO uint32_t  HCDMAB9;                           /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC10;                           /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4480,10 +4480,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC10_b;                                      /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED28;
-  
+
   union {
     __IO uint32_t  HCINT10;                         /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4495,10 +4495,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT10_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN10;                      /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4510,10 +4510,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN10_b;                                 /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ10;                        /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4524,10 +4524,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ10_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA10;                         /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4536,10 +4536,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED29;
   __IO uint32_t  HCDMAB10;                          /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC11;                           /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4558,10 +4558,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC11_b;                                      /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED30;
-  
+
   union {
     __IO uint32_t  HCINT11;                         /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4573,10 +4573,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT11_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN11;                      /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4588,10 +4588,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN11_b;                                 /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ11;                        /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4602,10 +4602,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ11_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA11;                         /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4614,10 +4614,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED31;
   __IO uint32_t  HCDMAB11;                          /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC12;                           /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4636,10 +4636,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC12_b;                                      /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED32;
-  
+
   union {
     __IO uint32_t  HCINT12;                         /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4651,10 +4651,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT12_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN12;                      /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4666,10 +4666,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN12_b;                                 /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ12;                        /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4680,10 +4680,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ12_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA12;                         /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4692,10 +4692,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED33;
   __IO uint32_t  HCDMAB12;                          /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC13;                           /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4714,10 +4714,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC13_b;                                      /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED34;
-  
+
   union {
     __IO uint32_t  HCINT13;                         /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4729,10 +4729,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT13_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN13;                      /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4744,10 +4744,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN13_b;                                 /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ13;                        /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4758,10 +4758,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ13_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA13;                         /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4770,10 +4770,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED35;
   __IO uint32_t  HCDMAB13;                          /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC14;                           /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4792,10 +4792,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC14_b;                                      /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED36;
-  
+
   union {
     __IO uint32_t  HCINT14;                         /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4807,10 +4807,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT14_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN14;                      /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4822,10 +4822,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN14_b;                                 /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ14;                        /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4836,10 +4836,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ14_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA14;                         /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4848,10 +4848,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __I  uint32_t  RESERVED37;
   __IO uint32_t  HCDMAB14;                          /*!< Host Channel-n DMA Buffer Address Register                            */
-  
+
   union {
     __IO uint32_t  HCC15;                           /*!< Host Channel Characteristics Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
       __IO uint32_t  EP_NUM     :  4;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4870,10 +4870,10 @@ typedef struct {                                    /*!< USB Structure          
     } HCC15_b;                                      /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED38;
-  
+
   union {
     __IO uint32_t  HCINT15;                         /*!< Host Channel Interrupt Register                                       */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4885,10 +4885,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT15_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCINT_EN15;                      /*!< Host Channel Interrupt Enable Register                                */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  CH_HALT    :  1;               /*!< Indicates the endpoint number on the device serving as the data
@@ -4900,10 +4900,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  DR         :  1;               /*!< the corresponding channel's descriptor list rolls over                */
     } HCINT_EN15_b;                                 /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCTSIZ15;                        /*!< Host Channel Transfer Size Register                                   */
-    
+
     struct {
       __IO uint32_t  SCHED_INFO :  8;               /*!< Every bit in this 8 bit register indicates scheduling for that
                                                          microframe.Bit N indicates scheduling for Nth microframe scheduling
@@ -4914,10 +4914,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  PING       :  1;               /*!< Setting this field to 1 directs the host to do PING protocol          */
     } HCTSIZ15_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  HCDMA15;                         /*!< Host Channel-n DMA Address Register                                   */
-    
+
     struct {
            uint32_t             :  3;
       __IO uint32_t  CTD        :  6;               /*!< Number of Transfer Descriptors for Non-Isochronous                    */
@@ -4927,10 +4927,10 @@ typedef struct {                                    /*!< USB Structure          
   __I  uint32_t  RESERVED39;
   __IO uint32_t  HCDMAB15;                          /*!< Host Channel-n DMA Buffer Address Register                            */
   __I  uint32_t  RESERVED40[64];
-  
+
   union {
     __IO uint32_t  DCFG;                            /*!< Device Configuration Register                                         */
-    
+
     struct {
       __IO uint32_t  DSPEED     :  2;               /*!< the maximum speed the application can support                         */
       __IO uint32_t  NZLSOH     :  1;               /*!< select the handshake the core sends on receiving a non zero-length
@@ -4948,10 +4948,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  RVP        :  6;               /*!< It controls the resume period when the core resumes from suspend      */
     } DCFG_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DCTL;                            /*!< Device Control Register                                               */
-    
+
     struct {
       __IO uint32_t  RWS        :  1;               /*!< If set, the core initiates remote signaling to wake the USB
                                                          hosts                                                                 */
@@ -4974,10 +4974,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  ECBNA      :  1;               /*!< After receiving BNA interrupt, the core disables the endpoint         */
     } DCTL_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  DSTS;                            /*!< Device Status Register                                                */
-    
+
     struct {
       __I  uint32_t  SUSPEND    :  1;               /*!< this bit is set as long as a Suspend condition is detected on
                                                          the USB                                                               */
@@ -4991,10 +4991,10 @@ typedef struct {                                    /*!< USB Structure          
     } DSTS_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED41;
-  
+
   union {
     __IO uint32_t  DIEPEN;                          /*!< Device IN Endpoint Common Interrupt Enable Register                   */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer Completed Interrupt                                          */
       __IO uint32_t  ED         :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5010,10 +5010,10 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  NAK        :  1;               /*!< NAK interrupt                                                         */
     } DIEPEN_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DOEPEN;                          /*!< Device OUT Endpoint Common Interrupt Enable Register                  */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer Completed Interrupt                                          */
       __IO uint32_t  ED         :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5033,29 +5033,29 @@ typedef struct {                                    /*!< USB Structure          
       __IO uint32_t  NYET       :  1;               /*!< NYET interrupt                                                        */
     } DOEPEN_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  DAINT;                           /*!< Device All Channels Interrupt Register                                */
-    
+
     struct {
       __I  uint32_t  INT        : 16;               /*!< IN Endpoint Interrupt Bits, from 0 to 15.                             */
       __I  uint32_t  OUT_INT    : 16;               /*!< OUT Endpoint Interrupt Bits, from 0 to 15.                            */
     } DAINT_b;                                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DAINT_EN;                        /*!< Device All Channels Interrupt Enable Register                         */
-    
+
     struct {
       __IO uint32_t  IN_EN      : 16;               /*!< IN EP Interrupt Enable, from 0 to 15.                                 */
       __IO uint32_t  OUT_EN     : 16;               /*!< OUT EP Interrupt Enable, from 0 to 15.                                */
     } DAINT_EN_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED42[4];
-  
+
   union {
     __IO uint32_t  DTHRCTL;                         /*!< Device Threshold Control Register                                     */
-    
+
     struct {
       __IO uint32_t  NISOINETE  :  1;               /*!< Non-ISO IN Endpoints Threshold Enable                                 */
       __IO uint32_t  ISOINETE   :  1;               /*!< ISO IN Endpoints Threshold Enable                                     */
@@ -5071,10 +5071,10 @@ typedef struct {                                    /*!< USB Structure          
   };
   __IO uint16_t  DIEPEMPEN;                         /*!< Device IN Endpoint FIFO Empty Interrupt Enable Register               */
   __I  uint16_t  RESERVED43[101];
-  
+
   union {
     __IO uint32_t  DIEPCTL0;                        /*!< Device Control IN Endpoint 0 Control Register                         */
-    
+
     struct {
       __IO uint32_t  MPS        :  2;               /*!< Indicates the maximum packet size of the associated endpoint,
                                                          applies to IN and OUT endpoints                                       */
@@ -5098,10 +5098,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL0_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED44;
-  
+
   union {
     __IO uint32_t  DIEPINT0;                        /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5121,10 +5121,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT0_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED45;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ0;                       /*!< Device IN Endpoint 0 Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       :  7;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
            uint32_t             : 12;
@@ -5135,10 +5135,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA0;                           /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED46;
   __I  uint32_t  DIEPDMAB0;                         /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL1;                        /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5162,10 +5162,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL1_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED47;
-  
+
   union {
     __IO uint32_t  DIEPINT1;                        /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5185,10 +5185,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT1_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED48;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ1;                       /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5200,10 +5200,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA1;                           /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED49;
   __I  uint32_t  DIEPDMAB1;                         /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL2;                        /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5227,10 +5227,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL2_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED50;
-  
+
   union {
     __IO uint32_t  DIEPINT2;                        /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5250,10 +5250,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT2_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED51;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ2;                       /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5265,10 +5265,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA2;                           /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED52;
   __I  uint32_t  DIEPDMAB2;                         /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL3;                        /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5292,10 +5292,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL3_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED53;
-  
+
   union {
     __IO uint32_t  DIEPINT3;                        /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5315,10 +5315,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT3_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED54;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ3;                       /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5330,10 +5330,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA3;                           /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED55;
   __I  uint32_t  DIEPDMAB3;                         /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL4;                        /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5357,10 +5357,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL4_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED56;
-  
+
   union {
     __IO uint32_t  DIEPINT4;                        /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5380,10 +5380,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT4_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED57;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ4;                       /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5395,10 +5395,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA4;                           /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED58;
   __I  uint32_t  DIEPDMAB4;                         /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL5;                        /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5422,10 +5422,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL5_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED59;
-  
+
   union {
     __IO uint32_t  DIEPINT5;                        /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5445,10 +5445,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT5_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED60;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ5;                       /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5460,10 +5460,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA5;                           /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED61;
   __I  uint32_t  DIEPDMAB5;                         /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL6;                        /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5487,10 +5487,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL6_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED62;
-  
+
   union {
     __IO uint32_t  DIEPINT6;                        /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5510,10 +5510,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT6_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED63;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ6;                       /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5525,10 +5525,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA6;                           /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED64;
   __I  uint32_t  DIEPDMAB6;                         /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL7;                        /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5552,10 +5552,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL7_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED65;
-  
+
   union {
     __IO uint32_t  DIEPINT7;                        /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5575,10 +5575,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT7_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED66;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ7;                       /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5590,10 +5590,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA7;                           /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED67;
   __I  uint32_t  DIEPDMAB7;                         /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL8;                        /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5617,10 +5617,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL8_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED68;
-  
+
   union {
     __IO uint32_t  DIEPINT8;                        /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5640,10 +5640,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT8_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED69;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ8;                       /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5655,10 +5655,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA8;                           /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED70;
   __I  uint32_t  DIEPDMAB8;                         /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL9;                        /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5682,10 +5682,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL9_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED71;
-  
+
   union {
     __IO uint32_t  DIEPINT9;                        /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5705,10 +5705,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT9_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED72;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ9;                       /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5720,10 +5720,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA9;                           /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED73;
   __I  uint32_t  DIEPDMAB9;                         /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL10;                       /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5747,10 +5747,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL10_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED74;
-  
+
   union {
     __IO uint32_t  DIEPINT10;                       /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5770,10 +5770,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT10_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED75;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ10;                      /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5785,10 +5785,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA10;                          /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED76;
   __I  uint32_t  DIEPDMAB10;                        /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL11;                       /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5812,10 +5812,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL11_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED77;
-  
+
   union {
     __IO uint32_t  DIEPINT11;                       /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5835,10 +5835,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT11_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED78;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ11;                      /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5850,10 +5850,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA11;                          /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED79;
   __I  uint32_t  DIEPDMAB11;                        /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL12;                       /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5877,10 +5877,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL12_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED80;
-  
+
   union {
     __IO uint32_t  DIEPINT12;                       /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5900,10 +5900,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT12_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED81;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ12;                      /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5915,10 +5915,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA12;                          /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED82;
   __I  uint32_t  DIEPDMAB12;                        /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL13;                       /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -5942,10 +5942,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL13_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED83;
-  
+
   union {
     __IO uint32_t  DIEPINT13;                       /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -5965,10 +5965,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT13_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED84;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ13;                      /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -5980,10 +5980,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA13;                          /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED85;
   __I  uint32_t  DIEPDMAB13;                        /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL14;                       /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6007,10 +6007,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL14_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED86;
-  
+
   union {
     __IO uint32_t  DIEPINT14;                       /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6030,10 +6030,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT14_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED87;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ14;                      /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6045,10 +6045,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA14;                          /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED88;
   __I  uint32_t  DIEPDMAB14;                        /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DIEPCTL15;                       /*!< Device IN Endpoint N Control Register                                 */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6072,10 +6072,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPCTL15_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED89;
-  
+
   union {
     __IO uint32_t  DIEPINT15;                       /*!< Device IN Endpoint-n Interrupt Register                               */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6095,10 +6095,10 @@ typedef struct {                                    /*!< USB Structure          
     } DIEPINT15_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED90;
-  
+
   union {
     __IO uint32_t  DIEPTSIZ15;                      /*!< Device IN Endpoint-n Transfer Size Register                           */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6110,10 +6110,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint16_t  DTXFSA15;                          /*!< Device IN Endpoint-n Transmit FIFO Space Avail Register               */
   __I  uint16_t  RESERVED91;
   __I  uint32_t  DIEPDMAB15;                        /*!< Device IN Endpoint-n DMA Buffer Address Register                      */
-  
+
   union {
     __IO uint32_t  DOEPCTL0;                        /*!< Device Control OUT Endpoint 0 Control Register                        */
-    
+
     struct {
       __IO uint32_t  MPS        :  2;               /*!< Indicates the maximum packet size of the associated endpoint,
                                                          applies to IN and OUT endpoints                                       */
@@ -6136,10 +6136,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL0_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED92;
-  
+
   union {
     __IO uint32_t  DOEPINT0;                        /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6161,10 +6161,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT0_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED93;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ0;                       /*!< Device OUT Endpoint 0 Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       :  7;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
            uint32_t             : 12;
@@ -6178,10 +6178,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA0;                          /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED94;
   __I  uint32_t  DOEPDMAB0;                         /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL1;                        /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6205,10 +6205,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL1_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED95;
-  
+
   union {
     __IO uint32_t  DOEPINT1;                        /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6230,10 +6230,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT1_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED96;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ1;                       /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6245,10 +6245,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA1;                          /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED97;
   __I  uint32_t  DOEPDMAB1;                         /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL2;                        /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6272,10 +6272,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL2_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED98;
-  
+
   union {
     __IO uint32_t  DOEPINT2;                        /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6297,10 +6297,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT2_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED99;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ2;                       /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6312,10 +6312,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA2;                          /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED100;
   __I  uint32_t  DOEPDMAB2;                         /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL3;                        /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6339,10 +6339,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL3_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED101;
-  
+
   union {
     __IO uint32_t  DOEPINT3;                        /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6364,10 +6364,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT3_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED102;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ3;                       /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6379,10 +6379,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA3;                          /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED103;
   __I  uint32_t  DOEPDMAB3;                         /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL4;                        /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6406,10 +6406,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL4_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED104;
-  
+
   union {
     __IO uint32_t  DOEPINT4;                        /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6431,10 +6431,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT4_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED105;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ4;                       /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6446,10 +6446,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA4;                          /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED106;
   __I  uint32_t  DOEPDMAB4;                         /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL5;                        /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6473,10 +6473,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL5_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED107;
-  
+
   union {
     __IO uint32_t  DOEPINT5;                        /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6498,10 +6498,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT5_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED108;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ5;                       /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6513,10 +6513,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA5;                          /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED109;
   __I  uint32_t  DOEPDMAB5;                         /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL6;                        /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6540,10 +6540,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL6_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED110;
-  
+
   union {
     __IO uint32_t  DOEPINT6;                        /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6565,10 +6565,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT6_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED111;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ6;                       /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6580,10 +6580,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA6;                          /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED112;
   __I  uint32_t  DOEPDMAB6;                         /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL7;                        /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6607,10 +6607,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL7_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED113;
-  
+
   union {
     __IO uint32_t  DOEPINT7;                        /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6632,10 +6632,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT7_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED114;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ7;                       /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6647,10 +6647,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA7;                          /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED115;
   __I  uint32_t  DOEPDMAB7;                         /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL8;                        /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6674,10 +6674,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL8_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED116;
-  
+
   union {
     __IO uint32_t  DOEPINT8;                        /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6699,10 +6699,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT8_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED117;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ8;                       /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6714,10 +6714,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA8;                          /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED118;
   __I  uint32_t  DOEPDMAB8;                         /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL9;                        /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6741,10 +6741,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL9_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED119;
-  
+
   union {
     __IO uint32_t  DOEPINT9;                        /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6766,10 +6766,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT9_b;                                   /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED120;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ9;                       /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6781,10 +6781,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA9;                          /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED121;
   __I  uint32_t  DOEPDMAB9;                         /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL10;                       /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6808,10 +6808,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL10_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED122;
-  
+
   union {
     __IO uint32_t  DOEPINT10;                       /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6833,10 +6833,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT10_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED123;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ10;                      /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6848,10 +6848,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA10;                         /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED124;
   __I  uint32_t  DOEPDMAB10;                        /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL11;                       /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6875,10 +6875,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL11_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED125;
-  
+
   union {
     __IO uint32_t  DOEPINT11;                       /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6900,10 +6900,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT11_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED126;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ11;                      /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6915,10 +6915,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA11;                         /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED127;
   __I  uint32_t  DOEPDMAB11;                        /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL12;                       /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -6942,10 +6942,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL12_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED128;
-  
+
   union {
     __IO uint32_t  DOEPINT12;                       /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -6967,10 +6967,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT12_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED129;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ12;                      /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -6982,10 +6982,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA12;                         /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED130;
   __I  uint32_t  DOEPDMAB12;                        /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL13;                       /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -7009,10 +7009,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL13_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED131;
-  
+
   union {
     __IO uint32_t  DOEPINT13;                       /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -7034,10 +7034,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT13_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED132;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ13;                      /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -7049,10 +7049,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA13;                         /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED133;
   __I  uint32_t  DOEPDMAB13;                        /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL14;                       /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -7076,10 +7076,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL14_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED134;
-  
+
   union {
     __IO uint32_t  DOEPINT14;                       /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -7101,10 +7101,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT14_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED135;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ14;                      /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -7116,10 +7116,10 @@ typedef struct {                                    /*!< USB Structure          
   __IO uint32_t  DOEPDMA14;                         /*!< Device OUT Endpoint-n DMA Address Register                            */
   __I  uint32_t  RESERVED136;
   __I  uint32_t  DOEPDMAB14;                        /*!< Device OUT Endpoint-n DMA Buffer Address Register                     */
-  
+
   union {
     __IO uint32_t  DOEPCTL15;                       /*!< Device OUT Endpoint N Control Register                                */
-    
+
     struct {
       __IO uint32_t  MPS        : 11;               /*!< Indicates the maximum packet size of the associated endpoint          */
            uint32_t             :  4;
@@ -7143,10 +7143,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPCTL15_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED137;
-  
+
   union {
     __IO uint32_t  DOEPINT15;                       /*!< Device OUT Endpoint-n Interrupt Register                              */
-    
+
     struct {
       __IO uint32_t  TC         :  1;               /*!< Transfer completed normally without any errors                        */
       __IO uint32_t  EPD        :  1;               /*!< Endpoint Disabled Interrupt                                           */
@@ -7168,10 +7168,10 @@ typedef struct {                                    /*!< USB Structure          
     } DOEPINT15_b;                                  /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED138;
-  
+
   union {
     __IO uint32_t  DOEPTSIZ15;                      /*!< Device OUT Endpoint-n Transfer Size Register                          */
-    
+
     struct {
       __IO uint32_t  SIZE       : 19;               /*!< Indicates the transfer size in bytes for endpoint 0                   */
       __IO uint32_t  PACKET_CNT : 10;               /*!< the total number of USB packets                                       */
@@ -7196,10 +7196,10 @@ typedef struct {                                    /*!< USB Structure          
   */
 
 typedef struct {                                    /*!< GLOBAL_CTRL Structure                                                 */
-  
+
   union {
     __I  uint32_t  AES_STATUS;                      /*!< AES status                                                            */
-    
+
     struct {
       __I  uint32_t  RD_ALMOST_EMPTY:  1;           /*!< FIFO read almost empty                                                */
       __I  uint32_t  RD_EMPTY   :  1;               /*!< FIFO read empty                                                       */
@@ -7209,10 +7209,10 @@ typedef struct {                                    /*!< GLOBAL_CTRL Structure  
     } AES_STATUS_b;                                 /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED0[253];
-  
+
   union {
     __IO uint32_t  CLK_SEL_0;                       /*!< clock select 0                                                        */
-    
+
     struct {
       __IO uint32_t  CAN1_CLK   :  2;               /*!< CAN1 clock frequency dividor based on system clock, which should
                                                          be 1/32, 1/4, 1/8, 1/16 from 0 to 3                                   */
@@ -7247,10 +7247,10 @@ typedef struct {                                    /*!< GLOBAL_CTRL Structure  
                                                          should be 1/1, 1/2, 1/4, 1/8 from 0 to 3                              */
     } CLK_SEL_0_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CLK_SEL_1;                       /*!< clock select 1                                                        */
-    
+
     struct {
       __IO uint32_t  ETH_AHB_CLK:  2;               /*!< ETH_AHB clock frequency dividor based on system clock, which
                                                          should be 1/1, 1/2, 1/4, 1/8 from 0 to 3                              */
@@ -7269,10 +7269,10 @@ typedef struct {                                    /*!< GLOBAL_CTRL Structure  
       __IO uint32_t  UTMI_CLK   :  1;               /*!< UTMI clock came from on-chip usb phy(0) or off-chip usb phy(1)        */
     } CLK_SEL_1_b;                                  /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  USB_PHY_CTRL;                    /*!< USB Phy Control Register                                              */
-    
+
     struct {
       __IO uint32_t  BITSTUFF   :  1;               /*!< 0: No bit stuff                                                       */
       __IO uint32_t  XTLSEL     :  1;               /*!< 0: 12MHz                                                              */
@@ -7288,39 +7288,39 @@ typedef struct {                                    /*!< GLOBAL_CTRL Structure  
       __IO uint32_t  RSTPRT     :  1;               /*!< 0: The reverse of usb_rst_n will reset, 1: Reset OTG PHY              */
     } USB_PHY_CTRL_b;                               /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RTC_INT_EN;                      /*!< RTC interrupt enable Register                                         */
-    
+
     struct {
       __IO uint32_t  SECOND     :  1;               /*!< 1s interrupt enable                                                   */
       __IO uint32_t  MILLSECOND :  1;               /*!< 1ms interrupt enable                                                  */
     } RTC_INT_EN_b;                                 /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED1;
-  
+
   union {
     __IO uint32_t  NMI_SEL;                         /*!< nmi interrupt selection                                               */
-    
+
     struct {
       __IO uint32_t  NMI        :  7;               /*!< NMI interrupt ID                                                      */
     } NMI_SEL_b;                                    /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED2;
   __IO uint32_t  AES_TARGET_ADDR;                   /*!< AES target address, default is frame decoder address(0x41800000)      */
-  
+
   union {
     __IO uint32_t  AES_BURST_TYPE;                  /*!< AES burst type                                                        */
-    
+
     struct {
       __IO uint32_t  TYPE       :  2;               /*!< burst type, fixed(0), incr(1)                                         */
     } AES_BURST_TYPE_b;                             /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED3[3];
-  
+
   union {
     __IO uint32_t  ICACHE;                          /*!< ICACHE Enable                                                         */
-    
+
     struct {
       __IO uint32_t  EN         :  1;               /*!< ICACHE Enable                                                         */
     } ICACHE_b;                                     /*!< BitSize                                                               */
@@ -7342,10 +7342,10 @@ typedef struct {                                    /*!< GLOBAL_CTRL Structure  
 
 typedef struct {                                    /*!< AES Structure                                                         */
   __IO uint32_t  FIFO;                              /*!< data FIFO to be decoded                                               */
-  
+
   union {
     __O  uint32_t  FIFO_CLEAR;                      /*!< clear data FIFO                                                       */
-    
+
     struct {
       __O  uint32_t  CLEAR      :  1;               /*!< clear after write 1 and write 0                                       */
     } FIFO_CLEAR_b;                                 /*!< BitSize                                                               */
@@ -7364,20 +7364,20 @@ typedef struct {                                    /*!< AES Structure          
 
 typedef struct {                                    /*!< DDRC Structure                                                        */
   __IO uint32_t  CMD;                               /*!< DDR commands to program                                               */
-  
+
   union {
     __IO uint32_t  CTRL;                            /*!< DDR Control                                                           */
-    
+
     struct {
       __IO uint32_t  TO         :  1;               /*!< Take over DDRC siggen                                                 */
       __IO uint32_t  CLR        :  1;               /*!< Clear commands in FIFO                                                */
       __O  uint32_t  STR        :  1;               /*!< Start to execute the commands in FIFO                                 */
     } CTRL_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  MODE;                            /*!< DDR mode                                                              */
-    
+
     struct {
       __IO uint32_t  MODE       :  6;               /*!< DDRC Mode                                                             */
            uint32_t             :  2;
@@ -7390,18 +7390,18 @@ typedef struct {                                    /*!< DDRC Structure         
       __IO uint32_t  CLKPOL     :  2;               /*!< DQS clkpol set by user on the PHY                                     */
     } MODE_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  QUE;                             /*!< DDRC queue depth                                                      */
-    
+
     struct {
       __IO uint32_t  DEPTH      :  1;               /*!< DDRC queue depth                                                      */
     } QUE_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  REF;                             /*!< Refresh control                                                       */
-    
+
     struct {
       __IO uint32_t  THRD       :  5;               /*!< Number of refresh requests which can be postponed                     */
            uint32_t             :  3;
@@ -7410,266 +7410,266 @@ typedef struct {                                    /*!< DDRC Structure         
       __IO uint32_t  TIME       : 16;               /*!< Refresh interval time                                                 */
     } REF_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __O  uint32_t  REF_TRIG;                        /*!< Refresh trigger                                                       */
-    
+
     struct {
       __O  uint32_t  GO         :  1;               /*!< Write 1 to trigger one refresh request by cbus                        */
     } REF_TRIG_b;                                   /*!< BitSize                                                               */
   };
-  
+
   union {
     __O  uint32_t  ZQ_TRIG;                         /*!< ZQCTL trigger                                                         */
-    
+
     struct {
       __O  uint32_t  CS         :  1;               /*!< Write 1 to trigger one ZQCS request by cbus                           */
       __O  uint32_t  CL         :  1;               /*!< Write 1 to trigger one ZQCL request by cbus                           */
     } ZQ_TRIG_b;                                    /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  ZQCSR;                           /*!< ZQCSR                                                                 */
-    
+
     struct {
       __IO uint32_t  EN         :  1;               /*!< Enable ZQCS request                                                   */
       __IO uint32_t  PRI        :  1;               /*!< 0: DMA access prior to ZQCS, 1: ZQCS prior to DMA access              */
     } ZQCSR_b;                                      /*!< BitSize                                                               */
   };
   __IO uint32_t  ZQCSI;                             /*!< ZQCS interval time                                                    */
-  
+
   union {
     __IO uint32_t  RCD;                             /*!< t(RCD)                                                                */
-    
+
     struct {
       __IO uint32_t  DI         :  5;               /*!< t(RCD), delay from ACT command to RW command of same bank             */
     } RCD_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RAS;                             /*!< t(RAS)                                                                */
-    
+
     struct {
       __IO uint32_t  DI         :  6;               /*!< t(RAS), delay from ACT command to PRE command of same bank            */
     } RAS_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RP;                              /*!< t(RP)                                                                 */
-    
+
     struct {
       __IO uint32_t  DI         :  5;               /*!< t(RP), delay from PRE command to ACT/REF/ZQ command                   */
            uint32_t             :  3;
       __IO uint32_t  RPA        :  1;               /*!< 0: t(RP) delay for PREA command; 1: t(RP)+1 delay for PREA command    */
     } RP_b;                                         /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RC;                              /*!< t(RC)                                                                 */
-    
+
     struct {
       __IO uint32_t  DI         :  7;               /*!< t(RC), delay from ACT command to ACT command of same bank             */
     } RC_b;                                         /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RRD;                             /*!< t(RRD)                                                                */
-    
+
     struct {
       __IO uint32_t  DI         :  4;               /*!< t(RRD), delay from ACT command to ACT command                         */
     } RRD_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  CCD;                             /*!< t(CCD)                                                                */
-    
+
     struct {
       __IO uint32_t  DI         :  3;               /*!< t(CCD), delay from RW command to RW command                           */
     } CCD_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RTW;                             /*!< t(RTW)                                                                */
-    
+
     struct {
       __IO uint32_t  DI         :  5;               /*!< t(RTW), delay from RD command to WR command                           */
     } RTW_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  WTR;                             /*!< t(WTR)                                                                */
-    
+
     struct {
       __IO uint32_t  DI         :  5;               /*!< t(WTR), delay from WR command to RD command                           */
     } WTR_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RTP;                             /*!< t(RTP)                                                                */
-    
+
     struct {
       __IO uint32_t  DI         :  3;               /*!< t(RTP), delay from RD command to PRE command of same bank             */
     } RTP_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  WTP;                             /*!< t(WTP)                                                                */
-    
+
     struct {
       __IO uint32_t  DI         :  6;               /*!< t(WTP), delay from WR command to PRE command of same bank             */
     } WTP_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RFC;                             /*!< t(RFC)                                                                */
-    
+
     struct {
       __IO uint32_t  DI         :  8;               /*!< t(WTP), delay from WR command to PRE command of same bank             */
     } RFC_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  ZQCL;                            /*!< t(ZQoper)                                                             */
-    
+
     struct {
       __IO uint32_t  DI         :  9;               /*!< t(ZQoper), delay from ZQCL command to REF/ZQ/ACT command              */
     } ZQCL_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  ZQCS;                            /*!< t(ZQCS)                                                               */
-    
+
     struct {
       __IO uint32_t  DI         :  7;               /*!< t(ZQCS), delay from ZQCS command to REF/ZQ/ACT command                */
     } ZQCS_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  FAW;                             /*!< t(FAW)                                                                */
-    
+
     struct {
       __IO uint32_t  DI         :  6;               /*!< t(FAW), 4 act command window time                                     */
     } FAW_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  BURST;                           /*!< BURST                                                                 */
-    
+
     struct {
       __IO uint32_t  LEN        :  1;               /*!< 0: length 8, 1: length 4                                              */
     } BURST_b;                                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  PHUNG;                           /*!< PHUNG                                                                 */
-    
+
     struct {
       __IO uint32_t  MODE       :  1;               /*!< 0: normal mode, 1: prevent read hang mode                             */
       __IO uint32_t  LPM        :  1;               /*!< 1: stop the IO clk                                                    */
     } PHUNG_b;                                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RL;                              /*!< READ Latency                                                          */
-    
+
     struct {
       __IO uint32_t  VAL        :  5;               /*!< READ Latency                                                          */
     } RL_b;                                         /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  WL;                              /*!< WRITE Latency                                                         */
-    
+
     struct {
       __IO uint32_t  VAL        :  5;               /*!< WRITE Latency                                                         */
     } WL_b;                                         /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  TRAIN;                           /*!< TRAIN                                                                 */
-    
+
     struct {
       __IO uint32_t  EN         :  4;               /*!< Enable lane N training mode                                           */
     } TRAIN_b;                                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DQSEN0;                          /*!< Delay cycles of dqsen of byte lane 0                                  */
-    
+
     struct {
       __IO uint32_t  DL         :  3;               /*!< Delay cycles of dqsen of byte lane 0                                  */
     } DQSEN0_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DQSEN1;                          /*!< Delay cycles of dqsen of byte lane 1                                  */
-    
+
     struct {
       __IO uint32_t  DL         :  3;               /*!< Delay cycles of dqsen of byte lane 1                                  */
     } DQSEN1_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DQSEN2;                          /*!< Delay cycles of dqsen of byte lane 2                                  */
-    
+
     struct {
       __IO uint32_t  DL         :  3;               /*!< Delay cycles of dqsen of byte lane 2                                  */
     } DQSEN2_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  DQSEN3;                          /*!< Delay cycles of dqsen of byte lane 0                                  */
-    
+
     struct {
       __IO uint32_t  DL         :  3;               /*!< Delay cycles of dqsen of byte lane 3                                  */
     } DQSEN3_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  ODTH;                            /*!< Delay from WR command to odt high transition                          */
-    
+
     struct {
       __IO uint32_t  DL         :  5;               /*!< Delay from WR command to odt high transition                          */
     } ODTH_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  ODTL;                            /*!< Delay from WR command to odt low transition                           */
-    
+
     struct {
       __IO uint32_t  DL         :  5;               /*!< Delay from WR command to odt low transition                           */
     } ODTL_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __O  uint32_t  ODT;                             /*!< Used in write leveling mode                                           */
-    
+
     struct {
       __O  uint32_t  TRIG       :  1;               /*!< 0: trigger odt low, 1: trigger odt high                               */
     } ODT_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __O  uint32_t  DQS;                             /*!< Used in write leveling mode                                           */
-    
+
     struct {
       __O  uint32_t  TRIG       :  1;               /*!< Writing 1 to this register triggers a dqs pulse                       */
     } DQS_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  STA;                             /*!< Commands FIFO                                                         */
-    
+
     struct {
       __I  uint32_t  MODE       :  1;               /*!< DDRC in sw_proc mode                                                  */
       __I  uint32_t  EMPTY      :  1;               /*!< Sw_proc command fifo empty                                            */
       __I  uint32_t  FULL       :  1;               /*!< Sw_proc command fifo full                                             */
     } STA_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INTCTL;                          /*!< Interrupt Control                                                     */
-    
+
     struct {
       __IO uint32_t  DONE       :  1;               /*!< 0: the sw_proc_done int will not be masked, 1: the sw_proc_done
                                                          int will be masked                                                    */
@@ -7679,36 +7679,36 @@ typedef struct {                                    /*!< DDRC Structure         
                                                          edge active                                                           */
     } INTCTL_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INTRAW;                          /*!< Interrupt RAW                                                         */
-    
+
     struct {
       __IO uint32_t  DONE       :  1;               /*!< Int register of sw_proc_done before mask                              */
       __IO uint32_t  ERR        :  1;               /*!< int reg of the lane sync error before masked                          */
     } INTRAW_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  INTSTA;                          /*!< Interrupt STA                                                         */
-    
+
     struct {
       __IO uint32_t  DONE       :  1;               /*!< Int register of sw_proc_done after mask                               */
       __IO uint32_t  ERR        :  1;               /*!< int register of lane sync error after masked                          */
     } INTSTA_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  PHY;                             /*!< PHY                                                                   */
-    
+
     struct {
       __IO uint32_t  RST        :  1;               /*!< FPGA version, reset read dq fifo. Low active                          */
     } PHY_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RDQ;                             /*!< FPGA version, read dq delay of byte lane N                            */
-    
+
     struct {
       __IO uint32_t  L3         :  6;               /*!< FPGA version, read dq delay of byte lane3                             */
            uint32_t             :  2;
@@ -7719,10 +7719,10 @@ typedef struct {                                    /*!< DDRC Structure         
       __IO uint32_t  L0         :  7;               /*!< FPGA version, read dq delay of byte lane0                             */
     } RDQ_b;                                        /*!< BitSize                                                               */
   };
-  
+
   union {
     __I  uint32_t  CALIB;                           /*!< calibration                                                           */
-    
+
     struct {
       __I  uint32_t  TPU        :  8;               /*!< calibration result values, if fail then 0x40                          */
       __I  uint32_t  TPD        :  8;               /*!< calibration result values, if fail then 0x40                          */
@@ -7733,12 +7733,12 @@ typedef struct {                                    /*!< DDRC Structure         
                                                          positive edge                                                         */
     } CALIB_b;                                      /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  ITMDLY;                          /*!< "itmdly" is the fine delay trim to the read path "dq", "itmsdly"
                                                          is to the read path of "dqs". From 000 to 111 increasingly,
                                                           each step is about 40ps                                              */
-    
+
     struct {
       __IO uint32_t  I0         :  4;               /*!< itmdly0                                                               */
       __IO uint32_t  IS0        :  4;               /*!< itmsdly0                                                              */
@@ -7750,10 +7750,10 @@ typedef struct {                                    /*!< DDRC Structure         
       __IO uint32_t  IS3        :  4;               /*!< itmsdly3                                                              */
     } ITMDLY_b;                                     /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  TUNE;                            /*!< CALIB_TUNE                                                            */
-    
+
     struct {
       __IO uint32_t  TPU        :  4;               /*!< tpu_tune, finial val = tune[3] ? val - tune : val + tune              */
       __IO uint32_t  TPD        :  4;               /*!< tpd_tune, tune[3:0] for TPD/TPU, [2:0] is the tune val                */
@@ -7761,10 +7761,10 @@ typedef struct {                                    /*!< DDRC Structure         
       __IO uint32_t  NDR        :  4;               /*!< ndr_tune, tune[2:0] for NDR/PDR, [1:0] is the tune val                */
     } TUNE_b;                                       /*!< BitSize                                                               */
   };
-  
+
   union {
     __IO uint32_t  RD_SEL;                          /*!< RD_WINDOWS_SEL                                                        */
-    
+
     struct {
       __IO uint32_t  PHY_SEL    :  3;               /*!< To fix the phy read valid issue, this is to adjust the read
                                                          data valid window to match the phy read valid by cycle level          */
@@ -7783,10 +7783,10 @@ typedef struct {                                    /*!< DDRC Structure         
   */
 
 typedef struct {                                    /*!< PDLOCK Structure                                                      */
-  
+
   union {
     __I  uint32_t  GCLK;                            /*!< GCLK                                                                  */
-    
+
     struct {
       __I  uint32_t  C1R2P      :  1;               /*!< gclk_c1r2_pll_lock                                                    */
       __I  uint32_t  C1R1P      :  1;               /*!< gclk_c1r1_pll_lock                                                    */
@@ -7811,10 +7811,10 @@ typedef struct {                                    /*!< PDLOCK Structure       
   */
 
 typedef struct {                                    /*!< PDPROT Structure                                                      */
-  
+
   union {
     __O  uint32_t  LOCK;                            /*!< LOCK                                                                  */
-    
+
     struct {
       __O  uint32_t  EN         :  1;               /*!< Enable the PLL DLL Lock to Protect it                                 */
     } LOCK_b;                                       /*!< BitSize                                                               */
@@ -7833,20 +7833,20 @@ typedef struct {                                    /*!< PDPROT Structure       
 
 typedef struct {                                    /*!< CFG_CTRL Structure                                                    */
   __I  uint32_t  RESERVED0[3];
-  
+
   union {
     __IO uint32_t  DONE;                            /*!< DONE CFG                                                              */
-    
+
     struct {
       __IO uint32_t  CMD        :  1;               /*!< Write 1 indicate all chain data write over                            */
       __IO uint32_t  STA        :  1;               /*!< 1= all chain config process over, chip is in user mode                */
     } DONE_b;                                       /*!< BitSize                                                               */
   };
   __I  uint32_t  RESERVED1[34];
-  
+
   union {
     __IO uint32_t  PDLLSTR;                         /*!< PLL DLL RESET                                                         */
-    
+
     struct {
       __IO uint32_t  C1R1P      :  1;               /*!< C1r1_rstpll_n, low active                                             */
       __IO uint32_t  C1R2P      :  1;               /*!< C1r2_rstpll_n, low active                                             */
@@ -7871,10 +7871,10 @@ typedef struct {                                    /*!< CFG_CTRL Structure     
   */
 
 typedef struct {                                    /*!< SOFT_RESET Structure                                                  */
-  
+
   union {
     __IO uint32_t  SOFTRST;                         /*!< SOFTRST                                                               */
-    
+
     struct {
       __IO uint32_t  CAN1_n     :  1;               /*!< soft_rst_can1_n                                                       */
       __IO uint32_t  CAN0_n     :  1;               /*!< soft_rst_can0_n                                                       */

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_adc.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_adc.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_adc.h
-	*
-	* @brief    CMEM7 ADC header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_adc.h
+    *
+    * @brief    CMEM7 ADC header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_ADC_H
 #define __CMEM7_ADC_H
 
@@ -38,8 +38,8 @@
   * @{
   */
 typedef enum {
-	ADC_PERIPH_1,
-	ADC_PERIPH_2,
+    ADC_PERIPH_1,
+    ADC_PERIPH_2,
 } ADC_PERIPH;
 
 #define IS_ADC_ALL_PERIPH(PERIPH)         (((PERIPH) == ADC_PERIPH_1) || \
@@ -67,7 +67,7 @@ typedef enum {
 /** @defgroup ADC_PHASE_CTRL
   * @{
   */
-#define ADC_PHASE_CTRL_0DEG_RISE_EDGE     0         /* ADC-1 and ADC-2 CLK are 0DEG Phase Difference(Rising Edge) */                                               
+#define ADC_PHASE_CTRL_0DEG_RISE_EDGE     0         /* ADC-1 and ADC-2 CLK are 0DEG Phase Difference(Rising Edge) */
 #define ADC_PHASE_CTRL_90DEG_AHEAD        1         /* ADC-1 90DEG ahead of ADC-2 */
 #define ADC_PHASE_CTRL_90DEG_LAG          2         /* ADC-1 90DEG lag of ADC-2 */
 #define ADC_PHASE_CTRL_0DEG_FALL_EDGE     3         /* ADC-1 and ADC-2 CLK are 0DEG Phase Difference(falling Edge) */
@@ -84,11 +84,11 @@ typedef enum {
   * @{
   */
 #define ADC_SYSTEM_MODE_SINGLE_CONV       1
-#define ADC_SYSTEM_MODE_CONTINUOUS_CONV   2	
+#define ADC_SYSTEM_MODE_CONTINUOUS_CONV   2
 
 #define IS_ADC_CONVERSION(CONV)           (((CONV) == ADC_SYSTEM_MODE_SINGLE_CONV) || \
                                            ((CONV) == ADC_SYSTEM_MODE_CONTINUOUS_CONV))
-																					 
+
 /**
   * @}
   */
@@ -119,7 +119,7 @@ typedef enum {
 /** @defgroup ADC1_CHANNEL
   * @{
   */
-#define ADC1_CHANNEL_VIP                  0x1		
+#define ADC1_CHANNEL_VIP                  0x1
 #define ADC1_CHANNEL_VSEN                 0x2
 #define ADC1_CHANNEL_VADIO_0              0x4
 #define ADC1_CHANNEL_VADIO_1              0x8
@@ -136,8 +136,8 @@ typedef enum {
 
 /** @defgroup ADC2_CHANNEL
   * @{
-  */																																										 
-#define ADC2_CHANNEL_VIN                  0x1		
+  */
+#define ADC2_CHANNEL_VIN                  0x1
 #define ADC2_CHANNEL_VTMP                 0x2
 #define ADC2_CHANNEL_VADIO_6              0x4
 #define ADC2_CHANNEL_VADIO_7              0x8
@@ -147,118 +147,118 @@ typedef enum {
 #define ADC2_CHANNEL_VADIO_11             0x80
 #define ADC2_CHANNEL_ALL                  0xFF
 
-#define IS_ADC2_CHANNEL(CHANNEL)          (((CHANNEL) != 0) && ((CHANNEL) & ~ADC2_CHANNEL_ALL) == 0)                                          																 
+#define IS_ADC2_CHANNEL(CHANNEL)          (((CHANNEL) != 0) && ((CHANNEL) & ~ADC2_CHANNEL_ALL) == 0)
 /**
   * @}
   */
 
 /** @defgroup ADC_INT
   * @{
-  */																					 
-#define ADC1_INT_ALMOST_FULL              0x1 
+  */
+#define ADC1_INT_ALMOST_FULL              0x1
 #define ADC2_INT_ALMOST_FULL              0x8
-#define ADC_INT_ALL              					0x9
+#define ADC_INT_ALL                                 0x9
 
-#define IS_ADC_INT(INT)        						(((INT) != 0) && (((INT) & ~ADC_INT_ALL) == 0))
+#define IS_ADC_INT(INT)                             (((INT) != 0) && (((INT) & ~ADC_INT_ALL) == 0))
 /**
   * @}
   */
 
 /**
   * @brief  ADC collection data structure
-	*/ 
+    */
 typedef struct {
-	uint8_t channel;												/*!< The channel of collected data, is a value of 
-																							 @ref ADC_CHANNEL, @ref ADC1_CHANNEL or @ref ADC2_CHANNEL */
-	uint16_t data;													/*!< collected data                    												*/
+    uint8_t channel;                                                /*!< The channel of collected data, is a value of
+                                                                                             @ref ADC_CHANNEL, @ref ADC1_CHANNEL or @ref ADC2_CHANNEL */
+    uint16_t data;                                                  /*!< collected data                                                                 */
 } ADC_Data;
 
 /**
   * @brief  ADC initialization structure
-	*/ 
+    */
 typedef struct
 {
-	uint8_t ADC_PhaseCtrl;                  /*!< Phase between ADC1 and ADC2, is a value of @ref ADC_PHASE_CTRL */
-	uint8_t ADC_VsenSelection;              /*!< ADC1 VSEN selection, is a value of @ref ADC_VSEN					*/
+    uint8_t ADC_PhaseCtrl;                  /*!< Phase between ADC1 and ADC2, is a value of @ref ADC_PHASE_CTRL */
+    uint8_t ADC_VsenSelection;              /*!< ADC1 VSEN selection, is a value of @ref ADC_VSEN                   */
 } ADC_InitTypeDef;
 
 /**
   * @brief  ADC initialization
   * @note   This function should be called at first before any other interfaces.
-	* @param[in] init A pointer to structure ADC_InitTypeDef
+    * @param[in] init A pointer to structure ADC_InitTypeDef
   * @retval None
-	*/ 
+    */
 void ADC_Init(ADC_InitTypeDef* init);
 
 /**
-  * @brief  Enable or disable ADC. 
-	* @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
-	* @param[in] Enable The bit indicates if the specific ADC is enable or not
+  * @brief  Enable or disable ADC.
+    * @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
+    * @param[in] Enable The bit indicates if the specific ADC is enable or not
   * @retval None
-	*/ 
+    */
 void ADC_Enable(uint8_t adc, BOOL enable);
 
 /**
-  * @brief  Enable or disable ADC interrupt. 
-	* @param[in] Int interrupt mask bits, which can be a combination of @ref ADC_INT
-	* @param[in] Enable The bit indicates if specific interrupts are enable or not
+  * @brief  Enable or disable ADC interrupt.
+    * @param[in] Int interrupt mask bits, which can be a combination of @ref ADC_INT
+    * @param[in] Enable The bit indicates if specific interrupts are enable or not
   * @retval None
-	*/ 
+    */
 void ADC_EnableInt(uint32_t Int, BOOL enable);
 
 /**
-  * @brief  Check specific interrupts are set or not 
-	* @param[in] Int interrupt mask bits, which can be a combination of @ref ADC_INT
-	* @retval BOOL The bit indicates if the specific interrupts are set or not
-	*/
+  * @brief  Check specific interrupts are set or not
+    * @param[in] Int interrupt mask bits, which can be a combination of @ref ADC_INT
+    * @retval BOOL The bit indicates if the specific interrupts are set or not
+    */
 BOOL ADC_GetIntStatus(uint32_t Int);
 
 /**
   * @brief  Clear specific interrupts
-	* @param[in] Int interrupt mask bits, which can be a value of @ref ADC_INT
+    * @param[in] Int interrupt mask bits, which can be a value of @ref ADC_INT
   * @retval None
-	*/
+    */
 void ADC_ClearInt(uint32_t Int);
 
 /**
-  * @brief  ADC starts to convert data 
-	* @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
-	* @param[in] convMode It should be a value of @ref ADC_CONVERSION
-	* @param[in] channel It should be the value of @ref ADC1_CHANNEL 
-	* 					 or @ref ADC2_CHANNEL according to parameter 'adc'
+  * @brief  ADC starts to convert data
+    * @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
+    * @param[in] convMode It should be a value of @ref ADC_CONVERSION
+    * @param[in] channel It should be the value of @ref ADC1_CHANNEL
+    *                    or @ref ADC2_CHANNEL according to parameter 'adc'
   * @retval BOOL The bit indicates if the specific ADC starts to convert data
-	*/ 
+    */
 BOOL ADC_StartConversion(uint8_t adc, uint8_t convMode, uint32_t channel);
 
 /**
   * @brief  ADC starts to calibrate and produces one sample
-	* @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
-	* @param[in] convMode It should be a value of @ref ADC_CALIBRATION
+    * @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
+    * @param[in] convMode It should be a value of @ref ADC_CALIBRATION
   * @retval BOOL The bit indicates if the specific ADC starts to convert data
-	*/ 
+    */
 BOOL ADC_StartCalibration(uint8_t adc, uint8_t calibration);
 
 /**
   * @brief  ADC stops conversion or calibration
-	* @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
-	* @retval NULL
-	*/ 
+    * @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
+    * @retval NULL
+    */
 void ADC_Stop(uint8_t adc);
 
 /**
   * @brief  Check if ADC is busy or not
-	* @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
-	* @retval BOOL The bit indicates if the specific ADC is busy or not
-	*/ 
+    * @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
+    * @retval BOOL The bit indicates if the specific ADC is busy or not
+    */
 BOOL ADC_IsBusy(uint8_t adc);
 
 /**
   * @brief  Read data from ADC
-	* @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
-	* @param[in] Size Expected data size to be read
-	* @param[out] data A user-allocated buffer to fetch data to be read
+    * @param[in] adc ADC peripheral, which is a value of @ref ADC_PERIPH
+    * @param[in] Size Expected data size to be read
+    * @param[out] data A user-allocated buffer to fetch data to be read
   * @retval uint8_t Actual read data size
-	*/
+    */
 uint8_t ADC_Read(uint8_t adc, uint8_t size, ADC_Data* data);
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_aes.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_aes.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_aes.h
-	*
-	* @brief    CMEM7 AES header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_aes.h
+    *
+    * @brief    CMEM7 AES header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_AES_H
 #define __CMEM7_AES_H
 
@@ -36,12 +36,12 @@
 
 /**
   * @brief  AES decryption
-	* @param[in] src A pointer to data to be decrypted
-	* @param[out] dst A user-allocated buffer to fetch decrypted data
+    * @param[in] src A pointer to data to be decrypted
+    * @param[out] dst A user-allocated buffer to fetch decrypted data
   * @param[in] len Expected data size to be decrypted, which should
-	*						 be multiply times of 16
-	* @retval BOOL True if succeed, or flase
-	*/
+    *                        be multiply times of 16
+    * @retval BOOL True if succeed, or flase
+    */
 BOOL AES_Decrypt(const void *src, void *dst, uint32_t len);
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_can.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_can.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_can.h
-	*
-	* @brief    CMEM7 CAN header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_can.h
+    *
+    * @brief    CMEM7 CAN header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_CAN_H
 #define __CMEM7_CAN_H
 
@@ -33,13 +33,13 @@
 
 #include "cmem7.h"
 #include "cmem7_conf.h"
-	 
+
 #define IS_CAN_ALL_PERIPH(PERIPH) (((PERIPH) == CAN0) || \
                                    ((PERIPH) == CAN1))
 
 /** @defgroup CAN_FLT
   * @{
-  */																
+  */
 #define CAN_FLT_STANDARD_SINGLE    0x00000000
 #define CAN_FLT_STANDARD_DUAL      0x00000001
 #define CAN_FLT_EXTENDED_SINGLE    0x00000002
@@ -47,15 +47,15 @@
 
 #define IS_CAN_FLT_TYPE(FILTER)    (((FILTER) == CAN_FLT_STANDARD_SINGLE) || \
                                     ((FILTER) == CAN_FLT_STANDARD_DUAL) || \
-																		((FILTER) == CAN_FLT_EXTENDED_SINGLE) || \
-                                    ((FILTER) == CAN_FLT_EXTENDED_DUAL))	
-																		
+                                                                        ((FILTER) == CAN_FLT_EXTENDED_SINGLE) || \
+                                    ((FILTER) == CAN_FLT_EXTENDED_DUAL))
+
 #define IS_CAN_FLT_SINGLE(FILTER)  (((FILTER) == CAN_FLT_STANDARD_SINGLE) || \
                                     ((FILTER) == CAN_FLT_EXTENDED_SINGLE))
 
 #define IS_CAN_FLT_DUAL(FILTER)    (IS_CAN_FLT_TYPE(FILTER) && \
                                     !IS_CAN_FLT_SINGLE(FILTER))
-																		
+
 /**
   * @}
   */
@@ -74,12 +74,12 @@
 
 #define IS_CAN_CDR_DIV(DIV)        (((DIV) == CAN_CDR_DIV_1_2) || \
                                     ((DIV) == CAN_CDR_DIV_1_4) || \
-																		((DIV) == CAN_CDR_DIV_1_6) || \
-																		((DIV) == CAN_CDR_DIV_1_8) || \
-																		((DIV) == CAN_CDR_DIV_1_10) || \
-																		((DIV) == CAN_CDR_DIV_1_12) || \
-																		((DIV) == CAN_CDR_DIV_1_14) || \
-																		((DIV) == CAN_CDR_DIV_1_1))		
+                                                                        ((DIV) == CAN_CDR_DIV_1_6) || \
+                                                                        ((DIV) == CAN_CDR_DIV_1_8) || \
+                                                                        ((DIV) == CAN_CDR_DIV_1_10) || \
+                                                                        ((DIV) == CAN_CDR_DIV_1_12) || \
+                                                                        ((DIV) == CAN_CDR_DIV_1_14) || \
+                                                                        ((DIV) == CAN_CDR_DIV_1_1))
 /**
   * @}
   */
@@ -97,137 +97,137 @@
 #define CAN_INT_BUS_ERR            0x80
 #define CAN_INT_All                0xFF
 
-#define IS_CAN_INT(INT)            (((INT) != 0) && (((INT) & ~CAN_INT_All) == 0))                                  
+#define IS_CAN_INT(INT)            (((INT) != 0) && (((INT) & ~CAN_INT_All) == 0))
 /**
   * @}
   */
 
 /**
   * @brief  CAN standard filter structure
-	*/ 
+    */
 typedef struct {
-	uint16_t  ID28_18;               /*!< 11 bits                                      */
+    uint16_t  ID28_18;               /*!< 11 bits                                      */
   BOOL      RTR;                   /*!< if remote frame                              */
-	uint8_t   data1;                 /*!< data byte 1, if not 2nd CAN_FLT_STANDARD_DUAL*/
-	uint8_t   data2;                 /*!< data byte 2, if CAN_FLT_STANDARD_SINGLE      */
+    uint8_t   data1;                 /*!< data byte 1, if not 2nd CAN_FLT_STANDARD_DUAL*/
+    uint8_t   data2;                 /*!< data byte 2, if CAN_FLT_STANDARD_SINGLE      */
 } CAN_STANDARD_FILTER;
 
 /**
   * @brief  CAN extended filter structure
-	*/
+    */
 typedef struct {
-	uint16_t  ID28_13;               /*!< 16 bits                                      */
-	uint16_t  ID12_0;                /*!< 13 bits, if CAN_FLT_EXTENDED_SINGLE          */
+    uint16_t  ID28_13;               /*!< 16 bits                                      */
+    uint16_t  ID12_0;                /*!< 13 bits, if CAN_FLT_EXTENDED_SINGLE          */
   BOOL      RTR;                   /*!< if remote frame, if CAN_FLT_EXTENDED_SINGLE  */
 } CAN_EXTENDED_FILTER;
 
 /**
   * @brief  CAN filter structure
-	*/
+    */
 typedef struct {
-	uint8_t   type;                  /*!< Filter type, which is a value of @ref CAN_FLT */
-	
-	/**
+    uint8_t   type;                  /*!< Filter type, which is a value of @ref CAN_FLT */
+
+    /**
   * @brief  accepted filter
-	*/
-	union {
-		CAN_STANDARD_FILTER sf;				 
-		CAN_EXTENDED_FILTER ef;				 
-	} ACCEPT;												 
-	
-	/**
-  * @brief  filter mask 
-	*/
-	union {
-		CAN_STANDARD_FILTER sf;        
-		CAN_EXTENDED_FILTER ef;				 
-	} MASK;													 
+    */
+    union {
+        CAN_STANDARD_FILTER sf;
+        CAN_EXTENDED_FILTER ef;
+    } ACCEPT;
+
+    /**
+  * @brief  filter mask
+    */
+    union {
+        CAN_STANDARD_FILTER sf;
+        CAN_EXTENDED_FILTER ef;
+    } MASK;
 } CAN_FILTER;
 
 /**
   * @brief  CAN initialization structure
-	*/
-typedef struct {	
-	BOOL CAN_TxEn;            			 /*!< if transmission is enable 										*/
-	BOOL CAN_Loopback;        			 /*!< loop back mode without phy						 				*/
-  uint8_t CAN_ClockDiv;     			 /*!< input clock divider, ref as @ref CAN_CDR_DIV  */                               
-	uint16_t CAN_Prescaler;   			 /*!< Specifies the length of a time quantum. 
-																				Time quantum = (CAN_Prescaler + 1) * 2 * input clock */ 
-  uint8_t CAN_SJW;          			 /*!< Specifies the maximum number of time quanta 
-																				the CAN hardware is allowed to lengthen or 
-																				shorten a bit to perform resynchronization.		*/
-	uint8_t CAN_TSEG1;        			 /*!< the maximum number of time quanta of 
-																				propagation and 1st phase segment 						*/
-  uint8_t CAN_TSEG2;        			 /*!< the maximum number of time quanta of 2nd 
-																				phase segment																	*/	
-  BOOL CAN_HighSpeed;       			 /*!< if CAN is running on high speed bus (class C) */
+    */
+typedef struct {
+    BOOL CAN_TxEn;                       /*!< if transmission is enable                                         */
+    BOOL CAN_Loopback;                   /*!< loop back mode without phy                                        */
+  uint8_t CAN_ClockDiv;                  /*!< input clock divider, ref as @ref CAN_CDR_DIV  */
+    uint16_t CAN_Prescaler;              /*!< Specifies the length of a time quantum.
+                                                                                Time quantum = (CAN_Prescaler + 1) * 2 * input clock */
+  uint8_t CAN_SJW;                       /*!< Specifies the maximum number of time quanta
+                                                                                the CAN hardware is allowed to lengthen or
+                                                                                shorten a bit to perform resynchronization.     */
+    uint8_t CAN_TSEG1;                   /*!< the maximum number of time quanta of
+                                                                                propagation and 1st phase segment                       */
+  uint8_t CAN_TSEG2;                     /*!< the maximum number of time quanta of 2nd
+                                                                                phase segment                                                                   */
+  BOOL CAN_HighSpeed;                    /*!< if CAN is running on high speed bus (class C) */
 } CAN_InitTypeDef;
 
 /**
   * @brief  CAN frame structure
-	*/
+    */
 typedef struct
 {
-  BOOL SFF;        								 /*!< If standard or extended frame format 					*/ 
-	uint32_t Id;     								 /*!< Specifies the identifier.This parameter can 
-																				be a value between 0 to 0x1FFFFFFF. 					*/
-  BOOL RTR;        								 /*!< Specifies if the frame is a remote frame      */
-  uint8_t DLC;     								 /*!< Specifies the length of the frame, which is 
-																				a value between  0 to 8 											*/
-  uint8_t Data[8]; 								 /*!< Frame data																		*/
+  BOOL SFF;                                      /*!< If standard or extended frame format                  */
+    uint32_t Id;                                     /*!< Specifies the identifier.This parameter can
+                                                                                be a value between 0 to 0x1FFFFFFF.                     */
+  BOOL RTR;                                      /*!< Specifies if the frame is a remote frame      */
+  uint8_t DLC;                                   /*!< Specifies the length of the frame, which is
+                                                                                a value between  0 to 8                                             */
+  uint8_t Data[8];                               /*!< Frame data                                                                        */
 } CAN_Frame;
 
 /**
   * @brief  CAN initialization
   * @note   This function should be called at first before any other interfaces.
-	* @param[in] CANx CAN peripheral, which is CAN0 or CAN1
-	* @param[in] Init A pointer to structure CAN_InitTypeDef
-	* @param[in] f1 A pointer to structure CAN_FILTER
-	* @param[in] f2 NULL if single filter, or a pointer to second filter while dual filters
+    * @param[in] CANx CAN peripheral, which is CAN0 or CAN1
+    * @param[in] Init A pointer to structure CAN_InitTypeDef
+    * @param[in] f1 A pointer to structure CAN_FILTER
+    * @param[in] f2 NULL if single filter, or a pointer to second filter while dual filters
   * @retval BOOL The bit indicates if specific CAN is initialized or not
-	*/ 
-BOOL CAN_Init(CAN0_Type* CANx, CAN_InitTypeDef* Init, 
+    */
+BOOL CAN_Init(CAN0_Type* CANx, CAN_InitTypeDef* Init,
   CAN_FILTER *f1, CAN_FILTER *f2);
 
 /**
   * @brief  CAN is set to sleep or wake up
   * @param[in] CANx CAN peripheral, which is CAN0 or CAN1
-	* @param[in] Enable The bit indicates if sleep mode is enable or not
-	* @retval None
-	*/
+    * @param[in] Enable The bit indicates if sleep mode is enable or not
+    * @retval None
+    */
 void CAN_SetSleepMode(CAN0_Type* CANx, BOOL enable);
 
 /**
-  * @brief  Enable or disable UART interrupt. 
-	* @param[in] CANx CAN peripheral, which is CAN0 or CAN1
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref CAN_INT
-	* @param[in] Enable The bit indicates if specific interrupts are enable or not
+  * @brief  Enable or disable UART interrupt.
+    * @param[in] CANx CAN peripheral, which is CAN0 or CAN1
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref CAN_INT
+    * @param[in] Enable The bit indicates if specific interrupts are enable or not
   * @retval None
-	*/ 
+    */
 void CAN_EnableInt(CAN0_Type* CANx, uint32_t Int, BOOL enable);
 
 /**
-  * @brief  Check specific interrupts are set or not 
-	* @note   All interrupts except for receive int are cleared after call this func.
-	* @param[in] CANx CAN peripheral, which is CAN0 or CAN1
-	* @retval uint8_t CAN interrupt bits, which can be the combination of @ref CAN_INT
-	*/
+  * @brief  Check specific interrupts are set or not
+    * @note   All interrupts except for receive int are cleared after call this func.
+    * @param[in] CANx CAN peripheral, which is CAN0 or CAN1
+    * @retval uint8_t CAN interrupt bits, which can be the combination of @ref CAN_INT
+    */
 uint8_t CAN_GetIntStatus(CAN0_Type* CANx);
 
 /**
   * @brief  CAN perform to transmit data
-	* @param[in] CANx CAN peripheral, which is CAN0 or CAN1
-	* @param[in] frame A pointer to the CAN_Frame to be transmitted
-	* @retval BOOL The bit indicates if data is transmitted or not
-	*/ 
+    * @param[in] CANx CAN peripheral, which is CAN0 or CAN1
+    * @param[in] frame A pointer to the CAN_Frame to be transmitted
+    * @retval BOOL The bit indicates if data is transmitted or not
+    */
 BOOL CAN_Transmit(CAN0_Type* CANx, CAN_Frame* frame);
 
 /**
   * @brief  CAN perform to receive data
-	* @param[in] CANx CAN peripheral, which is CAN0 or CAN1
-	* @param[out] frame A user-allocated buffer to fetch received frame
-	* @retval BOOL The bit indicates if data is recieved or not
-	*/
+    * @param[in] CANx CAN peripheral, which is CAN0 or CAN1
+    * @param[out] frame A user-allocated buffer to fetch received frame
+    * @retval BOOL The bit indicates if data is recieved or not
+    */
 BOOL CAN_Receive(CAN0_Type* CANx, CAN_Frame* frame);
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_conf.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_conf.h
@@ -1,28 +1,28 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_conf.h
-	*
-	* @brief    CMEM7 config file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
+    *****************************************************************************
+    * @file     cmem7_conf.h
+    *
+    * @brief    CMEM7 config file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
 
 #ifndef __CMEM7_CONF_H
 #define __CMEM7_CONF_H
@@ -50,7 +50,7 @@
 #define _M7NORFLASH
 #define _ME_6095_F
 
-#define USE_FULL_ASSERT    1 
+#define USE_FULL_ASSERT    1
 
 #ifdef  USE_FULL_ASSERT
 /**
@@ -62,11 +62,11 @@
   */
   #define assert_param(expr) ((expr) ? (void)0 : assert_failed((unsigned char *)__FILE__, __LINE__))
 
-	static void assert_failed(unsigned char* file, unsigned long line) {
-		while (1) {
-			;
-		}
-	}
+    static void assert_failed(unsigned char* file, unsigned long line) {
+        while (1) {
+            ;
+        }
+    }
 #else
   #define assert_param(expr) ((void)0)
 #endif /* USE_FULL_ASSERT */
@@ -76,16 +76,16 @@ typedef enum _BOOL {FALSE = 0, TRUE = 1} BOOL;
 /**
   * System clock frequency, unit is Hz.
   */
-#define SYSTEM_CLOCK_FREQ        300000000 
+#define SYSTEM_CLOCK_FREQ        300000000
 //250000000
 //300000000
 
 /**
-  * @brief  usecond delay 
-	* @note 	It can't delay in an accurate time
-	* @param[in] usec usecond to be delay
-	* @retval None
-	*/
+  * @brief  usecond delay
+    * @note     It can't delay in an accurate time
+    * @param[in] usec usecond to be delay
+    * @retval None
+    */
 static void udelay(unsigned long usec) {
   unsigned long count = 0;
   unsigned long utime = SYSTEM_CLOCK_FREQ / 1000000 * usec;
@@ -95,18 +95,18 @@ static void udelay(unsigned long usec) {
 
 /**
   * UART definition for print
-	*/
-#define PRINT_UART							UART2
+    */
+#define PRINT_UART                          UART2
 
 /**
   * DDR type definition
   */
-#define DDR_TYPE				3	// 2 for DDR2, 3 for DDR3
+#define DDR_TYPE                3   // 2 for DDR2, 3 for DDR3
 
 #if (DDR_TYPE == 3)
-# define DDR_SIZE				(256 << 20)
+# define DDR_SIZE               (256 << 20)
 #elif (DDR_TYPE == 2)
-# define DDR_SIZE				(128 << 20)
+# define DDR_SIZE               (128 << 20)
 #else
 # error
 #endif

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_ddr.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_ddr.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_ddr.h
-	*
-	* @brief    CMEM7 AES header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_ddr.h
+    *
+    * @brief    CMEM7 AES header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_DDR_H
 #define __CMEM7_DDR_H
 
@@ -36,11 +36,11 @@
 /** @defgroup _MEM_TYPE
   * @{
   */
-enum _MEM_TYPE 
+enum _MEM_TYPE
 {
-	MEM_DDR2=1,
-	MEM_DDR3		
-} ;	
+    MEM_DDR2=1,
+    MEM_DDR3
+} ;
 /**
   * @}
   */
@@ -50,30 +50,30 @@ enum _MEM_TYPE
   */
 enum _BUS_WIDTH
 {
-	BUS_WIDTH_8,
-	BUS_WIDTH_16,
-	BUS_WIDTH_MAX
+    BUS_WIDTH_8,
+    BUS_WIDTH_16,
+    BUS_WIDTH_MAX
 };
 /**
   * @}
   */
 /** @defgroup _CHIP_TYPE
   * @{
-  */  
+  */
 enum _CHIP_TYPE
 {
-	_32Mbx8,
-	_64Mbx8,
-	_128Mbx8,
-	_256Mbx8,
-	_512Mbx8,
-	_16Mbx16,
-	_32Mbx16,
-	_64Mbx16,
-	_128Mbx16,
-	_256Mbx16,
-	_512Mbx16,
-	CHIP_TYPE_MAX
+    _32Mbx8,
+    _64Mbx8,
+    _128Mbx8,
+    _256Mbx8,
+    _512Mbx8,
+    _16Mbx16,
+    _32Mbx16,
+    _64Mbx16,
+    _128Mbx16,
+    _256Mbx16,
+    _512Mbx16,
+    CHIP_TYPE_MAX
 };
 /**
   * @}
@@ -81,27 +81,27 @@ enum _CHIP_TYPE
 
 /** @defgroup _CHIP_NUM
   * @{
-  */  
+  */
 enum _CHIP_NUM
 {
-	CHIP_NUM_x1,
-	CHIP_NUM_x2,
-	CHIP_NUM_MAX
+    CHIP_NUM_x1,
+    CHIP_NUM_x2,
+    CHIP_NUM_MAX
 };
 /**
   * @}
   */
-  
+
 /** @defgroup MEM_CHIP_INFO
   * @{
   */
 typedef struct {
-	uint8_t mem_type;     /*!< ddr type @ref _MEM_TYPE*/
-	uint8_t Bus_width;	/*!< ddr qs bus width @ref _BUS_WIDTH*/
-	uint8_t Chip_type;	/*!< chip type @ref _CHIP_TYPE*/
-	uint8_t Chip_num;	/*!< chip number @ref _CHIP_NUM*/
-	uint8_t Chip_bank;      /*!< chip bank number*/		
-} MEM_CHIP_INFO;								
+    uint8_t mem_type;     /*!< ddr type @ref _MEM_TYPE*/
+    uint8_t Bus_width;  /*!< ddr qs bus width @ref _BUS_WIDTH*/
+    uint8_t Chip_type;  /*!< chip type @ref _CHIP_TYPE*/
+    uint8_t Chip_num;   /*!< chip number @ref _CHIP_NUM*/
+    uint8_t Chip_bank;      /*!< chip bank number*/
+} MEM_CHIP_INFO;
 /**
   * @}
   */
@@ -111,18 +111,18 @@ typedef struct {
   * @{
   */
 typedef struct {
-	uint32_t tCK;       		/*!< Period of clock(ps), not data period */ 
-	uint32_t tCL;						/*!< tCL */
-	uint32_t tRCD;						/*!< tRCD */
-	uint32_t tRP;						/*!< tRP */
-	uint32_t tRC;						/*!< tRC */
-	uint32_t tRAS;						/*!< tRAS */
-	uint32_t tWR;						/*!< tWR */
-	uint32_t tRRD;						/*!< tRRD */
-	uint32_t tWTR;						/*!< tWTR */
-	uint32_t tRTP;						/*!< tRTP */
-	uint32_t tFAW;						/*!< tFAW */
-} DDR2MEM;								/*!< DDR2时序定义 */
+    uint32_t tCK;               /*!< Period of clock(ps), not data period */
+    uint32_t tCL;                       /*!< tCL */
+    uint32_t tRCD;                      /*!< tRCD */
+    uint32_t tRP;                       /*!< tRP */
+    uint32_t tRC;                       /*!< tRC */
+    uint32_t tRAS;                      /*!< tRAS */
+    uint32_t tWR;                       /*!< tWR */
+    uint32_t tRRD;                      /*!< tRRD */
+    uint32_t tWTR;                      /*!< tWTR */
+    uint32_t tRTP;                      /*!< tRTP */
+    uint32_t tFAW;                      /*!< tFAW */
+} DDR2MEM;                              /*!< DDR2鏃跺簭瀹氫箟 */
 /**
   * @}
   */
@@ -131,20 +131,20 @@ typedef struct {
   * @{
   */
 typedef struct {
-	uint32_t tCK;       		/*!< Period of clock(ps), not data period */ 
-	uint32_t tCL;						/*!< tCL */
-	uint32_t tWCL;						/*!< tWCL */
-	uint32_t tRCD;						/*!< tRCD */
-	uint32_t tRAS;						/*!< tRAS */
-	uint32_t tRP;						/*!< tRP */
-	uint32_t tRC;						/*!< tRC */
-	uint32_t tRRD;						/*!< tRRD */
-	uint32_t tFAW;						/*!< tFAW */
-	uint32_t tWR;						/*!< tWR */
-	uint32_t tRTP;						/*!< tRTP */
-	uint32_t tZQoper;					/*!< tZQCL */
-	uint32_t tZQCS;						/*!< tZQCS */
-} DDR3MEM;								/*!< DDR3时序定义 */
+    uint32_t tCK;               /*!< Period of clock(ps), not data period */
+    uint32_t tCL;                       /*!< tCL */
+    uint32_t tWCL;                      /*!< tWCL */
+    uint32_t tRCD;                      /*!< tRCD */
+    uint32_t tRAS;                      /*!< tRAS */
+    uint32_t tRP;                       /*!< tRP */
+    uint32_t tRC;                       /*!< tRC */
+    uint32_t tRRD;                      /*!< tRRD */
+    uint32_t tFAW;                      /*!< tFAW */
+    uint32_t tWR;                       /*!< tWR */
+    uint32_t tRTP;                      /*!< tRTP */
+    uint32_t tZQoper;                   /*!< tZQCL */
+    uint32_t tZQCS;                     /*!< tZQCS */
+} DDR3MEM;                              /*!< DDR3鏃跺簭瀹氫箟 */
 /**
   * @}
   */
@@ -152,8 +152,8 @@ typedef struct {
 /** @defgroup DDR2PREDEF
   * @{
   */
-extern const DDR2MEM DDR2PREDEF[];		/*!< Pre-defined DDR2 Timing in library */
-#define DDR2_400C			0			/*!< sg5E: DDR2-400C CL=4, tCK=5000ps */
+extern const DDR2MEM DDR2PREDEF[];      /*!< Pre-defined DDR2 Timing in library */
+#define DDR2_400C           0           /*!< sg5E: DDR2-400C CL=4, tCK=5000ps */
 
 /**
   * @}
@@ -162,8 +162,8 @@ extern const DDR2MEM DDR2PREDEF[];		/*!< Pre-defined DDR2 Timing in library */
 /** @defgroup DDR3PREDEF
   * @{
   */
-extern const DDR3MEM DDR3PREDEF[];		/*!< Pre-defined DDR3 Timing in library */
-#define DDR3_400		  	0
+extern const DDR3MEM DDR3PREDEF[];      /*!< Pre-defined DDR3 Timing in library */
+#define DDR3_400            0
 #define DDR3_667        1
 
 /**

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_dma.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_dma.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_dma.h
-	*
-	* @brief    CMEM7 DMA header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_dma.h
+    *
+    * @brief    CMEM7 DMA header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_DMA_H
 #define __CMEM7_DMA_H
 
@@ -37,75 +37,75 @@
 /** @defgroup DMA_Int
   * @{
   */
-#define DMA_Int_TfrComplete                0x00000001    
+#define DMA_Int_TfrComplete                0x00000001
 #define DMA_Int_Err                        0x00000002
 #define DMA_Int_All                        0x00000003
 
 #define IS_DMA_INT(INT)        (((INT) != 0) && (((INT) & ~DMA_Int_All) == 0))
 /**
   * @}
-  */ 
+  */
 
 /**
   * @brief  Descriptor structure
-	*	@note		DMA requires users provides a list of descriptors to operation.
-	*					Meanwhile, memory occupied by descriptors should be in physical
-	*					memory and keep valid during DMA transfer.
-	*/ 
-typedef struct {                      
-	uint32_t srcAddr;                  /*!< source address 														*/		
-	uint32_t dstAddr;                  /*!< destination address 											*/	
-	uint32_t number;                   /*!< block byte number, no more than 2K Bytes 	*/
-	uint32_t nextBlock;                /*!< next block descriptor 										*/
-	uint32_t padding;                  /*!< Nonsense, only used to fill 							*/
+    *   @note       DMA requires users provides a list of descriptors to operation.
+    *                   Meanwhile, memory occupied by descriptors should be in physical
+    *                   memory and keep valid during DMA transfer.
+    */
+typedef struct {
+    uint32_t srcAddr;                  /*!< source address                                                      */
+    uint32_t dstAddr;                  /*!< destination address                                             */
+    uint32_t number;                   /*!< block byte number, no more than 2K Bytes    */
+    uint32_t nextBlock;                /*!< next block descriptor                                       */
+    uint32_t padding;                  /*!< Nonsense, only used to fill                             */
 } BLOCK_DESC;
-	
+
 /**
   * @brief  DMA initialization
   * @note   This function should be called at first before any other interfaces.
-	* @param  None
-	* @retval None
-	*/ 
+    * @param  None
+    * @retval None
+    */
 void DMA_Init(void);
 
 /**
-  * @brief  Enable or disable DMA interrupt. 
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref DMA_Int
-	* @param[in] Enable The bit indicates if specific interrupts are enable or not
+  * @brief  Enable or disable DMA interrupt.
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref DMA_Int
+    * @param[in] Enable The bit indicates if specific interrupts are enable or not
   * @retval None
-	*/ 
+    */
 void DMA_EnableInt(uint32_t Int, BOOL enable);
 
 /**
-  * @brief  Check specific interrupts are set or not 
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref DMA_Int
+  * @brief  Check specific interrupts are set or not
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref DMA_Int
   * @retval BOOL The bit indicates if specific interrupts are set or not
-	*/
+    */
 BOOL DMA_GetIntStatus(uint32_t Int);
 
 /**
   * @brief  Clear specific interrupts
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref DMA_Int
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref DMA_Int
   * @retval None
-	*/
+    */
 void DMA_ClearInt(uint32_t Int);
 
 /**
   * @brief  DMA transfer
-	* @note		Make sure that memory occupied by descriptors should be in physical
-	*					memory and keep valid before DMA transfer is finished (Return false by
-	*					calling DMA_IsBusy after DMA transfer started).
-	* @param[in] blockList A pointer to header of list of BLOCK_DESC
+    * @note     Make sure that memory occupied by descriptors should be in physical
+    *                   memory and keep valid before DMA transfer is finished (Return false by
+    *                   calling DMA_IsBusy after DMA transfer started).
+    * @param[in] blockList A pointer to header of list of BLOCK_DESC
   * @retval BOOL The bit indicates if DMA begins to transfer
-	* @see		DMA_IsBusy
-	*/
+    * @see      DMA_IsBusy
+    */
 BOOL DMA_Transfer(BLOCK_DESC *blockList);
 
 /**
   * @brief  DMA is busy or not
   * @param  None
-	* @retval BOOL The bit indicates if DMA is busy or not
-	*/ 
+    * @retval BOOL The bit indicates if DMA is busy or not
+    */
 BOOL DMA_IsBusy(void);
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_efuse.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_efuse.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_efuse.h
-	*
-	* @brief    CMEM7 EFUSE header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_efuse.h
+    *
+    * @brief    CMEM7 EFUSE header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_EFUSE_H
 #define __CMEM7_EFUSE_H
 
@@ -50,60 +50,60 @@
 
 /**
   * @brief  EFUSE timing structure
-	*/
+    */
 typedef struct
 {
-	uint32_t EFUSE_Tpwph;                  /*!< Nano second                                    */
+    uint32_t EFUSE_Tpwph;                  /*!< Nano second                                    */
   uint32_t EFUSE_Trac;                   /*!< Nano second                                    */
-	uint32_t EFUSE_Trah;                   /*!< Nano second                                    */
-	uint32_t EFUSE_Trpw;                   /*!< Nano second                                    */
-	uint32_t EFUSE_Trc;                    /*!< Nano second                                    */
-	uint32_t EFUSE_Tesr;                   /*!< Nano second                                    */
-	uint32_t EFUSE_Tprs;                   /*!< Nano second                                    */
-	uint32_t EFUSE_Tpi;                    /*!< Nano second                                    */
-	uint32_t EFUSE_Tpp;                    /*!< Nano second                                    */
-	uint32_t EFUSE_Teps;                   /*!< Nano second                                    */
-	uint32_t EFUSE_Tpwps;                  /*!< Nano second                                    */
+    uint32_t EFUSE_Trah;                   /*!< Nano second                                    */
+    uint32_t EFUSE_Trpw;                   /*!< Nano second                                    */
+    uint32_t EFUSE_Trc;                    /*!< Nano second                                    */
+    uint32_t EFUSE_Tesr;                   /*!< Nano second                                    */
+    uint32_t EFUSE_Tprs;                   /*!< Nano second                                    */
+    uint32_t EFUSE_Tpi;                    /*!< Nano second                                    */
+    uint32_t EFUSE_Tpp;                    /*!< Nano second                                    */
+    uint32_t EFUSE_Teps;                   /*!< Nano second                                    */
+    uint32_t EFUSE_Tpwps;                  /*!< Nano second                                    */
 } EFUSE_Timing;
 
 /**
   * @brief  EFUSE initialization structure
-	*/
+    */
 typedef struct
 {
-	uint8_t EFUSE_ClockDividor;       		 /*!< EFUSE clock dividor, 2 in n times */
-	uint8_t EFUSE_TMRF;                    /*!< EFUSE reference resistor select, @ref EFUSE_TMRF_R */
+    uint8_t EFUSE_ClockDividor;              /*!< EFUSE clock dividor, 2 in n times */
+    uint8_t EFUSE_TMRF;                    /*!< EFUSE reference resistor select, @ref EFUSE_TMRF_R */
   EFUSE_Timing* timing;                  /*!< Timing configuration, null if default           */
 } EFUSE_InitTypeDef;
 
 /**
   * @brief  EFUSE key structure
-	*/
+    */
 typedef struct
 {
-	uint32_t key0;                         /*!< EFUSE AES key [31:0]                            */
+    uint32_t key0;                         /*!< EFUSE AES key [31:0]                            */
   uint32_t key1;                         /*!< EFUSE AES key [63:32]                           */
-	uint32_t key2;                         /*!< EFUSE AES key [95:64]                           */
-	uint32_t key3;                         /*!< EFUSE AES key [127:96]                          */
-	uint32_t key4;                         /*!< EFUSE AES key [159:128]                         */
+    uint32_t key2;                         /*!< EFUSE AES key [95:64]                           */
+    uint32_t key3;                         /*!< EFUSE AES key [127:96]                          */
+    uint32_t key4;                         /*!< EFUSE AES key [159:128]                         */
   uint32_t key5;                         /*!< EFUSE AES key [191:160]                         */
-	uint32_t key6;                         /*!< EFUSE AES key [223:192]                         */
-	uint32_t key7;                         /*!< EFUSE AES key [255:224]                         */
+    uint32_t key6;                         /*!< EFUSE AES key [223:192]                         */
+    uint32_t key7;                         /*!< EFUSE AES key [255:224]                         */
 } EFUSE_AesKey;
 
 /**
   * @brief  EFUSE initialization
   * @note   This function should be called at first before any other interfaces.
-	* @param[in] init A pointer to structure EFUSE_InitTypeDef
+    * @param[in] init A pointer to structure EFUSE_InitTypeDef
   * @retval None
-	*/ 
+    */
 void EFUSE_Init(EFUSE_InitTypeDef* init);
 
 /**
   * @brief  EFUSE initialization
   * @param[in] key A pointer to EFUSE_AesKey to be compared
   * @retval BOOL True if equal, or false if different
-	*/ 
+    */
 BOOL EFUSE_Compare(EFUSE_AesKey* key);
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_eth.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_eth.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_eth.h
-	*
-	* @brief    CMEM7 ethernet header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_eth.h
+    *
+    * @brief    CMEM7 ethernet header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_ETH_H
 #define __CMEM7_ETH_H
 
@@ -41,9 +41,9 @@
 #define ETH_SPEED_100M              0x1
 #define ETH_SPEED_1000M             0x2
 
-#define IS_ETH_SPEED(SPEED)    			(((SPEED) == ETH_SPEED_10M)  || \
+#define IS_ETH_SPEED(SPEED)             (((SPEED) == ETH_SPEED_10M)  || \
                                      ((SPEED) == ETH_SPEED_100M) || \
-																		 ((SPEED) == ETH_SPEED_1000M))
+                                                                         ((SPEED) == ETH_SPEED_1000M))
 /**
   * @}
   */
@@ -54,33 +54,33 @@
 #define ETH_DUPLEX_HALF             0x0
 #define ETH_DUPLEX_FULL             0x1
 
-#define IS_ETH_DUPLEX(DUPLEX)  			(((DUPLEX) == ETH_DUPLEX_HALF) || \
-																		 ((DUPLEX) == ETH_DUPLEX_FULL))
+#define IS_ETH_DUPLEX(DUPLEX)           (((DUPLEX) == ETH_DUPLEX_HALF) || \
+                                                                         ((DUPLEX) == ETH_DUPLEX_FULL))
 /**
   * @}
   */
 
 /** @defgroup ETH_INT
   * @{
-  */																			
-#define ETH_INT_TX_COMPLETE_FRAME		0x0001
+  */
+#define ETH_INT_TX_COMPLETE_FRAME       0x0001
 #define ETH_INT_TX_STOP             0x0002
 #define ETH_INT_TX_BUF_UNAVAI       0x0004
-#define ETH_INT_RX_OVERFLOW					0x0010
-#define ETH_INT_TX_UNDERFLOW				0x0020
+#define ETH_INT_RX_OVERFLOW                 0x0010
+#define ETH_INT_TX_UNDERFLOW                0x0020
 #define ETH_INT_RX_COMPLETE_FRAME   0x0040
 #define ETH_INT_RX_BUF_UNAVAI       0x0080
 #define ETH_INT_RX_STOP             0x0100
 #define ETH_INT_BUS_FATAL_ERROR     0x2000
 #define ETH_INT_ALL                 (ETH_INT_TX_COMPLETE_FRAME | \
                                      ETH_INT_TX_STOP           | \
-																		 ETH_INT_TX_BUF_UNAVAI     | \
-																		 ETH_INT_RX_OVERFLOW       | \
-																		 ETH_INT_TX_UNDERFLOW      | \
-																		 ETH_INT_RX_COMPLETE_FRAME | \
-																		 ETH_INT_RX_BUF_UNAVAI     | \
-																		 ETH_INT_RX_STOP           | \
-																		 ETH_INT_BUS_FATAL_ERROR)
+                                                                         ETH_INT_TX_BUF_UNAVAI     | \
+                                                                         ETH_INT_RX_OVERFLOW       | \
+                                                                         ETH_INT_TX_UNDERFLOW      | \
+                                                                         ETH_INT_RX_COMPLETE_FRAME | \
+                                                                         ETH_INT_RX_BUF_UNAVAI     | \
+                                                                         ETH_INT_RX_STOP           | \
+                                                                         ETH_INT_BUS_FATAL_ERROR)
 
 #define IS_ETH_INT(INT)             (((INT) != 0) && (((INT) & ~ETH_INT_ALL) == 0))
 /**
@@ -88,132 +88,132 @@
   */
 /**
   * @brief  EFUSE receive filter structure
-	*/
+    */
 typedef struct
 {
-	BOOL ETH_BroadcastFilterEnable;   /*!< Broadcast is dropped or passed								        */ 
-	BOOL ETH_OwnFilterEnable;	        /*!< source address filter is on or off     							*/
-	BOOL ETH_SelfDrop;				  			/*!< Only own address is dropped or passed								*/
-	BOOL ETH_SourceFilterEnable;	    /*!< source address filter is on or off     							*/
-	BOOL ETH_SourceDrop;				      /*!< Only specific source address is dropped or passed  	*/
-	uint8_t ETH_SourceMacAddr[6];     /*!< Source MAC address                                   */
+    BOOL ETH_BroadcastFilterEnable;   /*!< Broadcast is dropped or passed                                       */
+    BOOL ETH_OwnFilterEnable;           /*!< source address filter is on or off                                 */
+    BOOL ETH_SelfDrop;                          /*!< Only own address is dropped or passed                              */
+    BOOL ETH_SourceFilterEnable;        /*!< source address filter is on or off                                 */
+    BOOL ETH_SourceDrop;                      /*!< Only specific source address is dropped or passed    */
+    uint8_t ETH_SourceMacAddr[6];     /*!< Source MAC address                                   */
 } ETH_FrameFilter;
 
 /**
   * @brief  Ethernet initialization structure
-	*/ 
+    */
 typedef struct
 {
-    BOOL ETH_LinkUp;                   /*!< If ETH is linked up and it can be retrieved from PHY */																	  
-	uint8_t ETH_Speed;                 /*!< speed of ETH, refer as @ref ETH_SPEED                */
-    uint8_t ETH_Duplex;                /*!< duplex mode of ETH, refer as @ref ETH_DUPLEX				 */
-	BOOL ETH_RxEn;                     /*!< Rx enable                                            */
-	BOOL ETH_TxEn;                     /*!< Tx enable                                            */
-	BOOL ETH_ChecksumOffload;          /*!< Checksum offload enable                              */
-	BOOL ETH_JumboFrame;               /*!< Jumbo Frame Enable                                   */
-	uint8_t ETH_MacAddr[6];            /*!< MAC address                                          */ 
+    BOOL ETH_LinkUp;                   /*!< If ETH is linked up and it can be retrieved from PHY */
+    uint8_t ETH_Speed;                 /*!< speed of ETH, refer as @ref ETH_SPEED                */
+    uint8_t ETH_Duplex;                /*!< duplex mode of ETH, refer as @ref ETH_DUPLEX                 */
+    BOOL ETH_RxEn;                     /*!< Rx enable                                            */
+    BOOL ETH_TxEn;                     /*!< Tx enable                                            */
+    BOOL ETH_ChecksumOffload;          /*!< Checksum offload enable                              */
+    BOOL ETH_JumboFrame;               /*!< Jumbo Frame Enable                                   */
+    uint8_t ETH_MacAddr[6];            /*!< MAC address                                          */
     ETH_FrameFilter *ETH_Filter;       /*!< Received frame address filter, receive all if null   */
 } ETH_InitTypeDef;
 
 /**
   * @brief  Ethernet Tx descriptor structure
-	*/ 
-typedef struct { 
-	union {
+    */
+typedef struct {
+    union {
     uint32_t  TX0;
-		
-		struct {
-			uint32_t 								:  1;
-			uint32_t UNDERFLOW_ERR  :  1; 	 /*!< [OUT] Underflow error            											*/
-			uint32_t 								:  1;
-			uint32_t COLLISION_CNT	:  4;		 /*!< [OUT] Collision count				                          */
-			uint32_t 								:  1;
-			uint32_t EX_COLLISION 	:  1;		 /*!< [OUT] Excessive collision error	                      */
-			uint32_t LATE_COLLISION :  1;		 /*!< [OUT] Late collision error	                          */
-			uint32_t NO_CARRIER     :  1;		 /*!< [OUT] No carrier error                          			*/
-			uint32_t LOSS_CARRIER   :  1;		 /*!< [OUT] loss of carrier error                          	*/
-			uint32_t PAYLOAD_ERR 		:  1;		 /*!< [OUT] IP payload error                          			*/
-			uint32_t 								:  2;
-			uint32_t ERR_SUM 				:  1;		 /*!< [OUT] Error summary		                          			*/
-			uint32_t HEADER_ERR 		:  1;		 /*!< [OUT] IP header error                          				*/
-			uint32_t 								:  8;
-			uint32_t TTSE           :  1; 	 /*!< enables IEEE1588 hardware timestamping in first segment */
-			uint32_t 								:  2;
-			uint32_t FS           	:  1; 	 /*!< first segment flag                                    */
-			uint32_t LS           	:  1; 	 /*!< last segment flag                                     */
-			uint32_t 								:  2;
-		} TX0_b;
-	} TX_0;
-	
-	union {
+
+        struct {
+            uint32_t                                :  1;
+            uint32_t UNDERFLOW_ERR  :  1;    /*!< [OUT] Underflow error                                                     */
+            uint32_t                                :  1;
+            uint32_t COLLISION_CNT  :  4;        /*!< [OUT] Collision count                                       */
+            uint32_t                                :  1;
+            uint32_t EX_COLLISION   :  1;        /*!< [OUT] Excessive collision error                         */
+            uint32_t LATE_COLLISION :  1;        /*!< [OUT] Late collision error                              */
+            uint32_t NO_CARRIER     :  1;        /*!< [OUT] No carrier error                                    */
+            uint32_t LOSS_CARRIER   :  1;        /*!< [OUT] loss of carrier error                           */
+            uint32_t PAYLOAD_ERR        :  1;        /*!< [OUT] IP payload error                                    */
+            uint32_t                                :  2;
+            uint32_t ERR_SUM                :  1;        /*!< [OUT] Error summary                                           */
+            uint32_t HEADER_ERR         :  1;        /*!< [OUT] IP header error                                         */
+            uint32_t                                :  8;
+            uint32_t TTSE           :  1;    /*!< enables IEEE1588 hardware timestamping in first segment */
+            uint32_t                                :  2;
+            uint32_t FS             :  1;    /*!< first segment flag                                    */
+            uint32_t LS             :  1;    /*!< last segment flag                                     */
+            uint32_t                                :  2;
+        } TX0_b;
+    } TX_0;
+
+    union {
     uint32_t  TX1;
-		
-		struct {
-			uint32_t SIZE						: 13; 	 	/*!< buffer size                                       */
-			uint32_t                : 19;
-		} TX1_b;
-	} TX_1;
-	
-	uint32_t bufAddr;											/*!< address of buffer						                     */
-	uint32_t nextDescAddr;								/*!< address of next descriptor		                     */
+
+        struct {
+            uint32_t SIZE                       : 13;       /*!< buffer size                                       */
+            uint32_t                : 19;
+        } TX1_b;
+    } TX_1;
+
+    uint32_t bufAddr;                                           /*!< address of buffer                                           */
+    uint32_t nextDescAddr;                              /*!< address of next descriptor                          */
   uint64_t reserved;
-	uint64_t timeStamp;									 	/*!< time stamp while last segment                     */
+    uint64_t timeStamp;                                     /*!< time stamp while last segment                     */
 } ETH_TX_DESC;
 
 /**
   * @brief  Ethernet Rx descriptor structure
-	*/ 
-typedef struct { 
-	union {
+    */
+typedef struct {
+    union {
     uint32_t  RX0;
-		
-		struct {
-			uint32_t 								:  1;
-			uint32_t CRC_ERR        :  1; 	 /*!< [OUT] CRC error while last segment                		*/
-			uint32_t 								:  5;
-			uint32_t TTSE           :  1; 	 /*!< timestamp available while last segment                */
-			uint32_t LS           	:  1; 	 /*!< [OUT] last segment flag                               */
-			uint32_t FS           	:  1; 	 /*!< [OUT] first segment flag                              */
-			uint32_t 								:  1;
-			uint32_t OVERFLOW_ERR   :  1; 	 /*!< [OUT] FIFO overflow while last segment                */
-			uint32_t LENGTH_ERR     :  1; 	 /*!< [OUT] length error while last segment                	*/
-			uint32_t 								:  2;
-			uint32_t ERR_SUM        :  1; 	 /*!< [OUT] Error summary while last segment              	*/
-			uint32_t FL           	: 14; 	 /*!< [OUT] frame length while last segment                 */
-			uint32_t 		           	:  2;
-		} RX0_b;
-	} RX_0;
-	
-	union {
+
+        struct {
+            uint32_t                                :  1;
+            uint32_t CRC_ERR        :  1;    /*!< [OUT] CRC error while last segment                        */
+            uint32_t                                :  5;
+            uint32_t TTSE           :  1;    /*!< timestamp available while last segment                */
+            uint32_t LS             :  1;    /*!< [OUT] last segment flag                               */
+            uint32_t FS             :  1;    /*!< [OUT] first segment flag                              */
+            uint32_t                                :  1;
+            uint32_t OVERFLOW_ERR   :  1;    /*!< [OUT] FIFO overflow while last segment                */
+            uint32_t LENGTH_ERR     :  1;    /*!< [OUT] length error while last segment                 */
+            uint32_t                                :  2;
+            uint32_t ERR_SUM        :  1;    /*!< [OUT] Error summary while last segment                */
+            uint32_t FL             : 14;    /*!< [OUT] frame length while last segment                 */
+            uint32_t                    :  2;
+        } RX0_b;
+    } RX_0;
+
+    union {
     uint32_t  RX1;
-		
-		struct {
-			uint32_t SIZE						: 13; 	 	/*!< buffer size                                       */
-			uint32_t                : 19;
-		} RX1_b;
-	} RX_1;
-	
-	uint32_t bufAddr;											/*!< buffer address                                    */
-	uint32_t nextDescAddr;								/*!< address of next descriptor                        */
+
+        struct {
+            uint32_t SIZE                       : 13;       /*!< buffer size                                       */
+            uint32_t                : 19;
+        } RX1_b;
+    } RX_1;
+
+    uint32_t bufAddr;                                           /*!< buffer address                                    */
+    uint32_t nextDescAddr;                              /*!< address of next descriptor                        */
   uint64_t reserved;
-	uint64_t timeStamp;									 	/*!< time stamp while the last segment                 */
+    uint64_t timeStamp;                                     /*!< time stamp while the last segment                 */
 } ETH_RX_DESC;
 
 /**
   * @brief  Read data from phy chip
-	* @param[in] phyAddr Address of phy chip
-	* @param[in] phyReg Address of phy's register to be read
+    * @param[in] phyAddr Address of phy chip
+    * @param[in] phyReg Address of phy's register to be read
   * @retval uint32_t value of phy's register
-	*/
+    */
 uint32_t ETH_PhyRead(uint32_t phyAddr, uint32_t phyReg);
 
 /**
   * @brief  Write data to phy chip
-	* @param[in] phyAddr Address of phy chip
-	* @param[in] phyReg Address of phy's register to be written
-	* @param[in] data Data to be written
+    * @param[in] phyAddr Address of phy chip
+    * @param[in] phyReg Address of phy's register to be written
+    * @param[in] data Data to be written
   * @retval None
-	*/
+    */
 void ETH_PhyWrite(uint32_t phyAddr, uint32_t phyReg, uint32_t data);
 /**
   * @brief  Fills each ETH_InitStruct member with its default value.
@@ -225,188 +225,188 @@ void ETH_StructInit(ETH_InitTypeDef* init);
 /**
   * @brief  Ethernet initialization
   * @note   This function should be called at first before any other interfaces.
-	* @param[in] init A pointer to structure ETH_InitTypeDef
+    * @param[in] init A pointer to structure ETH_InitTypeDef
   * @retval BOOL The bit indicates if ethernet is initialized successfully
-	*/ 
+    */
 BOOL ETH_Init(ETH_InitTypeDef *init);
 
 /**
-  * @brief  Enable or disable ethernet interrupt. 
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref ETH_INT
-	* @param[in] Enable The bit indicates if specific interrupts are enable or not
+  * @brief  Enable or disable ethernet interrupt.
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref ETH_INT
+    * @param[in] Enable The bit indicates if specific interrupts are enable or not
   * @retval None
-	*/ 
+    */
 void ETH_ITConfig(uint32_t Int, BOOL enable);
 
 /**
-  * @brief  Check specific interrupts are set or not 
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref ETH_INT
+  * @brief  Check specific interrupts are set or not
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref ETH_INT
   * @retval BOOL The bit indicates if specific interrupts are set or not
-	*/
+    */
 BOOL ETH_GetITStatus(uint32_t Int);
 
 /**
   * @brief  Clear specific interrupts
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref ETH_INT
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref ETH_INT
   * @retval None
-	*/
+    */
 void ETH_ClearITPendingBit(uint32_t Int);
 
 /**
   * @brief  Get ethernte MAC address
-	* @param[in] mac A user-allocated buffer to fetch MAC to be read, 6 bytes.
-	* @retval None
-	*/
+    * @param[in] mac A user-allocated buffer to fetch MAC to be read, 6 bytes.
+    * @retval None
+    */
 void ETH_GetMacAddr(uint8_t *mac);
 
 /**
-  * @brief  Set ethernet transmission descriptor ring 
-	* @note		Make sure that memory occupied by descriptors should be in physical
-	*					memory and keep valid before ethernet transmission is finished.
-	* @param[in] ring A pointer to header of ETH_TX_DESC ring, whose last node 
-	*					has a 'nextDescAddr' pointed to first node.
+  * @brief  Set ethernet transmission descriptor ring
+    * @note     Make sure that memory occupied by descriptors should be in physical
+    *                   memory and keep valid before ethernet transmission is finished.
+    * @param[in] ring A pointer to header of ETH_TX_DESC ring, whose last node
+    *                   has a 'nextDescAddr' pointed to first node.
   * @retval BOOL The bit indicates if valid ring is set
-	*/
+    */
 BOOL ETH_SetTxDescRing(ETH_TX_DESC *ring);
 
 /**
   * @brief  Start ethernet transmission
-	* @param	None
+    * @param    None
   * @retval None
-	*/
+    */
 void ETH_StartTx(void);
 
 /**
   * @brief  Stop ethernet transmission
-	* @param	None
+    * @param    None
   * @retval None
-	*/
+    */
 void ETH_StopTx(void);
 
 /**
   * @brief  Resume ethernet transmission\n
-	* 				While ethernet doesn't have enough buffer to transmit data, it will
-	*					pause and inform users by interrupt 'ETH_INT_TX_BUF_UNAVAI'. Users
-	*					must call this function to start ethernet again after new buffer 
-	*					prepared.
-	* @param	None
+    *               While ethernet doesn't have enough buffer to transmit data, it will
+    *                   pause and inform users by interrupt 'ETH_INT_TX_BUF_UNAVAI'. Users
+    *                   must call this function to start ethernet again after new buffer
+    *                   prepared.
+    * @param    None
   * @retval None
-	*/
+    */
 void ETH_ResumeTx(void);
 
 /**
   * @brief  Get free transmission descriptor\n
-	* @param	None
-  * @retval ETH_TX_DESC* A pointer of free transmission descriptor, 
-	*					NULL if no free descriptor
-	*/
+    * @param    None
+  * @retval ETH_TX_DESC* A pointer of free transmission descriptor,
+    *                   NULL if no free descriptor
+    */
 ETH_TX_DESC *ETH_AcquireFreeTxDesc(void);
 
 /**
   * @brief  Check if a transmission descriptor is free or not
-	* @param[in] desc A pointer of a transmission descriptor
+    * @param[in] desc A pointer of a transmission descriptor
   * @retval BOOL True if the transmission descriptor is free, or flase.
-	*/
+    */
 BOOL ETH_IsFreeTxDesc(ETH_TX_DESC *desc);
 
 /**
   * @brief  Release a transmission descriptor to ethernet\n
-	*					After users prepared data in the buffer of a free descriptor,
-	*					They must call this function to change ownership of the 
-	*					descriptor to hardware.
-	* @param[in] desc A pointer of a transmission descriptor
+    *                   After users prepared data in the buffer of a free descriptor,
+    *                   They must call this function to change ownership of the
+    *                   descriptor to hardware.
+    * @param[in] desc A pointer of a transmission descriptor
   * @retval None
-	*/
+    */
 void ETH_ReleaseTxDesc(ETH_TX_DESC *desc);
 
 /**
   * @brief  Set buffer address of the specific TX descriptor
-	* @param[in] desc A pointer of a transmission descriptor
+    * @param[in] desc A pointer of a transmission descriptor
   * @param[in] bufAddr buffer address to be sent
   * @retval None
-	*/
+    */
 void ETH_SetTxDescBufAddr(ETH_TX_DESC *desc, uint32_t bufAddr);
 
 /**
   * @brief  Get buffer address of the specific TX descriptor
-	* @param[in] desc A pointer of a transmission descriptor
+    * @param[in] desc A pointer of a transmission descriptor
   * @retval uint32_t buffer address to be gotten
-	*/
+    */
 uint32_t ETH_GetTxDescBufAddr(ETH_TX_DESC *desc);
 
 /**
   * @brief  Set ethernet receive descriptor ring
-	* @note		Make sure that memory occupied by descriptors should be in physical
-	*					memory and keep valid before ethernet receive is finished.
-	* @param[in] ring A pointer to header of ETH_TX_DESC ring, whose last node 
-	*					has a 'nextDescAddr' pointed to first node.
+    * @note     Make sure that memory occupied by descriptors should be in physical
+    *                   memory and keep valid before ethernet receive is finished.
+    * @param[in] ring A pointer to header of ETH_TX_DESC ring, whose last node
+    *                   has a 'nextDescAddr' pointed to first node.
   * @retval BOOL The bit indicates if valid ring is set
-	*/
+    */
 BOOL ETH_SetRxDescRing(ETH_RX_DESC *ring);
 
 /**
   * @brief  Start ethernet receive
-	* @param	None
+    * @param    None
   * @retval None
-	*/
+    */
 void ETH_StartRx(void);
 
 /**
   * @brief  Stop ethernet receive
-	* @param	None
+    * @param    None
   * @retval None
-	*/
+    */
 void ETH_StopRx(void);
 
 /**
   * @brief  Resume ethernet receive\n
-	* 				While ethernet doesn't have enough buffer to receive data, it will
-	*					pause and inform users by interrupt 'ETH_INT_RX_BUF_UNAVAI'. Users
-	*					must call this function to start ethernet again after new buffer 
-	*					prepared.
-	* @param	None
+    *               While ethernet doesn't have enough buffer to receive data, it will
+    *                   pause and inform users by interrupt 'ETH_INT_RX_BUF_UNAVAI'. Users
+    *                   must call this function to start ethernet again after new buffer
+    *                   prepared.
+    * @param    None
   * @retval None
-	*/
+    */
 void ETH_ResumeRx(void);
 
 /**
   * @brief  Get the free descriptor which contains received data\n
-	* @param	None
-  * @retval ETH_RX_DESC* A pointer of free receive descriptor, 
-	*					NULL if no free descriptor
-	*/
+    * @param    None
+  * @retval ETH_RX_DESC* A pointer of free receive descriptor,
+    *                   NULL if no free descriptor
+    */
 ETH_RX_DESC *ETH_AcquireFreeRxDesc(void);
 
 /**
   * @brief  Check if a receive descriptor is free or not
-	* @param[in] desc A pointer of a receive descriptor
+    * @param[in] desc A pointer of a receive descriptor
   * @retval BOOL True if the receive descriptor is free, or flase.
-	*/
+    */
 BOOL ETH_IsFreeRxDesc(ETH_RX_DESC *desc);
 
 /**
   * @brief  Release a receive descriptor to ethernet\n
-	*					After users handled data in the buffer of a free descriptor,
-	*					They must call this function to change ownership of the 
-	*					descriptor to hardware.
-	* @param[in] desc A pointer of a transmission descriptor
+    *                   After users handled data in the buffer of a free descriptor,
+    *                   They must call this function to change ownership of the
+    *                   descriptor to hardware.
+    * @param[in] desc A pointer of a transmission descriptor
   * @retval None
-	*/
+    */
 void ETH_ReleaseRxDesc(ETH_RX_DESC *desc);
 
 /**
   * @brief  Set buffer address of the specific RX descriptor
-	* @param[in] desc A pointer of a receive descriptor
+    * @param[in] desc A pointer of a receive descriptor
   * @param[in] bufAddr buffer address to be received
   * @retval None
-	*/
+    */
 void ETH_SetRxDescBufAddr(ETH_RX_DESC *desc, uint32_t bufAddr);
 
 /**
   * @brief  Get buffer address of the specific RX descriptor
-	* @param[in] desc A pointer of a receive descriptor
+    * @param[in] desc A pointer of a receive descriptor
   * @retval uint32_t buffer address to be gotten
-	*/
+    */
 uint32_t ETH_GetRxDescBufAddr(ETH_RX_DESC *desc);
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_flash.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_flash.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_flash.h
-	*
-	* @brief    CMEM7 flash controller source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_flash.h
+    *
+    * @brief    CMEM7 flash controller source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_FLASH_H
 #define __CMEM7_FLASH_H
 
@@ -37,15 +37,15 @@
 /** @defgroup FLASH_PROTECT_MODE
   * @{
   */
-#define FLASH_PROTECT_MODE_SW           0       /*!< The Status Register can be written to after a Write 
+#define FLASH_PROTECT_MODE_SW           0       /*!< The Status Register can be written to after a Write
                                                      Enable command.(Default) */
-#define FLASH_PROTECT_MODE_HW           1       /*!< WP pin decides if the Status Register can be written 
+#define FLASH_PROTECT_MODE_HW           1       /*!< WP pin decides if the Status Register can be written
                                                      WP#=0, the Status Register locked
-																									   WP#=1, the Status Register is unlocked and can be written to
+                                                                                                       WP#=1, the Status Register is unlocked and can be written to
                                                      after a Write Enable command */
-#define FLASH_PROTECT_MODE_POWERDOWN    2				/*!< Status Register is protected and can not be written to again
-                                                     until the next Power-Down, Power-Up cycle */	
-#define FLASH_PROTECT_MODE_OTP          3       /*!< Status Register is permanently protected */	
+#define FLASH_PROTECT_MODE_POWERDOWN    2               /*!< Status Register is protected and can not be written to again
+                                                     until the next Power-Down, Power-Up cycle */
+#define FLASH_PROTECT_MODE_OTP          3       /*!< Status Register is permanently protected */
 
 #define IS_FLASH_PROTECT_MODE(MODE)     (((MODE) == FLASH_PROTECT_MODE_SW) || \
                                          ((MODE) == FLASH_PROTECT_MODE_HW) || \
@@ -80,21 +80,21 @@
 #define IS_FLASH_PROTECT_REGION(REGION) (((REGION) == FLASH_PROTECT_REGION_NONE) || \
                                          ((REGION) == FLASH_PROTECT_REGION_UP_64K) || \
                                          ((REGION) == FLASH_PROTECT_REGION_UP_128K) || \
-																				 ((REGION) == FLASH_PROTECT_REGION_UP_256K) || \
-																				 ((REGION) == FLASH_PROTECT_REGION_UP_512K) || \
-																				 ((REGION) == FLASH_PROTECT_REGION_LOW_64K) || \
+                                                                                 ((REGION) == FLASH_PROTECT_REGION_UP_256K) || \
+                                                                                 ((REGION) == FLASH_PROTECT_REGION_UP_512K) || \
+                                                                                 ((REGION) == FLASH_PROTECT_REGION_LOW_64K) || \
                                          ((REGION) == FLASH_PROTECT_REGION_LOW_128K) || \
-																				 ((REGION) == FLASH_PROTECT_REGION_LOW_256K) || \
-																				 ((REGION) == FLASH_PROTECT_REGION_LOW_512K) || \
-																				 ((REGION) == FLASH_PROTECT_REGION_ALL) || \
+                                                                                 ((REGION) == FLASH_PROTECT_REGION_LOW_256K) || \
+                                                                                 ((REGION) == FLASH_PROTECT_REGION_LOW_512K) || \
+                                                                                 ((REGION) == FLASH_PROTECT_REGION_ALL) || \
                                          ((REGION) == FLASH_PROTECT_REGION_UP_4K) || \
                                          ((REGION) == FLASH_PROTECT_REGION_UP_8K) || \
-																				 ((REGION) == FLASH_PROTECT_REGION_UP_16K) || \
-																				 ((REGION) == FLASH_PROTECT_REGION_UP_32K) || \
-																				 ((REGION) == FLASH_PROTECT_REGION_LOW_4K) || \
+                                                                                 ((REGION) == FLASH_PROTECT_REGION_UP_16K) || \
+                                                                                 ((REGION) == FLASH_PROTECT_REGION_UP_32K) || \
+                                                                                 ((REGION) == FLASH_PROTECT_REGION_LOW_4K) || \
                                          ((REGION) == FLASH_PROTECT_REGION_LOW_8K) || \
-																				 ((REGION) == FLASH_PROTECT_REGION_LOW_16K) || \
-																				 ((REGION) == FLASH_PROTECT_REGION_LOW_32K))
+                                                                                 ((REGION) == FLASH_PROTECT_REGION_LOW_16K) || \
+                                                                                 ((REGION) == FLASH_PROTECT_REGION_LOW_32K))
 /**
   * @}
   */
@@ -110,96 +110,96 @@
 #define IS_FLASH_READ_MODE(MODE)       (((MODE) == FLASH_READ_MODE_NORMAL) || \
                                         ((MODE) == FLASH_READ_MODE_FAST) || \
                                         ((MODE) == FLASH_READ_MODE_FAST_DUAL) || \
-																				((MODE) == FLASH_READ_MODE_FAST_QUAD))																								
+                                                                                ((MODE) == FLASH_READ_MODE_FAST_QUAD))
 /**
   * @}
   */
 
 /**
   * @brief  UART initialization structure
-	*/ 
+    */
 typedef struct
 {
   uint8_t FLASH_ClockDividor;       /*!< flash clock dividor, 2 in n times */
-	uint8_t FLASH_ProtectMode;        /*!< Status Register protection mode */
-	uint8_t FLASH_ProtectRegion;      /*!< flash protection region */
-	BOOL FLASH_QuadEnable;            /*!< if allows Quad operation */
-	void (*FLASH_Wait)(void);         /*!< When the former read or write operation is excuting, 
-	                                       Flash has to call a callback to wait it finish. 
-	                                       If null, Flash will wait forever until finish */
+    uint8_t FLASH_ProtectMode;        /*!< Status Register protection mode */
+    uint8_t FLASH_ProtectRegion;      /*!< flash protection region */
+    BOOL FLASH_QuadEnable;            /*!< if allows Quad operation */
+    void (*FLASH_Wait)(void);         /*!< When the former read or write operation is excuting,
+                                           Flash has to call a callback to wait it finish.
+                                           If null, Flash will wait forever until finish */
 } FLASH_InitTypeDef;
 
 /**
   * @brief  flash initialization
   * @note   This function should be called at first before any other interfaces.
-	*					Users should make sure that doesn't erase or write data in a 
-	*					write-protected region.
-	* @param[in] init A pointer to structure FLASH_InitTypeDef
+    *                   Users should make sure that doesn't erase or write data in a
+    *                   write-protected region.
+    * @param[in] init A pointer to structure FLASH_InitTypeDef
   * @retval None
-	*/ 
+    */
 void FLASH_Init(FLASH_InitTypeDef* init);
 
 /**
-  * @brief  Get flash status 
+  * @brief  Get flash status
   * @param[out] ProtectMode flash protect mode, ref as @ref FLASH_PROTECT_MODE
   * @param[out] ProtectRegion flash protect region, ref as @ref FLASH_PROTECT_REGION
-	* @param[out] QuadEnable quad speed mode enable bit
-	* @retval None
-	*/ 
+    * @param[out] QuadEnable quad speed mode enable bit
+    * @retval None
+    */
 void FLASH_GetStatus(uint8_t* ProtectMode, uint8_t* ProtectRegion, BOOL* QuadEnable);
 
 /**
   * @brief  Erase a sector, which is 4K bytes large.
   * @param[in] addr Start address of a sector
-	* @retval None
-	*/
+    * @retval None
+    */
 void FLASH_EraseSector(uint32_t addr);
 
 /**
   * @brief  Erase a block, which is 32K bytes large.
   * @param[in] addr Start address of a block
-	* @retval None
-	*/
+    * @retval None
+    */
 void FLASH_Erase32kBlock(uint32_t addr);
 
 /**
   * @brief  Erase a block, which is 64K bytes large.
   * @param[in] addr Start address of a block
-	* @retval None
-	*/
+    * @retval None
+    */
 void FLASH_Erase64kBlock(uint32_t addr);
 
 /**
   * @brief  Erase all chip
-  * @param	None
-	* @retval None
-	*/
+  * @param  None
+    * @retval None
+    */
 void FLASH_EraseChip(void);
 
 /**
   * @brief  Enable flash power down mode or not
   * @param[in] enable The bit indicates if flash power down mode is enable or not
-	* @retval None
-	*/
+    * @retval None
+    */
 void FLASH_EnableDeepPowerDown(BOOL enable);
 
 /**
   * @brief  Read data from flash
-	* @param[in] ReadMode Normal or fast read, ref as @ref FLASH_READ_MODE
-	* @param[in] addr Start address to be read
-	* @param[in] size Expected data size to be read
-	* @param[out] data A user-allocated buffer to fetch data to be read
+    * @param[in] ReadMode Normal or fast read, ref as @ref FLASH_READ_MODE
+    * @param[in] addr Start address to be read
+    * @param[in] size Expected data size to be read
+    * @param[out] data A user-allocated buffer to fetch data to be read
   * @retval None
-	*/
+    */
 void FLASH_Read(uint8_t ReadMode, uint32_t addr, uint16_t size, uint8_t* data);
 
 /**
   * @brief  Write data to flash
-	* @param[in] addr Start address to be read
-	* @param[in] size Expected data size to be read
-	* @param[out] data A pointer to the data to be written
+    * @param[in] addr Start address to be read
+    * @param[in] size Expected data size to be read
+    * @param[out] data A pointer to the data to be written
   * @retval None
-	*/
+    */
 void FLASH_Write(uint32_t addr, uint16_t size, uint8_t* data);
 
 

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_gpio.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_gpio.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_gpio.h
-	*
-	* @brief    CMEM7 GPIO header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_gpio.h
+    *
+    * @brief    CMEM7 GPIO header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_GPIO_H
 #define __CMEM7_GPIO_H
 
@@ -38,7 +38,7 @@
   * @{
   */
 typedef enum {
-	GPIO_GROUP_GPIO,
+    GPIO_GROUP_GPIO,
 } GPIO_GROUP;
 
 #define IS_GPIO_GROUP(GROUP)  (((GROUP) == GPIO_GROUP_GPIO))
@@ -50,105 +50,105 @@ typedef enum {
   * @{
   */
 typedef enum {
-	GPIO_PWM_CHANNEL_GPIO_31,
+    GPIO_PWM_CHANNEL_GPIO_31,
 } GPIO_PWM_CHANNEL;
-        
+
 #define IS_GPIO_PWM_CHANNEL(CHANNEL)  (((CHANNEL) == GPIO_PWM_CHANNEL_GPIO_31))
 /**
   * @}
   */
-	
+
 /**
   * @brief  GPIO initialization
   * @note   This function should be called at first before any other interfaces.
-	* @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
-	* @param[in] PositiveTrigger Positive edge interrupt trigger if true, or negative edge
+    * @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
+    * @param[in] PositiveTrigger Positive edge interrupt trigger if true, or negative edge
   * @retval None
-	*/ 	
+    */
 void GPIO_Init(uint8_t Group, uint32_t PositiveTrigger);
 
 /**
-  * @brief  Enable or disable GPIO output in the specific group. 
-	* @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
-	* @param[in] Enable each bit indicates if the corresponding GPIO pin 
-	*						in the specific GPIO group is enable or not
+  * @brief  Enable or disable GPIO output in the specific group.
+    * @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
+    * @param[in] Enable each bit indicates if the corresponding GPIO pin
+    *                       in the specific GPIO group is enable or not
   * @retval None
-	*/ 
+    */
 void GPIO_EnableOutput(uint8_t Group, uint32_t Enable);
 
 /**
-  * @brief  Enable or disable GPIO interrupt in the specific group. 
-	* @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
-	* @param[in] Enable each bit indicates if the corresponding GPIO pin interrupt 
-	*						in the specific GPIO group is enable or not
+  * @brief  Enable or disable GPIO interrupt in the specific group.
+    * @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
+    * @param[in] Enable each bit indicates if the corresponding GPIO pin interrupt
+    *                       in the specific GPIO group is enable or not
   * @retval None
-	*/ 
+    */
 void GPIO_EnableInt(uint8_t Group, uint32_t Enable);
 
 /**
-  * @brief  Check specific interrupts are set or not 
-	* @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
-	* @retval uint32_t each bit indicates if the corresponding GPIO pin interrupt 
-	*					in the specific GPIO group is set or not
-	*/
+  * @brief  Check specific interrupts are set or not
+    * @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
+    * @retval uint32_t each bit indicates if the corresponding GPIO pin interrupt
+    *                   in the specific GPIO group is set or not
+    */
 uint32_t GPIO_GetIntStatus(uint8_t Group);
 
 /**
-  * @brief  Clear GPIO interrupt in the specific group. 
-	* @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
-	* @param[in] Clear each bit indicates if the corresponding GPIO pin interrupt 
-	*						in the specific GPIO group is clear or not
+  * @brief  Clear GPIO interrupt in the specific group.
+    * @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
+    * @param[in] Clear each bit indicates if the corresponding GPIO pin interrupt
+    *                       in the specific GPIO group is clear or not
   * @retval None
-	*/ 
+    */
 void GPIO_ClearInt(uint8_t Group, uint32_t Clear);
 
 /**
   * @brief  Get value of each GPIO pin in the specific group
-	* @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
-	* @retval uint32_t each bit indicates value of the corresponding GPIO pin 
-	*					in the specific GPIO group
-	*/
+    * @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
+    * @retval uint32_t each bit indicates value of the corresponding GPIO pin
+    *                   in the specific GPIO group
+    */
 uint32_t GPIO_Read(uint8_t Group);
 
 /**
   * @brief  Set value of each GPIO pin in the specific group
-	* @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
-	* @param[in] Unmask each bit indicates value of the corresponding GPIO pin 
-	*						 in the specific GPIO group is set or not
-	* @param[in] data each bit indicates value of the corresponding GPIO pin
-	*						 in the specific GPIO group to be set
+    * @param[in] Group GPIO group, which is a value of @ref GPIO_GROUP
+    * @param[in] Unmask each bit indicates value of the corresponding GPIO pin
+    *                        in the specific GPIO group is set or not
+    * @param[in] data each bit indicates value of the corresponding GPIO pin
+    *                        in the specific GPIO group to be set
   * @retval None
-	*/ 
+    */
 void GPIO_Write(uint8_t Group, uint32_t Unmask, uint32_t data);
 
 /**
   * @brief  Initialize PWM for the specific GPIO pin
-	* @note		It can work before call GPIO_EnableOutput for the specific GPIO pin
-	* @param[in] Channel PWM channel, which is a value of @ref GPIO_PWM_CHANNEL
-	* @param[in] HighLevelNanoSecond Nanosecond which high level lasts 
-	* @param[in] LowLevelNanoSecond Nanosecond which low level lasts 
+    * @note     It can work before call GPIO_EnableOutput for the specific GPIO pin
+    * @param[in] Channel PWM channel, which is a value of @ref GPIO_PWM_CHANNEL
+    * @param[in] HighLevelNanoSecond Nanosecond which high level lasts
+    * @param[in] LowLevelNanoSecond Nanosecond which low level lasts
   * @retval None
-	* @see		GPIO_EnableOutput
-	*/ 
+    * @see      GPIO_EnableOutput
+    */
 void GPIO_InitPwm(uint8_t Channel, uint32_t HighLevelNanoSecond, uint32_t LowLevelNanoSecond);
 
 /**
-  * @brief  Enable or disable GPIO PWM in the specific channel. 
-	*	@param[in] Channel PWM channel, which is a value of @ref GPIO_PWM_CHANNEL
-	* @param[in] Enable The bit indicates if the specific channel is enable or not
+  * @brief  Enable or disable GPIO PWM in the specific channel.
+    *   @param[in] Channel PWM channel, which is a value of @ref GPIO_PWM_CHANNEL
+    * @param[in] Enable The bit indicates if the specific channel is enable or not
   * @retval None
-	*/ 
+    */
 void GPIO_EnablePwm(uint8_t Channel, BOOL Enable);
 
 
 
 /**
   xjf 20150324
-  
+
 **/
 void GPIO_SetBits(uint32_t mask);
 void GPIO_clrBits(uint32_t mask);
-uint32_t GPIO_getBits(uint32_t mask); 
+uint32_t GPIO_getBits(uint32_t mask);
 
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_i2c.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_i2c.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_i2c.h
-	*
-	* @brief    CMEM7 I2C header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_i2c.h
+    *
+    * @brief    CMEM7 I2C header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_I2C_H
 #define __CMEM7_I2C_H
 
@@ -62,18 +62,18 @@
 
 /** @defgroup I2C_INT
   * @{
-  */			
-#define I2C_INT_RX_FIFO_NOT_EMPTY      0x00000004 		/*!< Can't be clear but read FIFO */
+  */
+#define I2C_INT_RX_FIFO_NOT_EMPTY      0x00000004       /*!< Can't be clear but read FIFO */
 #define I2C_INT_RD_REQUEST             0x00000020     /*!< Slave was requested to send data */
 #define I2C_INT_TX_ABORT               0x00000040     /*!< Error while sending data */
 #define I2C_INT_RX_DONE                0x00000080     /*!< Slave sent all requested data */
 #define I2C_INT_TX_DONE                0x00000100     /*!< Master accomplish to send all data */
 
 #define I2C_INT_ALL                    (I2C_INT_RX_FIFO_NOT_EMPTY | \
-																				I2C_INT_RD_REQUEST | \
-																				I2C_INT_TX_ABORT | \
-																				I2C_INT_RX_DONE | \
-																				I2C_INT_TX_DONE)
+                                                                                I2C_INT_RD_REQUEST | \
+                                                                                I2C_INT_TX_ABORT | \
+                                                                                I2C_INT_RX_DONE | \
+                                                                                I2C_INT_TX_DONE)
 
 #define IS_I2C_INT(INT)                (((INT) != 0) && (((INT) & ~I2C_INT_ALL) == 0))
 /**
@@ -83,17 +83,17 @@
 /** @defgroup I2C_STATUS
   * @{
   */
-#define I2C_STATUS_RX_FIFO_NOT_EMPTY   0x00200000 		/*!< Can't be clear but read FIFO */
+#define I2C_STATUS_RX_FIFO_NOT_EMPTY   0x00200000       /*!< Can't be clear but read FIFO */
 #define I2C_STATUS_RD_REQUEST          0x01000000     /*!< Slave was requested to send data */
 #define I2C_STATUS_TX_ABORT            0x02000000     /*!< Error while sending data */
 #define I2C_STATUS_RX_DONE             0x04000000     /*!< Slave sent all requested data */
 #define I2C_STATUS_TX_DONE             0x08000000     /*!< Master accomplish to send all data */
 
 #define I2C_STATUS_ALL                 (I2C_STATUS_RX_FIFO_NOT_EMPTY | \
-																				I2C_STATUS_RD_REQUEST | \
-																				I2C_STATUS_TX_ABORT | \
-																				I2C_STATUS_RX_DONE | \
-																				I2C_STATUS_TX_DONE)
+                                                                                I2C_STATUS_RD_REQUEST | \
+                                                                                I2C_STATUS_TX_ABORT | \
+                                                                                I2C_STATUS_RX_DONE | \
+                                                                                I2C_STATUS_TX_DONE)
 
 #define IS_I2C_STATUS(STATUS)          (((STATUS) != 0) && (((STATUS) & ~I2C_STATUS_ALL) == 0))
 /**
@@ -102,141 +102,141 @@
 
 /**
   * @brief  I2C timing structure
-	*/
+    */
 typedef struct
 {
   uint32_t I2C_Freq;                /*!< I2C frquency */
 
-	uint16_t I2C_TsuDat;              /*!< nano second of TSU:DAT */
-  uint16_t I2C_Tsetup;              /*!< nano second of THD:STA and TSU:STO */ 
-  uint16_t I2C_Tbuf;                /*!< nano second of TBUF */       	
-	uint16_t I2C_TsuSta;              /*!< nano second of TSU:STA */ 
-	
-	BOOL I2C_SdaFilterEn;             /*!< enabled flag of SDA filter */
-	uint8_t I2C_SdaFilterSpike;       /*!< spikes of SDA filter */
-	BOOL I2C_SclFilterEn;             /*!< enabled flag of SCL filter */
-	uint8_t I2C_SclFilterSpike;       /*!< spikes of SCL filter */
-	
+    uint16_t I2C_TsuDat;              /*!< nano second of TSU:DAT */
+  uint16_t I2C_Tsetup;              /*!< nano second of THD:STA and TSU:STO */
+  uint16_t I2C_Tbuf;                /*!< nano second of TBUF */
+    uint16_t I2C_TsuSta;              /*!< nano second of TSU:STA */
+
+    BOOL I2C_SdaFilterEn;             /*!< enabled flag of SDA filter */
+    uint8_t I2C_SdaFilterSpike;       /*!< spikes of SDA filter */
+    BOOL I2C_SclFilterEn;             /*!< enabled flag of SCL filter */
+    uint8_t I2C_SclFilterSpike;       /*!< spikes of SCL filter */
+
 } I2C_InitTimingDef;
 
 /**
   * @brief  I2C initialization structure
-	*/
+    */
 typedef struct
 {
   uint8_t I2C_Mode;                 /*!< Specifies the I2C mode.
                                          This parameter can be a value of @ref I2C_mode */
-	uint8_t I2C_AddressWidth;         /*!< 7- or 10-bits width address, ref as @ref I2C_ADDR_WIDTH */
-	uint8_t I2C_Address;              /*!< 7- or 10-bits address */
-	I2C_InitTimingDef* timing;        /*!< timing structure, null if don't set */		
+    uint8_t I2C_AddressWidth;         /*!< 7- or 10-bits width address, ref as @ref I2C_ADDR_WIDTH */
+    uint8_t I2C_Address;              /*!< 7- or 10-bits address */
+    I2C_InitTimingDef* timing;        /*!< timing structure, null if don't set */
 } I2C_InitTypeDef;
 
 /**
   * @brief  I2C initialization
   * @note   This function should be called at first before any other interfaces.
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @param[in] init A pointer to structure I2C_InitTypeDef
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @param[in] init A pointer to structure I2C_InitTypeDef
   * @retval None
-	*/ 
+    */
 void I2C_Init(I2C0_Type* I2Cx, I2C_InitTypeDef* I2C_Init);
 
 /**
-  * @brief  Enable or disable I2C. 
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @param[in] Enable The bit indicates if the specific I2C is enable or not
+  * @brief  Enable or disable I2C.
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @param[in] Enable The bit indicates if the specific I2C is enable or not
   * @retval None
-	*/ 
+    */
 void I2C_Enable(I2C0_Type* I2Cx, BOOL enable);
 
 /**
-  * @brief  Enable or disable I2C interrupt. 
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref I2C_Int
-	* @param[in] Enable The bit indicates if specific interrupts are enable or not
+  * @brief  Enable or disable I2C interrupt.
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref I2C_Int
+    * @param[in] Enable The bit indicates if specific interrupts are enable or not
   * @retval None
-	*/ 
+    */
 void I2C_EnableInt(I2C0_Type* I2Cx, uint32_t Int, BOOL enable);
 
 /**
-  * @brief  Check specific interrupts are set or not 
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref I2C_Int
+  * @brief  Check specific interrupts are set or not
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref I2C_Int
   * @retval BOOL The bit indicates if specific interrupts are enable or not
-	*/
+    */
 BOOL I2C_GetIntStatus(I2C0_Type* I2Cx, uint32_t Int);
 
 /**
   * @brief  Clear specific interrupts
-	* @note   Specific interrupt clear will clear correspective status as well
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref I2C_Int
+    * @note   Specific interrupt clear will clear correspective status as well
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref I2C_Int
   * @retval None
-	*/
+    */
 void I2C_ClearInt(I2C0_Type* I2Cx, uint32_t Int);
 
 /**
-  * @brief  Check specific status are set or not 
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @param[in] Status Status mask bits, which can be the combination of @ref I2C_STATUS
+  * @brief  Check specific status are set or not
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @param[in] Status Status mask bits, which can be the combination of @ref I2C_STATUS
   * @retval BOOL The bit indicates if specific status are set or not
-	*/
+    */
 BOOL I2C_GetStatus(I2C0_Type* I2Cx, uint32_t Status);
 
 /**
   * @brief  Clear specific status
-	* @note   Specific status clear will clear correspective interrupt as well
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @param[in] Status Status mask bits, which can be the combination of @ref I2C_STATUS
+    * @note   Specific status clear will clear correspective interrupt as well
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @param[in] Status Status mask bits, which can be the combination of @ref I2C_STATUS
   * @retval None
-	*/
+    */
 void I2C_ClearStatus(I2C0_Type* I2Cx, uint32_t Status);
 
 /**
   * @brief  I2C send read request in master mode
-	* @note   Users must call I2C_StopReq between 2 requests
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @param[in] size Expected data size to be read
+    * @note   Users must call I2C_StopReq between 2 requests
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @param[in] size Expected data size to be read
   * @retval BOOL The bit indicates if read request to be sent is valid
-	* @see		I2C_StopReq
-	*/
+    * @see      I2C_StopReq
+    */
 BOOL I2C_MasterReadReq(I2C0_Type* I2Cx, uint8_t size);
 
 /**
   * @brief  Read data from I2C
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @param[in] size Expected data size to be read
-	* @param[out] Data A user-allocated buffer to fetch data to be read
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @param[in] size Expected data size to be read
+    * @param[out] Data A user-allocated buffer to fetch data to be read
   * @retval uint8_t Actual read data size
-	*/
+    */
 uint8_t I2C_ReadFifo(I2C0_Type* I2Cx, uint8_t size, uint8_t* data);
 
 /**
   * @brief  I2C send write request in master or slave mode
-	* @note   Users must call I2C_StopReq between 2 requests
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @param[in] size Expected data size to be written, includes the first data
-	* @param[in] firstData The first data to be written
+    * @note   Users must call I2C_StopReq between 2 requests
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @param[in] size Expected data size to be written, includes the first data
+    * @param[in] firstData The first data to be written
   * @retval BOOL The bit indicates if write request to be sent is valid
-	* @see		I2C_StopReq
-	*/
+    * @see      I2C_StopReq
+    */
 BOOL I2C_WriteReq(I2C0_Type* I2Cx, uint8_t size, uint8_t firstData);
 
 /**
   * @brief  Write data to I2C
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @param[in] size Expected data size to be written
-	* @param[in] Data A pointer to the data to be written
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @param[in] size Expected data size to be written
+    * @param[in] Data A pointer to the data to be written
   * @retval uint8_t Actual written data size
-	*/
+    */
 uint8_t I2C_WriteFifo(I2C0_Type* I2Cx, uint8_t size, uint8_t* data);
 
 /**
   * @brief  I2C stop request
-	* @note   Users must call I2C_StopReq between 2 requests
-	* @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
-	* @retval BOOL The bit indicates if request is stopped.
-	* @see		I2C_MasterReadReq I2C_WriteReq 
-	*/
+    * @note   Users must call I2C_StopReq between 2 requests
+    * @param[in] I2Cx I2C peripheral, which is I2C0 or I2C1
+    * @retval BOOL The bit indicates if request is stopped.
+    * @see      I2C_MasterReadReq I2C_WriteReq
+    */
 BOOL I2C_StopReq(I2C0_Type* I2Cx);
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_includes.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_includes.h
@@ -1,28 +1,28 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_includes.h
-	*
-	* @brief    CMEM7 includes file, easy to use CMEM7 library
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
+    *****************************************************************************
+    * @file     cmem7_includes.h
+    *
+    * @brief    CMEM7 includes file, easy to use CMEM7 library
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
 
 #ifndef __CMEM7_INCLUDES_H
 #define __CMEM7_INCLUDES_H
@@ -33,84 +33,84 @@
 
 #include "cmem7_conf.h"
 #include "cmem7_it.h"
-	 
+
 #ifdef _ADC
-	#include "cmem7_adc.h"
+    #include "cmem7_adc.h"
 #endif
-	 
+
 #ifdef _AES
-	#include "cmem7_aes.h"
+    #include "cmem7_aes.h"
 #endif
-	 
+
 #ifdef _CAN
-	#include "cmem7_can.h"
+    #include "cmem7_can.h"
 #endif
-	 
+
 #ifdef _DDR
-	#include "cmem7_ddr.h"
+    #include "cmem7_ddr.h"
 #endif
-	 
+
 #ifdef _DMA
-	#include "cmem7_dma.h"
+    #include "cmem7_dma.h"
 #endif
-	 
+
 #ifdef _EFUSE
-	#include "cmem7_efuse.h"
+    #include "cmem7_efuse.h"
 #endif
-	 
+
 #ifdef _ETH
-	#include "cmem7_eth.h"
+    #include "cmem7_eth.h"
 #endif
-	 
+
 #ifdef _FLASH
-	#include "cmem7_flash.h"
+    #include "cmem7_flash.h"
 #endif
-	 
+
 #ifdef _GPIO
-	#include "cmem7_gpio.h"
+    #include "cmem7_gpio.h"
 #endif
-	 
+
 #ifdef _I2C
-	#include "cmem7_i2c.h"
+    #include "cmem7_i2c.h"
 #endif
-	 
+
 #ifdef _MISC
-	#include "cmem7_misc.h"
+    #include "cmem7_misc.h"
 #endif
-	 
+
 #ifdef _RTC
-	#include "cmem7_rtc.h"
+    #include "cmem7_rtc.h"
 #endif
-	 
+
 #ifdef _SPI
-	#include "cmem7_spi.h"
+    #include "cmem7_spi.h"
 #endif
-	 
+
 #ifdef _TIM
-	#include "cmem7_tim.h"
+    #include "cmem7_tim.h"
 #endif
-	 
+
 #ifdef _UART
-	#include "cmem7_uart.h"
+    #include "cmem7_uart.h"
 #endif
 
 #ifdef _USB
-	#include "cmem7_usb.h"
+    #include "cmem7_usb.h"
 #endif
 
 #ifdef _WDG
-	#include "cmem7_wdg.h"
+    #include "cmem7_wdg.h"
 #endif
 
 
 #ifdef _MARVELL
   #include <marvel_98dx242.h>
-	#include <s24g_i2c.h>
-#endif	
-	
+    #include <s24g_i2c.h>
+#endif
+
 #ifdef _IP1826D
   #include <ip1826d_v00.h>
-#endif	
+#endif
 
 #ifdef __cplusplus
 }

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_misc.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_misc.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_misc.h
-	*
-	* @brief    CMEM7 miscellaneous header file
-	* 
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_misc.h
+    *
+    * @brief    CMEM7 miscellaneous header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_MISC_H
 #define __CMEM7_MISC_H
 
@@ -36,36 +36,36 @@
 
 /**
   * @brief  NVIC initialization structure
-	*/
+    */
 /**
-@code  
-	The table below gives the allowed values of the pre-emption priority and subpriority according
-	to the Priority Grouping configuration performed by NVIC_PriorityGroupConfig function
-	============================================================================================================================
-		NVIC_PriorityGroup   | NVIC_IRQChannelPreemptionPriority | NVIC_IRQChannelSubPriority  | Description
-	============================================================================================================================
-	 NVIC_PriorityGroup_0  |                0                  |            0-15             |   0 bits for pre-emption priority
-												 |                                   |                             |   4 bits for subpriority
-	----------------------------------------------------------------------------------------------------------------------------
-	 NVIC_PriorityGroup_1  |                0-1                |            0-7              |   1 bits for pre-emption priority
-												 |                                   |                             |   3 bits for subpriority
-	----------------------------------------------------------------------------------------------------------------------------    
-	 NVIC_PriorityGroup_2  |                0-3                |            0-3              |   2 bits for pre-emption priority
-												 |                                   |                             |   2 bits for subpriority
-	----------------------------------------------------------------------------------------------------------------------------    
-	 NVIC_PriorityGroup_3  |                0-7                |            0-1              |   3 bits for pre-emption priority
-												 |                                   |                             |   1 bits for subpriority
-	----------------------------------------------------------------------------------------------------------------------------    
-	 NVIC_PriorityGroup_4  |                0-15               |            0                |   4 bits for pre-emption priority
-												 |                                   |                             |   0 bits for subpriority                       
-	============================================================================================================================
+@code
+    The table below gives the allowed values of the pre-emption priority and subpriority according
+    to the Priority Grouping configuration performed by NVIC_PriorityGroupConfig function
+    ============================================================================================================================
+        NVIC_PriorityGroup   | NVIC_IRQChannelPreemptionPriority | NVIC_IRQChannelSubPriority  | Description
+    ============================================================================================================================
+     NVIC_PriorityGroup_0  |                0                  |            0-15             |   0 bits for pre-emption priority
+                                                 |                                   |                             |   4 bits for subpriority
+    ----------------------------------------------------------------------------------------------------------------------------
+     NVIC_PriorityGroup_1  |                0-1                |            0-7              |   1 bits for pre-emption priority
+                                                 |                                   |                             |   3 bits for subpriority
+    ----------------------------------------------------------------------------------------------------------------------------
+     NVIC_PriorityGroup_2  |                0-3                |            0-3              |   2 bits for pre-emption priority
+                                                 |                                   |                             |   2 bits for subpriority
+    ----------------------------------------------------------------------------------------------------------------------------
+     NVIC_PriorityGroup_3  |                0-7                |            0-1              |   3 bits for pre-emption priority
+                                                 |                                   |                             |   1 bits for subpriority
+    ----------------------------------------------------------------------------------------------------------------------------
+     NVIC_PriorityGroup_4  |                0-15               |            0                |   4 bits for pre-emption priority
+                                                 |                                   |                             |   0 bits for subpriority
+    ============================================================================================================================
 @endcode
-	*/
-	
+    */
+
 typedef struct
 {
   uint8_t NVIC_IRQChannel;                    /*!< Specifies the IRQ channel to be enabled or disabled.
-                                                   This parameter can be a value of @ref IRQn_Type 
+                                                   This parameter can be a value of @ref IRQn_Type
                                                    (For the complete Capital-micro Devices IRQ Channels list, please
                                                     refer to cmem7.h file) */
 
@@ -78,10 +78,10 @@ typedef struct
                                                    between 0 and 15 as described in the table @ref NVIC_Priority_Table */
 
   BOOL NVIC_IRQChannelCmd;                    /*!< Specifies whether the IRQ channel defined in NVIC_IRQChannel
-                                                   will be enabled or disabled. 
-                                                   This parameter can be set either to ENABLE or DISABLE */   
+                                                   will be enabled or disabled.
+                                                   This parameter can be set either to ENABLE or DISABLE */
 } NVIC_InitTypeDef;
- 
+
 
 /** @defgroup NVIC_VectTab
   * @{
@@ -132,7 +132,7 @@ typedef struct
 /**
   * @}
   */
-	
+
 #define IS_NVIC_PREEMPTION_PRIORITY(PRIORITY)  ((PRIORITY) < 0x10)
 
 #define IS_NVIC_SUB_PRIORITY(PRIORITY)  ((PRIORITY) < 0x10)
@@ -141,7 +141,7 @@ typedef struct
 
 /**
   * @brief  Configures the priority grouping: pre-emption priority and subpriority.
-  * @param  NVIC_PriorityGroup: specifies the priority grouping bits length. 
+  * @param  NVIC_PriorityGroup: specifies the priority grouping bits length.
   *   This parameter can be one of the following values, ref as @ref NVIC_PriorityGroup:
   *     @arg NVIC_PriorityGroup_0: 0 bits for pre-emption priority
   *                                4 bits for subpriority
@@ -172,7 +172,7 @@ void NVIC_Init(NVIC_InitTypeDef* NVIC_InitStruct);
   *   This parameter can be one of the following values, ref as @ref NVIC_VectTab:
   *     @arg NVIC_VectTab_RAM
   *     @arg NVIC_VectTab_FLASH
-  * @param  Offset: Vector Table base offset field. This value must be a multiple 
+  * @param  Offset: Vector Table base offset field. This value must be a multiple
   *         of 0x200.
   * @retval None
   */
@@ -192,70 +192,70 @@ void NVIC_SystemLPConfig(uint8_t LowPowerMode, BOOL NewState);
 
 /**
   * @brief  Memory map from address 'from' to 'address 'to' and open icache or not
-	* @param[in] from address to be mapped from
-	* @param[in] to address to be mapped to
-	* @param[in] isIcacheOn icache is on or off
+    * @param[in] from address to be mapped from
+    * @param[in] to address to be mapped to
+    * @param[in] isIcacheOn icache is on or off
   * @retval None
-	*/
+    */
 void GLB_MMAP(uint32_t from, uint32_t to, BOOL isIcacheOn);
 
 /**
   * @brief  Convert the mapping destination address to source address
-	* @param[in] to address to be mapped to
+    * @param[in] to address to be mapped to
   * @retval uint32_t address to be mapped from
-	*/
+    */
 uint32_t GLB_ConvertToMappingFromAddr(uint32_t to);
 
 /**
   * @brief  Convert the mapping source address to destination address
-	* @param[in] from address to be mapped from
+    * @param[in] from address to be mapped from
   * @retval uint32_t address to be mapped to
-	*/
+    */
 uint32_t GLB_ConvertToMappingToAddr(uint32_t from);
 
 /**
   * @brief  Set NMI irq number, it should be one of @ref IRQn_Type.
-	* @Note		You can assign any valid IRQn_Type to NMI. After that, you will enter NMI 
-	*					interrupt routine if the specific 'irq' occurs. By default, NMI irq number
-	*					is 0, same as ETH_INT_IRQn
-	* @param[in] irq irq number 
+    * @Note     You can assign any valid IRQn_Type to NMI. After that, you will enter NMI
+    *                   interrupt routine if the specific 'irq' occurs. By default, NMI irq number
+    *                   is 0, same as ETH_INT_IRQn
+    * @param[in] irq irq number
   * @retval None
-	*/
+    */
 void GLB_SetNmiIrqNum(uint32_t irq);
 
 /** @defgroup SYS_CLK_SEL
   * @{
   */
-#define SYS_CLK_SEL_OSC					0x0
-#define SYS_CLK_SEL_DLL					0x1
-#define SYS_CLK_SEL_CRYSTAL			0x2
-#define SYS_CLK_SEL_EXTERNAL		0x3	
+#define SYS_CLK_SEL_OSC                 0x0
+#define SYS_CLK_SEL_DLL                 0x1
+#define SYS_CLK_SEL_CRYSTAL         0x2
+#define SYS_CLK_SEL_EXTERNAL        0x3
 /**
   * @}
   */
-	
+
 /**
   * @brief  Select system clock source, it should be one of @ref SYS_CLK_SEL.
-	* @Note		You MUST make sure externel clock has been stabled if clock 
-	*				  source is external before call this function. 
-	* 				Default value is SYS_CLK_SEL_OSC
-	* @param[in] irq irq number 
+    * @Note     You MUST make sure externel clock has been stabled if clock
+    *                 source is external before call this function.
+    *               Default value is SYS_CLK_SEL_OSC
+    * @param[in] irq irq number
   * @retval None
-	*/
+    */
 void GLB_SelectSysClkSource(uint8_t source);
 
 /**
   * @brief  Simulate instruction 'STRB' or 'STRH' with 'BFI'
-	* @Note		In M7, you have to write a register in 32-bit alignment,
-	*				  not in 8-bit or 16-bit. 
-	* @param[in] addr register address to be written 
+    * @Note     In M7, you have to write a register in 32-bit alignment,
+    *                 not in 8-bit or 16-bit.
+    * @param[in] addr register address to be written
   * @param[in] value value to be written
   * @param[in] lsb LSB in register to be written
   * @param[in] len bit length to be written
   * @retval None
-	*/
-	
-	
+    */
+
+
 //#define aaaa(len) __asm("LDR len, 11")
 
 #define CMEM7_BFI(addr, value, lsb, len)        \
@@ -266,7 +266,7 @@ void GLB_SelectSysClkSource(uint8_t source);
     __asm("LDR tmp, [tmp1]\n"                   \
       "BFI tmp, "#value", "#lsb", "#len" \n"    \
       "STR tmp, [tmp1]\n");                     \
-		} while (0)
+        } while (0)
 
 #ifdef __cplusplus
 }

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_retarget.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_retarget.h
@@ -1,28 +1,28 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_retarget.h
-	*
-	* @brief    CMEM7 retarget header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
+    *****************************************************************************
+    * @file     cmem7_retarget.h
+    *
+    * @brief    CMEM7 retarget header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
 
 #ifndef __CMEM7_RETARGET_H
 #define __CMEM7_RETARGET_H
@@ -46,21 +46,21 @@ FILE __stderr;
 
 int fputc(int c, FILE *f) {
   uint8_t ch = c;
-	if (c == '\n')  {
-		ch = '\r';
+    if (c == '\n')  {
+        ch = '\r';
     while (0 == UART_Write(PRINT_UART, 1, &ch));
-		ch = '\n';
+        ch = '\n';
   }
-	
-	while (0 == UART_Write(PRINT_UART, 1, &ch)) ;
+
+    while (0 == UART_Write(PRINT_UART, 1, &ch)) ;
   return ch;
 }
 
 
 int fgetc(FILE *f) {
-	uint8_t ch;
-	
-	while (0 == UART_Read(PRINT_UART, 1, &ch)) ;
+    uint8_t ch;
+
+    while (0 == UART_Read(PRINT_UART, 1, &ch)) ;
   return ch;
 }
 

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_rtc.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_rtc.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_rtc.h
-	*
-	* @brief    CMEM7 RTC header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_rtc.h
+    *
+    * @brief    CMEM7 RTC header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_RTC_H
 #define __CMEM7_RTC_H
 
@@ -44,41 +44,41 @@
 /**
   * @}
   */
-   
+
 /**
-  * @brief  Enable or disable RTC interrupt. 
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref RTC_Int
-	* @param[in] Enable The bit indicates if specific interrupts are enable or not
+  * @brief  Enable or disable RTC interrupt.
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref RTC_Int
+    * @param[in] Enable The bit indicates if specific interrupts are enable or not
   * @retval None
-	*/ 
+    */
 void RTC_ITConfig(uint32_t Int, BOOL Enable);
 
 /**
-  * @brief  Check specific interrupts are set or not 
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref RTC_Int
+  * @brief  Check specific interrupts are set or not
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref RTC_Int
   * @retval BOOL The bit indicates if specific interrupts are set or not
-	*/
+    */
 BOOL RTC_GetITStatus(uint32_t Int);
 
 /**
   * @brief  Clear specific interrupts
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref RTC_Int
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref RTC_Int
   * @retval None
-	*/
+    */
 void RTC_ClearITPendingBit(uint32_t Int);
 
 /**
   * @brief  Get seconds since power up
-	* @param	None
+    * @param    None
   * @retval uint32_t Seconds since power up
-	*/
+    */
 uint32_t RTC_GetSecond(void);
 
 /**
   * @brief  Get current millseconds
-	* @param	None
+    * @param    None
   * @retval uint32_t Current millseconds
-	*/
+    */
 uint16_t RTC_GetMillSecond(void);
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_spi.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_spi.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_spi.h
-	*
-	* @brief    CMEM7 SPI header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_spi.h
+    *
+    * @brief    CMEM7 SPI header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_SPI_H
 #define __CMEM7_SPI_H
 
@@ -43,29 +43,29 @@
 /** @defgroup SPI_MODE
   * @{
   */
-#define SPI_MODE_CPOL_0_CPHA_0         0   	/*!< CPOL : Idle clock level is low level. 
-																								 CPHA : Capture data at the first edge */
-#define SPI_MODE_CPOL_0_CPHA_1         1		/*!< CPOL : Idle clock level is low level. 
-																								 CPHA : Capture data at the second edge */	
-#define SPI_MODE_CPOL_1_CPHA_0         2		/*!< CPOL : Idle clock level is high level. 
-																								 CPHA : Capture data at the first edge */
-#define SPI_MODE_CPOL_1_CPHA_1         3	 	/*!< CPOL : Idle clock level is high level. 
-																								 CPHA : Capture data at the first edge */    
+#define SPI_MODE_CPOL_0_CPHA_0         0    /*!< CPOL : Idle clock level is low level.
+                                                                                                 CPHA : Capture data at the first edge */
+#define SPI_MODE_CPOL_0_CPHA_1         1        /*!< CPOL : Idle clock level is low level.
+                                                                                                 CPHA : Capture data at the second edge */
+#define SPI_MODE_CPOL_1_CPHA_0         2        /*!< CPOL : Idle clock level is high level.
+                                                                                                 CPHA : Capture data at the first edge */
+#define SPI_MODE_CPOL_1_CPHA_1         3        /*!< CPOL : Idle clock level is high level.
+                                                                                                 CPHA : Capture data at the first edge */
 #define IS_SPI_MODE(MODE)              (((MODE) == SPI_MODE_CPOL_0_CPHA_0) || \
                                         ((MODE) == SPI_MODE_CPOL_0_CPHA_1) || \
                                         ((MODE) == SPI_MODE_CPOL_1_CPHA_0) || \
-																				((MODE) == SPI_MODE_CPOL_1_CPHA_1))
+                                                                                ((MODE) == SPI_MODE_CPOL_1_CPHA_1))
 /**
   * @}
   */
 
 /** @defgroup SPI_INT
   * @{
-  */	
-#define SPI_INT_RX_FIFO_UNDERFLOW      0x00000001    
+  */
+#define SPI_INT_RX_FIFO_UNDERFLOW      0x00000001
 #define SPI_INT_RX_FIFO_OVERFLOW       0x00000002
 #define SPI_INT_RX_FIFO_ALMOST_FULL    0x00000004
-#define SPI_INT_TX_FIFO_UNDERFLOW      0x00000008    
+#define SPI_INT_TX_FIFO_UNDERFLOW      0x00000008
 #define SPI_INT_TX_FIFO_OVERFLOW       0x00000010
 #define SPI_INT_TX_FIFO_ALMOST_FULL    0x00000020
 #define SPI_INT_DONE                   0x00000040
@@ -78,14 +78,14 @@
 
 /**
   * @brief  SPI initialization structure
-	*/ 
+    */
 typedef struct
 {
   uint8_t SPI_Mode;                 /*!< indicates SPI's CPOL and CPHA, ref as @ref SPI_MODE */
   BOOL SPI_RxEn;                    /*!< indicates if SPI receiver is enabled or not */
   uint8_t SPI_BitLength;            /*!< bit length while transmitting and receiving */
-  uint8_t SPI_Gap;                  /*!< cycle number between continuous data frame */ 
-	uint8_t SPI_ClockDividor;         /*!< SPI clock dividor, 1 / ((1 + DIV) * 2) */
+  uint8_t SPI_Gap;                  /*!< cycle number between continuous data frame */
+    uint8_t SPI_ClockDividor;         /*!< SPI clock dividor, 1 / ((1 + DIV) * 2) */
 } SPI_InitTypeDef;
 /**
   * @}
@@ -94,69 +94,69 @@ typedef struct
 /**
   * @brief  SPI initialization
   * @note   This function should be called at first before any other interfaces.
-	* @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
-	* @param[in] init A pointer to structure SPI_InitTypeDef
+    * @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
+    * @param[in] init A pointer to structure SPI_InitTypeDef
   * @retval None
-	*/ 
+    */
 void SPI_Init(SPI0_Type* SPIx, SPI_InitTypeDef *init);
 
 /**
-  * @brief  Enable or disable SPI. 
-	* @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
-	* @param[in] Enable The bit indicates if the specific SPI is enable or not
+  * @brief  Enable or disable SPI.
+    * @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
+    * @param[in] Enable The bit indicates if the specific SPI is enable or not
   * @retval None
-	*/ 
+    */
 void SPI_Enable(SPI0_Type* SPIx, BOOL enable);
 
 /**
-  * @brief  Enable or disable SPI interrupt. 
-	* @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref SPI_Int
-	* @param[in] Enable The bit indicates if specific interrupts are enable or not
+  * @brief  Enable or disable SPI interrupt.
+    * @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref SPI_Int
+    * @param[in] Enable The bit indicates if specific interrupts are enable or not
   * @retval None
-	*/ 
+    */
 void SPI_EnableInt(SPI0_Type* SPIx, uint32_t Int, BOOL enable);
 
 /**
-  * @brief  Check specific interrupts are set or not 
-	* @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref SPI_Int
+  * @brief  Check specific interrupts are set or not
+    * @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref SPI_Int
   * @retval BOOL The bit indicates if specific interrupts are set or not
-	*/
+    */
 BOOL SPI_GetIntStatus(SPI0_Type* SPIx, uint32_t Int);
 
 /**
   * @brief  Clear specific interrupts
-	* @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref SPI_Int
+    * @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref SPI_Int
   * @retval None
-	*/
+    */
 void SPI_ClearInt(SPI0_Type* SPIx, uint32_t Int);
 
 /**
   * @brief  Read data from SPI FIFO
-	* @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
-	* @param[in] size Expected data size to be read
-	* @param[out] data A user-allocated buffer to fetch data to be read
+    * @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
+    * @param[in] size Expected data size to be read
+    * @param[out] data A user-allocated buffer to fetch data to be read
   * @retval uint8_t Actual read data size
-	*/
+    */
 uint8_t SPI_ReadFifo(SPI0_Type* SPIx, uint8_t size, uint32_t* data);
 
 /**
   * @brief  Write data to SPI FIFO
-	* @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
-	* @param[in] size Expected data size to be written
-	* @param[in] data A pointer to the data to be written
+    * @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
+    * @param[in] size Expected data size to be written
+    * @param[in] data A pointer to the data to be written
   * @retval uint8_t Actual written data size
-	*/
+    */
 uint8_t SPI_WriteFifo(SPI0_Type* SPIx, uint8_t Size, uint32_t* data);
 
 /**
-  * @brief  send a SPI transcation request 
-	* @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
-	* @param[in] size Expected data size to be written and read
-	* @retval BOOL The bit indicates if the request is sent
-	*/
+  * @brief  send a SPI transcation request
+    * @param[in] SPIx SPI peripheral, which is SPI0 or SPI1
+    * @param[in] size Expected data size to be written and read
+    * @retval BOOL The bit indicates if the request is sent
+    */
 BOOL SPI_Transcation(SPI0_Type* SPIx, uint8_t size);
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_tim.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_tim.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_tim.h
-	*
-	* @brief    CMEM7 timer header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_tim.h
+    *
+    * @brief    CMEM7 timer header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_TIM_H
 #define __CMEM7_TIM_H
 
@@ -39,58 +39,58 @@
                                    ((PERIPH) == TIMER1) || \
                                    ((PERIPH) == TIMER2) || \
                                    ((PERIPH) == TIMER3))
-																	 
+
 /**
   * @brief  Timer initialization
   * @note   This function should be called at first before any other interfaces.
-	* @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
-	* @param[in] Ms overflow micro-seconds of the specific timer
+    * @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
+    * @param[in] Ms overflow micro-seconds of the specific timer
   * @retval None
-	*/
+    */
 void TIM_Init(TIMER0_Type* Timx, uint16_t Ms);
 
 /**
-  * @brief  Enable or disable timer interrupt. 
-	* @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
-	* @param[in] Enable The bit indicates if the specific interrupt is enable or not
+  * @brief  Enable or disable timer interrupt.
+    * @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
+    * @param[in] Enable The bit indicates if the specific interrupt is enable or not
   * @retval None
-	*/ 
+    */
 void TIM_EnableInt(TIMER0_Type* Timx, BOOL Enable);
 
 /**
-  * @brief  Check the specific interrupt is set or not 
-	* @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
-	* @retval BOOL The bit indicates if the specific interrupt is set or not
-	*/
+  * @brief  Check the specific interrupt is set or not
+    * @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
+    * @retval BOOL The bit indicates if the specific interrupt is set or not
+    */
 BOOL TIM_GetIntStatus(TIMER0_Type* Timx);
 
 /**
   * @brief  Clear specific interrupts
-	* @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
-	* @retval None
-	*/
+    * @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
+    * @retval None
+    */
 void TIM_ClearInt(TIMER0_Type* Timx);
 
 /**
-  * @brief  Enable or disable timer. 
-	* @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
-	* @param[in] Enable The bit indicates if the specific timer is enable or not
+  * @brief  Enable or disable timer.
+    * @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
+    * @param[in] Enable The bit indicates if the specific timer is enable or not
   * @retval None
-	*/ 
+    */
 void TIM_Enable(TIMER0_Type* Timx, BOOL Enable);
 
 /**
-  * @brief  Check the specific timer is overflow or not 
-	* @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
-	* @retval BOOL The bit indicates if the specific timer is overflow or not
-	*/
+  * @brief  Check the specific timer is overflow or not
+    * @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
+    * @retval BOOL The bit indicates if the specific timer is overflow or not
+    */
 BOOL TIM_IsOverflow(TIMER0_Type* Timx);
 
 /**
   * @brief  Get current counter of timer
-	* @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
-	* @retval uint32_t current counter
-	*/
+    * @param[in] Timx Timer peripheral, which is timer0, timer1, timer2 or timer3
+    * @retval uint32_t current counter
+    */
 uint32_t TIM_GetCounter(TIMER0_Type* Timx);
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_uart.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_uart.h
@@ -1,28 +1,28 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_uart.h
-	*
-	* @brief    CMEM7 uart header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
+    *****************************************************************************
+    * @file     cmem7_uart.h
+    *
+    * @brief    CMEM7 uart header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
 
 #ifndef __CMEM7_UART_H
 #define __CMEM7_UART_H
@@ -37,7 +37,7 @@
 #define IS_UART_ALL_PERIPH(PERIPH) (((PERIPH) == UART0) || \
                                      ((PERIPH) == UART1) || \
                                      ((PERIPH) == UART2))
-	
+
 /** @defgroup UART_StopBits
   * @{
   */
@@ -61,7 +61,7 @@
 #define UART_Parity_None                  2
 #define IS_UART_PARITY(PARITY) (((PARITY) == UART_Parity_Even) || \
                                  ((PARITY) == UART_Parity_Odd) || \
-																 ((PARITY) == UART_Parity_None))										 
+                                                                 ((PARITY) == UART_Parity_None))
 /**
   * @}
   */
@@ -69,7 +69,7 @@
 /** @defgroup UART_Int
   * @{
   */
-#define UART_Int_RxNotEmpty               0x00000001    
+#define UART_Int_RxNotEmpty               0x00000001
 #define UART_Int_TxEmpty                  0x00000002
 #define UART_Int_TxHalfEmpty              0x00000004
 #define UART_Int_TxTimeoutNotEmpty        0x00000008
@@ -87,80 +87,80 @@
 /**
   * @}
   */
-	
+
 /**
   * @brief  UART initialization structure
-	*/ 
+    */
 typedef struct
 {
-	uint32_t UART_BaudRate;            /*!< Baudrate */																	  
-	uint8_t UART_StopBits;             /*!< Specifies the number of stop bits transmitted, 
-																					It's a value of @ref UART_StopBits */
-	uint8_t UART_Parity;               /*!< Specifies the parity mode. 
-																					It's a value of @ref UART_Parity */
-	BOOL UART_LoopBack;                /*!< loop back mode */
-	BOOL UART_RxEn;                    /*!< Receive enable bit */
-	BOOL UART_CtsEn;                   /*!< Clear to set */
+    uint32_t UART_BaudRate;            /*!< Baudrate */
+    uint8_t UART_StopBits;             /*!< Specifies the number of stop bits transmitted,
+                                                                                    It's a value of @ref UART_StopBits */
+    uint8_t UART_Parity;               /*!< Specifies the parity mode.
+                                                                                    It's a value of @ref UART_Parity */
+    BOOL UART_LoopBack;                /*!< loop back mode */
+    BOOL UART_RxEn;                    /*!< Receive enable bit */
+    BOOL UART_CtsEn;                   /*!< Clear to set */
 } UART_InitTypeDef;
 
 /**
   * @brief  UART initialization
   * @note   This function should be called at first before any other interfaces.
-	* @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
-	* @param[in] init A pointer to structure UART_InitTypeDef
+    * @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
+    * @param[in] init A pointer to structure UART_InitTypeDef
   * @retval None
-	*/ 
+    */
 void UART_Init(UART0_Type* UARTx, UART_InitTypeDef *init);
 
 /**
-  * @brief  Enable or disable UART interrupt. 
-	* @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref UART_Int
-	* @param[in] Enable The bit indicates if specific interrupts are enable or not
+  * @brief  Enable or disable UART interrupt.
+    * @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref UART_Int
+    * @param[in] Enable The bit indicates if specific interrupts are enable or not
   * @retval None
-	*/ 
+    */
 void UART_EnableInt(UART0_Type* UARTx, uint32_t Int, BOOL Enable);
 
 /**
-  * @brief  Enable or disable UART. 
-	* @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
-	* @param[in] Enable The bit indicates if the specific UART is enable or not
+  * @brief  Enable or disable UART.
+    * @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
+    * @param[in] Enable The bit indicates if the specific UART is enable or not
   * @retval None
-	*/ 
+    */
 void UART_Enable(UART0_Type* UARTx, BOOL enable);
 
 /**
-  * @brief  Check specific interrupts are set or not 
-	* @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref UART_Int
+  * @brief  Check specific interrupts are set or not
+    * @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref UART_Int
   * @retval BOOL The bit indicates if specific interrupts are set or not
-	*/
+    */
 BOOL UART_GetIntStatus(UART0_Type* UARTx, uint32_t Int);
 
 /**
   * @brief  Clear specific interrupts
-	* @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
-	* @param[in] Int interrupt mask bits, which can be the combination of @ref UART_Int
+    * @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
+    * @param[in] Int interrupt mask bits, which can be the combination of @ref UART_Int
   * @retval None
-	*/
+    */
 void UART_ClearInt(UART0_Type* UARTx, uint32_t Int);
 
 /**
   * @brief  Write data to UART
-	* @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
-	* @param[in] Size Expected data size to be written
-	* @param[in] Data A pointer to the data to be written
+    * @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
+    * @param[in] Size Expected data size to be written
+    * @param[in] Data A pointer to the data to be written
   * @retval uint8_t Actual written data size
-	*/
+    */
 uint8_t UART_Write(UART0_Type* UARTx, uint8_t Size, uint8_t* Data);
 
 /**
   * @brief  Read data from UART
-	* @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
-	* @param[in] Size Expected data size to be read
-	* @param[out] Data A user-allocated buffer to fetch data to be read
+    * @param[in] UARTx UART peripheral, which is UART0, UART1 or UART2
+    * @param[in] Size Expected data size to be read
+    * @param[out] Data A user-allocated buffer to fetch data to be read
   * @retval uint8_t Actual read data size
-	*/
+    */
 uint8_t UART_Read(UART0_Type* UARTx, uint8_t Size, uint8_t* Data);
 
 

--- a/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_wdg.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/cmem7_wdg.h
@@ -1,29 +1,29 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_wdg.h
-	*
-	* @brief    CMEM7 watchdog header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_wdg.h
+    *
+    * @brief    CMEM7 watchdog header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #ifndef __CMEM7_WDG_H
 #define __CMEM7_WDG_H
 
@@ -58,47 +58,47 @@
 
 /**
   * @brief  Deinitializes the Watchdog peripheral registers to their default reset values.
-	* @param[in] None
+    * @param[in] None
   * @retval None
-	*/ 
+    */
 void WDG_DeInit(void);
 
 /**
   * @brief  Watchdog initialization
   * @note   This function should be called at first before any other interfaces.
-	* @param[in] trigger Watchdog interrupt trigger mode, which is a value of @ref WDG_TRIGGER_MODE
-	* @param[in] ResetMillSecond MillSeconds lasts before global reset
+    * @param[in] trigger Watchdog interrupt trigger mode, which is a value of @ref WDG_TRIGGER_MODE
+    * @param[in] ResetMillSecond MillSeconds lasts before global reset
   * @retval None
-	*/ 
+    */
 void WDG_Init(uint8_t trigger, uint16_t ResetMillSecond);
 
 /**
-  * @brief  Enable or disable watchdog interrupt. 
-	* @param[in] Int interrupt mask bits, which is a value of @ref WDG_INT
-	* @param[in] Enable The bit indicates if the specific interrupt are enable or not
+  * @brief  Enable or disable watchdog interrupt.
+    * @param[in] Int interrupt mask bits, which is a value of @ref WDG_INT
+    * @param[in] Enable The bit indicates if the specific interrupt are enable or not
   * @retval None
-	*/ 
+    */
 void WDG_ITConfig(uint8_t Int, BOOL Enable);
 
 /**
-  * @brief  Check the specific interrupt are set or not 
-	* @param	None
+  * @brief  Check the specific interrupt are set or not
+    * @param    None
   * @retval BOOL The bit indicates if the specific interrupt are set or not
-	*/
+    */
 BOOL WDG_GetITStatus(void);
 
 /**
   * @brief  Clear the specific interrupt
-	* @param	None
+    * @param    None
   * @retval None
-	*/
+    */
 void WDG_ClearITPendingBit(void);
 
 /**
-  * @brief  Enable or disable watchdog. 
-	* @param[in] Enable The bit indicates if watchdog is enable or not
+  * @brief  Enable or disable watchdog.
+    * @param[in] Enable The bit indicates if watchdog is enable or not
   * @retval None
-	*/ 
+    */
 void WDG_Cmd(BOOL Enable);
 
 

--- a/bsp/CME_M7/StdPeriph_Driver/inc/system_cmem7.h
+++ b/bsp/CME_M7/StdPeriph_Driver/inc/system_cmem7.h
@@ -1,42 +1,42 @@
 /**
-	*****************************************************************************
-	* @file     system_cmem7.h
-	*
-	* @brief    CMEM7 system initial header file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note      
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
+    *****************************************************************************
+    * @file     system_cmem7.h
+    *
+    * @brief    CMEM7 system initial header file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
 
 #ifndef __SYSTEM_CMEM7_H
 #define __SYSTEM_CMEM7_H
 
 #ifdef __cplusplus
  extern "C" {
-#endif 
+#endif
 
 /**
   * @brief  Setup the microcontroller system.
   * @note   This function should be used only after reset.
-	* @param  None
+    * @param  None
   * @retval None
-	*/  
+    */
 void SystemInit(void);
 
 #ifdef __cplusplus

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_adc.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_adc.c
@@ -1,309 +1,309 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_adc.c
-	*
-	* @brief    CMEM7 ADC source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_adc.c
+    *
+    * @brief    CMEM7 ADC source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_adc.h"
 #include "cmem7.h"
 
 #define ADC_SYSTEM_MODE_IDLE       0
 
 static BOOL adc_IsMultiChannel(uint32_t channel) {
-	uint32_t i = 0;
-  
-	for (i = 0; channel != 0; i++) {
+    uint32_t i = 0;
+
+    for (i = 0; channel != 0; i++) {
     channel &= (channel - 1);
-	}
-	
-	return ((i > 1) ? TRUE : FALSE);
+    }
+
+    return ((i > 1) ? TRUE : FALSE);
 }
 
 static uint8_t adc_GetChannel(uint32_t channel) {
-	uint32_t i = 0;
-  
-	for (i = 0; channel > 1; i++) {
+    uint32_t i = 0;
+
+    for (i = 0; channel > 1; i++) {
     channel >>= 1;
-	}
-	
-	return i;
+    }
+
+    return i;
 }
 
 static void adc_Reset(uint8_t adc, BOOL enable) {
-	if (adc == ADC_PERIPH_1) {
-		ADC->POWERDOWN_RESET_b.POWERDOWN_ADC1 = TRUE;
-		ADC->POWERDOWN_RESET_b.RESET_ADC1 = TRUE;
-		udelay(8000);
-		if (enable) {
-			ADC->POWERDOWN_RESET_b.POWERDOWN_ADC1 = FALSE;
-			ADC->POWERDOWN_RESET_b.RESET_ADC1 = FALSE;
-			udelay(8000);
-		}
-	} else {
-		ADC->POWERDOWN_RESET_b.POWERDOWN_ADC2 = TRUE;
-		ADC->POWERDOWN_RESET_b.RESET_ADC2 = TRUE;
-		udelay(8000);
-		if (enable) {
-			ADC->POWERDOWN_RESET_b.POWERDOWN_ADC2 = FALSE;
-			ADC->POWERDOWN_RESET_b.RESET_ADC2 = FALSE;
-			udelay(8000);
-		}
-	}
+    if (adc == ADC_PERIPH_1) {
+        ADC->POWERDOWN_RESET_b.POWERDOWN_ADC1 = TRUE;
+        ADC->POWERDOWN_RESET_b.RESET_ADC1 = TRUE;
+        udelay(8000);
+        if (enable) {
+            ADC->POWERDOWN_RESET_b.POWERDOWN_ADC1 = FALSE;
+            ADC->POWERDOWN_RESET_b.RESET_ADC1 = FALSE;
+            udelay(8000);
+        }
+    } else {
+        ADC->POWERDOWN_RESET_b.POWERDOWN_ADC2 = TRUE;
+        ADC->POWERDOWN_RESET_b.RESET_ADC2 = TRUE;
+        udelay(8000);
+        if (enable) {
+            ADC->POWERDOWN_RESET_b.POWERDOWN_ADC2 = FALSE;
+            ADC->POWERDOWN_RESET_b.RESET_ADC2 = FALSE;
+            udelay(8000);
+        }
+    }
 }
 
 void ADC_Init(ADC_InitTypeDef* init) {
-	assert_param(init);
-	assert_param(IS_ADC_PHASE_CTRL(init->ADC_PhaseCtrl));
-	assert_param(IS_ADC_VSEN(init->ADC_VsenSelection));
-	
-	SOFT_RESET->SOFTRST_b.ADC_n = 0;
-	SOFT_RESET->SOFTRST_b.ADC_n = 1;
-	
-	ADC->CFG0_b.PHASE_CTRL = init->ADC_PhaseCtrl;
-	ADC->CFG0_b.VSEN = init->ADC_VsenSelection;
+    assert_param(init);
+    assert_param(IS_ADC_PHASE_CTRL(init->ADC_PhaseCtrl));
+    assert_param(IS_ADC_VSEN(init->ADC_VsenSelection));
+
+    SOFT_RESET->SOFTRST_b.ADC_n = 0;
+    SOFT_RESET->SOFTRST_b.ADC_n = 1;
+
+    ADC->CFG0_b.PHASE_CTRL = init->ADC_PhaseCtrl;
+    ADC->CFG0_b.VSEN = init->ADC_VsenSelection;
 }
 
 void ADC_Enable(uint8_t adc, BOOL enable) {
-	assert_param(IS_ADC_ALL_PERIPH(adc));
-	
-	adc_Reset(adc, enable);
+    assert_param(IS_ADC_ALL_PERIPH(adc));
+
+    adc_Reset(adc, enable);
 }
 
 void ADC_EnableInt(uint32_t Int, BOOL enable) {
-	assert_param(IS_ADC_INT(Int));
-	
-	if (enable) {
-	  ADC->INT_MASK &= ~Int;
-	} else {
-		ADC->INT_MASK |= Int;
-	}
+    assert_param(IS_ADC_INT(Int));
+
+    if (enable) {
+      ADC->INT_MASK &= ~Int;
+    } else {
+        ADC->INT_MASK |= Int;
+    }
 }
 
 BOOL ADC_GetIntStatus(uint32_t Int) {
-	assert_param(IS_ADC_INT(Int));
-	
-	if (0 != (ADC->INT_STATUS & Int)) {
-		return TRUE;
-	}
-	
-	return FALSE;
+    assert_param(IS_ADC_INT(Int));
+
+    if (0 != (ADC->INT_STATUS & Int)) {
+        return TRUE;
+    }
+
+    return FALSE;
 }
 
 void ADC_ClearInt(uint32_t Int) {
-	assert_param(IS_ADC_INT(Int));
-	
-	ADC->INT_STATUS = Int;
+    assert_param(IS_ADC_INT(Int));
+
+    ADC->INT_STATUS = Int;
 }
 
 BOOL ADC_StartConversion(uint8_t adc, uint8_t convMode, uint32_t channel) {
-	assert_param(IS_ADC_ALL_PERIPH(adc));
-	assert_param(IS_ADC_CONVERSION(convMode));
-	
-	if (adc == ADC_PERIPH_1) {
-		assert_param(IS_ADC1_CHANNEL(channel));
-		if (ADC->BUSY_b.ADC1_BUSY) {
-			return FALSE;
-		}
-		
-		if (adc_IsMultiChannel(channel)) {
-			ADC->CFG_ADC1_b.SYSTEM_MODE = ADC_SYSTEM_MODE_SINGLE_CONV;
-			ADC->CFG_ADC1_b.MULTI_CHANNEL_BIT = channel;
-			ADC->CFG_ADC1_b.MULTI_CHANNEL_CONTINUE_SCAN = 
-				(convMode == ADC_SYSTEM_MODE_CONTINUOUS_CONV) ? 1 : 0;
-		} else {
-			ADC->CFG_ADC1_b.SYSTEM_MODE = convMode;
-				
-			if (convMode == ADC_SYSTEM_MODE_CONTINUOUS_CONV) {
-				ADC->CFG_ADC1_b.CHANNEL_SEL = adc_GetChannel(channel);
-			} else {
-				ADC->CFG_ADC1_b.MULTI_CHANNEL_BIT = channel;
-				ADC->CFG_ADC1_b.MULTI_CHANNEL_CONTINUE_SCAN = 0;
-			}				
-		}
-				
-		ADC->ADC1_START_b.EN = TRUE;
-	} else {
-		assert_param(IS_ADC2_CHANNEL(channel));
-		if (ADC->BUSY_b.ADC2_BUSY) {
-			return FALSE;
-		}		
-		
-		if (adc_IsMultiChannel(channel)) {
-			ADC->CFG_ADC2_b.SYSTEM_MODE = ADC_SYSTEM_MODE_SINGLE_CONV;
-			ADC->CFG_ADC2_b.MULTI_CHANNEL_BIT = channel;
-			ADC->CFG_ADC2_b.MULTI_CHANNEL_CONTINUE_SCAN = 
-				(convMode == ADC_SYSTEM_MODE_CONTINUOUS_CONV) ? 1 : 0;
-		} else {
-			ADC->CFG_ADC2_b.SYSTEM_MODE = convMode;
-				
-			if (convMode == ADC_SYSTEM_MODE_CONTINUOUS_CONV) {
-				ADC->CFG_ADC2_b.CHANNEL_SEL = adc_GetChannel(channel);
-			} else {
-				ADC->CFG_ADC2_b.MULTI_CHANNEL_BIT = channel;
-				ADC->CFG_ADC2_b.MULTI_CHANNEL_CONTINUE_SCAN = 0;
-			}				
-		}
-				
-		ADC->ADC2_START_b.EN = TRUE;
-	}
-	
-	return TRUE;
+    assert_param(IS_ADC_ALL_PERIPH(adc));
+    assert_param(IS_ADC_CONVERSION(convMode));
+
+    if (adc == ADC_PERIPH_1) {
+        assert_param(IS_ADC1_CHANNEL(channel));
+        if (ADC->BUSY_b.ADC1_BUSY) {
+            return FALSE;
+        }
+
+        if (adc_IsMultiChannel(channel)) {
+            ADC->CFG_ADC1_b.SYSTEM_MODE = ADC_SYSTEM_MODE_SINGLE_CONV;
+            ADC->CFG_ADC1_b.MULTI_CHANNEL_BIT = channel;
+            ADC->CFG_ADC1_b.MULTI_CHANNEL_CONTINUE_SCAN =
+                (convMode == ADC_SYSTEM_MODE_CONTINUOUS_CONV) ? 1 : 0;
+        } else {
+            ADC->CFG_ADC1_b.SYSTEM_MODE = convMode;
+
+            if (convMode == ADC_SYSTEM_MODE_CONTINUOUS_CONV) {
+                ADC->CFG_ADC1_b.CHANNEL_SEL = adc_GetChannel(channel);
+            } else {
+                ADC->CFG_ADC1_b.MULTI_CHANNEL_BIT = channel;
+                ADC->CFG_ADC1_b.MULTI_CHANNEL_CONTINUE_SCAN = 0;
+            }
+        }
+
+        ADC->ADC1_START_b.EN = TRUE;
+    } else {
+        assert_param(IS_ADC2_CHANNEL(channel));
+        if (ADC->BUSY_b.ADC2_BUSY) {
+            return FALSE;
+        }
+
+        if (adc_IsMultiChannel(channel)) {
+            ADC->CFG_ADC2_b.SYSTEM_MODE = ADC_SYSTEM_MODE_SINGLE_CONV;
+            ADC->CFG_ADC2_b.MULTI_CHANNEL_BIT = channel;
+            ADC->CFG_ADC2_b.MULTI_CHANNEL_CONTINUE_SCAN =
+                (convMode == ADC_SYSTEM_MODE_CONTINUOUS_CONV) ? 1 : 0;
+        } else {
+            ADC->CFG_ADC2_b.SYSTEM_MODE = convMode;
+
+            if (convMode == ADC_SYSTEM_MODE_CONTINUOUS_CONV) {
+                ADC->CFG_ADC2_b.CHANNEL_SEL = adc_GetChannel(channel);
+            } else {
+                ADC->CFG_ADC2_b.MULTI_CHANNEL_BIT = channel;
+                ADC->CFG_ADC2_b.MULTI_CHANNEL_CONTINUE_SCAN = 0;
+            }
+        }
+
+        ADC->ADC2_START_b.EN = TRUE;
+    }
+
+    return TRUE;
 }
 
 BOOL ADC_StartCalibration(uint8_t adc, uint8_t calibration) {
-	assert_param(IS_ADC_ALL_PERIPH(adc));
-	assert_param(IS_ADC_CALIBRATION(calibration));
-	
-	if (adc == ADC_PERIPH_1) {
-		if (ADC->BUSY_b.ADC1_BUSY) {
-			return FALSE;
-		}
-		
-		ADC->CFG_ADC1_b.SYSTEM_MODE = calibration;
-		ADC->ADC1_START_b.EN = TRUE;
-	} else {
-		if (ADC->BUSY_b.ADC2_BUSY) {
-			return FALSE;
-		}
+    assert_param(IS_ADC_ALL_PERIPH(adc));
+    assert_param(IS_ADC_CALIBRATION(calibration));
 
-		ADC->CFG_ADC2_b.SYSTEM_MODE = calibration;
-		ADC->ADC2_START_b.EN = TRUE;
-	}
-	
-	return TRUE;	
+    if (adc == ADC_PERIPH_1) {
+        if (ADC->BUSY_b.ADC1_BUSY) {
+            return FALSE;
+        }
+
+        ADC->CFG_ADC1_b.SYSTEM_MODE = calibration;
+        ADC->ADC1_START_b.EN = TRUE;
+    } else {
+        if (ADC->BUSY_b.ADC2_BUSY) {
+            return FALSE;
+        }
+
+        ADC->CFG_ADC2_b.SYSTEM_MODE = calibration;
+        ADC->ADC2_START_b.EN = TRUE;
+    }
+
+    return TRUE;
 }
 
 void ADC_Stop(uint8_t adc) {
-	assert_param(IS_ADC_ALL_PERIPH(adc));
-	
-	if (adc == ADC_PERIPH_1) {
-		if (IS_ADC_CONVERSION(ADC->CFG_ADC1_b.SYSTEM_MODE)) {
-			ADC->ADC1_STOP_b.EN = TRUE;
-		}
-		while (ADC->BUSY_b.ADC1_BUSY) ;
-		
-		ADC->ADC1_FIFO_CLEAR_b.CLEAR = TRUE;
-		//udelay(1000);
-		ADC->ADC1_FIFO_CLEAR_b.CLEAR = FALSE;
-	} else {
-		if (IS_ADC_CONVERSION(ADC->CFG_ADC2_b.SYSTEM_MODE)) {
-			ADC->ADC2_STOP_b.EN = TRUE;
-		}
-		while (ADC->BUSY_b.ADC2_BUSY) ;
-			
-		ADC->ADC2_FIFO_CLEAR_b.CLEAR = TRUE;
-		//udelay(1000);
-		ADC->ADC2_FIFO_CLEAR_b.CLEAR = FALSE;
-	}	
+    assert_param(IS_ADC_ALL_PERIPH(adc));
+
+    if (adc == ADC_PERIPH_1) {
+        if (IS_ADC_CONVERSION(ADC->CFG_ADC1_b.SYSTEM_MODE)) {
+            ADC->ADC1_STOP_b.EN = TRUE;
+        }
+        while (ADC->BUSY_b.ADC1_BUSY) ;
+
+        ADC->ADC1_FIFO_CLEAR_b.CLEAR = TRUE;
+        //udelay(1000);
+        ADC->ADC1_FIFO_CLEAR_b.CLEAR = FALSE;
+    } else {
+        if (IS_ADC_CONVERSION(ADC->CFG_ADC2_b.SYSTEM_MODE)) {
+            ADC->ADC2_STOP_b.EN = TRUE;
+        }
+        while (ADC->BUSY_b.ADC2_BUSY) ;
+
+        ADC->ADC2_FIFO_CLEAR_b.CLEAR = TRUE;
+        //udelay(1000);
+        ADC->ADC2_FIFO_CLEAR_b.CLEAR = FALSE;
+    }
 }
 
 BOOL ADC_IsBusy(uint8_t adc) {
-	assert_param(IS_ADC_ALL_PERIPH(adc));
-	
-	if (adc == ADC_PERIPH_1) {
-		if (ADC->BUSY_b.ADC1_BUSY) {
-			return TRUE;
-		}
-	} else {
-		if (ADC->BUSY_b.ADC2_BUSY) {
-			return TRUE;
-		}
-	}
-	
-	return FALSE;
+    assert_param(IS_ADC_ALL_PERIPH(adc));
+
+    if (adc == ADC_PERIPH_1) {
+        if (ADC->BUSY_b.ADC1_BUSY) {
+            return TRUE;
+        }
+    } else {
+        if (ADC->BUSY_b.ADC2_BUSY) {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
 }
 
 /* return value is actual read data size */
 uint8_t ADC_Read(uint8_t adc, uint8_t size, ADC_Data* data) {
-	uint8_t count = 0;
-	uint8_t sysMode;
-	uint32_t tmp = 0;
-	assert_param(IS_ADC_ALL_PERIPH(adc));
-	assert_param(data);
-	
-	if (adc == ADC_PERIPH_1) {
-		sysMode = ADC->CFG_ADC1_b.SYSTEM_MODE;
-	} else {
-		sysMode = ADC->CFG_ADC2_b.SYSTEM_MODE;
-	}
-	
-	if ((sysMode == ADC_SYSTEM_MODE_SINGLE_CONV) ||
-		(sysMode == ADC_SYSTEM_MODE_CONTINUOUS_CONV)) {
-		while (count < size) {
-			if (adc == ADC_PERIPH_1) {
-				if (ADC->STATUS_b.ADC1_READ_EMPTY) {
-					break;
-				}
-				
-				tmp = ADC->ADC1_FIFO_READ;
-				(data + count)->channel = 1 << ((tmp&0xf000) >> 12);
-				(data + count++)->data = (tmp & 0xfff);
-			} else {
-				if (ADC->STATUS_b.ADC2_READ_EMPTY) {
-					break;
-				}
-				tmp = ADC->ADC2_FIFO_READ;
-				(data + count)->channel = 1 << ((tmp&0xf000) >> 12);
-				(data + count++)->data = (tmp & 0xfff);
-			}
-		}
-	} else if (sysMode == ADC_CALIBRATION_OFFSET) {
-		if (adc == ADC_PERIPH_1) {
-			if (!ADC->BUSY_b.ADC1_BUSY) {
-				(data + count)->channel = ADC_CHANNEL_CALIBRATION;
-				(data + count++)->data = ADC->ADC1_OUT_OFFSET_CALIBRATION;
-		  }	
-		} else {
-			if (!ADC->BUSY_b.ADC2_BUSY) {
-				(data + count)->channel = ADC_CHANNEL_CALIBRATION;
-				(data + count++)->data = ADC->ADC2_OUT_OFFSET_CALIBRATION;
-		  }
-		}
-	} else if (sysMode == ADC_CALIBRATION_NEGTIVE_GAIN) {	
-		if (adc == ADC_PERIPH_1) {
-			if (!ADC->BUSY_b.ADC1_BUSY) {
-				(data + count)->channel = ADC_CHANNEL_CALIBRATION;
-				(data + count++)->data = ADC->ADC1_OUT_NEGTIVE_GAIN_CALIBRATION;
-			}	
-		} else {
-			if (!ADC->BUSY_b.ADC2_BUSY) {
-			  (data + count)->channel = ADC_CHANNEL_CALIBRATION;
-				(data + count++)->data = ADC->ADC2_OUT_NEGTIVE_GAIN_CALIBRATION;
-		  }
-		}
-	} else {
-		if (adc == ADC_PERIPH_1) {
-			if (!ADC->BUSY_b.ADC1_BUSY) {
-				(data + count)->channel = ADC_CHANNEL_CALIBRATION;
-				(data + count++)->data = ADC->ADC1_OUT_POSITIVE_GAIN_CALIBRATION;
-			}	
-		} else {
-			if (!ADC->BUSY_b.ADC2_BUSY) {
-			  (data + count)->channel = ADC_CHANNEL_CALIBRATION;
-				(data + count++)->data = ADC->ADC2_OUT_POSITIVE_GAIN_CALIBRATION;
-		  }
-		}
-	}
-	
-	return count;
+    uint8_t count = 0;
+    uint8_t sysMode;
+    uint32_t tmp = 0;
+    assert_param(IS_ADC_ALL_PERIPH(adc));
+    assert_param(data);
+
+    if (adc == ADC_PERIPH_1) {
+        sysMode = ADC->CFG_ADC1_b.SYSTEM_MODE;
+    } else {
+        sysMode = ADC->CFG_ADC2_b.SYSTEM_MODE;
+    }
+
+    if ((sysMode == ADC_SYSTEM_MODE_SINGLE_CONV) ||
+        (sysMode == ADC_SYSTEM_MODE_CONTINUOUS_CONV)) {
+        while (count < size) {
+            if (adc == ADC_PERIPH_1) {
+                if (ADC->STATUS_b.ADC1_READ_EMPTY) {
+                    break;
+                }
+
+                tmp = ADC->ADC1_FIFO_READ;
+                (data + count)->channel = 1 << ((tmp&0xf000) >> 12);
+                (data + count++)->data = (tmp & 0xfff);
+            } else {
+                if (ADC->STATUS_b.ADC2_READ_EMPTY) {
+                    break;
+                }
+                tmp = ADC->ADC2_FIFO_READ;
+                (data + count)->channel = 1 << ((tmp&0xf000) >> 12);
+                (data + count++)->data = (tmp & 0xfff);
+            }
+        }
+    } else if (sysMode == ADC_CALIBRATION_OFFSET) {
+        if (adc == ADC_PERIPH_1) {
+            if (!ADC->BUSY_b.ADC1_BUSY) {
+                (data + count)->channel = ADC_CHANNEL_CALIBRATION;
+                (data + count++)->data = ADC->ADC1_OUT_OFFSET_CALIBRATION;
+          }
+        } else {
+            if (!ADC->BUSY_b.ADC2_BUSY) {
+                (data + count)->channel = ADC_CHANNEL_CALIBRATION;
+                (data + count++)->data = ADC->ADC2_OUT_OFFSET_CALIBRATION;
+          }
+        }
+    } else if (sysMode == ADC_CALIBRATION_NEGTIVE_GAIN) {
+        if (adc == ADC_PERIPH_1) {
+            if (!ADC->BUSY_b.ADC1_BUSY) {
+                (data + count)->channel = ADC_CHANNEL_CALIBRATION;
+                (data + count++)->data = ADC->ADC1_OUT_NEGTIVE_GAIN_CALIBRATION;
+            }
+        } else {
+            if (!ADC->BUSY_b.ADC2_BUSY) {
+              (data + count)->channel = ADC_CHANNEL_CALIBRATION;
+                (data + count++)->data = ADC->ADC2_OUT_NEGTIVE_GAIN_CALIBRATION;
+          }
+        }
+    } else {
+        if (adc == ADC_PERIPH_1) {
+            if (!ADC->BUSY_b.ADC1_BUSY) {
+                (data + count)->channel = ADC_CHANNEL_CALIBRATION;
+                (data + count++)->data = ADC->ADC1_OUT_POSITIVE_GAIN_CALIBRATION;
+            }
+        } else {
+            if (!ADC->BUSY_b.ADC2_BUSY) {
+              (data + count)->channel = ADC_CHANNEL_CALIBRATION;
+                (data + count++)->data = ADC->ADC2_OUT_POSITIVE_GAIN_CALIBRATION;
+          }
+        }
+    }
+
+    return count;
 }

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_aes.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_aes.c
@@ -1,53 +1,53 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_aes.c
-	*
-	* @brief    CMEM7 AES source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_aes.c
+    *
+    * @brief    CMEM7 AES source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_aes.h"
 
 BOOL AES_Decrypt(const void *src, void *dst, uint32_t len)
 {
-	uint32_t *po = dst;
-	const uint32_t *pi = src;
+    uint32_t *po = dst;
+    const uint32_t *pi = src;
 
-	if (len & 0xF)
-		return FALSE;
+    if (len & 0xF)
+        return FALSE;
 
-	AES->FIFO_CLEAR = 1;
-	AES->FIFO_CLEAR = 0;
-	GLOBAL_CTRL->AES_BURST_TYPE = 0x1;						// Cannot be 0
-	while (len > 0) {
-		while (0 == GLOBAL_CTRL->AES_STATUS_b.IDLE);		// 0x41007010
-		udelay(2);
-		GLOBAL_CTRL->AES_TARGET_ADDR = (uint32_t)po;		// 0x41800000;
-		po += 4;
-		len -= 4 * sizeof(uint32_t);
-		while (0 == GLOBAL_CTRL->AES_STATUS_b.RD_EMPTY);	// 0x41007010
-		AES->FIFO = *pi++;
-		AES->FIFO = *pi++;
-		AES->FIFO = *pi++;
-		AES->FIFO = *pi++;
-	}
-	return TRUE;
+    AES->FIFO_CLEAR = 1;
+    AES->FIFO_CLEAR = 0;
+    GLOBAL_CTRL->AES_BURST_TYPE = 0x1;                      // Cannot be 0
+    while (len > 0) {
+        while (0 == GLOBAL_CTRL->AES_STATUS_b.IDLE);        // 0x41007010
+        udelay(2);
+        GLOBAL_CTRL->AES_TARGET_ADDR = (uint32_t)po;        // 0x41800000;
+        po += 4;
+        len -= 4 * sizeof(uint32_t);
+        while (0 == GLOBAL_CTRL->AES_STATUS_b.RD_EMPTY);    // 0x41007010
+        AES->FIFO = *pi++;
+        AES->FIFO = *pi++;
+        AES->FIFO = *pi++;
+        AES->FIFO = *pi++;
+    }
+    return TRUE;
 }

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_can.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_can.c
@@ -1,36 +1,36 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_can.c
-	*
-	* @brief    CMEM7 CAN source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_can.c
+    *
+    * @brief    CMEM7 CAN source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_can.h"
 
 typedef struct {
   union {
     __IO uint8_t   FI;                        /*!< Transmit Frame Information if writting or Receive Frame Information
                                                    if reading, ACR[0] if reset mode                                      */
-                                                    
+
     struct {
       __IO uint8_t   DLC        :  4;         /*!< byte number in the data                                               */
            uint8_t              :  2;
@@ -42,12 +42,12 @@ typedef struct {
 } CAN_FRAME_INFO;
 
 typedef struct {
-	union {
+    union {
     uint16_t  ID;                             /*!< ID                                  */
-    
+
     struct {
       uint16_t  ID28_21   :  8;               /*!< ID28 to ID21                        */
-      uint16_t            :  4;               
+      uint16_t            :  4;
       uint16_t  RTR       :  1;               /*!< if remote frame                     */
       uint16_t  ID20_18   :  3;               /*!< ID20 to ID18                        */
     } ID_b;                                   /*!< BitSize                             */
@@ -57,12 +57,12 @@ typedef struct {
 typedef struct {
   union {
     uint32_t  ID;                             /*!< ID                                  */
-    
+
     struct {
       uint32_t  ID28_21   :  8;               /*!< ID28 to ID21                        */
       uint32_t  ID20_13   :  8;               /*!< ID20 to ID13                        */
-			uint32_t  ID12_5    :  8;               /*!< ID12 to ID5                         */
-			uint32_t            :  2;
+            uint32_t  ID12_5    :  8;               /*!< ID12 to ID5                         */
+            uint32_t            :  2;
       uint32_t  RTR       :  1;               /*!< if remote frame                     */
       uint32_t  ID4_0     :  5;               /*!< ID4 to ID0                          */
     } ID_b;                                   /*!< BitSize                             */
@@ -80,307 +80,307 @@ typedef struct {
 #define CAN_OCR_CLOCK              0x03
 
 static BOOL can_SetFilter(CAN0_Type* CANx, CAN_FILTER *f1, CAN_FILTER *f2) {
-	if (!f1) {
-		return FALSE;
-	}
-	
-	if (!IS_CAN_FLT_TYPE(f1->type)) {
-		return FALSE;
-	}
-	
-	if(IS_CAN_FLT_DUAL(f1->type)) {
-		if (!f2 || IS_CAN_FLT_SINGLE(f2->type)) {
-			return FALSE;
-		}
-	}
-	
-	if (f1->type == CAN_FLT_STANDARD_SINGLE) {
-	  CANx->FI_OR_ACR0 = f1->ACCEPT.sf.ID28_18 >> 3;
-		CANx->DI0_OR_ACR1 = (f1->ACCEPT.sf.ID28_18 & 0x07) << 5;
-		CANx->DI0_OR_ACR1 |= f1->ACCEPT.sf.RTR << 4;
-		CANx->DI1_OR_ACR2 = f1->ACCEPT.sf.data1;
-		CANx->DI2_OR_ACR3 = f1->ACCEPT.sf.data2;
-		
-		CANx->DI3_OR_AMR0 = f1->MASK.sf.ID28_18 >> 3;
-		CANx->DI4_OR_AMR1 = (f1->MASK.sf.ID28_18 & 0x07) << 5;
-		CANx->DI4_OR_AMR1 |= f1->MASK.sf.RTR << 4;
-		CANx->DI5_OR_AMR2 = f1->MASK.sf.data1;
-		CANx->DI6_OR_AMR3 = f1->MASK.sf.data2;
-	} else if (f1->type == CAN_FLT_STANDARD_DUAL) {
-	  CANx->FI_OR_ACR0 = f1->ACCEPT.sf.ID28_18 >> 3;
-		CANx->DI0_OR_ACR1 = (f1->ACCEPT.sf.ID28_18 & 0x07) << 5;
-		CANx->DI0_OR_ACR1 |= f1->ACCEPT.sf.RTR << 4;
-		CANx->DI0_OR_ACR1 |= f1->ACCEPT.sf.data1 >> 4;
-		CANx->DI2_OR_ACR3 = f1->ACCEPT.sf.data1 & 0x0F;
-		
-		CANx->DI3_OR_AMR0 = f1->MASK.sf.ID28_18 >> 3;
-		CANx->DI4_OR_AMR1 = (f1->MASK.sf.ID28_18 & 0x07) << 5;
-		CANx->DI4_OR_AMR1 |= f1->MASK.sf.RTR << 4;
-		CANx->DI4_OR_AMR1 = f1->MASK.sf.data1 >> 4;
-		CANx->DI6_OR_AMR3 = f1->MASK.sf.data1 & 0x0F;
-	} else if (f1->type == CAN_FLT_EXTENDED_SINGLE) {
-	  CANx->FI_OR_ACR0 = f1->ACCEPT.ef.ID28_13 >> 8;
-		CANx->DI0_OR_ACR1 = f1->ACCEPT.ef.ID28_13 & 0xFF;
-		CANx->DI1_OR_ACR2 = f1->ACCEPT.ef.ID12_0 >> 5;
-		CANx->DI2_OR_ACR3 = (f1->ACCEPT.ef.ID12_0 & 0x1F) << 3;
-		CANx->DI2_OR_ACR3 |= f1->ACCEPT.ef.RTR << 2;
-		
-		CANx->DI3_OR_AMR0 = f1->MASK.ef.ID28_13 >> 8;
-		CANx->DI4_OR_AMR1 = f1->MASK.ef.ID28_13 & 0xFF;
-		CANx->DI5_OR_AMR2 = f1->MASK.ef.ID12_0 >> 5;
-		CANx->DI6_OR_AMR3 = (f1->MASK.ef.ID12_0 & 0x1F) << 3;
-		CANx->DI6_OR_AMR3 |= f1->MASK.ef.RTR << 2;
-	} else {
-	  CANx->FI_OR_ACR0 = f1->ACCEPT.ef.ID28_13 >> 8;
-		CANx->DI0_OR_ACR1 = f1->ACCEPT.ef.ID28_13 & 0xFF;
-		
-		CANx->DI3_OR_AMR0 = f1->MASK.ef.ID28_13 >> 8;
-		CANx->DI4_OR_AMR1 = f1->MASK.ef.ID28_13 & 0xFF;
-	}
-	
-	if (IS_CAN_FLT_DUAL(f1->type)) {
-		if (f2->type == CAN_FLT_STANDARD_DUAL) {
-			CANx->DI1_OR_ACR2 = f2->ACCEPT.sf.ID28_18 >> 3;
-			CANx->DI2_OR_ACR3 |= (f2->ACCEPT.sf.ID28_18 & 0x07) << 5;
-			CANx->DI2_OR_ACR3 |= f2->ACCEPT.sf.RTR << 4;
-			
-			CANx->DI5_OR_AMR2 = f2->MASK.sf.ID28_18 >> 3;
-			CANx->DI6_OR_AMR3 |= (f2->MASK.sf.ID28_18 & 0x07) << 5;
-			CANx->DI6_OR_AMR3 |= f2->MASK.sf.RTR << 4;
-		} else {
-			CANx->DI1_OR_ACR2 = f2->ACCEPT.ef.ID28_13 >> 8;
-			CANx->DI2_OR_ACR3 = f2->ACCEPT.ef.ID28_13 & 0xFF;
-			
-			CANx->DI5_OR_AMR2 = f2->MASK.ef.ID28_13 >> 8;
-			CANx->DI6_OR_AMR3 = f2->MASK.ef.ID28_13 & 0xFF;
-		}
-	}
-	
-	if (IS_CAN_FLT_SINGLE(f1->type)) {
-		CANx->MODE_b.AFM = 1;
-	} else {
-	  CANx->MODE_b.AFM = 0;
-	}
-	
-	return TRUE;
+    if (!f1) {
+        return FALSE;
+    }
+
+    if (!IS_CAN_FLT_TYPE(f1->type)) {
+        return FALSE;
+    }
+
+    if(IS_CAN_FLT_DUAL(f1->type)) {
+        if (!f2 || IS_CAN_FLT_SINGLE(f2->type)) {
+            return FALSE;
+        }
+    }
+
+    if (f1->type == CAN_FLT_STANDARD_SINGLE) {
+      CANx->FI_OR_ACR0 = f1->ACCEPT.sf.ID28_18 >> 3;
+        CANx->DI0_OR_ACR1 = (f1->ACCEPT.sf.ID28_18 & 0x07) << 5;
+        CANx->DI0_OR_ACR1 |= f1->ACCEPT.sf.RTR << 4;
+        CANx->DI1_OR_ACR2 = f1->ACCEPT.sf.data1;
+        CANx->DI2_OR_ACR3 = f1->ACCEPT.sf.data2;
+
+        CANx->DI3_OR_AMR0 = f1->MASK.sf.ID28_18 >> 3;
+        CANx->DI4_OR_AMR1 = (f1->MASK.sf.ID28_18 & 0x07) << 5;
+        CANx->DI4_OR_AMR1 |= f1->MASK.sf.RTR << 4;
+        CANx->DI5_OR_AMR2 = f1->MASK.sf.data1;
+        CANx->DI6_OR_AMR3 = f1->MASK.sf.data2;
+    } else if (f1->type == CAN_FLT_STANDARD_DUAL) {
+      CANx->FI_OR_ACR0 = f1->ACCEPT.sf.ID28_18 >> 3;
+        CANx->DI0_OR_ACR1 = (f1->ACCEPT.sf.ID28_18 & 0x07) << 5;
+        CANx->DI0_OR_ACR1 |= f1->ACCEPT.sf.RTR << 4;
+        CANx->DI0_OR_ACR1 |= f1->ACCEPT.sf.data1 >> 4;
+        CANx->DI2_OR_ACR3 = f1->ACCEPT.sf.data1 & 0x0F;
+
+        CANx->DI3_OR_AMR0 = f1->MASK.sf.ID28_18 >> 3;
+        CANx->DI4_OR_AMR1 = (f1->MASK.sf.ID28_18 & 0x07) << 5;
+        CANx->DI4_OR_AMR1 |= f1->MASK.sf.RTR << 4;
+        CANx->DI4_OR_AMR1 = f1->MASK.sf.data1 >> 4;
+        CANx->DI6_OR_AMR3 = f1->MASK.sf.data1 & 0x0F;
+    } else if (f1->type == CAN_FLT_EXTENDED_SINGLE) {
+      CANx->FI_OR_ACR0 = f1->ACCEPT.ef.ID28_13 >> 8;
+        CANx->DI0_OR_ACR1 = f1->ACCEPT.ef.ID28_13 & 0xFF;
+        CANx->DI1_OR_ACR2 = f1->ACCEPT.ef.ID12_0 >> 5;
+        CANx->DI2_OR_ACR3 = (f1->ACCEPT.ef.ID12_0 & 0x1F) << 3;
+        CANx->DI2_OR_ACR3 |= f1->ACCEPT.ef.RTR << 2;
+
+        CANx->DI3_OR_AMR0 = f1->MASK.ef.ID28_13 >> 8;
+        CANx->DI4_OR_AMR1 = f1->MASK.ef.ID28_13 & 0xFF;
+        CANx->DI5_OR_AMR2 = f1->MASK.ef.ID12_0 >> 5;
+        CANx->DI6_OR_AMR3 = (f1->MASK.ef.ID12_0 & 0x1F) << 3;
+        CANx->DI6_OR_AMR3 |= f1->MASK.ef.RTR << 2;
+    } else {
+      CANx->FI_OR_ACR0 = f1->ACCEPT.ef.ID28_13 >> 8;
+        CANx->DI0_OR_ACR1 = f1->ACCEPT.ef.ID28_13 & 0xFF;
+
+        CANx->DI3_OR_AMR0 = f1->MASK.ef.ID28_13 >> 8;
+        CANx->DI4_OR_AMR1 = f1->MASK.ef.ID28_13 & 0xFF;
+    }
+
+    if (IS_CAN_FLT_DUAL(f1->type)) {
+        if (f2->type == CAN_FLT_STANDARD_DUAL) {
+            CANx->DI1_OR_ACR2 = f2->ACCEPT.sf.ID28_18 >> 3;
+            CANx->DI2_OR_ACR3 |= (f2->ACCEPT.sf.ID28_18 & 0x07) << 5;
+            CANx->DI2_OR_ACR3 |= f2->ACCEPT.sf.RTR << 4;
+
+            CANx->DI5_OR_AMR2 = f2->MASK.sf.ID28_18 >> 3;
+            CANx->DI6_OR_AMR3 |= (f2->MASK.sf.ID28_18 & 0x07) << 5;
+            CANx->DI6_OR_AMR3 |= f2->MASK.sf.RTR << 4;
+        } else {
+            CANx->DI1_OR_ACR2 = f2->ACCEPT.ef.ID28_13 >> 8;
+            CANx->DI2_OR_ACR3 = f2->ACCEPT.ef.ID28_13 & 0xFF;
+
+            CANx->DI5_OR_AMR2 = f2->MASK.ef.ID28_13 >> 8;
+            CANx->DI6_OR_AMR3 = f2->MASK.ef.ID28_13 & 0xFF;
+        }
+    }
+
+    if (IS_CAN_FLT_SINGLE(f1->type)) {
+        CANx->MODE_b.AFM = 1;
+    } else {
+      CANx->MODE_b.AFM = 0;
+    }
+
+    return TRUE;
 }
 
-BOOL CAN_Init(CAN0_Type* CANx, CAN_InitTypeDef* Init, 
+BOOL CAN_Init(CAN0_Type* CANx, CAN_InitTypeDef* Init,
   CAN_FILTER *f1, CAN_FILTER *f2) {
-	assert_param(IS_CAN_ALL_PERIPH(CANx));
-	assert_param(Init);
-	assert_param(IS_CAN_CDR_DIV(Init->CAN_ClockDiv));
-		
-	/* Quit to sleep mode in operation mode */
-	if (CANx->MODE_b.SM) {
-		CANx->MODE_b.RM = FALSE;
-		CANx->MODE_b.SM = FALSE;
-	}
-	
-	/* switch to reset mode to set parameter */
-	CANx->MODE_b.RM = TRUE;
+    assert_param(IS_CAN_ALL_PERIPH(CANx));
+    assert_param(Init);
+    assert_param(IS_CAN_CDR_DIV(Init->CAN_ClockDiv));
 
-	/* disable all interrupts and clear except receive interrupt */
-	{
-		uint8_t tmp;
-		CANx->INT_EN &= ~CAN_INT_All;
-		tmp = CANx->INT;
-		tmp = tmp;
-	}
-	
-	CANx->MODE_b.LOM = (Init->CAN_TxEn) ? FALSE : TRUE;
-	
-	CANx->MODE_b.STM = Init->CAN_Loopback;
-		
-	CANx->CDR_b.OFF = FALSE;
-	CANx->CDR_b.DIVIDER = Init->CAN_ClockDiv;
-	
-	CANx->BTR0_b.BRP = Init->CAN_Prescaler;
-	CANx->BTR0_b.SJW = Init->CAN_SJW;
-	
-	CANx->BTR1_b.TSEG1 = Init->CAN_TSEG1;
-	CANx->BTR1_b.TSEG2 = Init->CAN_TSEG2;
-	CANx->BTR1_b.SAM = !Init->CAN_HighSpeed;
-	
-	CANx->OCR_b.MODE = CAN_OCR_CLOCK;
-	
+    /* Quit to sleep mode in operation mode */
+    if (CANx->MODE_b.SM) {
+        CANx->MODE_b.RM = FALSE;
+        CANx->MODE_b.SM = FALSE;
+    }
+
+    /* switch to reset mode to set parameter */
+    CANx->MODE_b.RM = TRUE;
+
+    /* disable all interrupts and clear except receive interrupt */
+    {
+        uint8_t tmp;
+        CANx->INT_EN &= ~CAN_INT_All;
+        tmp = CANx->INT;
+        tmp = tmp;
+    }
+
+    CANx->MODE_b.LOM = (Init->CAN_TxEn) ? FALSE : TRUE;
+
+    CANx->MODE_b.STM = Init->CAN_Loopback;
+
+    CANx->CDR_b.OFF = FALSE;
+    CANx->CDR_b.DIVIDER = Init->CAN_ClockDiv;
+
+    CANx->BTR0_b.BRP = Init->CAN_Prescaler;
+    CANx->BTR0_b.SJW = Init->CAN_SJW;
+
+    CANx->BTR1_b.TSEG1 = Init->CAN_TSEG1;
+    CANx->BTR1_b.TSEG2 = Init->CAN_TSEG2;
+    CANx->BTR1_b.SAM = !Init->CAN_HighSpeed;
+
+    CANx->OCR_b.MODE = CAN_OCR_CLOCK;
+
   if (!can_SetFilter(CANx, f1, f2)) {
-		return FALSE;
-	}
-	
-	/* switch to operation mode */
-	CANx->MODE_b.RM = FALSE;
+        return FALSE;
+    }
 
-	return TRUE;
+    /* switch to operation mode */
+    CANx->MODE_b.RM = FALSE;
+
+    return TRUE;
 }
 
 void CAN_SetSleepMode(CAN0_Type* CANx, BOOL enable) {
-	assert_param(IS_CAN_ALL_PERIPH(CANx));
-	
-	/* switch to operation mode */
-	CANx->MODE_b.RM = FALSE;
-	
-	CANx->MODE_b.SM = enable;
+    assert_param(IS_CAN_ALL_PERIPH(CANx));
+
+    /* switch to operation mode */
+    CANx->MODE_b.RM = FALSE;
+
+    CANx->MODE_b.SM = enable;
 }
 
 void CAN_EnableInt(CAN0_Type* CANx, uint32_t Int, BOOL enable) {
   assert_param(IS_CAN_ALL_PERIPH(CANx));
-	assert_param(IS_CAN_INT(Int));
-	
-	if (enable) {
-		CANx->INT_EN |= CAN_INT_All;
-	} else {
-		CANx->INT_EN &= ~CAN_INT_All;
-	}
+    assert_param(IS_CAN_INT(Int));
+
+    if (enable) {
+        CANx->INT_EN |= CAN_INT_All;
+    } else {
+        CANx->INT_EN &= ~CAN_INT_All;
+    }
 }
 
 uint8_t CAN_GetIntStatus(CAN0_Type* CANx) {
-	assert_param(IS_CAN_ALL_PERIPH(CANx));
-	
-	return CANx->INT;
+    assert_param(IS_CAN_ALL_PERIPH(CANx));
+
+    return CANx->INT;
 }
 
 BOOL CAN_Transmit(CAN0_Type* CANx, CAN_Frame* frame) {
-	assert_param(IS_CAN_ALL_PERIPH(CANx));
-	
-	if (!frame) {
-		return FALSE;
-	}
-	
-	if (CANx->MODE_b.LOM) {
-		return FALSE;
-	}
-	
-	if (CANx->MODE_b.SM) {
-		CANx->MODE_b.RM = FALSE;
-		CANx->MODE_b.SM = FALSE;
-	}
-	
-	{
-		CAN_FRAME_INFO fi;
-		
-		fi.U.FI_b.FF = !frame->SFF;
-		fi.U.FI_b.RTR = frame->RTR;
-		fi.U.FI_b.DLC = frame->DLC;
+    assert_param(IS_CAN_ALL_PERIPH(CANx));
 
-		CANx->FI_OR_ACR0 = fi.U.FI;
+    if (!frame) {
+        return FALSE;
+    }
+
+    if (CANx->MODE_b.LOM) {
+        return FALSE;
+    }
+
+    if (CANx->MODE_b.SM) {
+        CANx->MODE_b.RM = FALSE;
+        CANx->MODE_b.SM = FALSE;
+    }
+
+    {
+        CAN_FRAME_INFO fi;
+
+        fi.U.FI_b.FF = !frame->SFF;
+        fi.U.FI_b.RTR = frame->RTR;
+        fi.U.FI_b.DLC = frame->DLC;
+
+        CANx->FI_OR_ACR0 = fi.U.FI;
   }
-	
+
   if (frame->SFF) {
-		CAN_STANDARD_ID id;
-		
-		id.U.ID_b.ID28_21 = frame->Id >> 3;
-		id.U.ID_b.RTR = frame->RTR;
-		id.U.ID_b.ID20_18 = frame->Id & 0x07;
-		
-		CANx->DI0_OR_ACR1 = id.U.ID & 0xFF;
-		CANx->DI1_OR_ACR2 = id.U.ID >> 8;
-		
-		CANx->DI2_OR_ACR3 = frame->Data[0];
-		CANx->DI3_OR_AMR0 = frame->Data[1];
-		CANx->DI4_OR_AMR1 = frame->Data[2];
-		CANx->DI5_OR_AMR2 = frame->Data[3];
-		CANx->DI6_OR_AMR3 = frame->Data[4];
-		CANx->DI7 = frame->Data[5];
-		CANx->DI8 = frame->Data[6];
-		CANx->DI9 = frame->Data[7];
-	} else {
-		CAN_EXTENDED_ID id;
-		
-		id.U.ID_b.ID28_21 = frame->Id >> 21;
-		id.U.ID_b.ID20_13 = (frame->Id >> 13) & 0xFF;
-		id.U.ID_b.ID12_5 = (frame->Id >> 5) & 0xFF;
-		id.U.ID_b.RTR = frame->RTR;
-		id.U.ID_b.ID4_0 = frame->Id & 0x1F;
-		
-		CANx->DI0_OR_ACR1 = id.U.ID & 0xFF;
-		CANx->DI1_OR_ACR2 = (id.U.ID >> 8) & 0xFF;
-		CANx->DI2_OR_ACR3 = (id.U.ID >> 16) & 0xFF;
-		CANx->DI3_OR_AMR0 = (id.U.ID >> 24) & 0xFF;
-		
-		CANx->DI4_OR_AMR1 = frame->Data[0];
-		CANx->DI5_OR_AMR2 = frame->Data[1];
-		CANx->DI6_OR_AMR3 = frame->Data[2];
-		CANx->DI7 = frame->Data[3];
-		CANx->DI8 = frame->Data[4];
-		CANx->DI9 = frame->Data[5];
-		CANx->DI10 = frame->Data[6];
-		CANx->DI11 = frame->Data[7];
-	}
+        CAN_STANDARD_ID id;
+
+        id.U.ID_b.ID28_21 = frame->Id >> 3;
+        id.U.ID_b.RTR = frame->RTR;
+        id.U.ID_b.ID20_18 = frame->Id & 0x07;
+
+        CANx->DI0_OR_ACR1 = id.U.ID & 0xFF;
+        CANx->DI1_OR_ACR2 = id.U.ID >> 8;
+
+        CANx->DI2_OR_ACR3 = frame->Data[0];
+        CANx->DI3_OR_AMR0 = frame->Data[1];
+        CANx->DI4_OR_AMR1 = frame->Data[2];
+        CANx->DI5_OR_AMR2 = frame->Data[3];
+        CANx->DI6_OR_AMR3 = frame->Data[4];
+        CANx->DI7 = frame->Data[5];
+        CANx->DI8 = frame->Data[6];
+        CANx->DI9 = frame->Data[7];
+    } else {
+        CAN_EXTENDED_ID id;
+
+        id.U.ID_b.ID28_21 = frame->Id >> 21;
+        id.U.ID_b.ID20_13 = (frame->Id >> 13) & 0xFF;
+        id.U.ID_b.ID12_5 = (frame->Id >> 5) & 0xFF;
+        id.U.ID_b.RTR = frame->RTR;
+        id.U.ID_b.ID4_0 = frame->Id & 0x1F;
+
+        CANx->DI0_OR_ACR1 = id.U.ID & 0xFF;
+        CANx->DI1_OR_ACR2 = (id.U.ID >> 8) & 0xFF;
+        CANx->DI2_OR_ACR3 = (id.U.ID >> 16) & 0xFF;
+        CANx->DI3_OR_AMR0 = (id.U.ID >> 24) & 0xFF;
+
+        CANx->DI4_OR_AMR1 = frame->Data[0];
+        CANx->DI5_OR_AMR2 = frame->Data[1];
+        CANx->DI6_OR_AMR3 = frame->Data[2];
+        CANx->DI7 = frame->Data[3];
+        CANx->DI8 = frame->Data[4];
+        CANx->DI9 = frame->Data[5];
+        CANx->DI10 = frame->Data[6];
+        CANx->DI11 = frame->Data[7];
+    }
 
   if (CANx->MODE_b.STM) {
-	  CANx->CMD_b.SSR = TRUE;
-	} else {
-		CANx->CMD_b.TR = TRUE;
-	}
+      CANx->CMD_b.SSR = TRUE;
+    } else {
+        CANx->CMD_b.TR = TRUE;
+    }
 
   return TRUE;
 }
 
 BOOL CAN_Receive(CAN0_Type* CANx, CAN_Frame* frame) {
-	assert_param(IS_CAN_ALL_PERIPH(CANx));
-	
-	if (!frame) {
-		return FALSE;
-	}
-	
-	if (CANx->MODE_b.SM) {
-		CANx->MODE_b.RM = FALSE;
-		CANx->MODE_b.SM = FALSE;
-	}
-	
-	{
-		CAN_FRAME_INFO fi;
-		
-		fi.U.FI = CANx->FI_OR_ACR0;
-		
-		frame->SFF = fi.U.FI_b.FF ? FALSE : TRUE;
-		frame->RTR = fi.U.FI_b.RTR ? TRUE : FALSE;
-		frame->DLC = fi.U.FI_b.DLC;
+    assert_param(IS_CAN_ALL_PERIPH(CANx));
+
+    if (!frame) {
+        return FALSE;
+    }
+
+    if (CANx->MODE_b.SM) {
+        CANx->MODE_b.RM = FALSE;
+        CANx->MODE_b.SM = FALSE;
+    }
+
+    {
+        CAN_FRAME_INFO fi;
+
+        fi.U.FI = CANx->FI_OR_ACR0;
+
+        frame->SFF = fi.U.FI_b.FF ? FALSE : TRUE;
+        frame->RTR = fi.U.FI_b.RTR ? TRUE : FALSE;
+        frame->DLC = fi.U.FI_b.DLC;
   }
-	
+
   if (frame->SFF) {
-		CAN_STANDARD_ID id;
-		
-		id.U.ID = CANx->DI0_OR_ACR1;
-		id.U.ID |= CANx->DI1_OR_ACR2 << 8;
-		
-		frame->Id = id.U.ID_b.ID28_21 << 3;
-		frame->Id |= id.U.ID_b.ID20_18;
-		
-		frame->Data[0] = CANx->DI2_OR_ACR3;
-		frame->Data[1] = CANx->DI3_OR_AMR0;
-		frame->Data[2] = CANx->DI4_OR_AMR1;
-		frame->Data[3] = CANx->DI5_OR_AMR2;
-		frame->Data[4] = CANx->DI6_OR_AMR3;
-		frame->Data[5] = CANx->DI7;
-		frame->Data[6] = CANx->DI8;
-		frame->Data[7] = CANx->DI9;
-	} else {
-		CAN_EXTENDED_ID id;
-		
-		id.U.ID = CANx->DI0_OR_ACR1;
-		id.U.ID |= CANx->DI1_OR_ACR2 << 8;
-		id.U.ID |= CANx->DI2_OR_ACR3 << 16;
-		id.U.ID |= CANx->DI3_OR_AMR0 << 24;
-		
+        CAN_STANDARD_ID id;
+
+        id.U.ID = CANx->DI0_OR_ACR1;
+        id.U.ID |= CANx->DI1_OR_ACR2 << 8;
+
+        frame->Id = id.U.ID_b.ID28_21 << 3;
+        frame->Id |= id.U.ID_b.ID20_18;
+
+        frame->Data[0] = CANx->DI2_OR_ACR3;
+        frame->Data[1] = CANx->DI3_OR_AMR0;
+        frame->Data[2] = CANx->DI4_OR_AMR1;
+        frame->Data[3] = CANx->DI5_OR_AMR2;
+        frame->Data[4] = CANx->DI6_OR_AMR3;
+        frame->Data[5] = CANx->DI7;
+        frame->Data[6] = CANx->DI8;
+        frame->Data[7] = CANx->DI9;
+    } else {
+        CAN_EXTENDED_ID id;
+
+        id.U.ID = CANx->DI0_OR_ACR1;
+        id.U.ID |= CANx->DI1_OR_ACR2 << 8;
+        id.U.ID |= CANx->DI2_OR_ACR3 << 16;
+        id.U.ID |= CANx->DI3_OR_AMR0 << 24;
+
     frame->Id = id.U.ID_b.ID28_21 << 21;
-		frame->Id |= id.U.ID_b.ID20_13 << 13;
-		frame->Id |= id.U.ID_b.ID12_5 << 5;
-		frame->Id |= id.U.ID_b.ID4_0;
-		
-		frame->Data[0] = CANx->DI4_OR_AMR1;
-		frame->Data[1] = CANx->DI5_OR_AMR2;
-		frame->Data[2] = CANx->DI6_OR_AMR3;
-		frame->Data[3] = CANx->DI7;
-		frame->Data[4] = CANx->DI8;
-		frame->Data[5] = CANx->DI9;
-		frame->Data[6] = CANx->DI10;
-		frame->Data[7] = CANx->DI11;
-	}
+        frame->Id |= id.U.ID_b.ID20_13 << 13;
+        frame->Id |= id.U.ID_b.ID12_5 << 5;
+        frame->Id |= id.U.ID_b.ID4_0;
+
+        frame->Data[0] = CANx->DI4_OR_AMR1;
+        frame->Data[1] = CANx->DI5_OR_AMR2;
+        frame->Data[2] = CANx->DI6_OR_AMR3;
+        frame->Data[3] = CANx->DI7;
+        frame->Data[4] = CANx->DI8;
+        frame->Data[5] = CANx->DI9;
+        frame->Data[6] = CANx->DI10;
+        frame->Data[7] = CANx->DI11;
+    }
 
   CANx->CMD_b.RRB = TRUE;
 
-  return TRUE;	
+  return TRUE;
 }
 

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_ddr.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_ddr.c
@@ -1,32 +1,32 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_ddr.c
-	*
-	* @brief    CMEM7 DDR source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_ddr.c
+    *
+    * @brief    CMEM7 DDR source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_ddr.h"
 
-#define MAX(a, b)	((a >= b) ? (a) : (b))
+#define MAX(a, b)   ((a >= b) ? (a) : (b))
 #define CAL_DDR3_CL(cl)   ((cl>11)?(((cl-12)<<MR_CL_OFFSET)|0x4):((cl-4)<<MR_CL_OFFSET))
 
 #define CHIP_MIN_CAPACITY  32
@@ -40,8 +40,8 @@
 /** @defgroup DDR time
   * @{
   */
-  #define POWER_UP_NOP		200*1000        /*ns*//*JEDEC Standard No. 79-2E   page 17   */
-  #define PRE_ALL_NOP			400        /*ns*/
+  #define POWER_UP_NOP      200*1000        /*ns*//*JEDEC Standard No. 79-2E   page 17   */
+  #define PRE_ALL_NOP           400        /*ns*/
   #define POWER_UP_MIN_CK    200
   #define DDR2_TMRD                2            /*JEDEC Standard No. 79-2E   page 80   */
   #define DDR3_TMRD                4            /*JEDEC Standard No. 79-2E   page 80   */
@@ -50,41 +50,41 @@
   #define DDR3_TZQINIT_CK                512         /*JEDEC Standard No. 79-3E   page 171  table 68   */
   #define DDR3_TZQINIT                640   /*ns*/      /*JEDEC Standard No. 79-3E   page 171  table 68   */
   #define DDR3_TDLLK_CK                512         /*JEDEC Standard No. 79-3E   page 171  table 68   */
-  #define RSTH_NOP		500*1000        /*ns*//*JEDEC Standard No. 79-3E   page 20   */
+  #define RSTH_NOP      500*1000        /*ns*//*JEDEC Standard No. 79-3E   page 20   */
   #define DDR_TREF      7800 /*ns*/
   /**
   * @}
   */
 #ifndef NULL
-#define	NULL	0
+#define NULL    0
 #endif
 
 /** @defgroup DDRC_SW_PROC_CMD
   * @{
   */
 #define SW_CMD_NO_PARM        0
-#define SW_CMD_DES			0x0       /*des 5'b00000     [31:29]=3'b000           [28:0] DES time cke hold*/	
-#define SW_CMD_NOP			0x20000000        /*nop 5'b00100     [31:29]=3'b001           [28:0] NOP time cke hold*/		
-#define SW_CMD_DESCKE         0x40000000	   /*descke 5'b01000     [31:29]=3'b010           [28:0] DES time change cke high*/			
-#define SW_CMD_NOPCKE         0x60000000	 /*nopcke 5'b01100     [31:29]=3'b011           [28:0] NOP time change cke high*/	
-#define SW_CMD_PREA         	0x80000000	 /*nopcke 5'b10000     [31:27]=5'b10000           */	
+#define SW_CMD_DES          0x0       /*des 5'b00000     [31:29]=3'b000           [28:0] DES time cke hold*/
+#define SW_CMD_NOP          0x20000000        /*nop 5'b00100     [31:29]=3'b001           [28:0] NOP time cke hold*/
+#define SW_CMD_DESCKE         0x40000000       /*descke 5'b01000     [31:29]=3'b010           [28:0] DES time change cke high*/
+#define SW_CMD_NOPCKE         0x60000000     /*nopcke 5'b01100     [31:29]=3'b011           [28:0] NOP time change cke high*/
+#define SW_CMD_PREA             0x80000000   /*nopcke 5'b10000     [31:27]=5'b10000           */
 
-#define SW_CMD_MR         	0x88000000		/*JEDEC Standard No. 79-2E   page 19   */
-#define SW_CMD_EMR1         	0x88010000	/*JEDEC Standard No. 79-2E   page 19   */
-#define SW_CMD_EMR2         	0x88020000
-#define SW_CMD_EMR3         	0x88030000
-#define SW_CMD_EMR1_TEST  0x88010004	
-#define SW_CMD_REF         	0x90000000  /*REF 5'b10010     [31:27]=5'b10010       */	
+#define SW_CMD_MR           0x88000000      /*JEDEC Standard No. 79-2E   page 19   */
+#define SW_CMD_EMR1             0x88010000  /*JEDEC Standard No. 79-2E   page 19   */
+#define SW_CMD_EMR2             0x88020000
+#define SW_CMD_EMR3             0x88030000
+#define SW_CMD_EMR1_TEST  0x88010004
+#define SW_CMD_REF          0x90000000  /*REF 5'b10010     [31:27]=5'b10010       */
 
-#define SW_CMD_RSTH        	0xb0000000  /*RSTH 5'b10110    [31:27]=5'b10110       */	
-#define SW_CMD_ZQCL       	0xb8000000  /*ZQCL 5'b10111    [31:27]=5'b10111       */	
+#define SW_CMD_RSTH         0xb0000000  /*RSTH 5'b10110    [31:27]=5'b10110       */
+#define SW_CMD_ZQCL         0xb8000000  /*ZQCL 5'b10111    [31:27]=5'b10111       */
 
 #define SW_CMD_DLL_EN         0x880103C4
 #define SW_CMD_DLL_RST        0x88000953
 /**
   * @}
   */
-/** @defgroup DDR2  mode register 
+/** @defgroup DDR2  mode register
   * @{
   */
  /*JEDEC Standard    */
@@ -92,7 +92,7 @@
 #define MR_BURST_LEN_8          0x3
 #define MR_BT_SEQ                    0x0
 #define MR_BT_INT                    0x08
-#define MR_CL_OFFSET             4 
+#define MR_CL_OFFSET             4
 #define MR_TM_NORMAL            0
 #define MR_TM_TEST                 0x80
 #define MR_DLL_NO                   0
@@ -106,418 +106,418 @@
   */
 const uint8_t DDR2_MODE[BUS_WIDTH_MAX][CHIP_NUM_MAX][CHIP_TYPE_MAX]=
 {
-	{
-		{0x20,0x23,0x28,0x2a,0x30,0x21,0x22,0x29,0x2b,0x31,0xff},/*chip x1*/
-		{0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff}/*chip x2*/
-	},/*bus width x8*/
+    {
+        {0x20,0x23,0x28,0x2a,0x30,0x21,0x22,0x29,0x2b,0x31,0xff},/*chip x1*/
+        {0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff}/*chip x2*/
+    },/*bus width x8*/
 
-	{
-		{0xff,0xff,0xff,0xff,0xff,0x25,0x26,0x2d,0x2f,0x33,0xff},/*chip x1*/
-		{0x24,0x27,0x2c,0x2e,0x32,0xff,0xff,0xff,0xff,0xff,0xff}/*chip x2*/
-	}/*bus width x16*/
+    {
+        {0xff,0xff,0xff,0xff,0xff,0x25,0x26,0x2d,0x2f,0x33,0xff},/*chip x1*/
+        {0x24,0x27,0x2c,0x2e,0x32,0xff,0xff,0xff,0xff,0xff,0xff}/*chip x2*/
+    }/*bus width x16*/
 };
 const uint8_t DDR3_MODE[BUS_WIDTH_MAX][CHIP_NUM_MAX][CHIP_TYPE_MAX]=
 {
-	{
-		{0xff,0x00,0x01,0x02,0x03,0xff,0x04,0x05,0x06,0x07,0x10},/*chip x1*/
-		{0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff}/*chip x2*/
-	},/*bus width x8*/
+    {
+        {0xff,0x00,0x01,0x02,0x03,0xff,0x04,0x05,0x06,0x07,0x10},/*chip x1*/
+        {0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff}/*chip x2*/
+    },/*bus width x8*/
 
-	{
-		{0xff,0xff,0xff,0xff,0xff,0xff,0x0c,0x0d,0x0e,0x0f,0x11},/*chip x1*/
-		{0xff,0x08,0x09,0x0a,0x0b,0xff,0xff,0xff,0xff,0xff,0xff}/*chip x2*/
-	}/*bus width x16*/
+    {
+        {0xff,0xff,0xff,0xff,0xff,0xff,0x0c,0x0d,0x0e,0x0f,0x11},/*chip x1*/
+        {0xff,0x08,0x09,0x0a,0x0b,0xff,0xff,0xff,0xff,0xff,0xff}/*chip x2*/
+    }/*bus width x16*/
 };
 const DDR2MEM DDR2PREDEF[] = {
-	{
-// #define DDR2_400C			4	// sg5E //DDR2-400C CL=4, tCK=5000 ps (dev-brd using)
-		/*tCK*/ 5000,
-		/*tCL*/ 6,//4,
-		/*RCD*/4, /*RP*/4, /*RC*/13, /*RAS*/9, /*WR*/3, /*RRD*/2, /*WTR*/11, /*RTP*/4,
-		/*FAW*/10,
-	},
-	 
-	{
-// #define DDR2_800D			0	// sg25E //DDR2-800D CL=5, tCK=2500 ps
-		/*tCK*/ 2500,
-		/*tCL*/ 5, /*RCD*/5, /*RP*/5, /*RC*/24, //from sim model
-		/*RAS*/18, /*WR*/6, /*RRD*/4, /*WTR*/11, /*RTP*/5,
-		/*FAW*/30, //from sim model
-	}, {
-// #define DDR2_667C			1	// sg3E //DDR2-667C CL=4, tCK=3000 ps
-		/*tCK*/ 3000,
-		/*tCL*/ 4, /*RCD*/4, /*RP*/4, /*RC*/19, /*RAS*/15, /*WR*/5, /*RRD*/4, /*WTR*/10, /*RTP*/5,
-		/*FAW*/17,
-	}, {
-// #define DDR2_667D			2	// sg3 //DDR2-667D CL=5, tCK=3000 ps
-		/*tCK*/ 3000,
-		/*tCL*/ 5, /*RCD*/5, /*RP*/5, /*RC*/20, /*RAS*/15, /*WR*/5, /*RRD*/4, /*WTR*/3, /*RTP*/3,
-		/*FAW*/17,
-	}, {
-// #define DDR2_533C			3	// sg37E //DDR2-533C CL=4, tCK=3750 ps
-		/*tCK*/ 3750,
-		/*tCL*/ 4, /*RCD*/4, /*RP*/4, /*RC*/16, /*RAS*/12, /*WR*/4, /*RRD*/3, /*WTR*/9, /*RTP*/4,
-		/*FAW*/14,
-	},
+    {
+// #define DDR2_400C            4   // sg5E //DDR2-400C CL=4, tCK=5000 ps (dev-brd using)
+        /*tCK*/ 5000,
+        /*tCL*/ 6,//4,
+        /*RCD*/4, /*RP*/4, /*RC*/13, /*RAS*/9, /*WR*/3, /*RRD*/2, /*WTR*/11, /*RTP*/4,
+        /*FAW*/10,
+    },
+
+    {
+// #define DDR2_800D            0   // sg25E //DDR2-800D CL=5, tCK=2500 ps
+        /*tCK*/ 2500,
+        /*tCL*/ 5, /*RCD*/5, /*RP*/5, /*RC*/24, //from sim model
+        /*RAS*/18, /*WR*/6, /*RRD*/4, /*WTR*/11, /*RTP*/5,
+        /*FAW*/30, //from sim model
+    }, {
+// #define DDR2_667C            1   // sg3E //DDR2-667C CL=4, tCK=3000 ps
+        /*tCK*/ 3000,
+        /*tCL*/ 4, /*RCD*/4, /*RP*/4, /*RC*/19, /*RAS*/15, /*WR*/5, /*RRD*/4, /*WTR*/10, /*RTP*/5,
+        /*FAW*/17,
+    }, {
+// #define DDR2_667D            2   // sg3 //DDR2-667D CL=5, tCK=3000 ps
+        /*tCK*/ 3000,
+        /*tCL*/ 5, /*RCD*/5, /*RP*/5, /*RC*/20, /*RAS*/15, /*WR*/5, /*RRD*/4, /*WTR*/3, /*RTP*/3,
+        /*FAW*/17,
+    }, {
+// #define DDR2_533C            3   // sg37E //DDR2-533C CL=4, tCK=3750 ps
+        /*tCK*/ 3750,
+        /*tCL*/ 4, /*RCD*/4, /*RP*/4, /*RC*/16, /*RAS*/12, /*WR*/4, /*RRD*/3, /*WTR*/9, /*RTP*/4,
+        /*FAW*/14,
+    },
 };
 
 const DDR3MEM DDR3PREDEF[] = {
-	{
-// #define DDR3_400			14	//  Base on DDR3-800D (5-5-5) tCK=5ns
-		/*tCK*/ 2500,
-		/*tCL*//*9*/ 5, /*WCL*/7/*cwl should be 5 ,but phy has 2 cycles delay.So,wcl should plus the 2 cycles delay.*/ , /*RCD*//*9*/5, /*RAS*//*24*/8, /*RP*//*9*/5, /*RC*//*33*/10, /*RRD*/ 100,
-		/*FAW*//*30*/10, /*WR*/5/*10*/, /*RTP*/4, /*ZQCL*/256, /*ZQCS*/64,
-	}  ,
+    {
+// #define DDR3_400         14  //  Base on DDR3-800D (5-5-5) tCK=5ns
+        /*tCK*/ 2500,
+        /*tCL*//*9*/ 5, /*WCL*/7/*cwl should be 5 ,but phy has 2 cycles delay.So,wcl should plus the 2 cycles delay.*/ , /*RCD*//*9*/5, /*RAS*//*24*/8, /*RP*//*9*/5, /*RC*//*33*/10, /*RRD*/ 100,
+        /*FAW*//*30*/10, /*WR*/5/*10*/, /*RTP*/4, /*ZQCL*/256, /*ZQCS*/64,
+    }  ,
 
-	{
-// #define DDR3_667			15	//  Base on DDR3-800D (5-5-5) tCK=5ns
-		/*tCK*/ 3000,
-		/*tCL*//*9*/ 5, /*WCL*/7 /*cwl should be 5 ,but phy has 2 cycles delay.So,wcl should plus the 2 cycles delay.*/ , /*RCD*//*9*/5, /*RAS*//*24*/30, /*RP*//*9*/5, /*RC*//*33*/60, /*RRD*/16,
-		/*FAW*//*30*/17, /*WR*/5/*10*/, /*RTP*/4, /*ZQCL*/256, /*ZQCS*/64,
-	},
+    {
+// #define DDR3_667         15  //  Base on DDR3-800D (5-5-5) tCK=5ns
+        /*tCK*/ 3000,
+        /*tCL*//*9*/ 5, /*WCL*/7 /*cwl should be 5 ,but phy has 2 cycles delay.So,wcl should plus the 2 cycles delay.*/ , /*RCD*//*9*/5, /*RAS*//*24*/30, /*RP*//*9*/5, /*RC*//*33*/60, /*RRD*/16,
+        /*FAW*//*30*/17, /*WR*/5/*10*/, /*RTP*/4, /*ZQCL*/256, /*ZQCS*/64,
+    },
 
-	{
-// #define DDR3_2133N			0	// sg093 //DDR3-2133N (14-14-14) tCK=0.938ns
-		/*tCK*/ 938,
-		/*tCL*/ 14, /*WCL*/10, /*RCD*/14, /*RAS*/36, /*RP*/14, /*RC*/50, /*RRD*/7,
-		/*FAW*/38, /*WR*/16, /*RTP*/10, /*ZQCL*/342, /*ZQCS*/86,
-	}, {
-// #define DDR3_2133M			1	// sg093E //DDR3-2133M (13-13-13) tCK=0.938ns
-		/*tCK*/ 938,
-		/*tCL*/ 13, /*WCL*/10, /*RCD*/13, /*RAS*/36, /*RP*/13, /*RC*/49, /*RRD*/7,
-		/*FAW*/38, /*WR*/16, /*RTP*/10, /*ZQCL*/342, /*ZQCS*/86,
-	}, {
-// #define DDR3_2133L			2	// sg093F //DDR3-2133L (12-12-12) tCK=0.938ns
-		/*tCK*/ 938,
-		/*tCL*/ 12, /*WCL*/10, /*RCD*/12, /*RAS*/36, /*RP*/12, /*RC*/48, /*RRD*/7,
-		/*FAW*/38, /*WR*/16, /*RTP*/10, /*ZQCL*/342, /*ZQCS*/86,
-	}, {
-// #define DDR3_1866L			3	// sg107E //DDR3-1866L (12-12-12) tCK=1.07ns
-		/*tCK*/ 1070,
-		/*tCL*/ 12, /*WCL*/9, /*RCD*/12, /*RAS*/32, /*RP*/12, /*RC*/44, /*RRD*/6,
-		/*FAW*/33, /*WR*/14, /*RTP*/9, /*ZQCL*/300, /*ZQCS*/75,
-	}, {
-// #define DDR3_1866K			4	// sg107F //DDR3-1866K (11-11-11) tCK=1.07ns
-		/*tCK*/ 1070,
-		/*tCL*/ 11, /*WCL*/9, /*RCD*/11, /*RAS*/32, /*RP*/11, /*RC*/43, /*RRD*/6,
-		/*FAW*/33, /*WR*/14, /*RTP*/9, /*ZQCL*/300, /*ZQCS*/75,
-	}, {
-// #define DDR3_1600J			5	// sg125E //DDR3-1600J (10-10-10) tCK=1.25ns
-		/*tCK*/ 1250,
-		/*tCL*/ 10, /*WCL*/8, /*RCD*/10, /*RAS*/28, /*RP*/10, /*RC*/38, /*RRD*/6,
-		/*FAW*/32, /*WR*/12, /*RTP*/8, /*ZQCL*/256, /*ZQCS*/64,
-	}, {
-// #define DDR3_1600K			6	// sg125 //DDR3-1600K (11-11-11) tCK=1.25ns
-		/*tCK*/ 1250,
-		/*tCL*/ 11, /*WCL*/8, /*RCD*/11, /*RAS*/28, /*RP*/11, /*RC*/37, /*RRD*/6,
-		/*FAW*/32, /*WR*/12, /*RTP*/8, /*ZQCL*/256, /*ZQCS*/64,
-	}, {
-// #define DDR3_1333H			7	// sg15E //DDR3-1333H (9-9-9) tCK=1.5ns
-		/*tCK*/ 1500,
-		/*tCL*/ 9, /*WCL*/7, /*RCD*/9, /*RAS*/24, /*RP*/9, /*RC*/33, /*RRD*/5,
-		/*FAW*/30, /*WR*/10, /*RTP*/5, /*ZQCL*/256, /*ZQCS*/64,
-	}, {
-// #define DDR3_1333J			8	// sg15 //DDR3-1333J (10-10-10) tCK=1.5ns
-		/*tCK*/ 1500,
-		/*tCL*/ 10, /*WCL*/7, /*RCD*/10, /*RAS*/24, /*RP*/10, /*RC*/34, /*RRD*/5,
-		/*FAW*/30, /*WR*/10, /*RTP*/7, /*ZQCL*/256, /*ZQCS*/64,
-	}, {
-// #define DDR3_1066F			9	// sg187E //DDR3-1066F (7-7-7) tCK=1.875ns
-		/*tCK*/ 1875,
-		/*tCL*/ 7, /*WCL*/6, /*RCD*/7, /*RAS*/20, /*RP*/7, /*RC*/27, /*RRD*/6,
-		/*FAW*/27, /*WR*/8, /*RTP*/6, /*ZQCL*/256, /*ZQCS*/64,
-	}, {
-// #define DDR3_1066G			10	// sg187 //DDR3-1066G (8-8-8) tCK=1.875ns
-		/*tCK*/ 1875,
-		/*tCL*/ 8, /*WCL*/6, /*RCD*/8, /*RAS*/20, /*RP*/8, /*RC*/28, /*RRD*/6,
-		/*FAW*/27, /*WR*/8, /*RTP*/6, /*ZQCL*/256, /*ZQCS*/64,
-	}, {
-// #define DDR3_800D			11	// sg25E //DDR3-800D (5-5-5) tCK=2.5ns
-		/*tCK*/ 2500,
-		/*tCL*/ 5, /*WCL*/5, /*RCD*/5, /*RAS*/15, /*RP*/5, /*RC*/20, /*RRD*/4,
-		/*FAW*/17, /*WR*/5, /*RTP*/3, /*ZQCL*/256, /*ZQCS*/64,
-	}, {
-// #define DDR3_800E			12	// sg25 //DDR3-800E (6-6-6) tCK=2.5ns
-		/*tCK*/ 2500,
-		/*tCL*/ 6, /*WCL*/5, /*RCD*/6, /*RAS*/15, /*RP*/6, /*RC*/21, /*RRD*/4,
-		/*FAW*/20, /*WR*/6, /*RTP*/6, /*ZQCL*/256, /*ZQCS*/64,
-	},
-	{
-	// #define DDR3_266MPW			13	// sg25 //DDR3-800E (5-5-5) tCK=2.5ns
-//		/*tCL*/ 5, /*WCL*/7, /*RCD*/5, /*RAS*/9/*37.5/4*/, /*RP*/5, /*RC*/13, /*RRD*/4,
-//		/*FAW 50/4*/15, /*WR6*/5, /*RTP*/4, /*ZQCL*/256, /*ZQCS*/64,
-// #define DDR3_250MPW			13	// sg25 //DDR3-800E (5-5-5) tCK=2.5ns
-		/*tCK*/ 2500,
-		/*tCL*/ 5, /*WCL*/7, /*RCD*/5, /*RAS*/9/*37.5/4*/, /*RP*/5, /*RC*/13, /*RRD*/4,
-		/*FAW 50/4*/15, /*WR6*/5, /*RTP*/4, /*ZQCL*/256, /*ZQCS*/64,
+    {
+// #define DDR3_2133N           0   // sg093 //DDR3-2133N (14-14-14) tCK=0.938ns
+        /*tCK*/ 938,
+        /*tCL*/ 14, /*WCL*/10, /*RCD*/14, /*RAS*/36, /*RP*/14, /*RC*/50, /*RRD*/7,
+        /*FAW*/38, /*WR*/16, /*RTP*/10, /*ZQCL*/342, /*ZQCS*/86,
+    }, {
+// #define DDR3_2133M           1   // sg093E //DDR3-2133M (13-13-13) tCK=0.938ns
+        /*tCK*/ 938,
+        /*tCL*/ 13, /*WCL*/10, /*RCD*/13, /*RAS*/36, /*RP*/13, /*RC*/49, /*RRD*/7,
+        /*FAW*/38, /*WR*/16, /*RTP*/10, /*ZQCL*/342, /*ZQCS*/86,
+    }, {
+// #define DDR3_2133L           2   // sg093F //DDR3-2133L (12-12-12) tCK=0.938ns
+        /*tCK*/ 938,
+        /*tCL*/ 12, /*WCL*/10, /*RCD*/12, /*RAS*/36, /*RP*/12, /*RC*/48, /*RRD*/7,
+        /*FAW*/38, /*WR*/16, /*RTP*/10, /*ZQCL*/342, /*ZQCS*/86,
+    }, {
+// #define DDR3_1866L           3   // sg107E //DDR3-1866L (12-12-12) tCK=1.07ns
+        /*tCK*/ 1070,
+        /*tCL*/ 12, /*WCL*/9, /*RCD*/12, /*RAS*/32, /*RP*/12, /*RC*/44, /*RRD*/6,
+        /*FAW*/33, /*WR*/14, /*RTP*/9, /*ZQCL*/300, /*ZQCS*/75,
+    }, {
+// #define DDR3_1866K           4   // sg107F //DDR3-1866K (11-11-11) tCK=1.07ns
+        /*tCK*/ 1070,
+        /*tCL*/ 11, /*WCL*/9, /*RCD*/11, /*RAS*/32, /*RP*/11, /*RC*/43, /*RRD*/6,
+        /*FAW*/33, /*WR*/14, /*RTP*/9, /*ZQCL*/300, /*ZQCS*/75,
+    }, {
+// #define DDR3_1600J           5   // sg125E //DDR3-1600J (10-10-10) tCK=1.25ns
+        /*tCK*/ 1250,
+        /*tCL*/ 10, /*WCL*/8, /*RCD*/10, /*RAS*/28, /*RP*/10, /*RC*/38, /*RRD*/6,
+        /*FAW*/32, /*WR*/12, /*RTP*/8, /*ZQCL*/256, /*ZQCS*/64,
+    }, {
+// #define DDR3_1600K           6   // sg125 //DDR3-1600K (11-11-11) tCK=1.25ns
+        /*tCK*/ 1250,
+        /*tCL*/ 11, /*WCL*/8, /*RCD*/11, /*RAS*/28, /*RP*/11, /*RC*/37, /*RRD*/6,
+        /*FAW*/32, /*WR*/12, /*RTP*/8, /*ZQCL*/256, /*ZQCS*/64,
+    }, {
+// #define DDR3_1333H           7   // sg15E //DDR3-1333H (9-9-9) tCK=1.5ns
+        /*tCK*/ 1500,
+        /*tCL*/ 9, /*WCL*/7, /*RCD*/9, /*RAS*/24, /*RP*/9, /*RC*/33, /*RRD*/5,
+        /*FAW*/30, /*WR*/10, /*RTP*/5, /*ZQCL*/256, /*ZQCS*/64,
+    }, {
+// #define DDR3_1333J           8   // sg15 //DDR3-1333J (10-10-10) tCK=1.5ns
+        /*tCK*/ 1500,
+        /*tCL*/ 10, /*WCL*/7, /*RCD*/10, /*RAS*/24, /*RP*/10, /*RC*/34, /*RRD*/5,
+        /*FAW*/30, /*WR*/10, /*RTP*/7, /*ZQCL*/256, /*ZQCS*/64,
+    }, {
+// #define DDR3_1066F           9   // sg187E //DDR3-1066F (7-7-7) tCK=1.875ns
+        /*tCK*/ 1875,
+        /*tCL*/ 7, /*WCL*/6, /*RCD*/7, /*RAS*/20, /*RP*/7, /*RC*/27, /*RRD*/6,
+        /*FAW*/27, /*WR*/8, /*RTP*/6, /*ZQCL*/256, /*ZQCS*/64,
+    }, {
+// #define DDR3_1066G           10  // sg187 //DDR3-1066G (8-8-8) tCK=1.875ns
+        /*tCK*/ 1875,
+        /*tCL*/ 8, /*WCL*/6, /*RCD*/8, /*RAS*/20, /*RP*/8, /*RC*/28, /*RRD*/6,
+        /*FAW*/27, /*WR*/8, /*RTP*/6, /*ZQCL*/256, /*ZQCS*/64,
+    }, {
+// #define DDR3_800D            11  // sg25E //DDR3-800D (5-5-5) tCK=2.5ns
+        /*tCK*/ 2500,
+        /*tCL*/ 5, /*WCL*/5, /*RCD*/5, /*RAS*/15, /*RP*/5, /*RC*/20, /*RRD*/4,
+        /*FAW*/17, /*WR*/5, /*RTP*/3, /*ZQCL*/256, /*ZQCS*/64,
+    }, {
+// #define DDR3_800E            12  // sg25 //DDR3-800E (6-6-6) tCK=2.5ns
+        /*tCK*/ 2500,
+        /*tCL*/ 6, /*WCL*/5, /*RCD*/6, /*RAS*/15, /*RP*/6, /*RC*/21, /*RRD*/4,
+        /*FAW*/20, /*WR*/6, /*RTP*/6, /*ZQCL*/256, /*ZQCS*/64,
+    },
+    {
+    // #define DDR3_266MPW          13  // sg25 //DDR3-800E (5-5-5) tCK=2.5ns
+//      /*tCL*/ 5, /*WCL*/7, /*RCD*/5, /*RAS*/9/*37.5/4*/, /*RP*/5, /*RC*/13, /*RRD*/4,
+//      /*FAW 50/4*/15, /*WR6*/5, /*RTP*/4, /*ZQCL*/256, /*ZQCS*/64,
+// #define DDR3_250MPW          13  // sg25 //DDR3-800E (5-5-5) tCK=2.5ns
+        /*tCK*/ 2500,
+        /*tCL*/ 5, /*WCL*/7, /*RCD*/5, /*RAS*/9/*37.5/4*/, /*RP*/5, /*RC*/13, /*RRD*/4,
+        /*FAW 50/4*/15, /*WR6*/5, /*RTP*/4, /*ZQCL*/256, /*ZQCS*/64,
 
-	},
+    },
 };
 uint32_t Get_DDR_Capacity(const MEM_CHIP_INFO *chip_info)
 {
-	uint32_t n=0;
-	uint32_t capacity=0;
+    uint32_t n=0;
+    uint32_t capacity=0;
 
-	assert_param(chip_info);
-	n=(chip_info->Chip_type<_16Mbx16)?(chip_info->Chip_type):(chip_info->Chip_type-_16Mbx16);
-	capacity=(chip_info->Chip_type<_16Mbx16)?(CHIP_MIN_CAPACITY*(1<<n)*(chip_info->Chip_num+1)):(CHIP_MIN_CAPACITY*(1<<n)*(chip_info->Bus_width+1)/(BUS_WIDTH_16+1));
-	return capacity;
-	
-	
+    assert_param(chip_info);
+    n=(chip_info->Chip_type<_16Mbx16)?(chip_info->Chip_type):(chip_info->Chip_type-_16Mbx16);
+    capacity=(chip_info->Chip_type<_16Mbx16)?(CHIP_MIN_CAPACITY*(1<<n)*(chip_info->Chip_num+1)):(CHIP_MIN_CAPACITY*(1<<n)*(chip_info->Bus_width+1)/(BUS_WIDTH_16+1));
+    return capacity;
+
+
 }
 uint32_t Calc_DDR_RFC(const MEM_CHIP_INFO *chip_info)
 {
-	uint32_t capacity=0;
-	uint32_t tRFC=0;
-	assert_param(chip_info);
+    uint32_t capacity=0;
+    uint32_t tRFC=0;
+    assert_param(chip_info);
 
-	
-	capacity=Get_DDR_Capacity(chip_info);
-	if (chip_info->mem_type==MEM_DDR2) {
-	
-		switch(capacity){
-			case CHIP_CAPACITY_32MB:tRFC=75;break;
-			case CHIP_CAPACITY_64MB:tRFC=105;break;
-			case CHIP_CAPACITY_128MB:tRFC=128;break;
-			case CHIP_CAPACITY_256MB:tRFC=195;break;
-			case CHIP_CAPACITY_512MB:tRFC=328;break;
-		}
-	}
-	else{
-		switch(capacity){
-			case CHIP_CAPACITY_64MB:tRFC=90;break;
-			case CHIP_CAPACITY_128MB:tRFC=110;break;
-			case CHIP_CAPACITY_256MB:tRFC=160;break;
-			case CHIP_CAPACITY_512MB:tRFC=300;break;
-			case CHIP_CAPACITY_1024MB:tRFC=350;break;
-		}
-	}
 
-	return tRFC;
-	
-	
+    capacity=Get_DDR_Capacity(chip_info);
+    if (chip_info->mem_type==MEM_DDR2) {
+
+        switch(capacity){
+            case CHIP_CAPACITY_32MB:tRFC=75;break;
+            case CHIP_CAPACITY_64MB:tRFC=105;break;
+            case CHIP_CAPACITY_128MB:tRFC=128;break;
+            case CHIP_CAPACITY_256MB:tRFC=195;break;
+            case CHIP_CAPACITY_512MB:tRFC=328;break;
+        }
+    }
+    else{
+        switch(capacity){
+            case CHIP_CAPACITY_64MB:tRFC=90;break;
+            case CHIP_CAPACITY_128MB:tRFC=110;break;
+            case CHIP_CAPACITY_256MB:tRFC=160;break;
+            case CHIP_CAPACITY_512MB:tRFC=300;break;
+            case CHIP_CAPACITY_1024MB:tRFC=350;break;
+        }
+    }
+
+    return tRFC;
+
+
 }
 static void DDR_Cmd(const uint32_t cmd ,const uint32_t param)
 {
-		DDRC->CMD =((cmd)|(param));
-	
+        DDRC->CMD =((cmd)|(param));
+
 }
 static void DDR_Latency(const uint32_t cycle  )
 {
-	DDR_Cmd(SW_CMD_NOP,cycle);
+    DDR_Cmd(SW_CMD_NOP,cycle);
 }
 static void DDR2_conf(const MEM_CHIP_INFO *chip_info ,const void *ddr)
 {
-	uint32_t period=0;
-	const DDR2MEM *ptr = (const DDR2MEM *)ddr;
-	uint32_t tRFC=0;
-	
-	assert_param(ddr);
-	tRFC=Calc_DDR_RFC(chip_info);
-	period = (1000 / (SYSTEM_CLOCK_FREQ / 1000000));	
-	CFG_CTRL->DONE_b.CMD = 0x1;
+    uint32_t period=0;
+    const DDR2MEM *ptr = (const DDR2MEM *)ddr;
+    uint32_t tRFC=0;
 
-	DDRC->MODE_b.LANE = 1;
-	DDRC->MODE_b.B16 = 1;
-	DDRC->REF_b.TIME =( DDR_TREF/period);
-	DDRC->RP_b.RPA = 1;
-	DDRC->RFC_b.DI = (tRFC/period);
-	DDRC->PHUNG_b.MODE = 1;
-	DDRC->RD_SEL_b.PHY_SEL = 5;
+    assert_param(ddr);
+    tRFC=Calc_DDR_RFC(chip_info);
+    period = (1000 / (SYSTEM_CLOCK_FREQ / 1000000));
+    CFG_CTRL->DONE_b.CMD = 0x1;
 
-	DDRC->DQSEN0_b.DL = 2;
-	DDRC->DQSEN1_b.DL = 2;
-	DDRC->DQSEN2_b.DL = 2;
-	DDRC->DQSEN3_b.DL = 2;
-	DDRC->INTCTL_b.DONE = 1;
-	DDRC->INTCTL_b.ERR = 0;
-	DDRC->RDQ_b.L3 = DDRC->RDQ_b.L2 = DDRC->RDQ_b.L1 = DDRC->RDQ_b.L0 = 0x32;
-	DDRC->ITMDLY_b.I0 = DDRC->ITMDLY_b.IS0 = DDRC->ITMDLY_b.I1 = DDRC->ITMDLY_b.IS1 = 
-		DDRC->ITMDLY_b.I2 = DDRC->ITMDLY_b.IS2 = DDRC->ITMDLY_b.I3 = DDRC->ITMDLY_b.IS3 = 3;
+    DDRC->MODE_b.LANE = 1;
+    DDRC->MODE_b.B16 = 1;
+    DDRC->REF_b.TIME =( DDR_TREF/period);
+    DDRC->RP_b.RPA = 1;
+    DDRC->RFC_b.DI = (tRFC/period);
+    DDRC->PHUNG_b.MODE = 1;
+    DDRC->RD_SEL_b.PHY_SEL = 5;
 
-	
-	DDR_Latency((POWER_UP_NOP/period));
-	DDR_Cmd(SW_CMD_NOPCKE,(PRE_ALL_NOP/period));
-	DDR_Cmd(SW_CMD_PREA,NULL);
-	DDR_Latency(ptr->tRP);/*tRP*/
-	DDR_Cmd(SW_CMD_EMR2,NULL);
-	DDR_Latency(DDR2_TMRD);
-	DDR_Cmd(SW_CMD_EMR3,NULL);
-	DDR_Latency(DDR2_TMRD);
-	DDR_Cmd(SW_CMD_DLL_EN,NULL);
-	DDR_Latency(DDR2_TMRD);
-	DDR_Cmd(SW_CMD_DLL_RST,NULL);
-	DDR_Latency(DDR2_TMRD);
-	DDR_Cmd(SW_CMD_PREA,NULL);
-	DDR_Latency(ptr->tRP);
-	DDR_Cmd(SW_CMD_REF,NULL);
-	DDR_Latency((tRFC/period));/*tRFC*/
-	DDR_Cmd(SW_CMD_REF,NULL);
-	DDR_Latency((tRFC/period));
-	DDR_Cmd(SW_CMD_MR,(((ptr->tWR-1)<<MR_WR_OFFSET)|(ptr->tCL<<MR_CL_OFFSET)|MR_BURST_LEN_8));
-	DDR_Latency(POWER_UP_MIN_CK);
-	DDR_Cmd(SW_CMD_EMR1_TEST,NULL);
-	DDR_Latency(DDR2_TMRD);
+    DDRC->DQSEN0_b.DL = 2;
+    DDRC->DQSEN1_b.DL = 2;
+    DDRC->DQSEN2_b.DL = 2;
+    DDRC->DQSEN3_b.DL = 2;
+    DDRC->INTCTL_b.DONE = 1;
+    DDRC->INTCTL_b.ERR = 0;
+    DDRC->RDQ_b.L3 = DDRC->RDQ_b.L2 = DDRC->RDQ_b.L1 = DDRC->RDQ_b.L0 = 0x32;
+    DDRC->ITMDLY_b.I0 = DDRC->ITMDLY_b.IS0 = DDRC->ITMDLY_b.I1 = DDRC->ITMDLY_b.IS1 =
+        DDRC->ITMDLY_b.I2 = DDRC->ITMDLY_b.IS2 = DDRC->ITMDLY_b.I3 = DDRC->ITMDLY_b.IS3 = 3;
+
+
+    DDR_Latency((POWER_UP_NOP/period));
+    DDR_Cmd(SW_CMD_NOPCKE,(PRE_ALL_NOP/period));
+    DDR_Cmd(SW_CMD_PREA,NULL);
+    DDR_Latency(ptr->tRP);/*tRP*/
+    DDR_Cmd(SW_CMD_EMR2,NULL);
+    DDR_Latency(DDR2_TMRD);
+    DDR_Cmd(SW_CMD_EMR3,NULL);
+    DDR_Latency(DDR2_TMRD);
+    DDR_Cmd(SW_CMD_DLL_EN,NULL);
+    DDR_Latency(DDR2_TMRD);
+    DDR_Cmd(SW_CMD_DLL_RST,NULL);
+    DDR_Latency(DDR2_TMRD);
+    DDR_Cmd(SW_CMD_PREA,NULL);
+    DDR_Latency(ptr->tRP);
+    DDR_Cmd(SW_CMD_REF,NULL);
+    DDR_Latency((tRFC/period));/*tRFC*/
+    DDR_Cmd(SW_CMD_REF,NULL);
+    DDR_Latency((tRFC/period));
+    DDR_Cmd(SW_CMD_MR,(((ptr->tWR-1)<<MR_WR_OFFSET)|(ptr->tCL<<MR_CL_OFFSET)|MR_BURST_LEN_8));
+    DDR_Latency(POWER_UP_MIN_CK);
+    DDR_Cmd(SW_CMD_EMR1_TEST,NULL);
+    DDR_Latency(DDR2_TMRD);
 }
 
 static void DDR3_conf(const MEM_CHIP_INFO *chip_info ,const void *ddr)
 {
 
-	uint32_t period = 0;
-	uint32_t tRFC = 0;
-	const DDR3MEM *ptr = (const DDR3MEM *)ddr;
+    uint32_t period = 0;
+    uint32_t tRFC = 0;
+    const DDR3MEM *ptr = (const DDR3MEM *)ddr;
 
-	tRFC = Calc_DDR_RFC(chip_info);
-	period = (1000 / (SYSTEM_CLOCK_FREQ / 1000000));	
-	
-	DDRC->MODE_b.LANE = 0x1;
-	DDRC->QUE_b.DEPTH=1;
-	DDRC->REF_b.TIME = (DDR_TREF / period);////// //2Gb periodic refresh interval 7.8us 7.8us/5ns
-	DDRC->REF_b.TRIG = 1;
-	DDRC->REF_b.THRD = 8; 
-	DDRC->ZQCSR_b.EN = 1;
-	DDRC->ZQCSI = 128 * 1000000 / period;
-	DDRC->RP_b.RPA = 1;
-	DDRC->RFC_b.DI = (tRFC / period);
-	
-	if (ptr->tCK == 2500) { // 200MHz 
-		DDRC->RD_SEL_b.PHY_SEL = 5;
-	} else if (ptr->tCK == 3000) { // 333MHz 
-		DDRC->RD_SEL_b.PHY_SEL = 6;
-	}
-	
-	DDRC->PHUNG_b.MODE = 1;	
-	DDRC->DQSEN0_b.DL = 2;
-	DDRC->DQSEN1_b.DL = 2;
-	DDRC->DQSEN2_b.DL = 2;
-	DDRC->DQSEN3_b.DL = 2;
+    tRFC = Calc_DDR_RFC(chip_info);
+    period = (1000 / (SYSTEM_CLOCK_FREQ / 1000000));
 
-	// config MR#
-	DDR_Latency((POWER_UP_NOP/period));//200us nop
-	DDR_Cmd(SW_CMD_RSTH,NULL);// RESET H
-	DDR_Latency((RSTH_NOP/period));// 500us nop  
-	DDR_Cmd(SW_CMD_NOPCKE,((tRFC+10)/period));//	 cke high 170/tck tck txpr max(5nck, trfc(min) + 10ns)	 2Gb refresh time 160ns
-	DDR_Cmd(SW_CMD_EMR2,((ptr->tWCL-5)<<MR2_CWL_OFFSET)); //MR2
-	DDR_Latency(DDR3_TMRD);// tmrd  4nck
-	DDR_Cmd(SW_CMD_EMR3,NULL);// MR3
-	DDR_Latency(DDR3_TMRD); // tmrd
-	DDR_Cmd(SW_CMD_EMR1,MR1_RZQ_4); // MR1	
-	DDR_Latency(DDR3_TMRD); // tmrd
-	DDR_Cmd(SW_CMD_MR,(MR_PPD_FAST|MR_DLL_YES|((ptr->tWR-1)<<MR_WR_OFFSET)|(CAL_DDR3_CL(ptr->tCL))));
-														// MR0
-														// A1 , A0 2'b0 fixed 8 
-														// A2 CL 0 
-														// A3 nibble sequential 0  Interleave 1
-														// A6,A5,A4 CL 101 CL =9 
-														// A7 normal mode 0
-														// A8 DLL reset 1
-														// A11,A10,A9 wr=(twr/ck)=(15/3)=5	=001
-														// A12 DLL control for precharge PD fast exit 1
-														// MR0 =0xb50
-	DDR_Latency(MAX(DDR3_TMOD_CK,(DDR3_TMOD/period)));// tmod max (12nck,15ns) 
-	DDR_Cmd(SW_CMD_ZQCL,NULL);// ZQCL starting ZQ calibration
-	DDR_Latency(MAX(DDR3_TZQINIT_CK,(DDR3_TZQINIT/period))); // tdllk 512nck (should be 500nck)
-	DDR_Latency(DDR3_TDLLK_CK); // tZQinit max(512nck,640ns) 
+    DDRC->MODE_b.LANE = 0x1;
+    DDRC->QUE_b.DEPTH=1;
+    DDRC->REF_b.TIME = (DDR_TREF / period);////// //2Gb periodic refresh interval 7.8us 7.8us/5ns
+    DDRC->REF_b.TRIG = 1;
+    DDRC->REF_b.THRD = 8;
+    DDRC->ZQCSR_b.EN = 1;
+    DDRC->ZQCSI = 128 * 1000000 / period;
+    DDRC->RP_b.RPA = 1;
+    DDRC->RFC_b.DI = (tRFC / period);
+
+    if (ptr->tCK == 2500) { // 200MHz
+        DDRC->RD_SEL_b.PHY_SEL = 5;
+    } else if (ptr->tCK == 3000) { // 333MHz
+        DDRC->RD_SEL_b.PHY_SEL = 6;
+    }
+
+    DDRC->PHUNG_b.MODE = 1;
+    DDRC->DQSEN0_b.DL = 2;
+    DDRC->DQSEN1_b.DL = 2;
+    DDRC->DQSEN2_b.DL = 2;
+    DDRC->DQSEN3_b.DL = 2;
+
+    // config MR#
+    DDR_Latency((POWER_UP_NOP/period));//200us nop
+    DDR_Cmd(SW_CMD_RSTH,NULL);// RESET H
+    DDR_Latency((RSTH_NOP/period));// 500us nop
+    DDR_Cmd(SW_CMD_NOPCKE,((tRFC+10)/period));//     cke high 170/tck tck txpr max(5nck, trfc(min) + 10ns)   2Gb refresh time 160ns
+    DDR_Cmd(SW_CMD_EMR2,((ptr->tWCL-5)<<MR2_CWL_OFFSET)); //MR2
+    DDR_Latency(DDR3_TMRD);// tmrd  4nck
+    DDR_Cmd(SW_CMD_EMR3,NULL);// MR3
+    DDR_Latency(DDR3_TMRD); // tmrd
+    DDR_Cmd(SW_CMD_EMR1,MR1_RZQ_4); // MR1
+    DDR_Latency(DDR3_TMRD); // tmrd
+    DDR_Cmd(SW_CMD_MR,(MR_PPD_FAST|MR_DLL_YES|((ptr->tWR-1)<<MR_WR_OFFSET)|(CAL_DDR3_CL(ptr->tCL))));
+                                                        // MR0
+                                                        // A1 , A0 2'b0 fixed 8
+                                                        // A2 CL 0
+                                                        // A3 nibble sequential 0  Interleave 1
+                                                        // A6,A5,A4 CL 101 CL =9
+                                                        // A7 normal mode 0
+                                                        // A8 DLL reset 1
+                                                        // A11,A10,A9 wr=(twr/ck)=(15/3)=5  =001
+                                                        // A12 DLL control for precharge PD fast exit 1
+                                                        // MR0 =0xb50
+    DDR_Latency(MAX(DDR3_TMOD_CK,(DDR3_TMOD/period)));// tmod max (12nck,15ns)
+    DDR_Cmd(SW_CMD_ZQCL,NULL);// ZQCL starting ZQ calibration
+    DDR_Latency(MAX(DDR3_TZQINIT_CK,(DDR3_TZQINIT/period))); // tdllk 512nck (should be 500nck)
+    DDR_Latency(DDR3_TDLLK_CK); // tZQinit max(512nck,640ns)
 
 }
 
 BOOL DDR_Init(const MEM_CHIP_INFO *chip_info, const void *ddr)
 {
-	uint32_t tCL, tWR, tWCL, tWTR, tCK,mode;
-	
-	assert_param(chip_info);
-	assert_param(ddr);
-	if((chip_info->Bus_width<BUS_WIDTH_MAX)
-		&&(chip_info->Chip_num<CHIP_NUM_MAX)
-		&&(chip_info->Chip_type<	CHIP_TYPE_MAX))
-	{
-		if(chip_info->mem_type==MEM_DDR2)
-		{
-			mode=DDR2_MODE[chip_info->Bus_width][chip_info->Chip_num][chip_info->Chip_type];
-		}
-		else
-		{
-			mode=DDR3_MODE[chip_info->Bus_width][chip_info->Chip_num][chip_info->Chip_type];
-		}
-		if(mode==0xff)
-		{
-			return FALSE;
-		}
-		
-	
-	}
-	else
-	{
-		return FALSE;
-	}
-		
-	
-	PDPROT->LOCK_b.EN = 0;
-	do {
-		CFG_CTRL->PDLLSTR_b.C2R1D = 0; // rst dll_c2r1
-		udelay(10);
-		CFG_CTRL->PDLLSTR_b.C2R1D = 1; // releset rst
-		udelay(10);
-	} while ((PDLOCK->GCLK & 0x40) != 0x40);
-	PDPROT->LOCK_b.EN = 1;
+    uint32_t tCL, tWR, tWCL, tWTR, tCK,mode;
 
-	DDRC->MODE_b.MODE = mode;
+    assert_param(chip_info);
+    assert_param(ddr);
+    if((chip_info->Bus_width<BUS_WIDTH_MAX)
+        &&(chip_info->Chip_num<CHIP_NUM_MAX)
+        &&(chip_info->Chip_type<    CHIP_TYPE_MAX))
+    {
+        if(chip_info->mem_type==MEM_DDR2)
+        {
+            mode=DDR2_MODE[chip_info->Bus_width][chip_info->Chip_num][chip_info->Chip_type];
+        }
+        else
+        {
+            mode=DDR3_MODE[chip_info->Bus_width][chip_info->Chip_num][chip_info->Chip_type];
+        }
+        if(mode==0xff)
+        {
+            return FALSE;
+        }
 
-	if (chip_info->mem_type==MEM_DDR2) {
-		const DDR2MEM *ptr = (const DDR2MEM *)ddr;
-		DDRC->RL_b.VAL = ptr->tCL;
-		DDRC->RCD_b.DI = ptr->tRCD;
-		DDRC->RP_b.DI = ptr->tRP;
-		DDRC->RC_b.DI = ptr->tRC;
-		DDRC->RAS_b.DI = ptr->tRAS;
-		tWR = ptr->tWR;
-		tWTR = ptr->tWTR;
-		DDRC->RRD_b.DI = ptr->tRRD;
-		DDRC->RTP_b.DI = ptr->tRTP;
-		DDRC->FAW_b.DI = ptr->tFAW;
-		DDR2_conf(chip_info,ptr);
-	} else {
-		const DDR3MEM *ptr = (const DDR3MEM *)ddr;
-		DDRC->RL_b.VAL = ptr->tCL;
-		tWCL = ptr->tWCL;
-		DDRC->RCD_b.DI = ptr->tRCD;
-		DDRC->RAS_b.DI = ptr->tRAS;
-		DDRC->RP_b.DI = ptr->tRP;
-		DDRC->RC_b.DI = ptr->tRC;
-		DDRC->RRD_b.DI = ptr->tRRD;
-		DDRC->FAW_b.DI = ptr->tFAW;
-		tWR = ptr->tWR;
-		tCK = ptr->tCK;
-		DDRC->RTP_b.DI = ptr->tRTP;
-		DDRC->ZQCL_b.DI = ptr->tZQoper;
-		DDRC->ZQCS_b.DI = ptr->tZQCS;
-		DDR3_conf(chip_info,ptr);
-	}
 
-	tCL = DDRC->RL_b.VAL;
+    }
+    else
+    {
+        return FALSE;
+    }
 
-	DDRC->WTR_b.DI  = (DDRC->MODE_b.MODE & 0x20) ? 
-		(tWCL + tWTR + (DDRC->BURST_b.LEN ? 2 : 4)) : 
-		((tCK * 4) > 7500) ? 18 : (tCK * 4 + 7500 - 1) / 7500;				 //4
 
-	DDRC->CCD_b.DI  = (DDRC->MODE_b.MODE & 0x20) ? (DDRC->BURST_b.LEN ? 2 : 4) : 4;
-	DDRC->RTW_b.DI  = (DDRC->MODE_b.MODE & 0x20) ? (DDRC->BURST_b.LEN ? 4 : 6) : (tCL + DDRC->CCD_b.DI - tWCL + (DDRC->BURST_b.LEN ? 0 : 2));
-	DDRC->WTP_b.DI  = (DDRC->MODE_b.MODE & 0x20) ? (tCL + tWR + (DDRC->BURST_b.LEN ? 1 : 3)) : (tWCL + tWR + (DDRC->BURST_b.LEN ? 2 : 4));
-	DDRC->WL_b.VAL  = (DDRC->MODE_b.MODE & 0x20) ? (MAX(tCL, 3) - 3) : (tWCL - 2);
-	DDRC->ODTH_b.DL = (DDRC->MODE_b.MODE & 0x20) ? (MAX(tCL, 4) - 4) : 0;
-	if (tCK == 2500) { // 200MHz 
-		DDRC->ODTL_b.DL = (DDRC->MODE_b.MODE & 0x20) ? (DDRC->BURST_b.LEN ? (tCL - 1) : (tCL + 1)) : (DDRC->BURST_b.LEN ? 4 : 6);
-	} else if (tCK == 3000) { // 333MHz 
-		DDRC->ODTL_b.DL = 0x1f;
-	}
+    PDPROT->LOCK_b.EN = 0;
+    do {
+        CFG_CTRL->PDLLSTR_b.C2R1D = 0; // rst dll_c2r1
+        udelay(10);
+        CFG_CTRL->PDLLSTR_b.C2R1D = 1; // releset rst
+        udelay(10);
+    } while ((PDLOCK->GCLK & 0x40) != 0x40);
+    PDPROT->LOCK_b.EN = 1;
 
-	
-	// DEBUG INFO HERE
-	DDRC->CTRL_b.STR = 1;
+    DDRC->MODE_b.MODE = mode;
 
-	while (0 == DDRC->STA_b.EMPTY);
-	while(0 == DDRC->INTRAW_b.DONE);
-	DDRC->CTRL_b.STR = DDRC->CTRL_b.TO = 0;
+    if (chip_info->mem_type==MEM_DDR2) {
+        const DDR2MEM *ptr = (const DDR2MEM *)ddr;
+        DDRC->RL_b.VAL = ptr->tCL;
+        DDRC->RCD_b.DI = ptr->tRCD;
+        DDRC->RP_b.DI = ptr->tRP;
+        DDRC->RC_b.DI = ptr->tRC;
+        DDRC->RAS_b.DI = ptr->tRAS;
+        tWR = ptr->tWR;
+        tWTR = ptr->tWTR;
+        DDRC->RRD_b.DI = ptr->tRRD;
+        DDRC->RTP_b.DI = ptr->tRTP;
+        DDRC->FAW_b.DI = ptr->tFAW;
+        DDR2_conf(chip_info,ptr);
+    } else {
+        const DDR3MEM *ptr = (const DDR3MEM *)ddr;
+        DDRC->RL_b.VAL = ptr->tCL;
+        tWCL = ptr->tWCL;
+        DDRC->RCD_b.DI = ptr->tRCD;
+        DDRC->RAS_b.DI = ptr->tRAS;
+        DDRC->RP_b.DI = ptr->tRP;
+        DDRC->RC_b.DI = ptr->tRC;
+        DDRC->RRD_b.DI = ptr->tRRD;
+        DDRC->FAW_b.DI = ptr->tFAW;
+        tWR = ptr->tWR;
+        tCK = ptr->tCK;
+        DDRC->RTP_b.DI = ptr->tRTP;
+        DDRC->ZQCL_b.DI = ptr->tZQoper;
+        DDRC->ZQCS_b.DI = ptr->tZQCS;
+        DDR3_conf(chip_info,ptr);
+    }
 
-	return TRUE;
+    tCL = DDRC->RL_b.VAL;
+
+    DDRC->WTR_b.DI  = (DDRC->MODE_b.MODE & 0x20) ?
+        (tWCL + tWTR + (DDRC->BURST_b.LEN ? 2 : 4)) :
+        ((tCK * 4) > 7500) ? 18 : (tCK * 4 + 7500 - 1) / 7500;               //4
+
+    DDRC->CCD_b.DI  = (DDRC->MODE_b.MODE & 0x20) ? (DDRC->BURST_b.LEN ? 2 : 4) : 4;
+    DDRC->RTW_b.DI  = (DDRC->MODE_b.MODE & 0x20) ? (DDRC->BURST_b.LEN ? 4 : 6) : (tCL + DDRC->CCD_b.DI - tWCL + (DDRC->BURST_b.LEN ? 0 : 2));
+    DDRC->WTP_b.DI  = (DDRC->MODE_b.MODE & 0x20) ? (tCL + tWR + (DDRC->BURST_b.LEN ? 1 : 3)) : (tWCL + tWR + (DDRC->BURST_b.LEN ? 2 : 4));
+    DDRC->WL_b.VAL  = (DDRC->MODE_b.MODE & 0x20) ? (MAX(tCL, 3) - 3) : (tWCL - 2);
+    DDRC->ODTH_b.DL = (DDRC->MODE_b.MODE & 0x20) ? (MAX(tCL, 4) - 4) : 0;
+    if (tCK == 2500) { // 200MHz
+        DDRC->ODTL_b.DL = (DDRC->MODE_b.MODE & 0x20) ? (DDRC->BURST_b.LEN ? (tCL - 1) : (tCL + 1)) : (DDRC->BURST_b.LEN ? 4 : 6);
+    } else if (tCK == 3000) { // 333MHz
+        DDRC->ODTL_b.DL = 0x1f;
+    }
+
+
+    // DEBUG INFO HERE
+    DDRC->CTRL_b.STR = 1;
+
+    while (0 == DDRC->STA_b.EMPTY);
+    while(0 == DDRC->INTRAW_b.DONE);
+    DDRC->CTRL_b.STR = DDRC->CTRL_b.TO = 0;
+
+    return TRUE;
 }

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_dma.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_dma.c
@@ -1,72 +1,72 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_dma.c
-	*
-	* @brief    CMEM7 DMA source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_dma.c
+    *
+    * @brief    CMEM7 DMA source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_dma.h"
 
 typedef struct {
-	union {
-    uint32_t  CTL_LOW;                              
-    
+    union {
+    uint32_t  CTL_LOW;
+
     struct {
-      uint32_t  INT_EN     :  1;               
-      uint32_t  DST_TR_WIDTH:  3;              
-      uint32_t  SRC_TR_WIDTH:  3;              
-      uint32_t  DINC       :  2;              
-      uint32_t  SINC       :  2;               
-      uint32_t  DEST_MSIZE :  3;              
-      uint32_t  SRC_MSIZE  :  3;              
-      uint32_t  SRC_GATHER_EN:  1;           
-      uint32_t  DST_SCATTER_EN:  1;          
+      uint32_t  INT_EN     :  1;
+      uint32_t  DST_TR_WIDTH:  3;
+      uint32_t  SRC_TR_WIDTH:  3;
+      uint32_t  DINC       :  2;
+      uint32_t  SINC       :  2;
+      uint32_t  DEST_MSIZE :  3;
+      uint32_t  SRC_MSIZE  :  3;
+      uint32_t  SRC_GATHER_EN:  1;
+      uint32_t  DST_SCATTER_EN:  1;
       uint32_t             :  1;
-      uint32_t  TT_FC      :  3;           
-      uint32_t  DMS        :  2;              
-      uint32_t  SMS        :  2;            
-      uint32_t  LLP_DST_EN :  1;              
-      uint32_t  LLP_SRC_EN :  1;              
-    } CTL_LOW_b;                                
+      uint32_t  TT_FC      :  3;
+      uint32_t  DMS        :  2;
+      uint32_t  SMS        :  2;
+      uint32_t  LLP_DST_EN :  1;
+      uint32_t  LLP_SRC_EN :  1;
+    } CTL_LOW_b;
   } INNER;
 } INNER_CTL_LOW;
 
 typedef struct {
   union {
-    uint32_t  CTL_HI;     
-    
+    uint32_t  CTL_HI;
+
     struct {
-      uint32_t  BLOCK_TS   : 12;    
-      uint32_t  DONE       :  1;                   
-    } CTL_HI_b;                                      
+      uint32_t  BLOCK_TS   : 12;
+      uint32_t  DONE       :  1;
+    } CTL_HI_b;
   } INNER;
 } INNER_CTL_HIGH;
 
-typedef struct {                      
-	uint32_t srcAddr;                  
-	uint32_t dstAddr;                  
-	uint32_t nextBlock;              
-	INNER_CTL_LOW low;                 
-	INNER_CTL_HIGH high;                 
+typedef struct {
+    uint32_t srcAddr;
+    uint32_t dstAddr;
+    uint32_t nextBlock;
+    INNER_CTL_LOW low;
+    INNER_CTL_HIGH high;
 } INNER_BLOCK_DESC;
 
 
@@ -87,176 +87,176 @@ typedef struct {
 #define DMA_LOCK_DMA_BLOCK_TRANSFER          1
 #define DMA_LOCK_DMA_BLOCK_TRANSACTION       2
 
-            
+
 void DMA_Init() {
-	DMA->DMA_EN_b.EN = TRUE;
-	
-	// only open channel 0
-	DMA->CH_EN = (0xFF << DMA_MAX_CHANNEL_NUM) | 0x0;
-	
-	DMA_ClearInt(DMA_Int_All);
- 	DMA_EnableInt(DMA_Int_All, FALSE);
-	
-	DMA->SAR0 = 0x0;
-	DMA->DAR0 = 0x0;
-	
-	DMA->CTL_HI0_b.BLOCK_TS 			= 0;
-	DMA->CTL_LOW0_b.INT_EN 				= FALSE;
-	DMA->CTL_LOW0_b.DST_TR_WIDTH 	= DMA_TR_WIDTH_32_BIT;
-	DMA->CTL_LOW0_b.SRC_TR_WIDTH 	= DMA_TR_WIDTH_32_BIT;
-	DMA->CTL_LOW0_b.DINC 					= DMA_INC_INCREMENT;
-	DMA->CTL_LOW0_b.SINC 					= DMA_INC_INCREMENT;
-	DMA->CTL_LOW0_b.DEST_MSIZE 		= 0;
-	DMA->CTL_LOW0_b.SRC_MSIZE 		= 0;
-	DMA->CTL_LOW0_b.SRC_GATHER_EN = FALSE;
-	DMA->CTL_LOW0_b.DST_SCATTER_EN = FALSE;
-	DMA->CTL_LOW0_b.TT_FC 				= 0;
-  DMA->CTL_LOW0_b.DMS    				= 0;
-	DMA->CTL_LOW0_b.SMS    				= 0;
-	DMA->CTL_LOW0_b.LLP_DST_EN   	= FALSE;
-	DMA->CTL_LOW0_b.LLP_SRC_EN   	= FALSE;
-	
-  DMA->LLP0_b.LOC = 0; 
-	DMA->LLP0_b.LMS = 0;
+    DMA->DMA_EN_b.EN = TRUE;
+
+    // only open channel 0
+    DMA->CH_EN = (0xFF << DMA_MAX_CHANNEL_NUM) | 0x0;
+
+    DMA_ClearInt(DMA_Int_All);
+    DMA_EnableInt(DMA_Int_All, FALSE);
+
+    DMA->SAR0 = 0x0;
+    DMA->DAR0 = 0x0;
+
+    DMA->CTL_HI0_b.BLOCK_TS             = 0;
+    DMA->CTL_LOW0_b.INT_EN              = FALSE;
+    DMA->CTL_LOW0_b.DST_TR_WIDTH    = DMA_TR_WIDTH_32_BIT;
+    DMA->CTL_LOW0_b.SRC_TR_WIDTH    = DMA_TR_WIDTH_32_BIT;
+    DMA->CTL_LOW0_b.DINC                    = DMA_INC_INCREMENT;
+    DMA->CTL_LOW0_b.SINC                    = DMA_INC_INCREMENT;
+    DMA->CTL_LOW0_b.DEST_MSIZE      = 0;
+    DMA->CTL_LOW0_b.SRC_MSIZE       = 0;
+    DMA->CTL_LOW0_b.SRC_GATHER_EN = FALSE;
+    DMA->CTL_LOW0_b.DST_SCATTER_EN = FALSE;
+    DMA->CTL_LOW0_b.TT_FC               = 0;
+  DMA->CTL_LOW0_b.DMS                   = 0;
+    DMA->CTL_LOW0_b.SMS                 = 0;
+    DMA->CTL_LOW0_b.LLP_DST_EN      = FALSE;
+    DMA->CTL_LOW0_b.LLP_SRC_EN      = FALSE;
+
+  DMA->LLP0_b.LOC = 0;
+    DMA->LLP0_b.LMS = 0;
 
   DMA->SGR0_b.SGC = 0x1;
-	DMA->SGR0_b.SGI = 0x0;
-	
-	DMA->DSR0_b.DSC = 0x0;
-	DMA->DSR0_b.DSI = 0x0;
+    DMA->SGR0_b.SGI = 0x0;
+
+    DMA->DSR0_b.DSC = 0x0;
+    DMA->DSR0_b.DSI = 0x0;
 
   DMA->SSTATAR0 = 0x0;
-	DMA->DSTATAR0 = 0x0;
-	
-	DMA->CFG_HI0 								= 0x0;
-	DMA->CFG_LOW0_b.CH_PRIOR 		= 0;
-	DMA->CFG_LOW0_b.CH_SUSP 		= 0;
-	DMA->CFG_LOW0_b.HS_SEL_DST 	= 0;
-	DMA->CFG_LOW0_b.LOCK_B_L 		= 0;
-  DMA->CFG_LOW0_b.HS_SEL_SRC 	= 0;
-	DMA->CFG_LOW0_b.LOCK_CH_L 	= DMA_LOCK_DMA_TRANSFER;
-  DMA->CFG_LOW0_b.LOCK_B_L 		= DMA_LOCK_DMA_TRANSFER;
-	DMA->CFG_LOW0_b.LOCK_CH 		= TRUE;
-	DMA->CFG_LOW0_b.LOCK_B 			= TRUE;
-	DMA->CFG_LOW0_b.DST_HS_POL 	= 0;
-	DMA->CFG_LOW0_b.SRC_HS_POL 	= 0;
-	DMA->CFG_LOW0_b.RELOAD_SRC 	= FALSE;
-	DMA->CFG_LOW0_b.RELOAD_DST 	= FALSE;
+    DMA->DSTATAR0 = 0x0;
+
+    DMA->CFG_HI0                                = 0x0;
+    DMA->CFG_LOW0_b.CH_PRIOR        = 0;
+    DMA->CFG_LOW0_b.CH_SUSP         = 0;
+    DMA->CFG_LOW0_b.HS_SEL_DST  = 0;
+    DMA->CFG_LOW0_b.LOCK_B_L        = 0;
+  DMA->CFG_LOW0_b.HS_SEL_SRC    = 0;
+    DMA->CFG_LOW0_b.LOCK_CH_L   = DMA_LOCK_DMA_TRANSFER;
+  DMA->CFG_LOW0_b.LOCK_B_L      = DMA_LOCK_DMA_TRANSFER;
+    DMA->CFG_LOW0_b.LOCK_CH         = TRUE;
+    DMA->CFG_LOW0_b.LOCK_B          = TRUE;
+    DMA->CFG_LOW0_b.DST_HS_POL  = 0;
+    DMA->CFG_LOW0_b.SRC_HS_POL  = 0;
+    DMA->CFG_LOW0_b.RELOAD_SRC  = FALSE;
+    DMA->CFG_LOW0_b.RELOAD_DST  = FALSE;
 }
 
 void DMA_EnableInt(uint32_t Int, BOOL enable) {
-	assert_param(IS_DMA_INT(Int));
-	
+    assert_param(IS_DMA_INT(Int));
+
   if (enable) {
-		if (Int & DMA_Int_TfrComplete) {
-			DMA->INT_EN_TFR = (0x1 << DMA_MAX_CHANNEL_NUM) | 0x1;
-		} 
-		
-		if (Int & DMA_Int_Err) {
-			DMA->INT_EN_ERR = (0x1 << DMA_MAX_CHANNEL_NUM) | 0x1;
-		}
-	} else {
-		if (Int & DMA_Int_TfrComplete) {
-			DMA->INT_EN_TFR = (0x1 << DMA_MAX_CHANNEL_NUM) | 0x0;
-		} 
-		
-		if (Int & DMA_Int_Err) {
-			DMA->INT_EN_ERR = (0x1 << DMA_MAX_CHANNEL_NUM) | 0x0;
-		}
-	}
+        if (Int & DMA_Int_TfrComplete) {
+            DMA->INT_EN_TFR = (0x1 << DMA_MAX_CHANNEL_NUM) | 0x1;
+        }
+
+        if (Int & DMA_Int_Err) {
+            DMA->INT_EN_ERR = (0x1 << DMA_MAX_CHANNEL_NUM) | 0x1;
+        }
+    } else {
+        if (Int & DMA_Int_TfrComplete) {
+            DMA->INT_EN_TFR = (0x1 << DMA_MAX_CHANNEL_NUM) | 0x0;
+        }
+
+        if (Int & DMA_Int_Err) {
+            DMA->INT_EN_ERR = (0x1 << DMA_MAX_CHANNEL_NUM) | 0x0;
+        }
+    }
 }
 
 BOOL DMA_GetIntStatus(uint32_t Int) {
-	assert_param(IS_DMA_INT(Int));
-	
-	if (Int & DMA_Int_TfrComplete) {
-		if (DMA->INT_TFR) {
-			return TRUE;
-		}
-	}
-	
-	if (Int & DMA_Int_Err) {
-		if (DMA->INT_ERR) {
-			return TRUE;
-		}
-	}
-		
-	return FALSE;
+    assert_param(IS_DMA_INT(Int));
+
+    if (Int & DMA_Int_TfrComplete) {
+        if (DMA->INT_TFR) {
+            return TRUE;
+        }
+    }
+
+    if (Int & DMA_Int_Err) {
+        if (DMA->INT_ERR) {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
 }
 
 void DMA_ClearInt(uint32_t Int) {
-	assert_param(IS_DMA_INT(Int));
-	
-	if (Int & DMA_Int_TfrComplete) {
-		DMA->INT_CLEAR_TFR = 0x1;
-	}
-	
-	if (Int & DMA_Int_Err) {
-		DMA->INT_CLEAR_ERR = 0x1;
-	}
+    assert_param(IS_DMA_INT(Int));
+
+    if (Int & DMA_Int_TfrComplete) {
+        DMA->INT_CLEAR_TFR = 0x1;
+    }
+
+    if (Int & DMA_Int_Err) {
+        DMA->INT_CLEAR_ERR = 0x1;
+    }
 }
 
 BOOL DMA_IsBusy() {
-	return (DMA->CH_EN_b.EN) ? TRUE : FALSE;
+    return (DMA->CH_EN_b.EN) ? TRUE : FALSE;
 }
 
 BOOL DMA_Transfer(BLOCK_DESC *blockList) {
-	BLOCK_DESC *p;
-	if (!blockList) {
-		return FALSE;
-	}
-	
-	if (DMA_IsBusy()) {
-		return FALSE;
-	}
-	
-	p = blockList;
-	while (p) {
-		BOOL llp = FALSE;
-		INNER_BLOCK_DESC *inner = (INNER_BLOCK_DESC *)p;
-		if (p->nextBlock) {
-			llp = TRUE;
-		}
-		
-		inner->high.INNER.CTL_HI = 0;
-		inner->high.INNER.CTL_HI_b.BLOCK_TS = (p->number >> DMA_TR_WIDTH_32_BIT);
-		inner->high.INNER.CTL_HI_b.DONE = 0;
-		
-		inner->nextBlock = p->nextBlock;
-		
-		inner->low.INNER.CTL_LOW = 0;
-		inner->low.INNER.CTL_LOW_b.INT_EN = TRUE;
-		inner->low.INNER.CTL_LOW_b.DST_TR_WIDTH 	= DMA_TR_WIDTH_32_BIT;
-	  inner->low.INNER.CTL_LOW_b.SRC_TR_WIDTH 	= DMA_TR_WIDTH_32_BIT;
-	  inner->low.INNER.CTL_LOW_b.DINC 					= DMA_INC_INCREMENT;
-	  inner->low.INNER.CTL_LOW_b.SINC 					= DMA_INC_INCREMENT;
-	  inner->low.INNER.CTL_LOW_b.DEST_MSIZE 		= 0;
-	  inner->low.INNER.CTL_LOW_b.SRC_MSIZE 		  = 0;
-	  inner->low.INNER.CTL_LOW_b.SRC_GATHER_EN  = FALSE;
-	  inner->low.INNER.CTL_LOW_b.DST_SCATTER_EN = FALSE;
-	  inner->low.INNER.CTL_LOW_b.TT_FC 					= 0;
-    inner->low.INNER.CTL_LOW_b.DMS    				= 0;
-	  inner->low.INNER.CTL_LOW_b.SMS    				= 0;
-	  inner->low.INNER.CTL_LOW_b.LLP_DST_EN   	= llp;
-	  inner->low.INNER.CTL_LOW_b.LLP_SRC_EN   	= llp;
-		
-		if ((uint32_t)inner == (uint32_t)blockList) {
-			// copy to DMA
-			DMA->SAR0 = llp ? 0x0 : inner->srcAddr ;
-			DMA->DAR0 = llp ? 0x0 : inner->dstAddr ;
-			
-			DMA->CTL_HI0 = llp ? 0x0 : inner->high.INNER.CTL_HI;
-			DMA->CTL_LOW0 = inner->low.INNER.CTL_LOW;
-			
-			DMA->LLP0 = llp ? (uint32_t)inner : 0x0;
-		}
-		
-		p = (BLOCK_DESC *)inner->nextBlock;
-	}
+    BLOCK_DESC *p;
+    if (!blockList) {
+        return FALSE;
+    }
 
-	// open channel 0
-	DMA->CH_EN = (0x1 << DMA_MAX_CHANNEL_NUM) | 0x1;
-	
-	return TRUE;
+    if (DMA_IsBusy()) {
+        return FALSE;
+    }
+
+    p = blockList;
+    while (p) {
+        BOOL llp = FALSE;
+        INNER_BLOCK_DESC *inner = (INNER_BLOCK_DESC *)p;
+        if (p->nextBlock) {
+            llp = TRUE;
+        }
+
+        inner->high.INNER.CTL_HI = 0;
+        inner->high.INNER.CTL_HI_b.BLOCK_TS = (p->number >> DMA_TR_WIDTH_32_BIT);
+        inner->high.INNER.CTL_HI_b.DONE = 0;
+
+        inner->nextBlock = p->nextBlock;
+
+        inner->low.INNER.CTL_LOW = 0;
+        inner->low.INNER.CTL_LOW_b.INT_EN = TRUE;
+        inner->low.INNER.CTL_LOW_b.DST_TR_WIDTH     = DMA_TR_WIDTH_32_BIT;
+      inner->low.INNER.CTL_LOW_b.SRC_TR_WIDTH   = DMA_TR_WIDTH_32_BIT;
+      inner->low.INNER.CTL_LOW_b.DINC                   = DMA_INC_INCREMENT;
+      inner->low.INNER.CTL_LOW_b.SINC                   = DMA_INC_INCREMENT;
+      inner->low.INNER.CTL_LOW_b.DEST_MSIZE         = 0;
+      inner->low.INNER.CTL_LOW_b.SRC_MSIZE        = 0;
+      inner->low.INNER.CTL_LOW_b.SRC_GATHER_EN  = FALSE;
+      inner->low.INNER.CTL_LOW_b.DST_SCATTER_EN = FALSE;
+      inner->low.INNER.CTL_LOW_b.TT_FC                  = 0;
+    inner->low.INNER.CTL_LOW_b.DMS                  = 0;
+      inner->low.INNER.CTL_LOW_b.SMS                    = 0;
+      inner->low.INNER.CTL_LOW_b.LLP_DST_EN     = llp;
+      inner->low.INNER.CTL_LOW_b.LLP_SRC_EN     = llp;
+
+        if ((uint32_t)inner == (uint32_t)blockList) {
+            // copy to DMA
+            DMA->SAR0 = llp ? 0x0 : inner->srcAddr ;
+            DMA->DAR0 = llp ? 0x0 : inner->dstAddr ;
+
+            DMA->CTL_HI0 = llp ? 0x0 : inner->high.INNER.CTL_HI;
+            DMA->CTL_LOW0 = inner->low.INNER.CTL_LOW;
+
+            DMA->LLP0 = llp ? (uint32_t)inner : 0x0;
+        }
+
+        p = (BLOCK_DESC *)inner->nextBlock;
+    }
+
+    // open channel 0
+    DMA->CH_EN = (0x1 << DMA_MAX_CHANNEL_NUM) | 0x1;
+
+    return TRUE;
 }
 

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_efuse.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_efuse.c
@@ -1,255 +1,255 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_efuse.c
-	*
-	* @brief    CMEM7 EFUSE source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_efuse.c
+    *
+    * @brief    CMEM7 EFUSE source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_efuse.h"
 
 static void efuse_SetClock(uint8_t dividor) {
-	if (dividor <= 2) {
-		GLOBAL_CTRL->CLK_SEL_1_b.EFUSE_CLK = 0;
-	} else if (dividor <= 4) {
-		GLOBAL_CTRL->CLK_SEL_1_b.EFUSE_CLK = 1;
-	} else if (dividor <= 8) {
-		GLOBAL_CTRL->CLK_SEL_1_b.EFUSE_CLK = 2;
-	} else {
-		GLOBAL_CTRL->CLK_SEL_1_b.EFUSE_CLK = 3;
-	}
+    if (dividor <= 2) {
+        GLOBAL_CTRL->CLK_SEL_1_b.EFUSE_CLK = 0;
+    } else if (dividor <= 4) {
+        GLOBAL_CTRL->CLK_SEL_1_b.EFUSE_CLK = 1;
+    } else if (dividor <= 8) {
+        GLOBAL_CTRL->CLK_SEL_1_b.EFUSE_CLK = 2;
+    } else {
+        GLOBAL_CTRL->CLK_SEL_1_b.EFUSE_CLK = 3;
+    }
 }
 
 static uint32_t efuse_GetClock() {
-	return SYSTEM_CLOCK_FREQ / (1 << (GLOBAL_CTRL->CLK_SEL_1_b.EFUSE_CLK + 1));
+    return SYSTEM_CLOCK_FREQ / (1 << (GLOBAL_CTRL->CLK_SEL_1_b.EFUSE_CLK + 1));
 }
 
 // static uint8_t efuse_Crc8Bit(uint8_t data, uint8_t crc) {
-// 	uint8_t newCrc;
-// 	uint8_t d[8], c[8], i;
-// 	
-// 	for (i = 0; i < 8; i++) {
-// 		d[i] = (data >> i) & 0x01;
-// 		c[i] = (crc >> i) & 0x01;
-// 	}
-// 	
-// 	newCrc = d[7] ^ d[6] ^ d[0] ^ c[0] ^ c[6] ^ c[7];
-// 	newCrc |= (d[6] ^ d[1] ^ d[0] ^ c[0] ^ c[1] ^ c[6]) << 1;
-// 	newCrc |= (d[6] ^ d[2] ^ d[1] ^ d[0] ^ c[0] ^ c[1] ^ c[2] ^ c[6]) << 2;
-// 	newCrc |= (d[7] ^ d[3] ^ d[2] ^ d[1] ^ c[1] ^ c[2] ^ c[3] ^ c[7]) << 3;
-// 	newCrc |= (d[4] ^ d[3] ^ d[2] ^ c[2] ^ c[3] ^ c[4]) << 4;
-// 	newCrc |= (d[5] ^ d[4] ^ d[3] ^ c[3] ^ c[4] ^ c[5]) << 5;
-// 	newCrc |= (d[6] ^ d[5] ^ d[4] ^ c[4] ^ c[5] ^ c[6]) << 6;
-// 	newCrc |= (d[7] ^ d[6] ^ d[5] ^ c[5] ^ c[6] ^ c[7]) << 1;
-// 	
-// 	return newCrc;
+//  uint8_t newCrc;
+//  uint8_t d[8], c[8], i;
+//
+//  for (i = 0; i < 8; i++) {
+//      d[i] = (data >> i) & 0x01;
+//      c[i] = (crc >> i) & 0x01;
+//  }
+//
+//  newCrc = d[7] ^ d[6] ^ d[0] ^ c[0] ^ c[6] ^ c[7];
+//  newCrc |= (d[6] ^ d[1] ^ d[0] ^ c[0] ^ c[1] ^ c[6]) << 1;
+//  newCrc |= (d[6] ^ d[2] ^ d[1] ^ d[0] ^ c[0] ^ c[1] ^ c[2] ^ c[6]) << 2;
+//  newCrc |= (d[7] ^ d[3] ^ d[2] ^ d[1] ^ c[1] ^ c[2] ^ c[3] ^ c[7]) << 3;
+//  newCrc |= (d[4] ^ d[3] ^ d[2] ^ c[2] ^ c[3] ^ c[4]) << 4;
+//  newCrc |= (d[5] ^ d[4] ^ d[3] ^ c[3] ^ c[4] ^ c[5]) << 5;
+//  newCrc |= (d[6] ^ d[5] ^ d[4] ^ c[4] ^ c[5] ^ c[6]) << 6;
+//  newCrc |= (d[7] ^ d[6] ^ d[5] ^ c[5] ^ c[6] ^ c[7]) << 1;
+//
+//  return newCrc;
 // }
 
 // static uint8_t efuse_Crc(EFUSE_AesKey* key, uint8_t lock, BOOL isLowRegion) {
-// 	uint8_t crc = 0;
-// 	
-// 	if (isLowRegion) {
-// 		crc = efuse_Crc8Bit(key->key0, crc);
-// 		crc = efuse_Crc8Bit(key->key0 >> 8, crc);
-// 		crc = efuse_Crc8Bit(key->key0 >> 16, crc);
-// 		crc = efuse_Crc8Bit(key->key0 >> 24, crc);
-// 		crc = efuse_Crc8Bit(key->key1, crc);
-// 		crc = efuse_Crc8Bit(key->key1 >> 8, crc);
-// 		crc = efuse_Crc8Bit(key->key1 >> 16, crc);
-// 		crc = efuse_Crc8Bit(key->key1 >> 24, crc);
-// 		crc = efuse_Crc8Bit(key->key2, crc);
-// 		crc = efuse_Crc8Bit(key->key2 >> 8, crc);
-// 		crc = efuse_Crc8Bit(key->key2 >> 16, crc);
-// 		crc = efuse_Crc8Bit(key->key2 >> 24, crc);
-// 		crc = efuse_Crc8Bit(key->key3, crc);
-// 		crc = efuse_Crc8Bit(key->key3 >> 8, crc);
-// 		crc = efuse_Crc8Bit(key->key3 >> 16, crc);
-// 		crc = efuse_Crc8Bit(key->key3 >> 24, crc);
-// 		crc = efuse_Crc8Bit(lock, crc);
-// 		crc = efuse_Crc8Bit(0x0, crc);
-// 		crc = efuse_Crc8Bit(0x0, crc);
-// 	} else {
-// 		crc = efuse_Crc8Bit(key->key4, crc);
-// 		crc = efuse_Crc8Bit(key->key4 >> 8, crc);
-// 		crc = efuse_Crc8Bit(key->key4 >> 16, crc);
-// 		crc = efuse_Crc8Bit(key->key4 >> 24, crc);
-// 		crc = efuse_Crc8Bit(key->key5, crc);
-// 		crc = efuse_Crc8Bit(key->key5 >> 8, crc);
-// 		crc = efuse_Crc8Bit(key->key5 >> 16, crc);
-// 		crc = efuse_Crc8Bit(key->key5 >> 24, crc);
-// 		crc = efuse_Crc8Bit(key->key6, crc);
-// 		crc = efuse_Crc8Bit(key->key6 >> 8, crc);
-// 		crc = efuse_Crc8Bit(key->key6 >> 16, crc);
-// 		crc = efuse_Crc8Bit(key->key6 >> 24, crc);
-// 		crc = efuse_Crc8Bit(key->key7, crc);
-// 		crc = efuse_Crc8Bit(key->key7 >> 8, crc);
-// 		crc = efuse_Crc8Bit(key->key7 >> 16, crc);
-// 		crc = efuse_Crc8Bit(key->key7 >> 24, crc);
-// 		crc = efuse_Crc8Bit(lock, crc);
-// 		crc = efuse_Crc8Bit(0x0, crc);
-// 		crc = efuse_Crc8Bit(0x0, crc);
-// 	}
-// 	
-// 	return crc;
+//  uint8_t crc = 0;
+//
+//  if (isLowRegion) {
+//      crc = efuse_Crc8Bit(key->key0, crc);
+//      crc = efuse_Crc8Bit(key->key0 >> 8, crc);
+//      crc = efuse_Crc8Bit(key->key0 >> 16, crc);
+//      crc = efuse_Crc8Bit(key->key0 >> 24, crc);
+//      crc = efuse_Crc8Bit(key->key1, crc);
+//      crc = efuse_Crc8Bit(key->key1 >> 8, crc);
+//      crc = efuse_Crc8Bit(key->key1 >> 16, crc);
+//      crc = efuse_Crc8Bit(key->key1 >> 24, crc);
+//      crc = efuse_Crc8Bit(key->key2, crc);
+//      crc = efuse_Crc8Bit(key->key2 >> 8, crc);
+//      crc = efuse_Crc8Bit(key->key2 >> 16, crc);
+//      crc = efuse_Crc8Bit(key->key2 >> 24, crc);
+//      crc = efuse_Crc8Bit(key->key3, crc);
+//      crc = efuse_Crc8Bit(key->key3 >> 8, crc);
+//      crc = efuse_Crc8Bit(key->key3 >> 16, crc);
+//      crc = efuse_Crc8Bit(key->key3 >> 24, crc);
+//      crc = efuse_Crc8Bit(lock, crc);
+//      crc = efuse_Crc8Bit(0x0, crc);
+//      crc = efuse_Crc8Bit(0x0, crc);
+//  } else {
+//      crc = efuse_Crc8Bit(key->key4, crc);
+//      crc = efuse_Crc8Bit(key->key4 >> 8, crc);
+//      crc = efuse_Crc8Bit(key->key4 >> 16, crc);
+//      crc = efuse_Crc8Bit(key->key4 >> 24, crc);
+//      crc = efuse_Crc8Bit(key->key5, crc);
+//      crc = efuse_Crc8Bit(key->key5 >> 8, crc);
+//      crc = efuse_Crc8Bit(key->key5 >> 16, crc);
+//      crc = efuse_Crc8Bit(key->key5 >> 24, crc);
+//      crc = efuse_Crc8Bit(key->key6, crc);
+//      crc = efuse_Crc8Bit(key->key6 >> 8, crc);
+//      crc = efuse_Crc8Bit(key->key6 >> 16, crc);
+//      crc = efuse_Crc8Bit(key->key6 >> 24, crc);
+//      crc = efuse_Crc8Bit(key->key7, crc);
+//      crc = efuse_Crc8Bit(key->key7 >> 8, crc);
+//      crc = efuse_Crc8Bit(key->key7 >> 16, crc);
+//      crc = efuse_Crc8Bit(key->key7 >> 24, crc);
+//      crc = efuse_Crc8Bit(lock, crc);
+//      crc = efuse_Crc8Bit(0x0, crc);
+//      crc = efuse_Crc8Bit(0x0, crc);
+//  }
+//
+//  return crc;
 // }
 
 void EFUSE_Init(EFUSE_InitTypeDef* init) {
-	assert_param(init);
-	assert_param(IS_EFUSE_TMRF(init->EFUSE_TMRF));
-	
-	efuse_SetClock(init->EFUSE_ClockDividor);
-	EFUSE->USER_CTRL_LOW_b.TMRF = init->EFUSE_TMRF;
-	EFUSE->USER_CTRL_HI_b.TMRF = init->EFUSE_TMRF;
-	if (init->timing) {
-		uint32_t value;
-		
-		value = (init->timing->EFUSE_Tpwph * (efuse_GetClock() / 1000000) / 1000);
-		value = (value == 0) ? 1 : value;
-		EFUSE->TIMING_0_b.TPWPH = value >> 2;
-		EFUSE->TIMING_1_b.TPWPH = value & 0x00000003;
+    assert_param(init);
+    assert_param(IS_EFUSE_TMRF(init->EFUSE_TMRF));
 
-		value = (init->timing->EFUSE_Trac * (efuse_GetClock() / 1000000) / 1000);
-		value = (value == 0) ? 1 : value;
-		EFUSE->TIMING_0_b.TRAC = value;
+    efuse_SetClock(init->EFUSE_ClockDividor);
+    EFUSE->USER_CTRL_LOW_b.TMRF = init->EFUSE_TMRF;
+    EFUSE->USER_CTRL_HI_b.TMRF = init->EFUSE_TMRF;
+    if (init->timing) {
+        uint32_t value;
 
-		value = (init->timing->EFUSE_Trah * (efuse_GetClock() / 1000000) / 1000);
-		value = (value == 0) ? 1 : value;
-		EFUSE->TIMING_0_b.TRAH = value;
-		
-		value = (init->timing->EFUSE_Trpw * (efuse_GetClock() / 1000000) / 1000);
-		value = (value == 0) ? 1 : value;
-		EFUSE->TIMING_0_b.TRPW = value;
+        value = (init->timing->EFUSE_Tpwph * (efuse_GetClock() / 1000000) / 1000);
+        value = (value == 0) ? 1 : value;
+        EFUSE->TIMING_0_b.TPWPH = value >> 2;
+        EFUSE->TIMING_1_b.TPWPH = value & 0x00000003;
 
-		value = (init->timing->EFUSE_Trc * (efuse_GetClock() / 1000000) / 1000);
-		value = (value == 0) ? 1 : value;
-		EFUSE->TIMING_0_b.TRC = value;
-		
-		value = (init->timing->EFUSE_Tesr * (efuse_GetClock() / 1000000) / 1000);
-		value = (value == 0) ? 1 : value;
-		EFUSE->TIMING_0_b.TESR = value;
+        value = (init->timing->EFUSE_Trac * (efuse_GetClock() / 1000000) / 1000);
+        value = (value == 0) ? 1 : value;
+        EFUSE->TIMING_0_b.TRAC = value;
 
-		value = (init->timing->EFUSE_Tprs * (efuse_GetClock() / 1000000) / 1000);
-		value = (value == 0) ? 1 : value;
-		EFUSE->TIMING_0_b.TPRS = value;
+        value = (init->timing->EFUSE_Trah * (efuse_GetClock() / 1000000) / 1000);
+        value = (value == 0) ? 1 : value;
+        EFUSE->TIMING_0_b.TRAH = value;
 
-		value = (init->timing->EFUSE_Tpi * (efuse_GetClock() / 1000000) / 1000);
-		value = (value == 0) ? 1 : value;
-		EFUSE->TIMING_1_b.TPIT = value;
+        value = (init->timing->EFUSE_Trpw * (efuse_GetClock() / 1000000) / 1000);
+        value = (value == 0) ? 1 : value;
+        EFUSE->TIMING_0_b.TRPW = value;
 
-		value = (init->timing->EFUSE_Tpp * (efuse_GetClock() / 1000000) / 1000);
-		value = (value == 0) ? 1 : value;
-		EFUSE->TIMING_1_b.TPP = value;
+        value = (init->timing->EFUSE_Trc * (efuse_GetClock() / 1000000) / 1000);
+        value = (value == 0) ? 1 : value;
+        EFUSE->TIMING_0_b.TRC = value;
 
-		value = (init->timing->EFUSE_Teps * (efuse_GetClock() / 1000000) / 1000);
-		value = (value == 0) ? 1 : value;
-		EFUSE->TIMING_1_b.TEPS = value;
+        value = (init->timing->EFUSE_Tesr * (efuse_GetClock() / 1000000) / 1000);
+        value = (value == 0) ? 1 : value;
+        EFUSE->TIMING_0_b.TESR = value;
 
-		value = (init->timing->EFUSE_Teps * (efuse_GetClock() / 1000000) / 1000);
-		value = (value == 0) ? 1 : value;
-		EFUSE->TIMING_1_b.TPWPS = value;
-	}
+        value = (init->timing->EFUSE_Tprs * (efuse_GetClock() / 1000000) / 1000);
+        value = (value == 0) ? 1 : value;
+        EFUSE->TIMING_0_b.TPRS = value;
+
+        value = (init->timing->EFUSE_Tpi * (efuse_GetClock() / 1000000) / 1000);
+        value = (value == 0) ? 1 : value;
+        EFUSE->TIMING_1_b.TPIT = value;
+
+        value = (init->timing->EFUSE_Tpp * (efuse_GetClock() / 1000000) / 1000);
+        value = (value == 0) ? 1 : value;
+        EFUSE->TIMING_1_b.TPP = value;
+
+        value = (init->timing->EFUSE_Teps * (efuse_GetClock() / 1000000) / 1000);
+        value = (value == 0) ? 1 : value;
+        EFUSE->TIMING_1_b.TEPS = value;
+
+        value = (init->timing->EFUSE_Teps * (efuse_GetClock() / 1000000) / 1000);
+        value = (value == 0) ? 1 : value;
+        EFUSE->TIMING_1_b.TPWPS = value;
+    }
 }
 
 /* It only can be written once */
 // BOOL EFUSE_Write(EFUSE_AesKey* key) {
-//   assert_param(key);	
-// 	
-// 	if ((EFUSE->USER_CTRL_LOW_b.LOCK || EFUSE->USER_CTRL_LOW_b.BUSY) ||
-// 		(EFUSE->USER_CTRL_HI_b.LOCK || EFUSE->USER_CTRL_HI_b.BUSY)) {
-// 		return FALSE;
-// 	}
-// 	
-// 	// write low region
-// 	EFUSE->USER_DATA0_LOW = key->key0;
-// 	EFUSE->USER_DATA1_LOW = key->key1;
-// 	EFUSE->USER_DATA2_LOW = key->key2;
-// 	EFUSE->USER_DATA3_LOW = key->key3;
-// 	EFUSE->USER_DATA4_LOW_b.CRC = efuse_Crc(key, 0x1, TRUE);
-// 	EFUSE->USER_DATA4_LOW_b.LOCK = 1;
-// 	EFUSE->USER_CTRL_LOW_b.WR_EN = FALSE;
-// 	EFUSE->USER_CTRL_LOW_b.WR_EN = TRUE;
-// 	
-// 	udelay(1000);
-// 	while (EFUSE->USER_CTRL_LOW_b.BUSY) ;
-// 	
-// 	if (EFUSE->USER_CTRL_LOW_b.WR_CRC_ERR) {
-// 		return FALSE;
-// 	}
-// 	
-// 	// write high region
-// 	EFUSE->USER_DATA0_HI = key->key4;
-// 	EFUSE->USER_DATA1_HI = key->key5;
-// 	EFUSE->USER_DATA2_HI = key->key6;
-// 	EFUSE->USER_DATA3_HI = key->key7;
-// 	EFUSE->USER_DATA4_HI_b.CRC = efuse_Crc(key, 0x1, FALSE);
-// 	EFUSE->USER_DATA4_HI_b.LOCK = 1;
-// 	EFUSE->USER_CTRL_HI_b.WR_EN = FALSE;
-// 	EFUSE->USER_CTRL_HI_b.WR_EN = TRUE;
-// 	
-// 	udelay(1000);
-// 	while (EFUSE->USER_CTRL_HI_b.BUSY) ;
-// 	
-// 	if (EFUSE->USER_CTRL_HI_b.WR_CRC_ERR) {
-// 		return FALSE;
-// 	}
-// 	return TRUE;
+//   assert_param(key);
+//
+//  if ((EFUSE->USER_CTRL_LOW_b.LOCK || EFUSE->USER_CTRL_LOW_b.BUSY) ||
+//      (EFUSE->USER_CTRL_HI_b.LOCK || EFUSE->USER_CTRL_HI_b.BUSY)) {
+//      return FALSE;
+//  }
+//
+//  // write low region
+//  EFUSE->USER_DATA0_LOW = key->key0;
+//  EFUSE->USER_DATA1_LOW = key->key1;
+//  EFUSE->USER_DATA2_LOW = key->key2;
+//  EFUSE->USER_DATA3_LOW = key->key3;
+//  EFUSE->USER_DATA4_LOW_b.CRC = efuse_Crc(key, 0x1, TRUE);
+//  EFUSE->USER_DATA4_LOW_b.LOCK = 1;
+//  EFUSE->USER_CTRL_LOW_b.WR_EN = FALSE;
+//  EFUSE->USER_CTRL_LOW_b.WR_EN = TRUE;
+//
+//  udelay(1000);
+//  while (EFUSE->USER_CTRL_LOW_b.BUSY) ;
+//
+//  if (EFUSE->USER_CTRL_LOW_b.WR_CRC_ERR) {
+//      return FALSE;
+//  }
+//
+//  // write high region
+//  EFUSE->USER_DATA0_HI = key->key4;
+//  EFUSE->USER_DATA1_HI = key->key5;
+//  EFUSE->USER_DATA2_HI = key->key6;
+//  EFUSE->USER_DATA3_HI = key->key7;
+//  EFUSE->USER_DATA4_HI_b.CRC = efuse_Crc(key, 0x1, FALSE);
+//  EFUSE->USER_DATA4_HI_b.LOCK = 1;
+//  EFUSE->USER_CTRL_HI_b.WR_EN = FALSE;
+//  EFUSE->USER_CTRL_HI_b.WR_EN = TRUE;
+//
+//  udelay(1000);
+//  while (EFUSE->USER_CTRL_HI_b.BUSY) ;
+//
+//  if (EFUSE->USER_CTRL_HI_b.WR_CRC_ERR) {
+//      return FALSE;
+//  }
+//  return TRUE;
 // }
 
 BOOL EFUSE_Compare(EFUSE_AesKey* key) {
-  assert_param(key);	
-	
-	if (EFUSE->USER_CTRL_LOW_b.BUSY || EFUSE->USER_CTRL_HI_b.BUSY) {
-		return FALSE;
-	}
-	
-	// compare low region
-	EFUSE->USER_DATA0_LOW = key->key0;
-	EFUSE->USER_DATA1_LOW = key->key1;
-	EFUSE->USER_DATA2_LOW = key->key2;
-	EFUSE->USER_DATA3_LOW = key->key3;
-	EFUSE->USER_CTRL_LOW_b.RD_EN = FALSE;
-	EFUSE->USER_CTRL_LOW_b.RD_EN = TRUE;
-	
-	udelay(2);
-	while (EFUSE->USER_CTRL_LOW_b.BUSY) ;
-	
-	if (EFUSE->USER_CTRL_LOW_b.COMPARE_FAIL) {
-		return FALSE;
-	}
-	
-	// compare high region
-	EFUSE->USER_DATA0_HI = key->key4;
-	EFUSE->USER_DATA1_HI = key->key5;
-	EFUSE->USER_DATA2_HI = key->key6;
-	EFUSE->USER_DATA3_HI = key->key7;
-	EFUSE->USER_CTRL_HI_b.RD_EN = FALSE;
-	EFUSE->USER_CTRL_HI_b.RD_EN = TRUE;
-	
-	udelay(2);
-	while (EFUSE->USER_CTRL_HI_b.BUSY) ;
-	
-	if (EFUSE->USER_CTRL_HI_b.COMPARE_FAIL) {
-		return FALSE;
-	}
-	
-	return TRUE;	
+  assert_param(key);
+
+    if (EFUSE->USER_CTRL_LOW_b.BUSY || EFUSE->USER_CTRL_HI_b.BUSY) {
+        return FALSE;
+    }
+
+    // compare low region
+    EFUSE->USER_DATA0_LOW = key->key0;
+    EFUSE->USER_DATA1_LOW = key->key1;
+    EFUSE->USER_DATA2_LOW = key->key2;
+    EFUSE->USER_DATA3_LOW = key->key3;
+    EFUSE->USER_CTRL_LOW_b.RD_EN = FALSE;
+    EFUSE->USER_CTRL_LOW_b.RD_EN = TRUE;
+
+    udelay(2);
+    while (EFUSE->USER_CTRL_LOW_b.BUSY) ;
+
+    if (EFUSE->USER_CTRL_LOW_b.COMPARE_FAIL) {
+        return FALSE;
+    }
+
+    // compare high region
+    EFUSE->USER_DATA0_HI = key->key4;
+    EFUSE->USER_DATA1_HI = key->key5;
+    EFUSE->USER_DATA2_HI = key->key6;
+    EFUSE->USER_DATA3_HI = key->key7;
+    EFUSE->USER_CTRL_HI_b.RD_EN = FALSE;
+    EFUSE->USER_CTRL_HI_b.RD_EN = TRUE;
+
+    udelay(2);
+    while (EFUSE->USER_CTRL_HI_b.BUSY) ;
+
+    if (EFUSE->USER_CTRL_HI_b.COMPARE_FAIL) {
+        return FALSE;
+    }
+
+    return TRUE;
 }
 

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_eth.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_eth.c
@@ -1,115 +1,115 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_eth.c
-	*
-	* @brief    CMEM7 ethernet source file
-	*
-	*
-	* @version  V2.0
-	* @date     3. September 2014
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_eth.c
+    *
+    * @brief    CMEM7 ethernet source file
+    *
+    *
+    * @version  V2.0
+    * @date     3. September 2014
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_eth.h"
 #include "cmem7_misc.h"
 
-typedef struct { 
-	union {
+typedef struct {
+    union {
     uint32_t  TX0;
-		
-		struct {
-			uint32_t 								:  1;
-			uint32_t UNDERFLOW_ERR  :  1; 	 /*!< [OUT] Underflow error            											*/
-			uint32_t 								:  1;
-			uint32_t COLLISION_CNT	:  4;		 /*!< [OUT] Collision count				                          */
-			uint32_t 								:  1;
-			uint32_t EX_COLLISION 	:  1;		 /*!< [OUT] Excessive collision error	                      */
-			uint32_t LATE_COLLISION :  1;		 /*!< [OUT] Late collision error	                          */
-			uint32_t NO_CARRIER     :  1;		 /*!< [OUT] No carrier error                          			*/
-			uint32_t LOSS_CARRIER   :  1;		 /*!< [OUT] loss of carrier error                          	*/
-			uint32_t PAYLOAD_ERR 		:  1;		 /*!< [OUT] IP payload error                          			*/
-			uint32_t 								:  2;
-			uint32_t ERR_SUM 				:  1;		 /*!< [OUT] Error summary		                          			*/
-			uint32_t HEADER_ERR 		:  1;		 /*!< [OUT] IP header error                          				*/
-			uint32_t 								:  3;
-			uint32_t TCH						:  1;		 /*!< Second Address Chained                                */
-			uint32_t 								:  4;
-			uint32_t TTSE           :  1; 	 /*!< enables IEEE1588 hardware timestamping in first segment */
-			uint32_t 							  :  2;  
-			uint32_t FS           	:  1; 	 /*!< first segment flag                                    */
-			uint32_t LS           	:  1; 	 /*!< last segment flag                                     */
-			uint32_t IC	           	:  1; 	 /*!< Interrupt on Completion                               */
-			uint32_t OWN          	:  1; 	 /*!< Descriptor is owned by self or hardware               */
-		} TX0_b;
-	} TX_0;
-	
-	union {
+
+        struct {
+            uint32_t                                :  1;
+            uint32_t UNDERFLOW_ERR  :  1;    /*!< [OUT] Underflow error                                                     */
+            uint32_t                                :  1;
+            uint32_t COLLISION_CNT  :  4;        /*!< [OUT] Collision count                                       */
+            uint32_t                                :  1;
+            uint32_t EX_COLLISION   :  1;        /*!< [OUT] Excessive collision error                         */
+            uint32_t LATE_COLLISION :  1;        /*!< [OUT] Late collision error                              */
+            uint32_t NO_CARRIER     :  1;        /*!< [OUT] No carrier error                                    */
+            uint32_t LOSS_CARRIER   :  1;        /*!< [OUT] loss of carrier error                           */
+            uint32_t PAYLOAD_ERR        :  1;        /*!< [OUT] IP payload error                                    */
+            uint32_t                                :  2;
+            uint32_t ERR_SUM                :  1;        /*!< [OUT] Error summary                                           */
+            uint32_t HEADER_ERR         :  1;        /*!< [OUT] IP header error                                         */
+            uint32_t                                :  3;
+            uint32_t TCH                        :  1;        /*!< Second Address Chained                                */
+            uint32_t                                :  4;
+            uint32_t TTSE           :  1;    /*!< enables IEEE1588 hardware timestamping in first segment */
+            uint32_t                              :  2;
+            uint32_t FS             :  1;    /*!< first segment flag                                    */
+            uint32_t LS             :  1;    /*!< last segment flag                                     */
+            uint32_t IC             :  1;    /*!< Interrupt on Completion                               */
+            uint32_t OWN            :  1;    /*!< Descriptor is owned by self or hardware               */
+        } TX0_b;
+    } TX_0;
+
+    union {
     uint32_t  TX1;
-		
-		struct {
-			uint32_t SIZE						: 13; 	 /*!< buffer size                                           */
-			uint32_t                : 19;
-		} TX1_b;
-	} TX_1;
-	
-	uint32_t bufAddr;
-	uint32_t nextDescAddr;
+
+        struct {
+            uint32_t SIZE                       : 13;    /*!< buffer size                                           */
+            uint32_t                : 19;
+        } TX1_b;
+    } TX_1;
+
+    uint32_t bufAddr;
+    uint32_t nextDescAddr;
   uint64_t reserved;
-	uint64_t timeStamp;									 /*!< time stamp in the last segment                         */
+    uint64_t timeStamp;                                  /*!< time stamp in the last segment                         */
 } INNER_ETH_TX_DESC;
 
-typedef struct { 
-	union {
+typedef struct {
+    union {
     uint32_t  RX0;
-		
-		struct {
-			uint32_t 								:  1;
-			uint32_t CRC_ERR        :  1; 	 /*!< [OUT] CRC error while last segment                		*/
-			uint32_t 								:  5;
-			uint32_t TTSE           :  1; 	 /*!< timestamp available while last segment                */
-			uint32_t LS           	:  1; 	 /*!< last segment flag                                     */
-			uint32_t FS           	:  1; 	 /*!< first segment flag                                    */
-			uint32_t 								:  1;
-			uint32_t OVERFLOW_ERR   :  1; 	 /*!< [OUT] FIFO overflow while last segment                */
-			uint32_t LENGTH_ERR     :  1; 	 /*!< [OUT] length error while last segment                	*/
-			uint32_t 								:  2;
-			uint32_t ERR_SUM        :  1; 	 /*!< [OUT] Error summary while last segment              	*/
-			uint32_t FL           	: 14; 	 /*!< frame length while last segment                       */
-			uint32_t 		           	:  1;
-			uint32_t OWN          	:  1; 	 /*!< Descriptor is owned by self or hardware               */
-		} RX0_b;
-	} RX_0;
-	
-	union {
+
+        struct {
+            uint32_t                                :  1;
+            uint32_t CRC_ERR        :  1;    /*!< [OUT] CRC error while last segment                        */
+            uint32_t                                :  5;
+            uint32_t TTSE           :  1;    /*!< timestamp available while last segment                */
+            uint32_t LS             :  1;    /*!< last segment flag                                     */
+            uint32_t FS             :  1;    /*!< first segment flag                                    */
+            uint32_t                                :  1;
+            uint32_t OVERFLOW_ERR   :  1;    /*!< [OUT] FIFO overflow while last segment                */
+            uint32_t LENGTH_ERR     :  1;    /*!< [OUT] length error while last segment                 */
+            uint32_t                                :  2;
+            uint32_t ERR_SUM        :  1;    /*!< [OUT] Error summary while last segment                */
+            uint32_t FL             : 14;    /*!< frame length while last segment                       */
+            uint32_t                    :  1;
+            uint32_t OWN            :  1;    /*!< Descriptor is owned by self or hardware               */
+        } RX0_b;
+    } RX_0;
+
+    union {
     uint32_t  RX1;
-		
-		struct {
-			uint32_t SIZE						: 13; 	 /*!< buffer size                                           */
-			uint32_t 		           	:  1;
-			uint32_t RCH            :  1;    /*!< Second Address Chained                                */
-			uint32_t 		           	: 16;
-			uint32_t DIC	          :  1; 	 /*!< Disable interrupt on Completion                       */
-		} RX1_b;
-	} RX_1;
-	
-	uint32_t bufAddr;
-	uint32_t nextDescAddr;
+
+        struct {
+            uint32_t SIZE                       : 13;    /*!< buffer size                                           */
+            uint32_t                    :  1;
+            uint32_t RCH            :  1;    /*!< Second Address Chained                                */
+            uint32_t                    : 16;
+            uint32_t DIC              :  1;      /*!< Disable interrupt on Completion                       */
+        } RX1_b;
+    } RX_1;
+
+    uint32_t bufAddr;
+    uint32_t nextDescAddr;
   uint64_t reserved;
-	uint64_t timeStamp;									 /*!< time stamp while the last segment                     */
+    uint64_t timeStamp;                                  /*!< time stamp while the last segment                     */
 } INNER_ETH_RX_DESC;
 
 
@@ -125,8 +125,8 @@ typedef struct {
 #define ETH_BURST_LENGTH_8X_SWITCH  32
 #define ETH_BURST_LENGTH_8X_MIN     8
 
-#define ETH_DMA_ARBITRATION_ROUND_ROBIN			0x0
-#define ETH_DMA_ARBITRATION_FIXED_PRIORITY	0x1
+#define ETH_DMA_ARBITRATION_ROUND_ROBIN         0x0
+#define ETH_DMA_ARBITRATION_FIXED_PRIORITY  0x1
 
 #define ETH_RX_THRESHOLD_64         0x0
 #define ETH_RX_THRESHOLD_32         0x1
@@ -145,26 +145,26 @@ typedef struct {
 #define ETH_INT_ABNORMAL_SUMMARY    0x8000
 #define ETH_INT_NORMAL_SUMMARY      0x10000
 
-#define IS_ETH_INT_NORMAL(INT)      ((INT & ETH_INT_TX_COMPLETE_FRAME) 	|| \
-																		 (INT & ETH_INT_TX_BUF_UNAVAI) 			|| \
-																		 (INT & ETH_INT_RX_COMPLETE_FRAME))
-																		 
-#define IS_ETH_INT_ABNORMAL(INT)    ((INT & ETH_INT_TX_STOP) 						|| \
-																		 (INT & ETH_INT_RX_OVERFLOW)        || \
-																		 (INT & ETH_INT_TX_UNDERFLOW)       || \
-																		 (INT & ETH_INT_RX_BUF_UNAVAI) 			|| \
-																		 (INT & ETH_INT_RX_STOP) 						|| \
-																		 (INT & ETH_INT_BUS_FATAL_ERROR))																		 
-						
+#define IS_ETH_INT_NORMAL(INT)      ((INT & ETH_INT_TX_COMPLETE_FRAME)  || \
+                                                                         (INT & ETH_INT_TX_BUF_UNAVAI)          || \
+                                                                         (INT & ETH_INT_RX_COMPLETE_FRAME))
+
+#define IS_ETH_INT_ABNORMAL(INT)    ((INT & ETH_INT_TX_STOP)                        || \
+                                                                         (INT & ETH_INT_RX_OVERFLOW)        || \
+                                                                         (INT & ETH_INT_TX_UNDERFLOW)       || \
+                                                                         (INT & ETH_INT_RX_BUF_UNAVAI)          || \
+                                                                         (INT & ETH_INT_RX_STOP)                        || \
+                                                                         (INT & ETH_INT_BUS_FATAL_ERROR))
+
 #define ETH_PREAMBLE_7_BYTE         0x0
 #define ETH_PREAMBLE_5_BYTE         0x1
 #define ETH_PREAMBLE_3_BYTE         0x2
 
-#define ETH_LINE_SPEED_1000M_BPS		0x0
-#define ETH_LINE_SPEED_10_100M_BPS	0x1
+#define ETH_LINE_SPEED_1000M_BPS        0x0
+#define ETH_LINE_SPEED_10_100M_BPS  0x1
 
-#define ETH_EXACT_SPEED_10M_BPS			0x0
-#define ETH_EXACT_SPEED_100M_BPS		0x1
+#define ETH_EXACT_SPEED_10M_BPS         0x0
+#define ETH_EXACT_SPEED_100M_BPS        0x1
 
 #define ETH_SOURCE_ADDR_REPLACE     0x3
 
@@ -175,217 +175,217 @@ typedef struct {
 
 
 static void mac_SwReset(void) {
-	ETH->BUS_MODE_b.SWR = 1;
-	while (ETH->BUS_MODE_b.SWR) ;
-	while (ETH->AHB_STATUS_b.BUSY) ;
+    ETH->BUS_MODE_b.SWR = 1;
+    while (ETH->BUS_MODE_b.SWR) ;
+    while (ETH->AHB_STATUS_b.BUSY) ;
 }
 
-static void mac_SetConfig(ETH_InitTypeDef *init) {	
-	ETH->CONFIG_b.PRELEN = ETH_PREAMBLE_7_BYTE;
-	ETH->CONFIG_b.RX_EN = init->ETH_RxEn;
-	ETH->CONFIG_b.TX_EN = init->ETH_TxEn;
-	ETH->CONFIG_b.DC_EN = FALSE;
-	ETH->CONFIG_b.ACS = FALSE;
-	ETH->CONFIG_b.LUD = init->ETH_LinkUp;
-	ETH->CONFIG_b.IPC = init->ETH_ChecksumOffload;
-	ETH->CONFIG_b.DM = init->ETH_Duplex;
-	ETH->CONFIG_b.LM = FALSE;
-	ETH->MMCRIMR = 0xFFFFFFFF;
-	ETH->MMCTIMR = 0xFFFFFFFF;
-	ETH->MMCIRCOIM = 0xFFFFFFFF;
-	
-	if (init->ETH_Speed == ETH_SPEED_10M) {
-		ETH->CONFIG_b.FES = ETH_EXACT_SPEED_10M_BPS;
-		ETH->CONFIG_b.PS = ETH_LINE_SPEED_10_100M_BPS;
-	} else if (init->ETH_Speed == ETH_SPEED_100M) {
-		ETH->CONFIG_b.FES = ETH_EXACT_SPEED_100M_BPS;
-		ETH->CONFIG_b.PS = ETH_LINE_SPEED_10_100M_BPS;
-	} else {
-		ETH->CONFIG_b.FES = ETH_EXACT_SPEED_100M_BPS;
-		ETH->CONFIG_b.PS = ETH_LINE_SPEED_1000M_BPS;
-	}
+static void mac_SetConfig(ETH_InitTypeDef *init) {
+    ETH->CONFIG_b.PRELEN = ETH_PREAMBLE_7_BYTE;
+    ETH->CONFIG_b.RX_EN = init->ETH_RxEn;
+    ETH->CONFIG_b.TX_EN = init->ETH_TxEn;
+    ETH->CONFIG_b.DC_EN = FALSE;
+    ETH->CONFIG_b.ACS = FALSE;
+    ETH->CONFIG_b.LUD = init->ETH_LinkUp;
+    ETH->CONFIG_b.IPC = init->ETH_ChecksumOffload;
+    ETH->CONFIG_b.DM = init->ETH_Duplex;
+    ETH->CONFIG_b.LM = FALSE;
+    ETH->MMCRIMR = 0xFFFFFFFF;
+    ETH->MMCTIMR = 0xFFFFFFFF;
+    ETH->MMCIRCOIM = 0xFFFFFFFF;
 
-	ETH->CONFIG_b.JE = init->ETH_JumboFrame;
-	
-	ETH->CONFIG_b.JD = TRUE;
-	ETH->CONFIG_b.WD = TRUE;
-	ETH->CONFIG_b.TC = FALSE;
-	ETH->CONFIG_b.CST = TRUE;
-	ETH->CONFIG_b.TWOKPE = FALSE;
-	ETH->CONFIG_b.SARC = ETH_SOURCE_ADDR_REPLACE;
+    if (init->ETH_Speed == ETH_SPEED_10M) {
+        ETH->CONFIG_b.FES = ETH_EXACT_SPEED_10M_BPS;
+        ETH->CONFIG_b.PS = ETH_LINE_SPEED_10_100M_BPS;
+    } else if (init->ETH_Speed == ETH_SPEED_100M) {
+        ETH->CONFIG_b.FES = ETH_EXACT_SPEED_100M_BPS;
+        ETH->CONFIG_b.PS = ETH_LINE_SPEED_10_100M_BPS;
+    } else {
+        ETH->CONFIG_b.FES = ETH_EXACT_SPEED_100M_BPS;
+        ETH->CONFIG_b.PS = ETH_LINE_SPEED_1000M_BPS;
+    }
+
+    ETH->CONFIG_b.JE = init->ETH_JumboFrame;
+
+    ETH->CONFIG_b.JD = TRUE;
+    ETH->CONFIG_b.WD = TRUE;
+    ETH->CONFIG_b.TC = FALSE;
+    ETH->CONFIG_b.CST = TRUE;
+    ETH->CONFIG_b.TWOKPE = FALSE;
+    ETH->CONFIG_b.SARC = ETH_SOURCE_ADDR_REPLACE;
 }
 
 static void mac_SetMacAddr(uint8_t *mac) {
-	ETH->ADDR0_HIGH = (mac[5] << 8) | mac[4];
-	ETH->ADDR0_LOW = (mac[3] << 24) | (mac[2] << 16) | 
-		  (mac[1] << 8) | mac[0];
+    ETH->ADDR0_HIGH = (mac[5] << 8) | mac[4];
+    ETH->ADDR0_LOW = (mac[3] << 24) | (mac[2] << 16) |
+          (mac[1] << 8) | mac[0];
 }
 
 static void mac_SetBurst(
   uint8_t mode, uint32_t rxBurstLen, uint32_t txBurstLen) {
-	ETH->BUS_MODE_b.RIB = FALSE;
-	ETH->BUS_MODE_b.AAL = FALSE;
-		
-	if (mode == ETH_BURST_MODE_FIXED) {
-		ETH->BUS_MODE_b.FB = TRUE;
-		ETH->BUS_MODE_b.MB = FALSE;
-	} else if (mode == ETH_BURST_MODE_UNDERSIZE) {
-		ETH->BUS_MODE_b.FB = FALSE;
-		ETH->BUS_MODE_b.MB = FALSE;
-	} else {
-		ETH->BUS_MODE_b.FB = TRUE;
-		ETH->BUS_MODE_b.MB = TRUE;
-	}
-	
-	rxBurstLen = 1 << rxBurstLen;
-	rxBurstLen = (rxBurstLen > ETH_BURST_LENGTH_MAX) ? 
-	  ETH_BURST_LENGTH_MAX : rxBurstLen;
-	
-	txBurstLen = 1 << txBurstLen;
-	txBurstLen = (txBurstLen > ETH_BURST_LENGTH_MAX) ? 
-	  ETH_BURST_LENGTH_MAX : txBurstLen;
-	
-	// Regrading PBLx8 register, if one of PBL and RPBL is more than 
-	// ETH_BURST_LENGTH_8X_SWITCH, another should be more than 
-	// ETH_BURST_LENGTH_8X_MIN.
-	// If not, the greater level down to ETH_BURST_LENGTH_8X_SWITCH.
-	if ((txBurstLen < ETH_BURST_LENGTH_8X_MIN) ||
-		(rxBurstLen < ETH_BURST_LENGTH_8X_MIN)) {
-		if (rxBurstLen > ETH_BURST_LENGTH_8X_SWITCH) {
-			rxBurstLen = ETH_BURST_LENGTH_8X_SWITCH;
-		}
-		
-		if (txBurstLen > ETH_BURST_LENGTH_8X_SWITCH) {
-			txBurstLen = ETH_BURST_LENGTH_8X_SWITCH;
-		}
-	}
-		
-	ETH->BUS_MODE_b.USP = (rxBurstLen == txBurstLen) ? FALSE : TRUE;
+    ETH->BUS_MODE_b.RIB = FALSE;
+    ETH->BUS_MODE_b.AAL = FALSE;
+
+    if (mode == ETH_BURST_MODE_FIXED) {
+        ETH->BUS_MODE_b.FB = TRUE;
+        ETH->BUS_MODE_b.MB = FALSE;
+    } else if (mode == ETH_BURST_MODE_UNDERSIZE) {
+        ETH->BUS_MODE_b.FB = FALSE;
+        ETH->BUS_MODE_b.MB = FALSE;
+    } else {
+        ETH->BUS_MODE_b.FB = TRUE;
+        ETH->BUS_MODE_b.MB = TRUE;
+    }
+
+    rxBurstLen = 1 << rxBurstLen;
+    rxBurstLen = (rxBurstLen > ETH_BURST_LENGTH_MAX) ?
+      ETH_BURST_LENGTH_MAX : rxBurstLen;
+
+    txBurstLen = 1 << txBurstLen;
+    txBurstLen = (txBurstLen > ETH_BURST_LENGTH_MAX) ?
+      ETH_BURST_LENGTH_MAX : txBurstLen;
+
+    // Regrading PBLx8 register, if one of PBL and RPBL is more than
+    // ETH_BURST_LENGTH_8X_SWITCH, another should be more than
+    // ETH_BURST_LENGTH_8X_MIN.
+    // If not, the greater level down to ETH_BURST_LENGTH_8X_SWITCH.
+    if ((txBurstLen < ETH_BURST_LENGTH_8X_MIN) ||
+        (rxBurstLen < ETH_BURST_LENGTH_8X_MIN)) {
+        if (rxBurstLen > ETH_BURST_LENGTH_8X_SWITCH) {
+            rxBurstLen = ETH_BURST_LENGTH_8X_SWITCH;
+        }
+
+        if (txBurstLen > ETH_BURST_LENGTH_8X_SWITCH) {
+            txBurstLen = ETH_BURST_LENGTH_8X_SWITCH;
+        }
+    }
+
+    ETH->BUS_MODE_b.USP = (rxBurstLen == txBurstLen) ? FALSE : TRUE;
   if ((txBurstLen > ETH_BURST_LENGTH_8X_SWITCH) ||
-		(rxBurstLen > ETH_BURST_LENGTH_8X_SWITCH)) {
-		ETH->BUS_MODE_b.PBLx8 = TRUE;
-	} else {
-		ETH->BUS_MODE_b.PBLx8 = FALSE;
-	}
-	
-	if (ETH->BUS_MODE_b.PBLx8) {
-		ETH->BUS_MODE_b.RPBL = rxBurstLen >> 3;
-		ETH->BUS_MODE_b.PBL = txBurstLen >> 3;
-	} else {
-		ETH->BUS_MODE_b.RPBL = rxBurstLen;
-		ETH->BUS_MODE_b.PBL = txBurstLen;
-	}	
+        (rxBurstLen > ETH_BURST_LENGTH_8X_SWITCH)) {
+        ETH->BUS_MODE_b.PBLx8 = TRUE;
+    } else {
+        ETH->BUS_MODE_b.PBLx8 = FALSE;
+    }
+
+    if (ETH->BUS_MODE_b.PBLx8) {
+        ETH->BUS_MODE_b.RPBL = rxBurstLen >> 3;
+        ETH->BUS_MODE_b.PBL = txBurstLen >> 3;
+    } else {
+        ETH->BUS_MODE_b.RPBL = rxBurstLen;
+        ETH->BUS_MODE_b.PBL = txBurstLen;
+    }
 }
 
 static void mac_SetPriority(BOOL isRxPrior, uint8_t priorityRate) {
   ETH->BUS_MODE_b.PRWG = 0;
-	ETH->BUS_MODE_b.DA = ETH_DMA_ARBITRATION_ROUND_ROBIN;
-	
-	ETH->BUS_MODE_b.TXPR = isRxPrior ? FALSE : TRUE;
-	ETH->BUS_MODE_b.PR = priorityRate;
+    ETH->BUS_MODE_b.DA = ETH_DMA_ARBITRATION_ROUND_ROBIN;
+
+    ETH->BUS_MODE_b.TXPR = isRxPrior ? FALSE : TRUE;
+    ETH->BUS_MODE_b.PR = priorityRate;
 }
 
 static void mac_SetDescMode(BOOL isAlternate, uint8_t gap) {
   ETH->BUS_MODE_b.ATDS = isAlternate;
-	ETH->BUS_MODE_b.DSL = gap;
+    ETH->BUS_MODE_b.DSL = gap;
 }
 
 static void mac_SetOpertionMode(void) {
-	ETH->OPERATION_b.OSF = FALSE;
-	ETH->OPERATION_b.RT = ETH_RX_THRESHOLD_32;
-	ETH->OPERATION_b.RSF = FALSE;
-	
-	ETH->OPERATION_b.DGF = FALSE;
-	ETH->OPERATION_b.FUF = FALSE;
-	ETH->OPERATION_b.FEF = FALSE;
-	ETH->OPERATION_b.TT = ETH_TX_THRESHOLD_64;
-	ETH->OPERATION_b.TSF = FALSE;
-	
-	ETH->OPERATION_b.FTF = TRUE;
-	ETH->OPERATION_b.DFF = TRUE;
+    ETH->OPERATION_b.OSF = FALSE;
+    ETH->OPERATION_b.RT = ETH_RX_THRESHOLD_32;
+    ETH->OPERATION_b.RSF = FALSE;
+
+    ETH->OPERATION_b.DGF = FALSE;
+    ETH->OPERATION_b.FUF = FALSE;
+    ETH->OPERATION_b.FEF = FALSE;
+    ETH->OPERATION_b.TT = ETH_TX_THRESHOLD_64;
+    ETH->OPERATION_b.TSF = FALSE;
+
+    ETH->OPERATION_b.FTF = TRUE;
+    ETH->OPERATION_b.DFF = TRUE;
 }
 
 static void mac_SetFrameFilter(ETH_FrameFilter *filter) {
-	ETH->FF_b.PR = FALSE;
-	ETH->FF_b.HUC = FALSE;
-	ETH->FF_b.HMC = FALSE;
-	ETH->FF_b.DAIF = FALSE;
-	ETH->FF_b.PM = FALSE;
-	ETH->FF_b.DBF = FALSE;
-	ETH->FF_b.PCF = ETH_PASS_CTRL_FRAME_ALL;
-	ETH->FF_b.SAIF = FALSE;
-	ETH->FF_b.SAF = FALSE;
-	ETH->FF_b.HPF = FALSE;
-	ETH->FF_b.VTFE = FALSE;
-	ETH->FF_b.IPFE = FALSE;
-	ETH->FF_b.DNTU = FALSE;
-	ETH->FF_b.RA = FALSE;//TRUE
-	
-	// receive all
-	if (!filter) {
-		return ;
-	}
-	
-	// broadcast 
-	if (filter->ETH_BroadcastFilterEnable) {
-		ETH->FF_b.RA = FALSE;
-		ETH->FF_b.DBF = TRUE;
-	}
-	
-	// DA
-	if (filter->ETH_OwnFilterEnable) {
-		ETH->FF_b.RA = FALSE;
-		ETH->FF_b.DAIF = filter->ETH_SelfDrop;
-	}
-	
-	// SA
-	if (filter->ETH_SourceFilterEnable) {
-		uint32_t value;
-    
+    ETH->FF_b.PR = FALSE;
+    ETH->FF_b.HUC = FALSE;
+    ETH->FF_b.HMC = FALSE;
+    ETH->FF_b.DAIF = FALSE;
+    ETH->FF_b.PM = FALSE;
+    ETH->FF_b.DBF = FALSE;
+    ETH->FF_b.PCF = ETH_PASS_CTRL_FRAME_ALL;
+    ETH->FF_b.SAIF = FALSE;
+    ETH->FF_b.SAF = FALSE;
+    ETH->FF_b.HPF = FALSE;
+    ETH->FF_b.VTFE = FALSE;
+    ETH->FF_b.IPFE = FALSE;
+    ETH->FF_b.DNTU = FALSE;
+    ETH->FF_b.RA = FALSE;//TRUE
+
+    // receive all
+    if (!filter) {
+        return ;
+    }
+
+    // broadcast
+    if (filter->ETH_BroadcastFilterEnable) {
+        ETH->FF_b.RA = FALSE;
+        ETH->FF_b.DBF = TRUE;
+    }
+
+    // DA
+    if (filter->ETH_OwnFilterEnable) {
+        ETH->FF_b.RA = FALSE;
+        ETH->FF_b.DAIF = filter->ETH_SelfDrop;
+    }
+
+    // SA
+    if (filter->ETH_SourceFilterEnable) {
+        uint32_t value;
+
     ETH->FF_b.RA = FALSE;
-		ETH->FF_b.SAF = TRUE;
-		ETH->FF_b.SAIF = filter->ETH_SourceDrop;
-		ETH->ADDR1_HIGH_b.AE = TRUE;
-		ETH->ADDR1_HIGH_b.SA = TRUE; 
-    ETH->ADDR1_HIGH_b.ADDR = 
-			(filter->ETH_SourceMacAddr[5] << 8) | filter->ETH_SourceMacAddr[4];
-		
-		
-// 		value = (filter->ETH_SourceMacAddr[5] << 8) | filter->ETH_SourceMacAddr[4];
+        ETH->FF_b.SAF = TRUE;
+        ETH->FF_b.SAIF = filter->ETH_SourceDrop;
+        ETH->ADDR1_HIGH_b.AE = TRUE;
+        ETH->ADDR1_HIGH_b.SA = TRUE;
+    ETH->ADDR1_HIGH_b.ADDR =
+            (filter->ETH_SourceMacAddr[5] << 8) | filter->ETH_SourceMacAddr[4];
+
+
+//      value = (filter->ETH_SourceMacAddr[5] << 8) | filter->ETH_SourceMacAddr[4];
 //     CMEM7_BFI(&(ETH->ADDR1_HIGH), value, 0, 16);
-    ETH->ADDR1_LOW = (filter->ETH_SourceMacAddr[3] << 24) | 
-			(filter->ETH_SourceMacAddr[2] << 16) | 
-		  (filter->ETH_SourceMacAddr[1] << 8) | 
-			filter->ETH_SourceMacAddr[0];
-	}
+    ETH->ADDR1_LOW = (filter->ETH_SourceMacAddr[3] << 24) |
+            (filter->ETH_SourceMacAddr[2] << 16) |
+          (filter->ETH_SourceMacAddr[1] << 8) |
+            filter->ETH_SourceMacAddr[0];
+    }
 }
 
 static void mac_setFlowControl(void) {
   ETH->FC_b.FCB = FALSE;
-	ETH->FC_b.TFE = FALSE;//TRUE
-	ETH->FC_b.RFE = FALSE;//TRUE
-	ETH->FC_b.UP = FALSE;//TRUE
+    ETH->FC_b.TFE = FALSE;//TRUE
+    ETH->FC_b.RFE = FALSE;//TRUE
+    ETH->FC_b.UP = FALSE;//TRUE
 }
 
 uint32_t ETH_PhyRead(uint32_t phyAddr, uint32_t phyReg) {
-	ETH->GMII_ADDR_b.PA = phyAddr;
-	ETH->GMII_ADDR_b.GR = phyReg;
-	ETH->GMII_ADDR_b.GW = PHY_OP_READ;
+    ETH->GMII_ADDR_b.PA = phyAddr;
+    ETH->GMII_ADDR_b.GR = phyReg;
+    ETH->GMII_ADDR_b.GW = PHY_OP_READ;
 
-	ETH->GMII_ADDR_b.BUSY = TRUE;
-	while (ETH->GMII_ADDR_b.BUSY) ;
-	
-	return ETH->GMII_DATA;
+    ETH->GMII_ADDR_b.BUSY = TRUE;
+    while (ETH->GMII_ADDR_b.BUSY) ;
+
+    return ETH->GMII_DATA;
 }
 
 void ETH_PhyWrite(uint32_t phyAddr, uint32_t phyReg, uint32_t data) {
-	ETH->GMII_ADDR_b.PA = phyAddr;
-	ETH->GMII_ADDR_b.GR = phyReg;
-	ETH->GMII_ADDR_b.GW = PHY_OP_WRITE;
+    ETH->GMII_ADDR_b.PA = phyAddr;
+    ETH->GMII_ADDR_b.GR = phyReg;
+    ETH->GMII_ADDR_b.GW = PHY_OP_WRITE;
   ETH->GMII_DATA = data;
-	
-	ETH->GMII_ADDR_b.BUSY = TRUE;
-	while (ETH->GMII_ADDR_b.BUSY) ;
+
+    ETH->GMII_ADDR_b.BUSY = TRUE;
+    while (ETH->GMII_ADDR_b.BUSY) ;
 }
 
 void ETH_StructInit(ETH_InitTypeDef* init)
@@ -404,195 +404,195 @@ void ETH_StructInit(ETH_InitTypeDef* init)
     init->ETH_MacAddr[3] = 0;
     init->ETH_MacAddr[4] = 0;
     init->ETH_MacAddr[5] = 0;
-    
+
 }
 BOOL ETH_Init(ETH_InitTypeDef *init) {
     assert_param(init);
     assert_param(IS_ETH_SPEED(init->ETH_Speed));
     assert_param(IS_ETH_DUPLEX(init->ETH_Duplex));
-	
+
     mac_SwReset();
     mac_SetConfig(init);
     mac_SetMacAddr(init->ETH_MacAddr);
-	
+
     mac_SetBurst(ETH_BURST_MODE_MIXED, 3, 4);
     mac_SetPriority(TRUE, 0);
     mac_SetDescMode(TRUE, 0);
     mac_SetOpertionMode();
     mac_SetFrameFilter(init->ETH_Filter);
     mac_setFlowControl();
-	
+
     return TRUE;
 }
 
 void ETH_ITConfig(uint32_t Int, BOOL enable) {
-	assert_param(IS_ETH_INT(Int));
-	
-	if (enable) {
-		if (IS_ETH_INT_NORMAL(Int)) {
-			ETH->INT_EN_b.NIE = TRUE;
-		}
-		
-		if (IS_ETH_INT_ABNORMAL(Int)) {
-			ETH->INT_EN_b.AIE = TRUE;
-		}
-		
-		ETH->INT_EN |= Int;
-	} else {
-		ETH->INT_EN &= ~Int;
-		
-		if (!IS_ETH_INT_NORMAL(ETH->INT_EN)) {
-			ETH->INT_EN_b.NIE = FALSE;
-		}
-		
-		if (!IS_ETH_INT_ABNORMAL(ETH->INT_EN)) {
-			ETH->INT_EN_b.AIE = FALSE;
-		}
-	}
+    assert_param(IS_ETH_INT(Int));
+
+    if (enable) {
+        if (IS_ETH_INT_NORMAL(Int)) {
+            ETH->INT_EN_b.NIE = TRUE;
+        }
+
+        if (IS_ETH_INT_ABNORMAL(Int)) {
+            ETH->INT_EN_b.AIE = TRUE;
+        }
+
+        ETH->INT_EN |= Int;
+    } else {
+        ETH->INT_EN &= ~Int;
+
+        if (!IS_ETH_INT_NORMAL(ETH->INT_EN)) {
+            ETH->INT_EN_b.NIE = FALSE;
+        }
+
+        if (!IS_ETH_INT_ABNORMAL(ETH->INT_EN)) {
+            ETH->INT_EN_b.AIE = FALSE;
+        }
+    }
 }
 BOOL ETH_GetITStatus(uint32_t Int) {
-	assert_param(IS_ETH_INT(Int));
-	
-	Int &= ETH->INT_EN;
-	if (0 != (ETH->STATUS & Int)) {
-		return TRUE;
-	}
-	
-	return FALSE;
+    assert_param(IS_ETH_INT(Int));
+
+    Int &= ETH->INT_EN;
+    if (0 != (ETH->STATUS & Int)) {
+        return TRUE;
+    }
+
+    return FALSE;
 }
 void ETH_ClearITPendingBit(uint32_t Int) {
-	uint32_t sta;
-	assert_param(IS_ETH_INT(Int));
-		
-	sta = ETH->STATUS;
-	sta &= ETH->INT_EN;
-	sta &= ~Int;
-	
-	// write 1 clear
-	ETH->STATUS = Int;
-	
-	if (IS_ETH_INT_NORMAL(Int)) {
-		if (!IS_ETH_INT_NORMAL(sta)) {
-			// write 1 clear NIS
-			ETH->STATUS = ETH_INT_NORMAL_SUMMARY;
-		}
-	}
-	
-	if (IS_ETH_INT_ABNORMAL(Int)) {
-		if (!IS_ETH_INT_ABNORMAL(sta)) {
-			// write 1 clear AIS
-			ETH->STATUS = ETH_INT_ABNORMAL_SUMMARY;
-		}
-	}
+    uint32_t sta;
+    assert_param(IS_ETH_INT(Int));
+
+    sta = ETH->STATUS;
+    sta &= ETH->INT_EN;
+    sta &= ~Int;
+
+    // write 1 clear
+    ETH->STATUS = Int;
+
+    if (IS_ETH_INT_NORMAL(Int)) {
+        if (!IS_ETH_INT_NORMAL(sta)) {
+            // write 1 clear NIS
+            ETH->STATUS = ETH_INT_NORMAL_SUMMARY;
+        }
+    }
+
+    if (IS_ETH_INT_ABNORMAL(Int)) {
+        if (!IS_ETH_INT_ABNORMAL(sta)) {
+            // write 1 clear AIS
+            ETH->STATUS = ETH_INT_ABNORMAL_SUMMARY;
+        }
+    }
 }
 
 void ETH_GetMacAddr(uint8_t *mac) {
   uint32_t tmp;
-	
-	if (!mac) {
-		return ;
-	}
-	
-	tmp = ETH->ADDR0_LOW;
-	*(mac + 0) = (tmp >> 0) & 0xFF;
-	*(mac + 1) = (tmp >> 8) & 0xFF;
-	*(mac + 2) = (tmp >> 16) & 0xFF;
-	*(mac + 3) = (tmp >> 24) & 0xFF;
-	tmp = ETH->ADDR0_HIGH;
-	*(mac + 4) = (tmp >> 0) & 0xFF;
-	*(mac + 5) = (tmp >> 8) & 0xFF;
+
+    if (!mac) {
+        return ;
+    }
+
+    tmp = ETH->ADDR0_LOW;
+    *(mac + 0) = (tmp >> 0) & 0xFF;
+    *(mac + 1) = (tmp >> 8) & 0xFF;
+    *(mac + 2) = (tmp >> 16) & 0xFF;
+    *(mac + 3) = (tmp >> 24) & 0xFF;
+    tmp = ETH->ADDR0_HIGH;
+    *(mac + 4) = (tmp >> 0) & 0xFF;
+    *(mac + 5) = (tmp >> 8) & 0xFF;
 }
 
 BOOL ETH_SetTxDescRing(ETH_TX_DESC *ring) {
-	ETH_TX_DESC *buf = ring;
-	
-	if (!ring) {
-		return FALSE;
-	}
-	
-	if (ETH->OPERATION_b.ST) {
-		return FALSE;
-	}
+    ETH_TX_DESC *buf = ring;
+
+    if (!ring) {
+        return FALSE;
+    }
+
+    if (ETH->OPERATION_b.ST) {
+        return FALSE;
+    }
 
   /* If code mapping */
   ring = (ETH_TX_DESC *)GLB_ConvertToMappingFromAddr((uint32_t)ring);
   buf = ring;
-  
-	do {
-		INNER_ETH_TX_DESC *desc = (INNER_ETH_TX_DESC *)buf;
+
+    do {
+        INNER_ETH_TX_DESC *desc = (INNER_ETH_TX_DESC *)buf;
     uint8_t first = desc->TX_0.TX0_b.FS;
     uint8_t last = desc->TX_0.TX0_b.LS;
-    
+
     // clear all bits
     desc->TX_0.TX0 = 0;
     desc->TX_0.TX0_b.FS = first;
     desc->TX_0.TX0_b.LS = last;
-		desc->TX_0.TX0_b.TCH = TRUE;
-		desc->TX_0.TX0_b.IC = TRUE;
-		desc->TX_0.TX0_b.OWN = ETH_DESC_OWN_BY_SELF;
-		
+        desc->TX_0.TX0_b.TCH = TRUE;
+        desc->TX_0.TX0_b.IC = TRUE;
+        desc->TX_0.TX0_b.OWN = ETH_DESC_OWN_BY_SELF;
+
     buf->bufAddr = GLB_ConvertToMappingFromAddr(buf->bufAddr);
     buf->nextDescAddr = GLB_ConvertToMappingFromAddr(buf->nextDescAddr);
-		buf = (ETH_TX_DESC *)buf->nextDescAddr;
-	} while (buf != ring);
-	
-	ETH->TDESLA = (uint32_t)ring;
- 
-	return TRUE;
+        buf = (ETH_TX_DESC *)buf->nextDescAddr;
+    } while (buf != ring);
+
+    ETH->TDESLA = (uint32_t)ring;
+
+    return TRUE;
 }
 
 void ETH_StartTx() {
-	ETH->OPERATION_b.ST = TRUE;
+    ETH->OPERATION_b.ST = TRUE;
 }
 
 void ETH_StopTx() {
-	ETH->OPERATION_b.ST = FALSE;
+    ETH->OPERATION_b.ST = FALSE;
 }
 
 void ETH_ResumeTx() {
-	ETH->TPD = 0;
+    ETH->TPD = 0;
 }
 
 ETH_TX_DESC *ETH_AcquireFreeTxDesc(void) {
-	uint32_t cur = ETH->CURTDESAPTR;
-	INNER_ETH_TX_DESC *desc = (INNER_ETH_TX_DESC *)cur;
-	
-	do {
-		if (desc->TX_0.TX0_b.OWN == ETH_DESC_OWN_BY_SELF) {
-			return (ETH_TX_DESC *)desc;
-		}
-		desc = (INNER_ETH_TX_DESC *)desc->nextDescAddr;
-	} while ((uint32_t)desc != cur);
-	
-  return 0;		
+    uint32_t cur = ETH->CURTDESAPTR;
+    INNER_ETH_TX_DESC *desc = (INNER_ETH_TX_DESC *)cur;
+
+    do {
+        if (desc->TX_0.TX0_b.OWN == ETH_DESC_OWN_BY_SELF) {
+            return (ETH_TX_DESC *)desc;
+        }
+        desc = (INNER_ETH_TX_DESC *)desc->nextDescAddr;
+    } while ((uint32_t)desc != cur);
+
+  return 0;
 }
 
 BOOL ETH_IsFreeTxDesc(ETH_TX_DESC *desc) {
-	INNER_ETH_TX_DESC *inner;
-	
-	if (!desc) {
-		return FALSE;
-	}
-	
-	inner = (INNER_ETH_TX_DESC *)desc;
-	return (inner->TX_0.TX0_b.OWN == ETH_DESC_OWN_BY_SELF) ? TRUE : FALSE;
+    INNER_ETH_TX_DESC *inner;
+
+    if (!desc) {
+        return FALSE;
+    }
+
+    inner = (INNER_ETH_TX_DESC *)desc;
+    return (inner->TX_0.TX0_b.OWN == ETH_DESC_OWN_BY_SELF) ? TRUE : FALSE;
 }
 
 void ETH_ReleaseTxDesc(ETH_TX_DESC *desc) {
-	INNER_ETH_TX_DESC *inner;
-	
-	if (!desc) {
-		return;
-	}
-	
-	inner = (INNER_ETH_TX_DESC *)desc;
-	inner->TX_0.TX0_b.OWN = ETH_DESC_OWN_BY_HW;
+    INNER_ETH_TX_DESC *inner;
+
+    if (!desc) {
+        return;
+    }
+
+    inner = (INNER_ETH_TX_DESC *)desc;
+    inner->TX_0.TX0_b.OWN = ETH_DESC_OWN_BY_HW;
 }
 
 void ETH_SetTxDescBufAddr(ETH_TX_DESC *desc, uint32_t bufAddr) {
-	if (desc) {
-		desc->bufAddr = GLB_ConvertToMappingFromAddr(bufAddr);;
-	}
+    if (desc) {
+        desc->bufAddr = GLB_ConvertToMappingFromAddr(bufAddr);;
+    }
 }
 
 uint32_t ETH_GetTxDescBufAddr(ETH_TX_DESC *desc) {
@@ -600,88 +600,88 @@ uint32_t ETH_GetTxDescBufAddr(ETH_TX_DESC *desc) {
 }
 
 BOOL ETH_SetRxDescRing(ETH_RX_DESC *ring) {
-	ETH_RX_DESC *buf = ring;
-	
-	if (!ring) {
-		return FALSE;
-	}
-	
-	if (ETH->OPERATION_b.SR) {
-		return FALSE;
-	}
+    ETH_RX_DESC *buf = ring;
+
+    if (!ring) {
+        return FALSE;
+    }
+
+    if (ETH->OPERATION_b.SR) {
+        return FALSE;
+    }
 
   /* If code mapping */
   ring = (ETH_RX_DESC *)GLB_ConvertToMappingFromAddr((uint32_t)ring);
   buf = ring;
-	do {
-		INNER_ETH_RX_DESC *desc = (INNER_ETH_RX_DESC *)buf;
-		desc->RX_1.RX1_b.RCH = TRUE;
-		desc->RX_1.RX1_b.DIC = FALSE;
-		desc->RX_0.RX0_b.OWN = ETH_DESC_OWN_BY_HW;
+    do {
+        INNER_ETH_RX_DESC *desc = (INNER_ETH_RX_DESC *)buf;
+        desc->RX_1.RX1_b.RCH = TRUE;
+        desc->RX_1.RX1_b.DIC = FALSE;
+        desc->RX_0.RX0_b.OWN = ETH_DESC_OWN_BY_HW;
 
     buf->bufAddr = GLB_ConvertToMappingFromAddr(buf->bufAddr);
     buf->nextDescAddr = GLB_ConvertToMappingFromAddr(buf->nextDescAddr);
-		buf = (ETH_RX_DESC *)buf->nextDescAddr;
-	} while (buf != ring);
-	
-	ETH->RDESLA = (uint32_t)ring;
- 
-	return TRUE;
+        buf = (ETH_RX_DESC *)buf->nextDescAddr;
+    } while (buf != ring);
+
+    ETH->RDESLA = (uint32_t)ring;
+
+    return TRUE;
 }
 
 void ETH_StartRx() {
-	ETH->OPERATION_b.SR = TRUE;
+    ETH->OPERATION_b.SR = TRUE;
 }
 
 void ETH_StopRx() {
-	ETH->OPERATION_b.SR = FALSE;
+    ETH->OPERATION_b.SR = FALSE;
 }
 
 void ETH_ResumeRx() {
-	ETH->RPD = 0;
+    ETH->RPD = 0;
 }
 
 ETH_RX_DESC *ETH_AcquireFreeRxDesc(void) {
-	uint32_t cur = ETH->CURRDESAPTR;
-	INNER_ETH_RX_DESC *desc = (INNER_ETH_RX_DESC *)cur;
-	
-	do {
-		if (desc->RX_0.RX0_b.OWN == ETH_DESC_OWN_BY_SELF) {
-			return (ETH_RX_DESC *)desc;
-		}
-		desc = (INNER_ETH_RX_DESC *)desc->nextDescAddr;
-	} while ((uint32_t)desc != cur);
-	
-  return 0;		
+    uint32_t cur = ETH->CURRDESAPTR;
+    INNER_ETH_RX_DESC *desc = (INNER_ETH_RX_DESC *)cur;
+
+    do {
+        if (desc->RX_0.RX0_b.OWN == ETH_DESC_OWN_BY_SELF) {
+            return (ETH_RX_DESC *)desc;
+        }
+        desc = (INNER_ETH_RX_DESC *)desc->nextDescAddr;
+    } while ((uint32_t)desc != cur);
+
+  return 0;
 }
 
 BOOL ETH_IsFreeRxDesc(ETH_RX_DESC *desc) {
-	INNER_ETH_RX_DESC *inner;
-	
-	if (!desc) {
-		return FALSE;
-	}
-	
-	inner = (INNER_ETH_RX_DESC *)desc;
-	return (inner->RX_0.RX0_b.OWN == ETH_DESC_OWN_BY_SELF) ? TRUE : FALSE;
+    INNER_ETH_RX_DESC *inner;
+
+    if (!desc) {
+        return FALSE;
+    }
+
+    inner = (INNER_ETH_RX_DESC *)desc;
+    return (inner->RX_0.RX0_b.OWN == ETH_DESC_OWN_BY_SELF) ? TRUE : FALSE;
 }
 
 void ETH_ReleaseRxDesc(ETH_RX_DESC *desc) {
-	INNER_ETH_RX_DESC *inner;
-	
-	if (!desc) {
-		return;
-	}
-	
-	inner = (INNER_ETH_RX_DESC *)desc;
-	inner->RX_0.RX0_b.OWN = ETH_DESC_OWN_BY_HW;
+    INNER_ETH_RX_DESC *inner;
+
+    if (!desc) {
+        return;
+    }
+
+    inner = (INNER_ETH_RX_DESC *)desc;
+    inner->RX_0.RX0_b.OWN = ETH_DESC_OWN_BY_HW;
 }
 
 
 void ETH_SetRxDescBufAddr(ETH_RX_DESC *desc, uint32_t bufAddr) {
-	if (desc) {
-		desc->bufAddr = GLB_ConvertToMappingFromAddr(bufAddr);;
-	}
+    if (desc) {
+        desc->bufAddr = GLB_ConvertToMappingFromAddr(bufAddr);;
+    }
 }
 
 uint32_t ETH_GetRxDescBufAddr(ETH_RX_DESC *desc) {

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_flash.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_flash.c
@@ -1,35 +1,35 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_flash.c
-	*
-	* @brief    CMEM7 flash controller source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_flash.c
+    *
+    * @brief    CMEM7 flash controller source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_flash.h"
 
 typedef struct {
   union {
     uint16_t  STATUS;                         /*!< status register                     */
-    
+
     struct {
       uint16_t  WIP:  1;                      /*!< in writting                         */
       uint16_t  WEL:  1;                      /*!< write enable                        */
@@ -76,325 +76,325 @@ typedef void (*WAIT)(void);
 static WAIT wait;
 
 static void flash_setClock(uint8_t dividor) {
-	dividor = (dividor < 2) ? 2 : dividor;
-	NOR_FLASH->CTRL0_b.DIV = dividor / 2 - 1;
+    dividor = (dividor < 2) ? 2 : dividor;
+    NOR_FLASH->CTRL0_b.DIV = dividor / 2 - 1;
 }
 
 static void flash_cleanOperation() {
-	NOR_FLASH->TRIGGER_b.OP_CLEAN = TRUE;	
-	while (NOR_FLASH->STATUS_b.BUSY);
-	
-	NOR_FLASH->TRIGGER_b.OP_CLEAN = FALSE;	
-	while (NOR_FLASH->STATUS_b.BUSY);
+    NOR_FLASH->TRIGGER_b.OP_CLEAN = TRUE;
+    while (NOR_FLASH->STATUS_b.BUSY);
+
+    NOR_FLASH->TRIGGER_b.OP_CLEAN = FALSE;
+    while (NOR_FLASH->STATUS_b.BUSY);
 }
 
 static uint8_t flash_ReadInnerStatusLow() {
-	NOR_FLASH->CTRL0_b.RW_BYTE_CNT = 1;
-	NOR_FLASH->CTRL1_b.CMD = FLASH_CMD_RD_INNER_STATUS_LOW;
-	NOR_FLASH->TRIGGER_b.OP_START = TRUE;
-	
-	while (NOR_FLASH->STATUS_b.BUSY);
-	
-	return (uint8_t)NOR_FLASH->DATA;
+    NOR_FLASH->CTRL0_b.RW_BYTE_CNT = 1;
+    NOR_FLASH->CTRL1_b.CMD = FLASH_CMD_RD_INNER_STATUS_LOW;
+    NOR_FLASH->TRIGGER_b.OP_START = TRUE;
+
+    while (NOR_FLASH->STATUS_b.BUSY);
+
+    return (uint8_t)NOR_FLASH->DATA;
 }
 
 static uint8_t flash_ReadInnerStatusHigh() {
   NOR_FLASH->CTRL0_b.RW_BYTE_CNT = 1;
-	NOR_FLASH->CTRL1_b.CMD = FLASH_CMD_RD_INNER_STATUS_HIGH;
-	NOR_FLASH->TRIGGER_b.OP_START = TRUE;
-	
-	while (NOR_FLASH->STATUS_b.BUSY);
-	
-	return (uint8_t)NOR_FLASH->DATA;	
+    NOR_FLASH->CTRL1_b.CMD = FLASH_CMD_RD_INNER_STATUS_HIGH;
+    NOR_FLASH->TRIGGER_b.OP_START = TRUE;
+
+    while (NOR_FLASH->STATUS_b.BUSY);
+
+    return (uint8_t)NOR_FLASH->DATA;
 }
 
 //static void flash_WaitInWritting() {
 void flash_WaitInWritting(void) {
-	FLASH_INNER_STATUS s;
-	
-	while (NOR_FLASH->STATUS_b.BUSY);
-	
-	do {
-		s.INNER.STATUS = flash_ReadInnerStatusLow();
-		if (!s.INNER.STATUS_b.WIP) {
-			break;
-		}
-		
-		if (wait) {
-			(*wait)();
-		}
-	} while (1);
+    FLASH_INNER_STATUS s;
+
+    while (NOR_FLASH->STATUS_b.BUSY);
+
+    do {
+        s.INNER.STATUS = flash_ReadInnerStatusLow();
+        if (!s.INNER.STATUS_b.WIP) {
+            break;
+        }
+
+        if (wait) {
+            (*wait)();
+        }
+    } while (1);
 }
 
 static void flash_WriteWriteEnable(BOOL enable) {
   NOR_FLASH->CTRL0_b.RW_BYTE_CNT = 0;
-	NOR_FLASH->CTRL1_b.CMD = 
-	  enable ? FLASH_CMD_WR_WRITE_ENABLE : FLASH_CMD_WR_WRITE_DISABLE;
-	
-	NOR_FLASH->TRIGGER_b.OP_START = TRUE;
-	
-	flash_WaitInWritting();
+    NOR_FLASH->CTRL1_b.CMD =
+      enable ? FLASH_CMD_WR_WRITE_ENABLE : FLASH_CMD_WR_WRITE_DISABLE;
+
+    NOR_FLASH->TRIGGER_b.OP_START = TRUE;
+
+    flash_WaitInWritting();
 }
 
 static void flash_WriteStatusReg(FLASH_INNER_STATUS *s) {
   uint16_t tmp = s->INNER.STATUS;
-	
-	NOR_FLASH->CTRL0_b.RW_BYTE_CNT = 2;
-	NOR_FLASH->CTRL1_b.CMD = FLASH_CME_WR_STATUS_REG;
-	NOR_FLASH->DATA = ((tmp << 8) | (tmp >> 8)) << 16;
-	NOR_FLASH->TRIGGER_b.OP_START = TRUE;
-	
-	flash_WaitInWritting();
+
+    NOR_FLASH->CTRL0_b.RW_BYTE_CNT = 2;
+    NOR_FLASH->CTRL1_b.CMD = FLASH_CME_WR_STATUS_REG;
+    NOR_FLASH->DATA = ((tmp << 8) | (tmp >> 8)) << 16;
+    NOR_FLASH->TRIGGER_b.OP_START = TRUE;
+
+    flash_WaitInWritting();
 }
 
-static void flash_Erase(uint8_t cmd, uint32_t addr) {	
-	NOR_FLASH->CTRL0_b.RW_BYTE_CNT = 0;
-	NOR_FLASH->CTRL1_b.CMD = cmd;
-	NOR_FLASH->CTRL1_b.ADDRESS = addr;
-	NOR_FLASH->TRIGGER_b.OP_START = TRUE;
-	
-	flash_WaitInWritting();
+static void flash_Erase(uint8_t cmd, uint32_t addr) {
+    NOR_FLASH->CTRL0_b.RW_BYTE_CNT = 0;
+    NOR_FLASH->CTRL1_b.CMD = cmd;
+    NOR_FLASH->CTRL1_b.ADDRESS = addr;
+    NOR_FLASH->TRIGGER_b.OP_START = TRUE;
+
+    flash_WaitInWritting();
 }
 
 static void flash_WriteDeepPowerDownEnable(BOOL enable) {
   NOR_FLASH->CTRL0_b.RW_BYTE_CNT = 0;
-	NOR_FLASH->CTRL1_b.CMD = 
-	  enable ? FLASH_CME_WR_ENTER_DEEP_PD : FLASH_CME_WR_EXIT_DEEP_PD;
-	
-	NOR_FLASH->TRIGGER_b.OP_START = TRUE;
-	
-	flash_WaitInWritting();
+    NOR_FLASH->CTRL1_b.CMD =
+      enable ? FLASH_CME_WR_ENTER_DEEP_PD : FLASH_CME_WR_EXIT_DEEP_PD;
+
+    NOR_FLASH->TRIGGER_b.OP_START = TRUE;
+
+    flash_WaitInWritting();
 }
 
 static void flash_RwReq(uint8_t cmd, uint32_t addr, uint16_t size) {
-	NOR_FLASH->CTRL0_b.RW_BYTE_CNT = size;
-	NOR_FLASH->CTRL1_b.CMD = cmd;
-	NOR_FLASH->CTRL1_b.ADDRESS = addr;
-	
-	NOR_FLASH->TRIGGER_b.OP_START = TRUE;
+    NOR_FLASH->CTRL0_b.RW_BYTE_CNT = size;
+    NOR_FLASH->CTRL1_b.CMD = cmd;
+    NOR_FLASH->CTRL1_b.ADDRESS = addr;
+
+    NOR_FLASH->TRIGGER_b.OP_START = TRUE;
 }
 
 //static void flash_WaitReadFifoNotEmpty() {
 void flash_WaitReadFifoNotEmpty(void) {
-	while (NOR_FLASH->STATUS_b.RD_FIFO_EMPTY) {
-		if (wait) {
-			(*wait)();
-		}
-	}
+    while (NOR_FLASH->STATUS_b.RD_FIFO_EMPTY) {
+        if (wait) {
+            (*wait)();
+        }
+    }
 }
 
 //static uint16_t flash_ReadFifo(uint16_t size, uint8_t* data) {
 uint16_t flash_ReadFifo(uint16_t size, uint8_t* data) {
-	uint16_t count = 0;
-	
-	while (!NOR_FLASH->STATUS_b.RD_FIFO_EMPTY && size != 0) {
-  	uint32_t d =	NOR_FLASH->DATA;
-		if (size > 3) {
-			*(data + count++) = d >> 24;
-			*(data + count++) = (d & 0x00FF0000) >> 16;
-			*(data + count++) = (d & 0x0000FF00) >> 8;
-			*(data + count++) = (d & 0x000000FF);
-			size -= 4;
-		} else if (size == 3) {
-			*(data + count++) = (d & 0x00FF0000) >> 16;
-			*(data + count++) = (d & 0x0000FF00) >> 8;
-			*(data + count++) = (d & 0x000000FF);
-			size -= 3;
-		} else if (size == 2) {
-			*(data + count++) = (d & 0x0000FF00) >> 8;
-			*(data + count++) = (d & 0x000000FF);
-			size -= 2;
-		} else if (size == 1) {
-			*(data + count++) = (d & 0x000000FF);
-			size -= 1;
-		}
-	}
-	
-	return count;
+    uint16_t count = 0;
+
+    while (!NOR_FLASH->STATUS_b.RD_FIFO_EMPTY && size != 0) {
+    uint32_t d =    NOR_FLASH->DATA;
+        if (size > 3) {
+            *(data + count++) = d >> 24;
+            *(data + count++) = (d & 0x00FF0000) >> 16;
+            *(data + count++) = (d & 0x0000FF00) >> 8;
+            *(data + count++) = (d & 0x000000FF);
+            size -= 4;
+        } else if (size == 3) {
+            *(data + count++) = (d & 0x00FF0000) >> 16;
+            *(data + count++) = (d & 0x0000FF00) >> 8;
+            *(data + count++) = (d & 0x000000FF);
+            size -= 3;
+        } else if (size == 2) {
+            *(data + count++) = (d & 0x0000FF00) >> 8;
+            *(data + count++) = (d & 0x000000FF);
+            size -= 2;
+        } else if (size == 1) {
+            *(data + count++) = (d & 0x000000FF);
+            size -= 1;
+        }
+    }
+
+    return count;
 }
 
 static uint16_t flash_WriteFifo(uint16_t size, uint8_t* data) {
-	uint16_t count = 0;
-	
-	while (!NOR_FLASH->STATUS_b.WR_FIFO_FULL && size != 0) { 	
-		uint32_t d = 0;
-		
-		if (size > 3) {
-			d = *(data + count++) << 24;
-			d |= *(data + count++) << 16;
-			d |= *(data + count++) << 8;
-			d |= *(data + count++);
-			size -= 4;
-		} else if (size == 3) {
-			d = *(data + count++) << 24;
-			d |= *(data + count++) << 16;
-			d |= *(data + count++) << 8;
-			size -= 3;
-		} else if (size == 2) {
-			d = *(data + count++) << 24;
-			d |= *(data + count++) << 16;
-			size -= 2;
-		} else if (size == 1) {
-			d = *(data + count++) << 24;
-			size -= 1;
-		}
-		
-		NOR_FLASH->DATA = d;		
-	}
-	
-	return count;
+    uint16_t count = 0;
+
+    while (!NOR_FLASH->STATUS_b.WR_FIFO_FULL && size != 0) {
+        uint32_t d = 0;
+
+        if (size > 3) {
+            d = *(data + count++) << 24;
+            d |= *(data + count++) << 16;
+            d |= *(data + count++) << 8;
+            d |= *(data + count++);
+            size -= 4;
+        } else if (size == 3) {
+            d = *(data + count++) << 24;
+            d |= *(data + count++) << 16;
+            d |= *(data + count++) << 8;
+            size -= 3;
+        } else if (size == 2) {
+            d = *(data + count++) << 24;
+            d |= *(data + count++) << 16;
+            size -= 2;
+        } else if (size == 1) {
+            d = *(data + count++) << 24;
+            size -= 1;
+        }
+
+        NOR_FLASH->DATA = d;
+    }
+
+    return count;
 }
 
 static uint16_t flash_WritePage(uint32_t addr, uint16_t size, uint8_t* data) {
-	uint16_t actualSize, retSize;
-  
-	flash_WriteWriteEnable(TRUE);
-	
-	actualSize = FLASH_PAGE_SIZE - (addr & (FLASH_PAGE_SIZE - 1)); 
-	actualSize = (size > actualSize) ? actualSize : size;
+    uint16_t actualSize, retSize;
+
+    flash_WriteWriteEnable(TRUE);
+
+    actualSize = FLASH_PAGE_SIZE - (addr & (FLASH_PAGE_SIZE - 1));
+    actualSize = (size > actualSize) ? actualSize : size;
   retSize = actualSize;
-	
-	flash_RwReq(FLASH_CME_WR, addr, actualSize);
-	
-	while (actualSize != 0) {
-		uint8_t count = flash_WriteFifo(actualSize, data);
-		
-		actualSize -= count;
-		data += count;
-	}
-	
-	flash_WaitInWritting();
-	
-	return retSize;
+
+    flash_RwReq(FLASH_CME_WR, addr, actualSize);
+
+    while (actualSize != 0) {
+        uint8_t count = flash_WriteFifo(actualSize, data);
+
+        actualSize -= count;
+        data += count;
+    }
+
+    flash_WaitInWritting();
+
+    return retSize;
 }
 
 void FLASH_Init(FLASH_InitTypeDef* init) {
-	FLASH_INNER_STATUS s;
-	
-	assert_param(init);
-	assert_param(IS_FLASH_PROTECT_MODE(init->FLASH_ProtectMode));
-	assert_param(IS_FLASH_PROTECT_REGION(init->FLASH_ProtectRegion));
-	
-	wait = init->FLASH_Wait;
-	flash_setClock(init->FLASH_ClockDividor);
-	
-	flash_cleanOperation();
-	
-	flash_WaitInWritting();
-	
-	s.INNER.STATUS = flash_ReadInnerStatusLow();
-	s.INNER.STATUS |= ((uint16_t)flash_ReadInnerStatusHigh()) << 8;
-	s.INNER.STATUS_b.BP = init->FLASH_ProtectRegion;
-	s.INNER.STATUS_b.SRP = init->FLASH_ProtectMode;
-	s.INNER.STATUS_b.QE = init->FLASH_QuadEnable;
+    FLASH_INNER_STATUS s;
 
-	flash_WriteWriteEnable(TRUE);
-	flash_WriteStatusReg(&s);
+    assert_param(init);
+    assert_param(IS_FLASH_PROTECT_MODE(init->FLASH_ProtectMode));
+    assert_param(IS_FLASH_PROTECT_REGION(init->FLASH_ProtectRegion));
+
+    wait = init->FLASH_Wait;
+    flash_setClock(init->FLASH_ClockDividor);
+
+    flash_cleanOperation();
+
+    flash_WaitInWritting();
+
+    s.INNER.STATUS = flash_ReadInnerStatusLow();
+    s.INNER.STATUS |= ((uint16_t)flash_ReadInnerStatusHigh()) << 8;
+    s.INNER.STATUS_b.BP = init->FLASH_ProtectRegion;
+    s.INNER.STATUS_b.SRP = init->FLASH_ProtectMode;
+    s.INNER.STATUS_b.QE = init->FLASH_QuadEnable;
+
+    flash_WriteWriteEnable(TRUE);
+    flash_WriteStatusReg(&s);
 }
 
 void FLASH_GetStatus(uint8_t* ProtectMode, uint8_t* ProtectRegion, BOOL* QuadEnable) {
-	FLASH_INNER_STATUS s;
-	
-	assert_param(ProtectMode);
-	assert_param(ProtectRegion);
-	assert_param(QuadEnable);
-	
-	flash_WaitInWritting();
-	
-	s.INNER.STATUS = flash_ReadInnerStatusLow();
-	s.INNER.STATUS |= ((uint16_t)flash_ReadInnerStatusHigh()) << 8;
-	*ProtectRegion = s.INNER.STATUS_b.BP;
-	*ProtectMode = s.INNER.STATUS_b.SRP;
-	*QuadEnable = (s.INNER.STATUS_b.QE == 1) ?  TRUE : FALSE;
+    FLASH_INNER_STATUS s;
+
+    assert_param(ProtectMode);
+    assert_param(ProtectRegion);
+    assert_param(QuadEnable);
+
+    flash_WaitInWritting();
+
+    s.INNER.STATUS = flash_ReadInnerStatusLow();
+    s.INNER.STATUS |= ((uint16_t)flash_ReadInnerStatusHigh()) << 8;
+    *ProtectRegion = s.INNER.STATUS_b.BP;
+    *ProtectMode = s.INNER.STATUS_b.SRP;
+    *QuadEnable = (s.INNER.STATUS_b.QE == 1) ?  TRUE : FALSE;
 }
 
 void FLASH_EraseSector(uint32_t addr) {
-	flash_WaitInWritting();
-	flash_WriteWriteEnable(TRUE);
-	
-	addr = (addr << 8) >> 8;
-	addr = addr / FLASH_SECTOR_SIZE * FLASH_SECTOR_SIZE;
-	flash_Erase(FLASH_CME_ERASE_SECTOR, addr);
+    flash_WaitInWritting();
+    flash_WriteWriteEnable(TRUE);
+
+    addr = (addr << 8) >> 8;
+    addr = addr / FLASH_SECTOR_SIZE * FLASH_SECTOR_SIZE;
+    flash_Erase(FLASH_CME_ERASE_SECTOR, addr);
 }
 
 void FLASH_Erase32kBlock(uint32_t addr) {
-	flash_WaitInWritting();
-	flash_WriteWriteEnable(TRUE);
-	
-	addr = (addr << 8) >> 8;
-	addr = addr / FLASH_BLOCK_32K_SIZE * FLASH_BLOCK_32K_SIZE;
-	flash_Erase(FLASH_CME_ERASE_BLOCK_32K, addr);
+    flash_WaitInWritting();
+    flash_WriteWriteEnable(TRUE);
+
+    addr = (addr << 8) >> 8;
+    addr = addr / FLASH_BLOCK_32K_SIZE * FLASH_BLOCK_32K_SIZE;
+    flash_Erase(FLASH_CME_ERASE_BLOCK_32K, addr);
 }
 
 void FLASH_Erase64kBlock(uint32_t addr) {
-	flash_WaitInWritting();
-	flash_WriteWriteEnable(TRUE);
-	
-	addr = (addr << 8) >> 8;
-	addr = addr / FLASH_BLOCK_64K_SIZE * FLASH_BLOCK_64K_SIZE;
-	flash_Erase(FLASH_CME_ERASE_BLOCK_64K, addr);
+    flash_WaitInWritting();
+    flash_WriteWriteEnable(TRUE);
+
+    addr = (addr << 8) >> 8;
+    addr = addr / FLASH_BLOCK_64K_SIZE * FLASH_BLOCK_64K_SIZE;
+    flash_Erase(FLASH_CME_ERASE_BLOCK_64K, addr);
 }
 
 void FLASH_EraseChip(void) {
-	flash_WaitInWritting();
-	flash_WriteWriteEnable(TRUE);
-	flash_Erase(FLASH_CME_ERASE_CHIP, 0x0);
+    flash_WaitInWritting();
+    flash_WriteWriteEnable(TRUE);
+    flash_Erase(FLASH_CME_ERASE_CHIP, 0x0);
 }
 
 void FLASH_EnableDeepPowerDown(BOOL enable) {
-	flash_WaitInWritting();
-	flash_WriteWriteEnable(TRUE);
-	flash_WriteDeepPowerDownEnable(enable);
+    flash_WaitInWritting();
+    flash_WriteWriteEnable(TRUE);
+    flash_WriteDeepPowerDownEnable(enable);
 }
 
 void FLASH_Read(uint8_t ReadMode, uint32_t addr, uint16_t size, uint8_t* data) {
-	uint8_t cmd;
-	
-	assert_param(IS_FLASH_READ_MODE(ReadMode));
-	assert_param(addr + size <= FLASH_MAX_SIZE);
-	assert_param(data);
-	
-	if (size == 0) {
-		return ;
-	}
-	
-	flash_WaitInWritting();
-	
-	if (ReadMode == FLASH_READ_MODE_NORMAL) {
-		cmd = FLASH_CME_RD_NORMAL;
-	} else if (ReadMode == FLASH_READ_MODE_FAST) {
-		cmd = FLASH_CME_RD_FAST;
-	} else if (ReadMode == FLASH_READ_MODE_FAST_DUAL) {
-		cmd = FLASH_CME_RD_FAST_DUAL;
-	} else {
-		cmd = FLASH_CME_RD_FAST_QUAD;
-	}
-	
-	flash_RwReq(cmd, addr, size);
-	
+    uint8_t cmd;
+
+    assert_param(IS_FLASH_READ_MODE(ReadMode));
+    assert_param(addr + size <= FLASH_MAX_SIZE);
+    assert_param(data);
+
+    if (size == 0) {
+        return ;
+    }
+
+    flash_WaitInWritting();
+
+    if (ReadMode == FLASH_READ_MODE_NORMAL) {
+        cmd = FLASH_CME_RD_NORMAL;
+    } else if (ReadMode == FLASH_READ_MODE_FAST) {
+        cmd = FLASH_CME_RD_FAST;
+    } else if (ReadMode == FLASH_READ_MODE_FAST_DUAL) {
+        cmd = FLASH_CME_RD_FAST_DUAL;
+    } else {
+        cmd = FLASH_CME_RD_FAST_QUAD;
+    }
+
+    flash_RwReq(cmd, addr, size);
+
   while (size > 0) {
-		uint16_t count = 0;
-		
+        uint16_t count = 0;
+
     flash_WaitReadFifoNotEmpty();
-	
-	  count = flash_ReadFifo(size, data);
-		size -= count;
-		data += count;
-	}
+
+      count = flash_ReadFifo(size, data);
+        size -= count;
+        data += count;
+    }
 }
 
 void FLASH_Write(uint32_t addr, uint16_t size, uint8_t* data) {
-	assert_param(addr + size <= FLASH_MAX_SIZE);
-	assert_param(data);
-	
-	flash_WaitInWritting();
-	
-	while (size > 0) {
-	  uint16_t count = flash_WritePage(addr, size, data);
+    assert_param(addr + size <= FLASH_MAX_SIZE);
+    assert_param(data);
 
-		addr += count;
-		size -= count;
-		data += count;
-	}
+    flash_WaitInWritting();
+
+    while (size > 0) {
+      uint16_t count = flash_WritePage(addr, size, data);
+
+        addr += count;
+        size -= count;
+        data += count;
+    }
 }
 

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_gpio.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_gpio.c
@@ -1,204 +1,204 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_gpio.c
-	*
-	* @brief    CMEM7 GPIO source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_gpio.c
+    *
+    * @brief    CMEM7 GPIO source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_gpio.h"
 
-#define GPIO_GROUP_GPIO_H 					(GPIO_GROUP_GPIO + 1)
-#define GPIO_GROUP_GPIO_N 					(GPIO_GROUP_GPIO + 2)
+#define GPIO_GROUP_GPIO_H                   (GPIO_GROUP_GPIO + 1)
+#define GPIO_GROUP_GPIO_N                   (GPIO_GROUP_GPIO + 2)
 
 #define IS_INNER_GPIO_GROUP(GROUP)  (((GROUP) == GPIO_GROUP_GPIO) || \
-																			((GROUP) == GPIO_GROUP_GPIO_H) || \
-																			((GROUP) == GPIO_GROUP_GPIO_N))
+                                                                            ((GROUP) == GPIO_GROUP_GPIO_H) || \
+                                                                            ((GROUP) == GPIO_GROUP_GPIO_N))
 
-#define GPIO_PWM_CHANNEL_GPIO_H_9 	(GPIO_PWM_CHANNEL_GPIO_31 + 1)
-#define GPIO_PWM_CHANNEL_GPIO_H_19 	(GPIO_PWM_CHANNEL_GPIO_31 + 2)
-#define GPIO_PWM_CHANNEL_GPIO_H_20 	(GPIO_PWM_CHANNEL_GPIO_31 + 3)
-        
+#define GPIO_PWM_CHANNEL_GPIO_H_9   (GPIO_PWM_CHANNEL_GPIO_31 + 1)
+#define GPIO_PWM_CHANNEL_GPIO_H_19  (GPIO_PWM_CHANNEL_GPIO_31 + 2)
+#define GPIO_PWM_CHANNEL_GPIO_H_20  (GPIO_PWM_CHANNEL_GPIO_31 + 3)
+
 #define IS_INNER_GPIO_PWM_CHANNEL(CHANNEL)  (((CHANNEL) == GPIO_PWM_CHANNEL_GPIO_31) || \
                                        ((CHANNEL) == GPIO_PWM_CHANNEL_GPIO_H_9) || \
                                        ((CHANNEL) == GPIO_PWM_CHANNEL_GPIO_H_19) || \
                                        ((CHANNEL) == GPIO_PWM_CHANNEL_GPIO_H_20))
 static uint32_t gpio_GetClock() {
-	return SYSTEM_CLOCK_FREQ / (1 << (GLOBAL_CTRL->CLK_SEL_0_b.GPIO_CLK + 1));
+    return SYSTEM_CLOCK_FREQ / (1 << (GLOBAL_CTRL->CLK_SEL_0_b.GPIO_CLK + 1));
 }
 
 void GPIO_Init(uint8_t Group, uint32_t PositiveTrigger) {
-	assert_param(IS_GPIO_GROUP(Group));
-	
-	if (Group == GPIO_GROUP_GPIO) {
-	  GPIO->GPIO_POSITIVE_EDGE_INT_TRIGGER = PositiveTrigger;
-	} else if (Group == GPIO_GROUP_GPIO_H) {
-		GPIO->GPIO_H_POSITIVE_EDGE_INT_TRIGGER = PositiveTrigger;
-	} else {
-		GPIO->GPIO_N_POSITIVE_EDGE_INT_TRIGGER = PositiveTrigger;
-	}
+    assert_param(IS_GPIO_GROUP(Group));
+
+    if (Group == GPIO_GROUP_GPIO) {
+      GPIO->GPIO_POSITIVE_EDGE_INT_TRIGGER = PositiveTrigger;
+    } else if (Group == GPIO_GROUP_GPIO_H) {
+        GPIO->GPIO_H_POSITIVE_EDGE_INT_TRIGGER = PositiveTrigger;
+    } else {
+        GPIO->GPIO_N_POSITIVE_EDGE_INT_TRIGGER = PositiveTrigger;
+    }
 }
 
 void GPIO_EnableOutput(uint8_t Group, uint32_t Enable) {
-	assert_param(IS_GPIO_GROUP(Group));
-	
-	if (Group == GPIO_GROUP_GPIO) {
-	  GPIO->GPIO_OE = Enable;
-	} else if (Group == GPIO_GROUP_GPIO_H) {
-		GPIO->GPIO_H_OE = Enable;
-	} else {
-		GPIO->GPIO_N_OE = Enable;
-	}
+    assert_param(IS_GPIO_GROUP(Group));
+
+    if (Group == GPIO_GROUP_GPIO) {
+      GPIO->GPIO_OE = Enable;
+    } else if (Group == GPIO_GROUP_GPIO_H) {
+        GPIO->GPIO_H_OE = Enable;
+    } else {
+        GPIO->GPIO_N_OE = Enable;
+    }
 }
 
 void GPIO_EnableInt(uint8_t Group, uint32_t Enable) {
-	assert_param(IS_GPIO_GROUP(Group));
-	
-	if (Group == GPIO_GROUP_GPIO) {
-	  GPIO->GPIO_INT_MASK = ~Enable;
-	} else if (Group == GPIO_GROUP_GPIO_H) {
-		GPIO->GPIO_H_INT_MASK = ~Enable;
-	} else {
-		GPIO->GPIO_N_INT_MASK = ~Enable;
-	}
+    assert_param(IS_GPIO_GROUP(Group));
+
+    if (Group == GPIO_GROUP_GPIO) {
+      GPIO->GPIO_INT_MASK = ~Enable;
+    } else if (Group == GPIO_GROUP_GPIO_H) {
+        GPIO->GPIO_H_INT_MASK = ~Enable;
+    } else {
+        GPIO->GPIO_N_INT_MASK = ~Enable;
+    }
 }
 
 uint32_t GPIO_GetIntStatus(uint8_t Group) {
-	assert_param(IS_GPIO_GROUP(Group));
-	
-	if (Group == GPIO_GROUP_GPIO) {
-	  return GPIO->GPIO_INT_STATUS;
-	} else if (Group == GPIO_GROUP_GPIO_H) {
-		return GPIO->GPIO_H_INT_STATUS;
-	} 
-	
-	return GPIO->GPIO_N_INT_STATUS;
+    assert_param(IS_GPIO_GROUP(Group));
+
+    if (Group == GPIO_GROUP_GPIO) {
+      return GPIO->GPIO_INT_STATUS;
+    } else if (Group == GPIO_GROUP_GPIO_H) {
+        return GPIO->GPIO_H_INT_STATUS;
+    }
+
+    return GPIO->GPIO_N_INT_STATUS;
 }
 
 void GPIO_ClearInt(uint8_t Group, uint32_t Clear) {
-	assert_param(IS_GPIO_GROUP(Group));
-	
-	if (Group == GPIO_GROUP_GPIO) {
-	  GPIO->GPIO_INT_STATUS = Clear;
-	} else if (Group == GPIO_GROUP_GPIO_H) {
-		GPIO->GPIO_H_INT_STATUS = Clear;
-	} else {
-		GPIO->GPIO_N_INT_STATUS = Clear;
-	}
+    assert_param(IS_GPIO_GROUP(Group));
+
+    if (Group == GPIO_GROUP_GPIO) {
+      GPIO->GPIO_INT_STATUS = Clear;
+    } else if (Group == GPIO_GROUP_GPIO_H) {
+        GPIO->GPIO_H_INT_STATUS = Clear;
+    } else {
+        GPIO->GPIO_N_INT_STATUS = Clear;
+    }
 }
 
 uint32_t GPIO_Read(uint8_t Group) {
   uint32_t data;
-	
-	assert_param(IS_GPIO_GROUP(Group));
-	
-	if (Group == GPIO_GROUP_GPIO) {
-	  data = GPIO->GPIO_IN;
-	} else if (Group == GPIO_GROUP_GPIO_H) {
-		data = GPIO->GPIO_H_IN;
-	} else {
-		data = GPIO->GPIO_N_IN;
-	}
-	
-	return data;
+
+    assert_param(IS_GPIO_GROUP(Group));
+
+    if (Group == GPIO_GROUP_GPIO) {
+      data = GPIO->GPIO_IN;
+    } else if (Group == GPIO_GROUP_GPIO_H) {
+        data = GPIO->GPIO_H_IN;
+    } else {
+        data = GPIO->GPIO_N_IN;
+    }
+
+    return data;
 }
 
 void GPIO_Write(uint8_t Group, uint32_t Unmask, uint32_t data) {
-	assert_param(IS_GPIO_GROUP(Group));
-	
-	if (Group == GPIO_GROUP_GPIO) {
-		GPIO->GPIO_OUT_UNMASK = Unmask;
-	  GPIO->GPIO_OUT_DATA = data;
-	} else if (Group == GPIO_GROUP_GPIO_H) {
-		GPIO->GPIO_H_OUT_UNMASK = Unmask;
-	  GPIO->GPIO_H_OUT_DATA = data;
-	} else {
-		GPIO->GPIO_N_OUT_UNMASK = Unmask;
-	  GPIO->GPIO_N_OUT_DATA = data;
-	}
+    assert_param(IS_GPIO_GROUP(Group));
+
+    if (Group == GPIO_GROUP_GPIO) {
+        GPIO->GPIO_OUT_UNMASK = Unmask;
+      GPIO->GPIO_OUT_DATA = data;
+    } else if (Group == GPIO_GROUP_GPIO_H) {
+        GPIO->GPIO_H_OUT_UNMASK = Unmask;
+      GPIO->GPIO_H_OUT_DATA = data;
+    } else {
+        GPIO->GPIO_N_OUT_UNMASK = Unmask;
+      GPIO->GPIO_N_OUT_DATA = data;
+    }
 }
 
 void GPIO_InitPwm(uint8_t Channel, uint32_t HighLevelNanoSecond, uint32_t LowLevelNanoSecond) {
-	uint16_t lowTick, highTick;
-	
-	assert_param(IS_GPIO_PWM_CHANNEL(Channel));
-	
-	lowTick = LowLevelNanoSecond * (gpio_GetClock() / 1000000) / 1000;
-	highTick = HighLevelNanoSecond * (gpio_GetClock() / 1000000) / 1000;
-	lowTick = (lowTick < 1) ? lowTick : lowTick - 1;
-	highTick = (highTick < 1) ? highTick : highTick - 1;
-	
-	if (Channel == GPIO_PWM_CHANNEL_GPIO_31) {
-		GPIO->PWM_OUT0_LEN_b.LOW_LEVEL_TICK = lowTick; 
-		GPIO->PWM_OUT0_LEN_b.HIGH_LEVEL_TICK = highTick; 
-	} else if (Channel == GPIO_PWM_CHANNEL_GPIO_H_9) {
-		GPIO->PWM_OUT1_LEN_b.LOW_LEVEL_TICK = lowTick; 
-		GPIO->PWM_OUT1_LEN_b.HIGH_LEVEL_TICK = highTick; 
-	} else if (Channel == GPIO_PWM_CHANNEL_GPIO_H_19) {
-		GPIO->PWM_OUT2_LEN_b.LOW_LEVEL_TICK = lowTick; 
-		GPIO->PWM_OUT2_LEN_b.HIGH_LEVEL_TICK = highTick; 
+    uint16_t lowTick, highTick;
+
+    assert_param(IS_GPIO_PWM_CHANNEL(Channel));
+
+    lowTick = LowLevelNanoSecond * (gpio_GetClock() / 1000000) / 1000;
+    highTick = HighLevelNanoSecond * (gpio_GetClock() / 1000000) / 1000;
+    lowTick = (lowTick < 1) ? lowTick : lowTick - 1;
+    highTick = (highTick < 1) ? highTick : highTick - 1;
+
+    if (Channel == GPIO_PWM_CHANNEL_GPIO_31) {
+        GPIO->PWM_OUT0_LEN_b.LOW_LEVEL_TICK = lowTick;
+        GPIO->PWM_OUT0_LEN_b.HIGH_LEVEL_TICK = highTick;
+    } else if (Channel == GPIO_PWM_CHANNEL_GPIO_H_9) {
+        GPIO->PWM_OUT1_LEN_b.LOW_LEVEL_TICK = lowTick;
+        GPIO->PWM_OUT1_LEN_b.HIGH_LEVEL_TICK = highTick;
+    } else if (Channel == GPIO_PWM_CHANNEL_GPIO_H_19) {
+        GPIO->PWM_OUT2_LEN_b.LOW_LEVEL_TICK = lowTick;
+        GPIO->PWM_OUT2_LEN_b.HIGH_LEVEL_TICK = highTick;
   } else {
-		GPIO->PWM_OUT3_LEN_b.LOW_LEVEL_TICK = lowTick; 
-		GPIO->PWM_OUT3_LEN_b.HIGH_LEVEL_TICK = highTick; 
-	}
+        GPIO->PWM_OUT3_LEN_b.LOW_LEVEL_TICK = lowTick;
+        GPIO->PWM_OUT3_LEN_b.HIGH_LEVEL_TICK = highTick;
+    }
 }
 
 void GPIO_EnablePwm(uint8_t Channel, BOOL Enable) {
-	assert_param(IS_GPIO_PWM_CHANNEL(Channel));
-	
-	if (Channel == GPIO_PWM_CHANNEL_GPIO_31) {
-		GPIO->PWM_OUT_EN_b.GPIO_31 = Enable; 
-		GPIO->PWM_OUT_SEL_b.GPIO_31 = Enable; 
-	} else if (Channel == GPIO_PWM_CHANNEL_GPIO_H_9) {
-		GPIO->PWM_OUT_EN_b.GPIO_H_9 = Enable; 
-		GPIO->PWM_OUT_SEL_b.GPIO_H_9 = Enable;
-	} else if (Channel == GPIO_PWM_CHANNEL_GPIO_H_19) {
-		GPIO->PWM_OUT_EN_b.GPIO_H_19 = Enable;
-	GPIO->PWM_OUT_SEL_b.GPIO_H_19 = Enable;		
+    assert_param(IS_GPIO_PWM_CHANNEL(Channel));
+
+    if (Channel == GPIO_PWM_CHANNEL_GPIO_31) {
+        GPIO->PWM_OUT_EN_b.GPIO_31 = Enable;
+        GPIO->PWM_OUT_SEL_b.GPIO_31 = Enable;
+    } else if (Channel == GPIO_PWM_CHANNEL_GPIO_H_9) {
+        GPIO->PWM_OUT_EN_b.GPIO_H_9 = Enable;
+        GPIO->PWM_OUT_SEL_b.GPIO_H_9 = Enable;
+    } else if (Channel == GPIO_PWM_CHANNEL_GPIO_H_19) {
+        GPIO->PWM_OUT_EN_b.GPIO_H_19 = Enable;
+    GPIO->PWM_OUT_SEL_b.GPIO_H_19 = Enable;
   } else {
-		GPIO->PWM_OUT_EN_b.GPIO_H_20 = Enable; 
-		GPIO->PWM_OUT_SEL_b.GPIO_H_20 = Enable;
-	}
+        GPIO->PWM_OUT_EN_b.GPIO_H_20 = Enable;
+        GPIO->PWM_OUT_SEL_b.GPIO_H_20 = Enable;
+    }
 }
 
 /**
    xjf 20150324
-   
+
 **/
 void GPIO_SetBits(uint32_t mask)
 {
   static uint32_t g_GPIO_OUT_UNMASK;
   static uint32_t g_GPIO_OUT_DATA;
   static uint32_t g_GPIO_OE;
-	
-	g_GPIO_OUT_UNMASK = GPIO->GPIO_OUT_UNMASK ;
+
+    g_GPIO_OUT_UNMASK = GPIO->GPIO_OUT_UNMASK ;
   g_GPIO_OUT_DATA   = GPIO->GPIO_OUT_DATA   ;
-	g_GPIO_OE         = GPIO->GPIO_OE ;
-  g_GPIO_OUT_UNMASK |=mask;  
+    g_GPIO_OE         = GPIO->GPIO_OE ;
+  g_GPIO_OUT_UNMASK |=mask;
   g_GPIO_OE         |=mask;
-	g_GPIO_OUT_DATA   |=mask;
-	
-	GPIO->GPIO_OUT_UNMASK =g_GPIO_OUT_UNMASK ;
+    g_GPIO_OUT_DATA   |=mask;
+
+    GPIO->GPIO_OUT_UNMASK =g_GPIO_OUT_UNMASK ;
   GPIO->GPIO_OUT_DATA   =g_GPIO_OUT_DATA ;
-	GPIO->GPIO_OE         =g_GPIO_OE       ;
+    GPIO->GPIO_OE         =g_GPIO_OE       ;
 }
 
 void GPIO_clrBits(uint32_t mask)
@@ -206,17 +206,17 @@ void GPIO_clrBits(uint32_t mask)
   static uint32_t g_GPIO_OUT_UNMASK;
   static uint32_t g_GPIO_OUT_DATA;
   static uint32_t g_GPIO_OE;
-	
-	g_GPIO_OUT_UNMASK = GPIO->GPIO_OUT_UNMASK ;
+
+    g_GPIO_OUT_UNMASK = GPIO->GPIO_OUT_UNMASK ;
   g_GPIO_OUT_DATA   = GPIO->GPIO_OUT_DATA   ;
-	g_GPIO_OE         = GPIO->GPIO_OE ;
-  g_GPIO_OUT_UNMASK |=mask;  
+    g_GPIO_OE         = GPIO->GPIO_OE ;
+  g_GPIO_OUT_UNMASK |=mask;
   g_GPIO_OE         |=mask;
-	g_GPIO_OUT_DATA   &=(~ mask);
-	
-	GPIO->GPIO_OUT_UNMASK =g_GPIO_OUT_UNMASK ;
+    g_GPIO_OUT_DATA   &=(~ mask);
+
+    GPIO->GPIO_OUT_UNMASK =g_GPIO_OUT_UNMASK ;
   GPIO->GPIO_OUT_DATA   =g_GPIO_OUT_DATA ;
-	GPIO->GPIO_OE         =g_GPIO_OE       ;
+    GPIO->GPIO_OE         =g_GPIO_OE       ;
 }
 
 uint32_t GPIO_getBits(uint32_t mask)
@@ -224,33 +224,33 @@ uint32_t GPIO_getBits(uint32_t mask)
   static uint32_t g_GPIO_OUT_UNMASK;
   //static uint32_t g_GPIO_OUT_DATA;
   static uint32_t g_GPIO_OE;
-	
-	uint32_t  get_delay = 0;
-	uint32_t  saved_mask;
-	
-	saved_mask=mask;
-	
-	g_GPIO_OUT_UNMASK      = GPIO->GPIO_OUT_UNMASK ;
-	g_GPIO_OE              = GPIO->GPIO_OE ;
-  g_GPIO_OUT_UNMASK     &=(~mask);  
+
+    uint32_t  get_delay = 0;
+    uint32_t  saved_mask;
+
+    saved_mask=mask;
+
+    g_GPIO_OUT_UNMASK      = GPIO->GPIO_OUT_UNMASK ;
+    g_GPIO_OE              = GPIO->GPIO_OE ;
+  g_GPIO_OUT_UNMASK     &=(~mask);
   g_GPIO_OE             &=(~mask);
-	GPIO->GPIO_OUT_UNMASK  =g_GPIO_OUT_UNMASK ;
-	GPIO->GPIO_OE          =g_GPIO_OE       ;
-	for(get_delay=0;get_delay<100;get_delay++)
-	  {
+    GPIO->GPIO_OUT_UNMASK  =g_GPIO_OUT_UNMASK ;
+    GPIO->GPIO_OE          =g_GPIO_OE       ;
+    for(get_delay=0;get_delay<100;get_delay++)
+      {
     }
-	//get_delay=(GPIO->GPIO_IN)&saved_mask;
-  if(((GPIO->GPIO_IN)&saved_mask)==saved_mask)	
-	   {
-			 return(1);
-	    }		
-	else
-   	{
-			return(0);
+    //get_delay=(GPIO->GPIO_IN)&saved_mask;
+  if(((GPIO->GPIO_IN)&saved_mask)==saved_mask)
+       {
+             return(1);
+        }
+    else
+    {
+            return(0);
     }
-	
+
 }
 /**
    xjf 20150324
-   
+
 **/

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_i2c.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_i2c.c
@@ -43,6 +43,7 @@ typedef struct {
 
 static uint32_t i2c_GetClock(I2C0_Type* I2Cx) {
 	uint32_t dividor;
+	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
 
 	if ((uint32_t)I2Cx == (uint32_t)I2C0) {
 		dividor = GLOBAL_CTRL->CLK_SEL_0_b.I2C0_CLK;
@@ -54,7 +55,7 @@ static uint32_t i2c_GetClock(I2C0_Type* I2Cx) {
 }
 
 static uint16_t i2c_NormalizeAddr(I2C0_Type* I2Cx, uint16_t addr) {
-  assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+  	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
 	
 	if (I2Cx->CTRL_b.MODE == I2C_Mode_Master) {
 		if (I2Cx->CTRL_b.MASTER_ADDR_WIDTH == I2C_ADDR_WIDTH_7BIT) {
@@ -97,12 +98,12 @@ void I2C_Init(I2C0_Type* I2Cx, I2C_InitTypeDef* I2C_Init) {
 	
 	I2Cx->CTRL_b.MODE = I2C_Init->I2C_Mode;
 	if (I2Cx->CTRL_b.MODE == I2C_Mode_Master) {
-	  I2Cx->CTRL_b.MASTER_ADDR_WIDTH = I2C_Init->I2C_AddressWidth;
+	  	I2Cx->CTRL_b.MASTER_ADDR_WIDTH = I2C_Init->I2C_AddressWidth;
 		I2Cx->TAR_b.START_BYTE = TRUE;
 		I2Cx->TAR_b.ADDR10 = i2c_NormalizeAddr(I2Cx, I2C_Init->I2C_Address);
 	}
 	if (I2Cx->CTRL_b.MODE == I2C_Mode_Slave) {
-	  I2Cx->CTRL_b.SLAVE_ADDR_WIDTH = I2C_Init->I2C_AddressWidth;
+	  	I2Cx->CTRL_b.SLAVE_ADDR_WIDTH = I2C_Init->I2C_AddressWidth;
 		I2Cx->SAR_b.ADDR10 = i2c_NormalizeAddr(I2Cx, I2C_Init->I2C_Address);
 	}
 	
@@ -116,13 +117,13 @@ void I2C_Init(I2C0_Type* I2Cx, I2C_InitTypeDef* I2C_Init) {
 		  i2c_GetClock(I2Cx) / I2C_Init->timing->I2C_Freq / 2;
 		I2Cx->SCL_CNT_b.LOW_LEVEL_TICK = 
 		  i2c_GetClock(I2Cx) / I2C_Init->timing->I2C_Freq / 2;
-	  I2Cx->SDA_SETUP_b.TSU_DAT = ((uint64_t)I2C_Init->timing->I2C_TsuDat) * 
+	  	I2Cx->SDA_SETUP_b.TSU_DAT = ((uint64_t)I2C_Init->timing->I2C_TsuDat) * 
 		  i2c_GetClock(I2Cx) / 1000000000;
 		I2Cx->SDA_SETUP_b.TSETUP = ((uint64_t)I2C_Init->timing->I2C_Tsetup) * 
 		  i2c_GetClock(I2Cx) / 1000000000;
 		I2Cx->TSU_STA_SETUP_b.TBUF = ((uint64_t)I2C_Init->timing->I2C_Tbuf) * 
 		  i2c_GetClock(I2Cx) / 1000000000;
-	  I2Cx->TSU_STA_SETUP_b.TSU_STA = ((uint64_t)I2C_Init->timing->I2C_TsuSta) * 
+	  	I2Cx->TSU_STA_SETUP_b.TSU_STA = ((uint64_t)I2C_Init->timing->I2C_TsuSta) * 
 		  i2c_GetClock(I2Cx) / 1000000000;
 		I2Cx->TSU_STA_SETUP_b.SDA_FILTER_EN = I2C_Init->timing->I2C_SdaFilterEn;
 		I2Cx->TSU_STA_SETUP_b.SDA_FILTER_CNT = I2C_Init->timing->I2C_SdaFilterSpike;
@@ -134,14 +135,14 @@ void I2C_Init(I2C0_Type* I2Cx, I2C_InitTypeDef* I2C_Init) {
 void I2C_Enable(I2C0_Type* I2Cx, BOOL enable) {
 	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
 	
-  I2Cx->ENABLE_b.EN = enable;
+  	I2Cx->ENABLE_b.EN = enable;
 }
 
 void I2C_EnableInt(I2C0_Type* I2Cx, uint32_t Int, BOOL enable) {
-  assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+  	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
 	assert_param(IS_I2C_INT(Int));
 	
-  if (enable) {
+  	if (enable) {
 	  I2Cx->INT_MASK &= ~Int;
 	} else {
 		I2Cx->INT_MASK |= Int;

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_i2c.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_i2c.c
@@ -1,322 +1,322 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_i2c.c
-	*
-	* @brief    CMEM7 I2C source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_i2c.c
+    *
+    * @brief    CMEM7 I2C source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_i2c.h"
 
-#define I2C_INNER_INT_ALL				0x3FF
+#define I2C_INNER_INT_ALL               0x3FF
 
 typedef struct {
-	union {
-    uint32_t  DATA_CMD;                                                           
-    
+    union {
+    uint32_t  DATA_CMD;
+
     struct {
-      uint32_t  DATA       :  8;                                                                   
-      uint32_t  RD_CMD     :  1;              
-      uint32_t  WR_CMD     :  1;                
-      uint32_t  WR_RD_CMD  :  1;               
-    } DATA_CMD_b;                                   
+      uint32_t  DATA       :  8;
+      uint32_t  RD_CMD     :  1;
+      uint32_t  WR_CMD     :  1;
+      uint32_t  WR_RD_CMD  :  1;
+    } DATA_CMD_b;
   } INNER;
 } I2C_INNER_DATA_CMD;
 
 static uint32_t i2c_GetClock(I2C0_Type* I2Cx) {
-	uint32_t dividor;
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+    uint32_t dividor;
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
 
-	if ((uint32_t)I2Cx == (uint32_t)I2C0) {
-		dividor = GLOBAL_CTRL->CLK_SEL_0_b.I2C0_CLK;
-	} else if ((uint32_t)I2Cx == (uint32_t)I2C1) {
-		dividor = GLOBAL_CTRL->CLK_SEL_0_b.I2C1_CLK;
-	} 
-	
-	return SYSTEM_CLOCK_FREQ / (1 << (dividor + 1));
+    if ((uint32_t)I2Cx == (uint32_t)I2C0) {
+        dividor = GLOBAL_CTRL->CLK_SEL_0_b.I2C0_CLK;
+    } else if ((uint32_t)I2Cx == (uint32_t)I2C1) {
+        dividor = GLOBAL_CTRL->CLK_SEL_0_b.I2C1_CLK;
+    }
+
+    return SYSTEM_CLOCK_FREQ / (1 << (dividor + 1));
 }
 
 static uint16_t i2c_NormalizeAddr(I2C0_Type* I2Cx, uint16_t addr) {
-  	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	
-	if (I2Cx->CTRL_b.MODE == I2C_Mode_Master) {
-		if (I2Cx->CTRL_b.MASTER_ADDR_WIDTH == I2C_ADDR_WIDTH_7BIT) {
-			addr &= 0x007F;
-		} else {
-			addr &= 0x3FF;
-		}
-	}
-	
-	if (I2Cx->CTRL_b.MODE == I2C_Mode_Slave) {
-		if (I2Cx->CTRL_b.SLAVE_ADDR_WIDTH == I2C_ADDR_WIDTH_7BIT) {
-			addr &= 0x007F;
-		} else {
-			addr &= 0x3FF;
-		}
-	}
-	
-	return addr;
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+
+    if (I2Cx->CTRL_b.MODE == I2C_Mode_Master) {
+        if (I2Cx->CTRL_b.MASTER_ADDR_WIDTH == I2C_ADDR_WIDTH_7BIT) {
+            addr &= 0x007F;
+        } else {
+            addr &= 0x3FF;
+        }
+    }
+
+    if (I2Cx->CTRL_b.MODE == I2C_Mode_Slave) {
+        if (I2Cx->CTRL_b.SLAVE_ADDR_WIDTH == I2C_ADDR_WIDTH_7BIT) {
+            addr &= 0x007F;
+        } else {
+            addr &= 0x3FF;
+        }
+    }
+
+    return addr;
 }
 
 static void i2c_ReadClear(uint32_t bit) {
-	uint32_t tmp;
-	tmp = bit;
-	tmp = tmp;	
+    uint32_t tmp;
+    tmp = bit;
+    tmp = tmp;
 }
-		
+
 void I2C_Init(I2C0_Type* I2Cx, I2C_InitTypeDef* I2C_Init) {
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	assert_param(I2C_Init);
-	assert_param(IS_I2C_MODE(I2C_Init->I2C_Mode));
-	assert_param(IS_I2C_ADDR_WIDTH(I2C_Init->I2C_AddressWidth));
-	
-	// reset
-	I2Cx->ENABLE_b.RESET = FALSE;
-	I2Cx->ENABLE_b.RESET = TRUE;
-	
-	// clear interrupt
-	I2Cx->INT_MASK = I2C_INNER_INT_ALL;
-	i2c_ReadClear(I2Cx->CLR_ALL_INT_b.CLEAR);
-	
-	I2Cx->CTRL_b.MODE = I2C_Init->I2C_Mode;
-	if (I2Cx->CTRL_b.MODE == I2C_Mode_Master) {
-	  	I2Cx->CTRL_b.MASTER_ADDR_WIDTH = I2C_Init->I2C_AddressWidth;
-		I2Cx->TAR_b.START_BYTE = TRUE;
-		I2Cx->TAR_b.ADDR10 = i2c_NormalizeAddr(I2Cx, I2C_Init->I2C_Address);
-	}
-	if (I2Cx->CTRL_b.MODE == I2C_Mode_Slave) {
-	  	I2Cx->CTRL_b.SLAVE_ADDR_WIDTH = I2C_Init->I2C_AddressWidth;
-		I2Cx->SAR_b.ADDR10 = i2c_NormalizeAddr(I2Cx, I2C_Init->I2C_Address);
-	}
-	
-	I2Cx->RX_TL_b.THRESHOLD = 0;
-	I2Cx->TX_TL_b.THRESHOLD = 0;
-	
-	I2Cx->SLAVE_NACK_b.NACK = FALSE;
-	
-	if (I2C_Init->timing) {
-		I2Cx->SCL_CNT_b.HIGH_LEVEL_TICK = 
-		  i2c_GetClock(I2Cx) / I2C_Init->timing->I2C_Freq / 2;
-		I2Cx->SCL_CNT_b.LOW_LEVEL_TICK = 
-		  i2c_GetClock(I2Cx) / I2C_Init->timing->I2C_Freq / 2;
-	  	I2Cx->SDA_SETUP_b.TSU_DAT = ((uint64_t)I2C_Init->timing->I2C_TsuDat) * 
-		  i2c_GetClock(I2Cx) / 1000000000;
-		I2Cx->SDA_SETUP_b.TSETUP = ((uint64_t)I2C_Init->timing->I2C_Tsetup) * 
-		  i2c_GetClock(I2Cx) / 1000000000;
-		I2Cx->TSU_STA_SETUP_b.TBUF = ((uint64_t)I2C_Init->timing->I2C_Tbuf) * 
-		  i2c_GetClock(I2Cx) / 1000000000;
-	  	I2Cx->TSU_STA_SETUP_b.TSU_STA = ((uint64_t)I2C_Init->timing->I2C_TsuSta) * 
-		  i2c_GetClock(I2Cx) / 1000000000;
-		I2Cx->TSU_STA_SETUP_b.SDA_FILTER_EN = I2C_Init->timing->I2C_SdaFilterEn;
-		I2Cx->TSU_STA_SETUP_b.SDA_FILTER_CNT = I2C_Init->timing->I2C_SdaFilterSpike;
-		I2Cx->TSU_STA_SETUP_b.SCL_FILTER_EN = I2C_Init->timing->I2C_SclFilterEn;
-		I2Cx->TSU_STA_SETUP_b.SCL_FILTER_CNT = I2C_Init->timing->I2C_SclFilterSpike;
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+    assert_param(I2C_Init);
+    assert_param(IS_I2C_MODE(I2C_Init->I2C_Mode));
+    assert_param(IS_I2C_ADDR_WIDTH(I2C_Init->I2C_AddressWidth));
+
+    // reset
+    I2Cx->ENABLE_b.RESET = FALSE;
+    I2Cx->ENABLE_b.RESET = TRUE;
+
+    // clear interrupt
+    I2Cx->INT_MASK = I2C_INNER_INT_ALL;
+    i2c_ReadClear(I2Cx->CLR_ALL_INT_b.CLEAR);
+
+    I2Cx->CTRL_b.MODE = I2C_Init->I2C_Mode;
+    if (I2Cx->CTRL_b.MODE == I2C_Mode_Master) {
+        I2Cx->CTRL_b.MASTER_ADDR_WIDTH = I2C_Init->I2C_AddressWidth;
+        I2Cx->TAR_b.START_BYTE = TRUE;
+        I2Cx->TAR_b.ADDR10 = i2c_NormalizeAddr(I2Cx, I2C_Init->I2C_Address);
+    }
+    if (I2Cx->CTRL_b.MODE == I2C_Mode_Slave) {
+        I2Cx->CTRL_b.SLAVE_ADDR_WIDTH = I2C_Init->I2C_AddressWidth;
+        I2Cx->SAR_b.ADDR10 = i2c_NormalizeAddr(I2Cx, I2C_Init->I2C_Address);
+    }
+
+    I2Cx->RX_TL_b.THRESHOLD = 0;
+    I2Cx->TX_TL_b.THRESHOLD = 0;
+
+    I2Cx->SLAVE_NACK_b.NACK = FALSE;
+
+    if (I2C_Init->timing) {
+        I2Cx->SCL_CNT_b.HIGH_LEVEL_TICK =
+          i2c_GetClock(I2Cx) / I2C_Init->timing->I2C_Freq / 2;
+        I2Cx->SCL_CNT_b.LOW_LEVEL_TICK =
+          i2c_GetClock(I2Cx) / I2C_Init->timing->I2C_Freq / 2;
+        I2Cx->SDA_SETUP_b.TSU_DAT = ((uint64_t)I2C_Init->timing->I2C_TsuDat) *
+          i2c_GetClock(I2Cx) / 1000000000;
+        I2Cx->SDA_SETUP_b.TSETUP = ((uint64_t)I2C_Init->timing->I2C_Tsetup) *
+          i2c_GetClock(I2Cx) / 1000000000;
+        I2Cx->TSU_STA_SETUP_b.TBUF = ((uint64_t)I2C_Init->timing->I2C_Tbuf) *
+          i2c_GetClock(I2Cx) / 1000000000;
+        I2Cx->TSU_STA_SETUP_b.TSU_STA = ((uint64_t)I2C_Init->timing->I2C_TsuSta) *
+          i2c_GetClock(I2Cx) / 1000000000;
+        I2Cx->TSU_STA_SETUP_b.SDA_FILTER_EN = I2C_Init->timing->I2C_SdaFilterEn;
+        I2Cx->TSU_STA_SETUP_b.SDA_FILTER_CNT = I2C_Init->timing->I2C_SdaFilterSpike;
+        I2Cx->TSU_STA_SETUP_b.SCL_FILTER_EN = I2C_Init->timing->I2C_SclFilterEn;
+        I2Cx->TSU_STA_SETUP_b.SCL_FILTER_CNT = I2C_Init->timing->I2C_SclFilterSpike;
   }
 }
 
 void I2C_Enable(I2C0_Type* I2Cx, BOOL enable) {
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	
-  	I2Cx->ENABLE_b.EN = enable;
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+
+    I2Cx->ENABLE_b.EN = enable;
 }
 
 void I2C_EnableInt(I2C0_Type* I2Cx, uint32_t Int, BOOL enable) {
-  	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	assert_param(IS_I2C_INT(Int));
-	
-  	if (enable) {
-	  I2Cx->INT_MASK &= ~Int;
-	} else {
-		I2Cx->INT_MASK |= Int;
-	}
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+    assert_param(IS_I2C_INT(Int));
+
+    if (enable) {
+      I2Cx->INT_MASK &= ~Int;
+    } else {
+        I2Cx->INT_MASK |= Int;
+    }
 }
 
 BOOL I2C_GetIntStatus(I2C0_Type* I2Cx, uint32_t Int) {
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	assert_param(IS_I2C_INT(Int));
-	
-	if (0 != (I2Cx->INT_STATUS & Int)) {
-		return TRUE;
-	}
-	
-	return FALSE;
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+    assert_param(IS_I2C_INT(Int));
+
+    if (0 != (I2Cx->INT_STATUS & Int)) {
+        return TRUE;
+    }
+
+    return FALSE;
 }
 void I2C_ClearInt(I2C0_Type* I2Cx, uint32_t Int) {
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	assert_param(IS_I2C_INT(Int));
-	
-	if (Int == I2C_INT_RX_FIFO_NOT_EMPTY) {
-		// It can't be clear by sw but read data
-	} 
-	
-	if (Int == I2C_INT_RD_REQUEST) {
-		i2c_ReadClear(I2Cx->CLR_RD_REQ_b.CLEAR);
-	} 
-	
-	if (Int == I2C_INT_TX_ABORT) {
-		i2c_ReadClear(I2Cx->CLR_TX_ABRT_b.CLEAR);
-	} 
-	
-	if (Int == I2C_INT_RX_DONE) {
-		i2c_ReadClear(I2Cx->CLR_RX_DONE_b.CLEAR);
-	} 
-	
-	if (Int == I2C_INT_TX_DONE) {
-		i2c_ReadClear(I2Cx->CLR_TX_DONE_b.CLEAR);
-	} 
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+    assert_param(IS_I2C_INT(Int));
+
+    if (Int == I2C_INT_RX_FIFO_NOT_EMPTY) {
+        // It can't be clear by sw but read data
+    }
+
+    if (Int == I2C_INT_RD_REQUEST) {
+        i2c_ReadClear(I2Cx->CLR_RD_REQ_b.CLEAR);
+    }
+
+    if (Int == I2C_INT_TX_ABORT) {
+        i2c_ReadClear(I2Cx->CLR_TX_ABRT_b.CLEAR);
+    }
+
+    if (Int == I2C_INT_RX_DONE) {
+        i2c_ReadClear(I2Cx->CLR_RX_DONE_b.CLEAR);
+    }
+
+    if (Int == I2C_INT_TX_DONE) {
+        i2c_ReadClear(I2Cx->CLR_TX_DONE_b.CLEAR);
+    }
 }
 
 BOOL I2C_GetStatus(I2C0_Type* I2Cx, uint32_t Status) {
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	assert_param(IS_I2C_STATUS(Status));
-	
-	if (0 != (I2Cx->STATUS & Status)) {
-		return TRUE;
-	}
-	
-	return FALSE;
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+    assert_param(IS_I2C_STATUS(Status));
+
+    if (0 != (I2Cx->STATUS & Status)) {
+        return TRUE;
+    }
+
+    return FALSE;
 }
 
 void I2C_ClearStatus(I2C0_Type* I2Cx, uint32_t Status) {
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	assert_param(IS_I2C_STATUS(Status));
-	
-	if (Status & I2C_STATUS_RX_FIFO_NOT_EMPTY) {
-		// It can't be clear by sw but read
-	} 
-	
-	if (Status & I2C_STATUS_RD_REQUEST) {
-		i2c_ReadClear(I2Cx->CLR_RD_REQ_b.CLEAR);
-	} 
-	
-	if (Status & I2C_STATUS_TX_ABORT) {
-		i2c_ReadClear(I2Cx->CLR_TX_ABRT_b.CLEAR);
-	} 
-	
-	if (Status & I2C_STATUS_RX_DONE) {
-		i2c_ReadClear(I2Cx->CLR_RX_DONE_b.CLEAR);
-	} 
-	
-	if (Status & I2C_STATUS_TX_DONE) {
-		i2c_ReadClear(I2Cx->CLR_TX_DONE_b.CLEAR);
-	} 
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+    assert_param(IS_I2C_STATUS(Status));
+
+    if (Status & I2C_STATUS_RX_FIFO_NOT_EMPTY) {
+        // It can't be clear by sw but read
+    }
+
+    if (Status & I2C_STATUS_RD_REQUEST) {
+        i2c_ReadClear(I2Cx->CLR_RD_REQ_b.CLEAR);
+    }
+
+    if (Status & I2C_STATUS_TX_ABORT) {
+        i2c_ReadClear(I2Cx->CLR_TX_ABRT_b.CLEAR);
+    }
+
+    if (Status & I2C_STATUS_RX_DONE) {
+        i2c_ReadClear(I2Cx->CLR_RX_DONE_b.CLEAR);
+    }
+
+    if (Status & I2C_STATUS_TX_DONE) {
+        i2c_ReadClear(I2Cx->CLR_TX_DONE_b.CLEAR);
+    }
 }
 
 BOOL I2C_MasterReadReq(I2C0_Type* I2Cx, uint8_t size) {
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	
-	if (!I2Cx->ENABLE_b.EN || I2Cx->STATUS_b.BUSY) {
-		return FALSE;
-	}
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
 
-	if (I2Cx->CTRL_b.MODE == I2C_Mode_Slave) {
-	  return FALSE;
-	}
-	
-	if (size == 0) {
-		return FALSE;
-	}
-	
-	I2Cx->WRITE_READ_CNT_b.RD_BYTE_CNT = size;
-	if (size != 0) {
+    if (!I2Cx->ENABLE_b.EN || I2Cx->STATUS_b.BUSY) {
+        return FALSE;
+    }
+
+    if (I2Cx->CTRL_b.MODE == I2C_Mode_Slave) {
+      return FALSE;
+    }
+
+    if (size == 0) {
+        return FALSE;
+    }
+
+    I2Cx->WRITE_READ_CNT_b.RD_BYTE_CNT = size;
+    if (size != 0) {
     I2C_INNER_DATA_CMD inner;
-    
+
     inner.INNER.DATA_CMD_b.DATA = 0;
-		inner.INNER.DATA_CMD_b.RD_CMD = TRUE;
-		inner.INNER.DATA_CMD_b.WR_CMD = FALSE;
-		inner.INNER.DATA_CMD_b.WR_RD_CMD = FALSE;
-		
-		I2Cx->DATA_CMD = inner.INNER.DATA_CMD;
-	}
-	
-	return TRUE;
+        inner.INNER.DATA_CMD_b.RD_CMD = TRUE;
+        inner.INNER.DATA_CMD_b.WR_CMD = FALSE;
+        inner.INNER.DATA_CMD_b.WR_RD_CMD = FALSE;
+
+        I2Cx->DATA_CMD = inner.INNER.DATA_CMD;
+    }
+
+    return TRUE;
 }
 
 uint8_t I2C_ReadFifo(I2C0_Type* I2Cx, uint8_t size, uint8_t* data) {
-	uint8_t count;
-	
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	assert_param(data);
-	
-	if (!I2Cx->ENABLE_b.EN) {
-		return 0;
-	}
-	
-	count = 0;
-	while (I2Cx->STATUS_b.RX_FIFO_NOT_EMPTY && count < size) {
-		*(data + count++) = I2Cx->DATA_CMD_b.DATA;
-	}
-	
-	return count;
+    uint8_t count;
+
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+    assert_param(data);
+
+    if (!I2Cx->ENABLE_b.EN) {
+        return 0;
+    }
+
+    count = 0;
+    while (I2Cx->STATUS_b.RX_FIFO_NOT_EMPTY && count < size) {
+        *(data + count++) = I2Cx->DATA_CMD_b.DATA;
+    }
+
+    return count;
 }
 
 BOOL I2C_WriteReq(I2C0_Type* I2Cx, uint8_t size, uint8_t firstData) {
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	
-	if (!I2Cx->ENABLE_b.EN || I2Cx->STATUS_b.BUSY) {
-		return FALSE;
-	}
-	
-	if (size == 0) {
-		return FALSE;
-	}
-	
-	I2Cx->WRITE_READ_CNT_b.WR_BYTE_CNT = size;
-	if (size != 0) {
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+
+    if (!I2Cx->ENABLE_b.EN || I2Cx->STATUS_b.BUSY) {
+        return FALSE;
+    }
+
+    if (size == 0) {
+        return FALSE;
+    }
+
+    I2Cx->WRITE_READ_CNT_b.WR_BYTE_CNT = size;
+    if (size != 0) {
     I2C_INNER_DATA_CMD inner;
-    
-    inner.INNER.DATA_CMD_b.DATA = firstData	;
-		inner.INNER.DATA_CMD_b.RD_CMD = FALSE;
-		inner.INNER.DATA_CMD_b.WR_CMD = 
-		  (I2Cx->CTRL_b.MODE == I2C_Mode_Slave) ? FALSE : TRUE;
-		inner.INNER.DATA_CMD_b.WR_RD_CMD = FALSE;
 
-		I2Cx->DATA_CMD = inner.INNER.DATA_CMD;
-	}
+    inner.INNER.DATA_CMD_b.DATA = firstData ;
+        inner.INNER.DATA_CMD_b.RD_CMD = FALSE;
+        inner.INNER.DATA_CMD_b.WR_CMD =
+          (I2Cx->CTRL_b.MODE == I2C_Mode_Slave) ? FALSE : TRUE;
+        inner.INNER.DATA_CMD_b.WR_RD_CMD = FALSE;
 
-	return TRUE;
+        I2Cx->DATA_CMD = inner.INNER.DATA_CMD;
+    }
+
+    return TRUE;
 }
 
 uint8_t I2C_WriteFifo(I2C0_Type* I2Cx, uint8_t size, uint8_t* data) {
-	uint8_t count;
-	
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	assert_param(data);
-	
-	if (!I2Cx->ENABLE_b.EN) {
-		return 0;
-	}
+    uint8_t count;
 
-	count = 0;
-	while (I2Cx->STATUS_b.TX_FIFO_NOT_FULL && count < size) {
-	  I2Cx->DATA_CMD_b.DATA = *(data + count++);
-	}
-	
-	return count;	
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+    assert_param(data);
+
+    if (!I2Cx->ENABLE_b.EN) {
+        return 0;
+    }
+
+    count = 0;
+    while (I2Cx->STATUS_b.TX_FIFO_NOT_FULL && count < size) {
+      I2Cx->DATA_CMD_b.DATA = *(data + count++);
+    }
+
+    return count;
 }
 
 BOOL I2C_StopReq(I2C0_Type* I2Cx) {
-	assert_param(IS_I2C_ALL_PERIPH(I2Cx));
-	
-	udelay(600);
-	
-	return TRUE;
+    assert_param(IS_I2C_ALL_PERIPH(I2Cx));
+
+    udelay(600);
+
+    return TRUE;
 }

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_misc.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_misc.c
@@ -1,28 +1,28 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_misc.c
-	*
-	* @brief    CMEM7 miscellaneous file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
+    *****************************************************************************
+    * @file     cmem7_misc.c
+    *
+    * @brief    CMEM7 miscellaneous file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
 
 #include "cmem7_misc.h"
 
@@ -32,7 +32,7 @@ void NVIC_PriorityGroupConfig(uint32_t NVIC_PriorityGroup)
 {
   /* Check the parameters */
   assert_param(IS_NVIC_PRIORITY_GROUP(NVIC_PriorityGroup));
-  
+
   /* Set the PRIGROUP[10:8] bits according to NVIC_PriorityGroup value */
   SCB->AIRCR = AIRCR_VECTKEY_MASK | NVIC_PriorityGroup;
 }
@@ -40,14 +40,14 @@ void NVIC_PriorityGroupConfig(uint32_t NVIC_PriorityGroup)
 void NVIC_Init(NVIC_InitTypeDef* NVIC_InitStruct)
 {
   uint32_t tmppriority = 0x00, tmppre = 0x00, tmpsub = 0x0F;
-  
+
   /* Check the parameters */
-  assert_param(IS_NVIC_PREEMPTION_PRIORITY(NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority));  
+  assert_param(IS_NVIC_PREEMPTION_PRIORITY(NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority));
   assert_param(IS_NVIC_SUB_PRIORITY(NVIC_InitStruct->NVIC_IRQChannelSubPriority));
-    
+
   if (NVIC_InitStruct->NVIC_IRQChannelCmd != FALSE)
   {
-    /* Compute the Corresponding IRQ Priority --------------------------------*/    
+    /* Compute the Corresponding IRQ Priority --------------------------------*/
     tmppriority = (0x700 - ((SCB->AIRCR) & (uint32_t)0x700))>> 0x08;
     tmppre = (0x4 - tmppriority);
     tmpsub = tmpsub >> tmppriority;
@@ -55,9 +55,9 @@ void NVIC_Init(NVIC_InitTypeDef* NVIC_InitStruct)
     tmppriority = (uint32_t)NVIC_InitStruct->NVIC_IRQChannelPreemptionPriority << tmppre;
     tmppriority |=  NVIC_InitStruct->NVIC_IRQChannelSubPriority & tmpsub;
     tmppriority = tmppriority << 0x04;
-        
+
     NVIC->IP[NVIC_InitStruct->NVIC_IRQChannel] = tmppriority;
-    
+
     /* Enable the Selected IRQ Channels --------------------------------------*/
     NVIC->ISER[NVIC_InitStruct->NVIC_IRQChannel >> 0x05] =
       (uint32_t)0x01 << (NVIC_InitStruct->NVIC_IRQChannel & (uint8_t)0x1F);
@@ -71,11 +71,11 @@ void NVIC_Init(NVIC_InitTypeDef* NVIC_InitStruct)
 }
 
 void NVIC_SetVectorTable(uint32_t NVIC_VectTab, uint32_t Offset)
-{ 
+{
   /* Check the parameters */
   assert_param(IS_NVIC_VECTTAB(NVIC_VectTab));
-  assert_param(IS_NVIC_OFFSET(Offset));  
-   
+  assert_param(IS_NVIC_OFFSET(Offset));
+
   SCB->VTOR = NVIC_VectTab | (Offset & (uint32_t)0x1FFFFF80);
 }
 
@@ -83,20 +83,20 @@ void NVIC_SystemLPConfig(uint8_t LowPowerMode, BOOL NewState)
 {
   /* Check the parameters */
   assert_param(IS_NVIC_LP(LowPowerMode));
-  
+
   if (!NewState)
   {
     SCB->SCR &= (uint32_t)(~(uint32_t)LowPowerMode);
   } else {
-		SCB->SCR |= LowPowerMode;
-	}
+        SCB->SCR |= LowPowerMode;
+    }
 }
 
 #define DEF_IBUS_OFFSET     0x1FFE0000
 #define DEF_EXT_ADDR        0x08020000
 static BOOL isMappingOn() {
   /* If default values aren't changed */
-  if ((GLOBAL_CTRL->IBUSOFF == DEF_IBUS_OFFSET) && 
+  if ((GLOBAL_CTRL->IBUSOFF == DEF_IBUS_OFFSET) &&
     (GLOBAL_CTRL->EXTADDR == DEF_EXT_ADDR)) {
     return FALSE;
   }
@@ -105,15 +105,15 @@ static BOOL isMappingOn() {
 }
 
 void GLB_MMAP(uint32_t from, uint32_t to, BOOL isIcacheOn) {
-	volatile int n;
-	
-	GLOBAL_CTRL->IBUSOFF = GLOBAL_CTRL->DBUSOFF = (from - to);
-	GLOBAL_CTRL->EXTADDR = to;
-	
-	// Delay several cycles 
-	for (n = 0; n < 100; n++);
-	GLOBAL_CTRL->ICACHE_b.EN = isIcacheOn;
-	for (n = 0; n < 100; n++);
+    volatile int n;
+
+    GLOBAL_CTRL->IBUSOFF = GLOBAL_CTRL->DBUSOFF = (from - to);
+    GLOBAL_CTRL->EXTADDR = to;
+
+    // Delay several cycles
+    for (n = 0; n < 100; n++);
+    GLOBAL_CTRL->ICACHE_b.EN = isIcacheOn;
+    for (n = 0; n < 100; n++);
 }
 
 /*
@@ -128,11 +128,11 @@ uint32_t GLB_ConvertToMappingFromAddr(uint32_t to) {
   if (!isMappingOn()) {
     return to;
   }
-  
+
   if ((to > MAPPING_TO_REGION_END) || (to < GLOBAL_CTRL->EXTADDR)) {
     return to;
   }
-  
+
   return (to + GLOBAL_CTRL->IBUSOFF);
 }
 
@@ -140,44 +140,44 @@ uint32_t GLB_ConvertToMappingToAddr(uint32_t from) {
   if (!isMappingOn()) {
     return from;
   }
-  
+
   if (from < MAPPING_FROM_REGION_START) {
     return from;
   }
-  
+
   return (from - GLOBAL_CTRL->IBUSOFF);
 }
 
 void GLB_SetNmiIrqNum(uint32_t irq) {
-	GLOBAL_CTRL->NMI_SEL_b.NMI = irq;
+    GLOBAL_CTRL->NMI_SEL_b.NMI = irq;
 }
 
 void GLB_SelectSysClkSource(uint8_t source) {
-	switch (source) {
-	case SYS_CLK_SEL_DLL :
-		// M7's DLL clock should be fixed at PLL loation 2
-		// In constrast, it's C2R1.
-		// Wait DLL clock stable
-		while (PDLOCK->GCLK_b.C2R1D == 0) ;
-		GLOBAL_CTRL->CLK_SEL_1_b.SYS_CLK = SYS_CLK_SEL_DLL;
-		break;
-	case SYS_CLK_SEL_CRYSTAL :
-		GLOBAL_CTRL->CLK_SEL_1_b.SYS_CLK = SYS_CLK_SEL_CRYSTAL;
-		break;
-	case SYS_CLK_SEL_EXTERNAL :
-		// TODO, Add the condition that makes sure input
-		// external clock is stable
-		// For example :
-		//	PLL location 0
-		// 	while (PDLOCK->GCLK_b.C1R1P == 0) ;
-		// 	DLL location 0
-		// 	while (PDLOCK->GCLK_b.C1R1D == 0) ;
-		GLOBAL_CTRL->CLK_SEL_1_b.SYS_CLK = SYS_CLK_SEL_EXTERNAL;
-		break;
-	case SYS_CLK_SEL_OSC :
-		// Fall through
-	default :
-		GLOBAL_CTRL->CLK_SEL_1_b.SYS_CLK = SYS_CLK_SEL_OSC;
-		break;		
-	}
+    switch (source) {
+    case SYS_CLK_SEL_DLL :
+        // M7's DLL clock should be fixed at PLL loation 2
+        // In constrast, it's C2R1.
+        // Wait DLL clock stable
+        while (PDLOCK->GCLK_b.C2R1D == 0) ;
+        GLOBAL_CTRL->CLK_SEL_1_b.SYS_CLK = SYS_CLK_SEL_DLL;
+        break;
+    case SYS_CLK_SEL_CRYSTAL :
+        GLOBAL_CTRL->CLK_SEL_1_b.SYS_CLK = SYS_CLK_SEL_CRYSTAL;
+        break;
+    case SYS_CLK_SEL_EXTERNAL :
+        // TODO, Add the condition that makes sure input
+        // external clock is stable
+        // For example :
+        //  PLL location 0
+        //  while (PDLOCK->GCLK_b.C1R1P == 0) ;
+        //  DLL location 0
+        //  while (PDLOCK->GCLK_b.C1R1D == 0) ;
+        GLOBAL_CTRL->CLK_SEL_1_b.SYS_CLK = SYS_CLK_SEL_EXTERNAL;
+        break;
+    case SYS_CLK_SEL_OSC :
+        // Fall through
+    default :
+        GLOBAL_CTRL->CLK_SEL_1_b.SYS_CLK = SYS_CLK_SEL_OSC;
+        break;
+    }
 }

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_rtc.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_rtc.c
@@ -1,63 +1,63 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_rtc.c
-	*
-	* @brief    CMEM7 RTC source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_rtc.c
+    *
+    * @brief    CMEM7 RTC source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_rtc.h"
 
 #define SECONDS_IN_A_DAY                (86400)
 
 void RTC_ITConfig(uint32_t Int, BOOL Enable) {
-	assert_param(IS_RTC_INT(Int));  
-	
-	if (Enable) {
-	  GLOBAL_CTRL->RTC_INT_EN |= Int;
-	} else {
-		GLOBAL_CTRL->RTC_INT_EN &= ~Int;
-	}
+    assert_param(IS_RTC_INT(Int));
+
+    if (Enable) {
+      GLOBAL_CTRL->RTC_INT_EN |= Int;
+    } else {
+        GLOBAL_CTRL->RTC_INT_EN &= ~Int;
+    }
 }
 
 BOOL RTC_GetITStatus(uint32_t Int) {
-	assert_param(IS_RTC_INT(Int)); 
-	
-	if (0 != (RTC->INT_STATUS & Int)) {
-		return TRUE;
-	}
-	
-	return FALSE;
+    assert_param(IS_RTC_INT(Int));
+
+    if (0 != (RTC->INT_STATUS & Int)) {
+        return TRUE;
+    }
+
+    return FALSE;
 }
 
 void RTC_ClearITPendingBit(uint32_t Int) {
-  assert_param(IS_RTC_INT(Int));  
-	
-	RTC->INT_STATUS = Int;
+  assert_param(IS_RTC_INT(Int));
+
+    RTC->INT_STATUS = Int;
 }
 
 uint32_t RTC_GetSecond() {
-	return RTC->SECOND;
+    return RTC->SECOND;
 }
 
 uint16_t RTC_GetMillSecond() {
-	return RTC->MILLSECOND_b.MS;
+    return RTC->MILLSECOND_b.MS;
 }

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_spi.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_spi.c
@@ -1,145 +1,145 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_spi.c
-	*
-	* @brief    CMEM7 SPI source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_spi.c
+    *
+    * @brief    CMEM7 SPI source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_spi.h"
 
 void SPI_Init(SPI0_Type* SPIx, SPI_InitTypeDef *init) {
-	assert_param(IS_SPI_ALL_PERIPH(SPIx));
-	assert_param(init);
-	assert_param(IS_SPI_MODE(init->SPI_Mode));
-	assert_param(init->SPI_BitLength != 0);
-	
-	if (init->SPI_Mode == SPI_MODE_CPOL_0_CPHA_0) {
-		SPIx->CTRL_b.CLK_HIGH = FALSE;
-		SPIx->CTRL_b.NEG_EDGE = TRUE;
-  } else if (init->SPI_Mode == SPI_MODE_CPOL_0_CPHA_1) {
-		SPIx->CTRL_b.CLK_HIGH = FALSE;
-		SPIx->CTRL_b.NEG_EDGE = FALSE;
-  } else if (init->SPI_Mode == SPI_MODE_CPOL_1_CPHA_0) {
-		SPIx->CTRL_b.CLK_HIGH = TRUE;
-		SPIx->CTRL_b.NEG_EDGE = FALSE;
-  } else {
-		SPIx->CTRL_b.CLK_HIGH = TRUE;
-		SPIx->CTRL_b.NEG_EDGE = TRUE;
-  } 		
+    assert_param(IS_SPI_ALL_PERIPH(SPIx));
+    assert_param(init);
+    assert_param(IS_SPI_MODE(init->SPI_Mode));
+    assert_param(init->SPI_BitLength != 0);
 
-	SPIx->CTRL_b.RX_EN = init->SPI_RxEn;
-	SPIx->BCNT_b.CNT = init->SPI_BitLength - 1;
-	SPIx->DIV = init->SPI_ClockDividor;
-	SPIx->GAP = (init->SPI_Gap == 0) ? 0 : init->SPI_Gap / 2 + 1;
+    if (init->SPI_Mode == SPI_MODE_CPOL_0_CPHA_0) {
+        SPIx->CTRL_b.CLK_HIGH = FALSE;
+        SPIx->CTRL_b.NEG_EDGE = TRUE;
+  } else if (init->SPI_Mode == SPI_MODE_CPOL_0_CPHA_1) {
+        SPIx->CTRL_b.CLK_HIGH = FALSE;
+        SPIx->CTRL_b.NEG_EDGE = FALSE;
+  } else if (init->SPI_Mode == SPI_MODE_CPOL_1_CPHA_0) {
+        SPIx->CTRL_b.CLK_HIGH = TRUE;
+        SPIx->CTRL_b.NEG_EDGE = FALSE;
+  } else {
+        SPIx->CTRL_b.CLK_HIGH = TRUE;
+        SPIx->CTRL_b.NEG_EDGE = TRUE;
+  }
+
+    SPIx->CTRL_b.RX_EN = init->SPI_RxEn;
+    SPIx->BCNT_b.CNT = init->SPI_BitLength - 1;
+    SPIx->DIV = init->SPI_ClockDividor;
+    SPIx->GAP = (init->SPI_Gap == 0) ? 0 : init->SPI_Gap / 2 + 1;
 }
 
 void SPI_Enable(SPI0_Type* SPIx, BOOL enable) {
-	assert_param(IS_SPI_ALL_PERIPH(SPIx));
-	
+    assert_param(IS_SPI_ALL_PERIPH(SPIx));
+
   SPIx->CTRL_b.EN = enable;
 }
 
 void SPI_EnableInt(SPI0_Type* SPIx, uint32_t Int, BOOL enable) {
   assert_param(IS_SPI_ALL_PERIPH(SPIx));
-	assert_param(IS_SPI_INT(Int));
-	
+    assert_param(IS_SPI_INT(Int));
+
   if (enable) {
-	  SPIx->INT_MASK &= ~Int;
-	} else {
-		SPIx->INT_MASK |= Int;
-	}
-	
-	SPIx->INT_MASK &= SPI_INT_ALL;
+      SPIx->INT_MASK &= ~Int;
+    } else {
+        SPIx->INT_MASK |= Int;
+    }
+
+    SPIx->INT_MASK &= SPI_INT_ALL;
 }
 
 BOOL SPI_GetIntStatus(SPI0_Type* SPIx, uint32_t Int) {
-	assert_param(IS_SPI_ALL_PERIPH(SPIx));
-	assert_param(IS_SPI_INT(Int));
-	
-	if (0 != (SPIx->INT_STATUS & Int)) {
-		return TRUE;
-	}
-	
-	return FALSE;
+    assert_param(IS_SPI_ALL_PERIPH(SPIx));
+    assert_param(IS_SPI_INT(Int));
+
+    if (0 != (SPIx->INT_STATUS & Int)) {
+        return TRUE;
+    }
+
+    return FALSE;
 }
 void SPI_ClearInt(SPI0_Type* SPIx, uint32_t Int) {
-	assert_param(IS_SPI_ALL_PERIPH(SPIx));
-	assert_param(IS_SPI_INT(Int));
-	
-	SPIx->INT_STATUS = Int;
+    assert_param(IS_SPI_ALL_PERIPH(SPIx));
+    assert_param(IS_SPI_INT(Int));
+
+    SPIx->INT_STATUS = Int;
 }
 
 uint8_t SPI_ReadFifo(SPI0_Type* SPIx, uint8_t size, uint32_t* data) {
-	uint8_t count;
-	
-	assert_param(IS_SPI_ALL_PERIPH(SPIx));
-	assert_param(data);
-	
-	if (!SPIx->CTRL_b.EN) {
-		return 0;
-	}
-	
-	count = 0;
-	while (!SPIx->STATUS_b.RFIFO_EMPTY && count < size) {
-	  uint32_t d = SPIx->RW_DATA;
-	  d <<= (32 - SPIx->BCNT_b.CNT - 1);
-	  d >>= (32 - SPIx->BCNT_b.CNT - 1);
-		*(data + count++) = d;
-	}
-	
-	return count;
+    uint8_t count;
+
+    assert_param(IS_SPI_ALL_PERIPH(SPIx));
+    assert_param(data);
+
+    if (!SPIx->CTRL_b.EN) {
+        return 0;
+    }
+
+    count = 0;
+    while (!SPIx->STATUS_b.RFIFO_EMPTY && count < size) {
+      uint32_t d = SPIx->RW_DATA;
+      d <<= (32 - SPIx->BCNT_b.CNT - 1);
+      d >>= (32 - SPIx->BCNT_b.CNT - 1);
+        *(data + count++) = d;
+    }
+
+    return count;
 }
-	
+
 uint8_t SPI_WriteFifo(SPI0_Type* SPIx, uint8_t Size, uint32_t* data) {
-	uint8_t count;
-	
-	assert_param(IS_SPI_ALL_PERIPH(SPIx));
-	assert_param(data);
-	
-	if (!SPIx->CTRL_b.EN) {
-		return 0;
-	}
-	
-	count = 0;
-	while (!SPIx->STATUS_b.TFIFO_FULL && count < Size) {
-	  uint32_t d = *(data + count++);
-		d <<= (32 - SPIx->BCNT_b.CNT - 1);
-		SPIx->RW_DATA = d;
-	}
-	
-	return count;
+    uint8_t count;
+
+    assert_param(IS_SPI_ALL_PERIPH(SPIx));
+    assert_param(data);
+
+    if (!SPIx->CTRL_b.EN) {
+        return 0;
+    }
+
+    count = 0;
+    while (!SPIx->STATUS_b.TFIFO_FULL && count < Size) {
+      uint32_t d = *(data + count++);
+        d <<= (32 - SPIx->BCNT_b.CNT - 1);
+        SPIx->RW_DATA = d;
+    }
+
+    return count;
 }
 
 BOOL SPI_Transcation(SPI0_Type* SPIx, uint8_t size) {
-	assert_param(IS_SPI_ALL_PERIPH(SPIx));
-	assert_param(size);
-	
-	if (!SPIx->CTRL_b.EN) {
-		return FALSE;
-	}
-	
-	SPIx->TRANS_CNT = size - 1;
-	SPIx->TRANS_START_b.TX_TRIGGER = TRUE;
-	
-	return TRUE;
+    assert_param(IS_SPI_ALL_PERIPH(SPIx));
+    assert_param(size);
+
+    if (!SPIx->CTRL_b.EN) {
+        return FALSE;
+    }
+
+    SPIx->TRANS_CNT = size - 1;
+    SPIx->TRANS_START_b.TX_TRIGGER = TRUE;
+
+    return TRUE;
 }
 

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_tim.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_tim.c
@@ -1,80 +1,80 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_tim.c
-	*
-	* @brief    CMEM7 timer source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_tim.c
+    *
+    * @brief    CMEM7 timer source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_tim.h"
 
 static uint32_t tim_GetClock() {
-	return SYSTEM_CLOCK_FREQ / (1 << (GLOBAL_CTRL->CLK_SEL_0_b.TIMER_CLK + 1));
+    return SYSTEM_CLOCK_FREQ / (1 << (GLOBAL_CTRL->CLK_SEL_0_b.TIMER_CLK + 1));
 }
 
 void TIM_Init(TIMER0_Type* Timx, uint16_t Ms) {
-	assert_param(IS_TIM_ALL_PERIPH(Timx));
-	
-	Timx->CTRL_b.EN = FALSE;
-	Timx->LEN = tim_GetClock() / 1000 * Ms;
-	Timx->TYPE_b.SIGNLE_SHOT = TRUE;
+    assert_param(IS_TIM_ALL_PERIPH(Timx));
+
+    Timx->CTRL_b.EN = FALSE;
+    Timx->LEN = tim_GetClock() / 1000 * Ms;
+    Timx->TYPE_b.SIGNLE_SHOT = TRUE;
 }
 
 void TIM_EnableInt(TIMER0_Type* Timx, BOOL Enable) {
-	assert_param(IS_TIM_ALL_PERIPH(Timx));
-	
-	if (Enable == TRUE) {
-	  Timx->INT_EN_b.EN_REVERSE = FALSE;
-	} else {
-		Timx->INT_EN_b.EN_REVERSE = TRUE;
-	}
+    assert_param(IS_TIM_ALL_PERIPH(Timx));
+
+    if (Enable == TRUE) {
+      Timx->INT_EN_b.EN_REVERSE = FALSE;
+    } else {
+        Timx->INT_EN_b.EN_REVERSE = TRUE;
+    }
 }
 
 BOOL TIM_GetIntStatus(TIMER0_Type* Timx) {
-	assert_param(IS_TIM_ALL_PERIPH(Timx));
-	
-	return (Timx->INT_STA_b.STA ? TRUE : FALSE);
+    assert_param(IS_TIM_ALL_PERIPH(Timx));
+
+    return (Timx->INT_STA_b.STA ? TRUE : FALSE);
 }
 
 void TIM_ClearInt(TIMER0_Type* Timx) {
-	assert_param(IS_TIM_ALL_PERIPH(Timx));
-	
-	Timx->INT_STA_b.STA = 1;
+    assert_param(IS_TIM_ALL_PERIPH(Timx));
+
+    Timx->INT_STA_b.STA = 1;
 }
 
 void TIM_Enable(TIMER0_Type* Timx, BOOL Enable) {
-	assert_param(IS_TIM_ALL_PERIPH(Timx));
-	
-	Timx->CTRL_b.EN = Enable;
+    assert_param(IS_TIM_ALL_PERIPH(Timx));
+
+    Timx->CTRL_b.EN = Enable;
 }
 
 BOOL TIM_IsOverflow(TIMER0_Type* Timx) {
-	assert_param(IS_TIM_ALL_PERIPH(Timx));
-	
-	return (Timx->CNT == 0) ? TRUE : FALSE;
+    assert_param(IS_TIM_ALL_PERIPH(Timx));
+
+    return (Timx->CNT == 0) ? TRUE : FALSE;
 }
 
 uint32_t TIM_GetCounter(TIMER0_Type* Timx) {
-	assert_param(IS_TIM_ALL_PERIPH(Timx));
-	
-	return Timx->CNT;
+    assert_param(IS_TIM_ALL_PERIPH(Timx));
+
+    return Timx->CNT;
 }
 

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_uart.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_uart.c
@@ -1,28 +1,28 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_uart.c
-	*
-	* @brief    CMEM7 uart file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
+    *****************************************************************************
+    * @file     cmem7_uart.c
+    *
+    * @brief    CMEM7 uart file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
 
 #include "cmem7_uart.h"
 
@@ -31,147 +31,147 @@
 
 #define UART_BaudMode_0                     0
 #define UART_BaudMode_1                     1
-#define UART_BaudMode_Division							19200
+#define UART_BaudMode_Division                          19200
 
-#define UART_WR_MAX_FIFO_SIZE               16	
+#define UART_WR_MAX_FIFO_SIZE               16
 
 static uint32_t UART_GetClock(UART0_Type* UARTx) {
-	uint32_t dividor;
+    uint32_t dividor;
 
-	if ((uint32_t)UARTx == (uint32_t)UART0) {
-		dividor = GLOBAL_CTRL->CLK_SEL_0_b.UART0_CLK;
-	} else if ((uint32_t)UARTx == (uint32_t)UART1) {
-		dividor = GLOBAL_CTRL->CLK_SEL_0_b.UART1_CLK;
-	} else if ((uint32_t)UARTx == (uint32_t)UART2) {
-		dividor = GLOBAL_CTRL->CLK_SEL_1_b.UART2_CLK;
-	}
-	
-	return SYSTEM_CLOCK_FREQ / (1 << (dividor + 1));
+    if ((uint32_t)UARTx == (uint32_t)UART0) {
+        dividor = GLOBAL_CTRL->CLK_SEL_0_b.UART0_CLK;
+    } else if ((uint32_t)UARTx == (uint32_t)UART1) {
+        dividor = GLOBAL_CTRL->CLK_SEL_0_b.UART1_CLK;
+    } else if ((uint32_t)UARTx == (uint32_t)UART2) {
+        dividor = GLOBAL_CTRL->CLK_SEL_1_b.UART2_CLK;
+    }
+
+    return SYSTEM_CLOCK_FREQ / (1 << (dividor + 1));
 }
 
 static uint16_t UART_CalcBaudrateReload(uint32_t FreqHz, uint32_t Baudrate) {
-  if (Baudrate <= UART_BaudMode_Division) {                     
-		/** reload in mode 0
-		  *    reload = FreqHz / 16 * Baudrate
-		  * round up 
-		  *    reload = FreqHz / 16 * Baudrate + 1/ 2
-		  *    reload = (2 * FreqHz + 16 * Baudrate) / 2 * 16 * Baudrate
-		  */
-		return ((FreqHz << 1) + (Baudrate << 4)) / (Baudrate << 5);
-	} 
-	
-	/** reload in mode 1
-		*    reload = Baudrate * 16 * 65536 / FreqHz
-		* round up 
-		*    reload = Baudrate * 16 * 65536 / FreqHz + 1/ 2
-		*    reload = (2 * Baudrate * 16 * 65536 + FreqHz) / 2 * FreqHz
-		*/
-	return ((((uint64_t)(Baudrate)) << 21) + FreqHz) / (FreqHz << 1);
+  if (Baudrate <= UART_BaudMode_Division) {
+        /** reload in mode 0
+          *    reload = FreqHz / 16 * Baudrate
+          * round up
+          *    reload = FreqHz / 16 * Baudrate + 1/ 2
+          *    reload = (2 * FreqHz + 16 * Baudrate) / 2 * 16 * Baudrate
+          */
+        return ((FreqHz << 1) + (Baudrate << 4)) / (Baudrate << 5);
+    }
+
+    /** reload in mode 1
+        *    reload = Baudrate * 16 * 65536 / FreqHz
+        * round up
+        *    reload = Baudrate * 16 * 65536 / FreqHz + 1/ 2
+        *    reload = (2 * Baudrate * 16 * 65536 + FreqHz) / 2 * FreqHz
+        */
+    return ((((uint64_t)(Baudrate)) << 21) + FreqHz) / (FreqHz << 1);
 }
-            
+
 void UART_Init(UART0_Type* UARTx, UART_InitTypeDef *init) {
- 	assert_param(IS_UART_ALL_PERIPH(UARTx));
-	assert_param(init);
- 	assert_param(IS_UART_STOPBITS(init->UART_StopBits));
- 	assert_param(IS_UART_PARITY(init->UART_Parity));
-	
-	/* TODO : assume clock is 50MHz */
-	UARTx->BAUDRATE = UART_CalcBaudrateReload(
-	  UART_GetClock(UARTx), init->UART_BaudRate);
-	UARTx->CTRL_b.MODE = 
-	  (init->UART_Parity == UART_Parity_None) ? 
-	  UART_Mode_8b : UART_Mode_8b_Parity;	
-	UARTx->CTRL_b.STOP = init->UART_StopBits;
-	UARTx->CTRL_b.PARITY = 
-	  (init->UART_Parity == UART_Parity_None) ? 
-	  UART_Parity_Even : init->UART_Parity;
-	UARTx->CTRL_b.LOOPBACK = init->UART_LoopBack;
-	UARTx->CTRL_b.RX_EN = init->UART_RxEn;
-	UARTx->CTRL_b.CTS = init->UART_CtsEn;
-	UARTx->CTRL_b.BAUD_MODE = 
-	  (init->UART_BaudRate > UART_BaudMode_Division) ? 
-	  UART_BaudMode_1 : UART_BaudMode_0;
-	UARTx->CTRL_b.FIFO_EN = TRUE;
-	UARTx->CTRL_b.RX_THRESHOLD = UART_WR_MAX_FIFO_SIZE;
-	UARTx->CTRL_b.RX_HALF_FULL = (UART_WR_MAX_FIFO_SIZE >> 1);
-	UARTx->TIMEOUT = 0xFF;
-	
-	UARTx->INT_MASK |= UART_Int_All;
-	UARTx->INT_SEEN &= UART_Int_All;
+    assert_param(IS_UART_ALL_PERIPH(UARTx));
+    assert_param(init);
+    assert_param(IS_UART_STOPBITS(init->UART_StopBits));
+    assert_param(IS_UART_PARITY(init->UART_Parity));
+
+    /* TODO : assume clock is 50MHz */
+    UARTx->BAUDRATE = UART_CalcBaudrateReload(
+      UART_GetClock(UARTx), init->UART_BaudRate);
+    UARTx->CTRL_b.MODE =
+      (init->UART_Parity == UART_Parity_None) ?
+      UART_Mode_8b : UART_Mode_8b_Parity;
+    UARTx->CTRL_b.STOP = init->UART_StopBits;
+    UARTx->CTRL_b.PARITY =
+      (init->UART_Parity == UART_Parity_None) ?
+      UART_Parity_Even : init->UART_Parity;
+    UARTx->CTRL_b.LOOPBACK = init->UART_LoopBack;
+    UARTx->CTRL_b.RX_EN = init->UART_RxEn;
+    UARTx->CTRL_b.CTS = init->UART_CtsEn;
+    UARTx->CTRL_b.BAUD_MODE =
+      (init->UART_BaudRate > UART_BaudMode_Division) ?
+      UART_BaudMode_1 : UART_BaudMode_0;
+    UARTx->CTRL_b.FIFO_EN = TRUE;
+    UARTx->CTRL_b.RX_THRESHOLD = UART_WR_MAX_FIFO_SIZE;
+    UARTx->CTRL_b.RX_HALF_FULL = (UART_WR_MAX_FIFO_SIZE >> 1);
+    UARTx->TIMEOUT = 0xFF;
+
+    UARTx->INT_MASK |= UART_Int_All;
+    UARTx->INT_SEEN &= UART_Int_All;
 }
 
 void UART_EnableInt(UART0_Type* UARTx, uint32_t Int, BOOL enable) {
-	assert_param(IS_UART_ALL_PERIPH(UARTx));
-	assert_param(IS_UART_INT(Int));
-	
+    assert_param(IS_UART_ALL_PERIPH(UARTx));
+    assert_param(IS_UART_INT(Int));
+
   if (enable) {
-	  UARTx->INT_MASK &= ~Int;
-	} else {
-		UARTx->INT_MASK |= Int;
-	}
-	
-	UARTx->INT_MASK &= UART_Int_All;
+      UARTx->INT_MASK &= ~Int;
+    } else {
+        UARTx->INT_MASK |= Int;
+    }
+
+    UARTx->INT_MASK &= UART_Int_All;
 }
 
 void UART_Enable(UART0_Type* UARTx, BOOL enable) {
-	assert_param(IS_UART_ALL_PERIPH(UARTx));
-	
-	UARTx->RUN_b.EN = enable;
+    assert_param(IS_UART_ALL_PERIPH(UARTx));
+
+    UARTx->RUN_b.EN = enable;
 }
 
 BOOL UART_GetIntStatus(UART0_Type* UARTx, uint32_t Int) {
-	assert_param(IS_UART_ALL_PERIPH(UARTx));
-	assert_param(IS_UART_INT(Int));
-	
-	if (0 != (UARTx->INT_SEEN & Int)) {
-		return TRUE;
-	}
-	
-	return FALSE;
+    assert_param(IS_UART_ALL_PERIPH(UARTx));
+    assert_param(IS_UART_INT(Int));
+
+    if (0 != (UARTx->INT_SEEN & Int)) {
+        return TRUE;
+    }
+
+    return FALSE;
 }
 
 void UART_ClearInt(UART0_Type* UARTx, uint32_t Int) {
-	assert_param(IS_UART_ALL_PERIPH(UARTx));
-	assert_param(IS_UART_INT(Int));
-	
-	UARTx->INT_SEEN = Int;
+    assert_param(IS_UART_ALL_PERIPH(UARTx));
+    assert_param(IS_UART_INT(Int));
+
+    UARTx->INT_SEEN = Int;
 }
 
 uint8_t UART_Write(UART0_Type* UARTx, uint8_t Size, uint8_t* Data) {
-	uint8_t count;
-	
-	/* Check the parameters */
+    uint8_t count;
+
+    /* Check the parameters */
   assert_param(IS_UART_ALL_PERIPH(UARTx));
-	assert_param(Data);
-	
-	if (!UARTx->RUN_b.EN) {
-		return 0;
-	}
-	
-	count = 0;
-	while (!UARTx->STATUS_b.TF && count < Size) {
-		UARTx->TX_BUF = *(Data + count++);
-	}
-  
-	return count;
+    assert_param(Data);
+
+    if (!UARTx->RUN_b.EN) {
+        return 0;
+    }
+
+    count = 0;
+    while (!UARTx->STATUS_b.TF && count < Size) {
+        UARTx->TX_BUF = *(Data + count++);
+    }
+
+    return count;
 }
 
 /* return value is actual read data size */
 uint8_t UART_Read(UART0_Type* UARTx, uint8_t Size, uint8_t* Data) {
-	uint8_t count;
-	
-	assert_param(IS_UART_ALL_PERIPH(UARTx));
-	assert_param(Data);
-	
-	if (!UARTx->RUN_b.EN) {
-		return 0;
-	}
-	
-	count = 0;
-	while (UARTx->STATUS_b.RNE && count < Size) {
-		*(Data + count++) = (UARTx->RX_BUF & 0x00FF);
-	}
-	
-	return count;	
+    uint8_t count;
+
+    assert_param(IS_UART_ALL_PERIPH(UARTx));
+    assert_param(Data);
+
+    if (!UARTx->RUN_b.EN) {
+        return 0;
+    }
+
+    count = 0;
+    while (UARTx->STATUS_b.RNE && count < Size) {
+        *(Data + count++) = (UARTx->RX_BUF & 0x00FF);
+    }
+
+    return count;
 }
 

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_uart.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_uart.c
@@ -37,7 +37,8 @@
 
 static uint32_t UART_GetClock(UART0_Type* UARTx) {
     uint32_t dividor;
-
+    assert_param(IS_UART_ALL_PERIPH(UARTx));
+    
     if ((uint32_t)UARTx == (uint32_t)UART0) {
         dividor = GLOBAL_CTRL->CLK_SEL_0_b.UART0_CLK;
     } else if ((uint32_t)UARTx == (uint32_t)UART1) {

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_uart.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_uart.c
@@ -38,7 +38,7 @@
 static uint32_t UART_GetClock(UART0_Type* UARTx) {
     uint32_t dividor;
     assert_param(IS_UART_ALL_PERIPH(UARTx));
-    
+
     if ((uint32_t)UARTx == (uint32_t)UART0) {
         dividor = GLOBAL_CTRL->CLK_SEL_0_b.UART0_CLK;
     } else if ((uint32_t)UARTx == (uint32_t)UART1) {

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_usb.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_usb.c
@@ -1,842 +1,842 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_usb.c
-	*
-	* @brief    CMEM7 USB source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_usb.c
+    *
+    * @brief    CMEM7 USB source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_usb.h"
 
 static void USB_SET_REG_HPRT(const USB_REG_HPRT *clr, const USB_REG_HPRT *set)
 {
-	USB_REG_HPRT hprt;
-	hprt.HPRT = USB->__HPRT;					// @0x41300440
-	hprt.HPRT_b.POC = hprt.HPRT_b.PEDC = hprt.HPRT_b.PE = hprt.HPRT_b.PCD = 0;
-	if (clr)
-		hprt.HPRT &= (~clr->HPRT);
-	if (set)
-		hprt.HPRT |= (set->HPRT);
-	USB->__HPRT = hprt.HPRT;
+    USB_REG_HPRT hprt;
+    hprt.HPRT = USB->__HPRT;                    // @0x41300440
+    hprt.HPRT_b.POC = hprt.HPRT_b.PEDC = hprt.HPRT_b.PE = hprt.HPRT_b.PCD = 0;
+    if (clr)
+        hprt.HPRT &= (~clr->HPRT);
+    if (set)
+        hprt.HPRT |= (set->HPRT);
+    USB->__HPRT = hprt.HPRT;
 }
 
 void USB_coreInit(uint32_t type)
 {
-	USB->GINTEN = 0;
-	USB->GINTSTS = ~0;
-	GLOBAL_CTRL->USB_PHY_CTRL_b.CKISEL = 0;		// Crystal
-	// core initialization
-	// choose PHY and soft reset
-	USB->GUSBCFG_b.PHY_IF = 0;					// 60MHz, 8bit
-	USB->GUSBCFG_b.ULPI_UTMI_SEL = 0;			// UTMI
-	USB->GUSBCFG_b.PHY_SEL = 0;					// USB 2.0 HS UTMI+
-	USB->GRSTCTL_b.CORE_SOFT_RST = 1;
-	while (USB->GRSTCTL_b.CORE_SOFT_RST == 1) ;
-	while (USB->GRSTCTL_b.AHB_IDLE == 0) ;
+    USB->GINTEN = 0;
+    USB->GINTSTS = ~0;
+    GLOBAL_CTRL->USB_PHY_CTRL_b.CKISEL = 0;     // Crystal
+    // core initialization
+    // choose PHY and soft reset
+    USB->GUSBCFG_b.PHY_IF = 0;                  // 60MHz, 8bit
+    USB->GUSBCFG_b.ULPI_UTMI_SEL = 0;           // UTMI
+    USB->GUSBCFG_b.PHY_SEL = 0;                 // USB 2.0 HS UTMI+
+    USB->GRSTCTL_b.CORE_SOFT_RST = 1;
+    while (USB->GRSTCTL_b.CORE_SOFT_RST == 1) ;
+    while (USB->GRSTCTL_b.AHB_IDLE == 0) ;
 
-	USB->GAHBCFG_b.DMA_EN = 1;
-	USB->GAHBCFG_b.GLBL_INTR_EN = 1;
-	USB->GAHBCFG_b.BST_LEN = 0x1;   			// INCR
+    USB->GAHBCFG_b.DMA_EN = 1;
+    USB->GAHBCFG_b.GLBL_INTR_EN = 1;
+    USB->GAHBCFG_b.BST_LEN = 0x1;               // INCR
 
-	USB->GINTEN_b.RFNE = FALSE;
+    USB->GINTEN_b.RFNE = FALSE;
 
-	USB->GUSBCFG_b.USB_TRD_TIM = 0x9; 			// 8-bit UTMI+
-	USB->GUSBCFG_b.SRP_CAP = (type & 0x10) ? 1 : 0;
-	USB->GUSBCFG_b.HNP_CAP = (type & 0x20) ? 1 : 0;
-	if (type & 0x1) {
-		USB->GUSBCFG_b.FORCE_HOST_MODE = 1;
-		USB->GUSBCFG_b.FORCE_DEVICE_MODE = 0;
-	} else if (type & 0x2) {
-		USB->GUSBCFG_b.FORCE_DEVICE_MODE = 1;
-		USB->GUSBCFG_b.FORCE_HOST_MODE = 0;
-	}
-	udelay(50000);
+    USB->GUSBCFG_b.USB_TRD_TIM = 0x9;           // 8-bit UTMI+
+    USB->GUSBCFG_b.SRP_CAP = (type & 0x10) ? 1 : 0;
+    USB->GUSBCFG_b.HNP_CAP = (type & 0x20) ? 1 : 0;
+    if (type & 0x1) {
+        USB->GUSBCFG_b.FORCE_HOST_MODE = 1;
+        USB->GUSBCFG_b.FORCE_DEVICE_MODE = 0;
+    } else if (type & 0x2) {
+        USB->GUSBCFG_b.FORCE_DEVICE_MODE = 1;
+        USB->GUSBCFG_b.FORCE_HOST_MODE = 0;
+    }
+    udelay(50000);
 }
 
 void USB_EnableInt(BOOL enable)
 {
-	USB->GAHBCFG_b.GLBL_INTR_EN = enable;
+    USB->GAHBCFG_b.GLBL_INTR_EN = enable;
 }
 
 void USB_FlushFIFO(uint32_t num)
 {
-	if (num < 0x10) {
-		USB->GRSTCTL_b.TX_FIFO_FLUSH_NUM = num;
-		USB->GRSTCTL_b.TX_FIFO_FLUSH = 1;
-		while (USB->GRSTCTL_b.TX_FIFO_FLUSH);
-	} else if (num > 0x10) {
-		USB->GRSTCTL_b.RX_FIFO_FLUSH = 1;
-		while (USB->GRSTCTL_b.RX_FIFO_FLUSH);
-	} else {
-		USB->GRSTCTL_b.TX_FIFO_FLUSH_NUM = 0;
-		USB->GRSTCTL_b.TX_FIFO_ALL = 1;
-		USB->GRSTCTL_b.TX_FIFO_FLUSH = 1;
-		while (USB->GRSTCTL_b.TX_FIFO_FLUSH);
-	}
+    if (num < 0x10) {
+        USB->GRSTCTL_b.TX_FIFO_FLUSH_NUM = num;
+        USB->GRSTCTL_b.TX_FIFO_FLUSH = 1;
+        while (USB->GRSTCTL_b.TX_FIFO_FLUSH);
+    } else if (num > 0x10) {
+        USB->GRSTCTL_b.RX_FIFO_FLUSH = 1;
+        while (USB->GRSTCTL_b.RX_FIFO_FLUSH);
+    } else {
+        USB->GRSTCTL_b.TX_FIFO_FLUSH_NUM = 0;
+        USB->GRSTCTL_b.TX_FIFO_ALL = 1;
+        USB->GRSTCTL_b.TX_FIFO_FLUSH = 1;
+        while (USB->GRSTCTL_b.TX_FIFO_FLUSH);
+    }
 }
 
 BOOL USB_ogtIsBdevID()
 {
-	return USB->GOTGCTL_b.CON_ID_STS ? TRUE : FALSE;
+    return USB->GOTGCTL_b.CON_ID_STS ? TRUE : FALSE;
 }
 
 BOOL USB_hostVBus(uint32_t opt)
 {
-	if (opt & 0x2) {
-		USB_REG_HPRT hprt;
-		hprt.HPRT = 0;
-		hprt.HPRT_b.PP = 1;
-		if (opt & 0x1)
-			USB_SET_REG_HPRT(NULL, &hprt);
-		else
-			USB_SET_REG_HPRT(&hprt, NULL);
-	}
-	return USB->__HPRT_b.PP ? TRUE : FALSE;
+    if (opt & 0x2) {
+        USB_REG_HPRT hprt;
+        hprt.HPRT = 0;
+        hprt.HPRT_b.PP = 1;
+        if (opt & 0x1)
+            USB_SET_REG_HPRT(NULL, &hprt);
+        else
+            USB_SET_REG_HPRT(&hprt, NULL);
+    }
+    return USB->__HPRT_b.PP ? TRUE : FALSE;
 }
 
 void USB_hostInit()
 {
-	USB_REG_HPRT hprt;
-	// HOST MODE
-	USB->HCFG_b.FS_LS_PCS = 0x0;				// PHY clock is running at 30/60 MHz
-	USB->HCFG_b.FS_LS_SUPPORT = 0x0;			// HS/FS/LS
-	USB->HCFG_b.EN_SG_DMA = 0x1;				// Enable Scatter/Gather DMA
-	hprt.HPRT = 0;
-	hprt.HPRT_b.PP = 1;
-	USB_SET_REG_HPRT(NULL, &hprt);
+    USB_REG_HPRT hprt;
+    // HOST MODE
+    USB->HCFG_b.FS_LS_PCS = 0x0;                // PHY clock is running at 30/60 MHz
+    USB->HCFG_b.FS_LS_SUPPORT = 0x0;            // HS/FS/LS
+    USB->HCFG_b.EN_SG_DMA = 0x1;                // Enable Scatter/Gather DMA
+    hprt.HPRT = 0;
+    hprt.HPRT_b.PP = 1;
+    USB_SET_REG_HPRT(NULL, &hprt);
 }
 
 void USB_HostResetPort(BOOL rst)
 {
-	USB_REG_HPRT hprt;
-	hprt.HPRT = 0;
-	hprt.HPRT_b.PRESET = 1;
-	if (rst)
-		USB_SET_REG_HPRT(NULL, &hprt);
-	else
-		USB_SET_REG_HPRT(&hprt, NULL);
+    USB_REG_HPRT hprt;
+    hprt.HPRT = 0;
+    hprt.HPRT_b.PRESET = 1;
+    if (rst)
+        USB_SET_REG_HPRT(NULL, &hprt);
+    else
+        USB_SET_REG_HPRT(&hprt, NULL);
 }
 
 uint16_t USB_HostGetCurFrame()
 {
-	return USB->HFNUM_b.FN;
+    return USB->HFNUM_b.FN;
 }
 
 void USB_HostSuspendPort()
 {
-	USB_REG_HPRT hprt;
-	hprt.HPRT = 0;
-	hprt.HPRT_b.PS = 1;
-	USB_SET_REG_HPRT(NULL, &hprt);
+    USB_REG_HPRT hprt;
+    hprt.HPRT = 0;
+    hprt.HPRT_b.PS = 1;
+    USB_SET_REG_HPRT(NULL, &hprt);
 }
 
 USB_ENUM_SPEED USB_hostGetEnumSpd()
 {
-	return (USB_ENUM_SPEED)USB->__HPRT_b.SPEED;
+    return (USB_ENUM_SPEED)USB->__HPRT_b.SPEED;
 }
 
 BOOL USB_hostPrtConn()
 {
-	return USB->__HPRT_b.PCS ? TRUE : FALSE;
+    return USB->__HPRT_b.PCS ? TRUE : FALSE;
 }
 
 void USB_hostCH0(uint32_t devaddr, OTG_DESCRIPTOR *desc, uint32_t ctd, uint32_t ntd, BOOL ping, uint32_t pid, uint32_t mps, uint32_t epnum, BOOL in, USB_EP_TYPE eptype, USB_ENUM_SPEED speed)
 {
-	USB->HCDMA0_b.ADDR = SET_HCDMA_DESC_ADDR(desc);
-	USB->HCDMA0_b.CTD = ctd;
-	USB->HCTSIZ0_b.PING = ping ? 1 : 0;
-	USB->HCTSIZ0_b.NTD = ntd;
-	USB->HCTSIZ0_b.PID = pid;
-	USB->HCC0_b.MPS = mps;
-	USB->HCC0_b.EP_NUM = epnum;
-	USB->HCC0_b.EP_DIR = in ? 1 : 0;
-	USB->HCC0_b.LSD = (USB_ENUM_SPEED_LS == speed) ? 1 : 0;
-	USB->HCC0_b.EP_TYPE = eptype;
-	USB->HCC0_b.EC = 0;
-	USB->HCC0_b.DA = devaddr;
-	USB->HCC0_b.CE = 1;
+    USB->HCDMA0_b.ADDR = SET_HCDMA_DESC_ADDR(desc);
+    USB->HCDMA0_b.CTD = ctd;
+    USB->HCTSIZ0_b.PING = ping ? 1 : 0;
+    USB->HCTSIZ0_b.NTD = ntd;
+    USB->HCTSIZ0_b.PID = pid;
+    USB->HCC0_b.MPS = mps;
+    USB->HCC0_b.EP_NUM = epnum;
+    USB->HCC0_b.EP_DIR = in ? 1 : 0;
+    USB->HCC0_b.LSD = (USB_ENUM_SPEED_LS == speed) ? 1 : 0;
+    USB->HCC0_b.EP_TYPE = eptype;
+    USB->HCC0_b.EC = 0;
+    USB->HCC0_b.DA = devaddr;
+    USB->HCC0_b.CE = 1;
 }
 
 void USB_hostCH1(uint32_t devaddr, OTG_DESCRIPTOR *desc, uint32_t ctd, uint32_t ntd, BOOL ping, uint32_t pid, uint32_t mps, uint32_t epnum, BOOL in, USB_EP_TYPE eptype, USB_ENUM_SPEED speed)
 {
-	USB->HCDMA1_b.ADDR = SET_HCDMA_DESC_ADDR(desc);
-	USB->HCDMA1_b.CTD = ctd;
-	USB->HCTSIZ1_b.PING = ping ? 1 : 0;
-	USB->HCTSIZ1_b.NTD = ntd;
-	USB->HCTSIZ1_b.PID = pid;
-	USB->HCC1_b.MPS = mps;
-	USB->HCC1_b.EP_NUM = epnum;
-	USB->HCC1_b.EP_DIR = in ? 1 : 0;
-	USB->HCC1_b.LSD = (USB_ENUM_SPEED_LS == speed) ? 1 : 0;
-	USB->HCC1_b.EP_TYPE = eptype;
-	USB->HCC1_b.EC = 0;
-	USB->HCC1_b.DA = devaddr;
-	USB->HCC1_b.CE = 1;
+    USB->HCDMA1_b.ADDR = SET_HCDMA_DESC_ADDR(desc);
+    USB->HCDMA1_b.CTD = ctd;
+    USB->HCTSIZ1_b.PING = ping ? 1 : 0;
+    USB->HCTSIZ1_b.NTD = ntd;
+    USB->HCTSIZ1_b.PID = pid;
+    USB->HCC1_b.MPS = mps;
+    USB->HCC1_b.EP_NUM = epnum;
+    USB->HCC1_b.EP_DIR = in ? 1 : 0;
+    USB->HCC1_b.LSD = (USB_ENUM_SPEED_LS == speed) ? 1 : 0;
+    USB->HCC1_b.EP_TYPE = eptype;
+    USB->HCC1_b.EC = 0;
+    USB->HCC1_b.DA = devaddr;
+    USB->HCC1_b.CE = 1;
 }
 
 void USB_hostCH2(uint32_t devaddr, OTG_DESCRIPTOR *desc, uint32_t ctd, uint32_t ntd, BOOL ping, uint32_t pid, uint32_t mps, uint32_t epnum, BOOL in, USB_EP_TYPE eptype, USB_ENUM_SPEED speed)
 {
-	USB->HCDMA2_b.ADDR = SET_HCDMA_DESC_ADDR(desc);
-	USB->HCDMA2_b.CTD = ctd;
-	USB->HCTSIZ2_b.PING = ping ? 1 : 0;
-	USB->HCTSIZ2_b.NTD = ntd;
-	USB->HCTSIZ2_b.PID = pid;
-	USB->HCC2_b.MPS = mps;
-	USB->HCC2_b.EP_NUM = epnum;
-	USB->HCC2_b.EP_DIR = in ? 1 : 0;
-	USB->HCC2_b.LSD = (USB_ENUM_SPEED_LS == speed) ? 1 : 0;
-	USB->HCC2_b.EP_TYPE = eptype;
-	USB->HCC2_b.EC = 0;
-	USB->HCC2_b.DA = devaddr;
-	USB->HCC2_b.CE = 1;
+    USB->HCDMA2_b.ADDR = SET_HCDMA_DESC_ADDR(desc);
+    USB->HCDMA2_b.CTD = ctd;
+    USB->HCTSIZ2_b.PING = ping ? 1 : 0;
+    USB->HCTSIZ2_b.NTD = ntd;
+    USB->HCTSIZ2_b.PID = pid;
+    USB->HCC2_b.MPS = mps;
+    USB->HCC2_b.EP_NUM = epnum;
+    USB->HCC2_b.EP_DIR = in ? 1 : 0;
+    USB->HCC2_b.LSD = (USB_ENUM_SPEED_LS == speed) ? 1 : 0;
+    USB->HCC2_b.EP_TYPE = eptype;
+    USB->HCC2_b.EC = 0;
+    USB->HCC2_b.DA = devaddr;
+    USB->HCC2_b.CE = 1;
 }
 
 int USB_hostCHn(uint32_t ch, uint32_t devaddr, OTG_DESCRIPTOR *desc, uint32_t ctd, uint32_t ntd, BOOL ping, uint32_t pid, uint32_t mps, uint32_t epnum, BOOL in, USB_EP_TYPE eptype, USB_ENUM_SPEED speed)
 {
-	USB_Type *USBn = (USB_Type *)(((char *)USB) + (ch * 0x20));
+    USB_Type *USBn = (USB_Type *)(((char *)USB) + (ch * 0x20));
 
-	if (ch > 15)
-		return -1;
-	USBn->HCDMA0_b.ADDR = SET_HCDMA_DESC_ADDR(desc);
-	USBn->HCDMA0_b.CTD = ctd;
-	USBn->HCTSIZ0_b.PING = ping ? 1 : 0;
-	USBn->HCTSIZ0_b.NTD = ntd;
-	USBn->HCTSIZ0_b.PID = pid;
-	USBn->HCC0_b.MPS = mps;
-	USBn->HCC0_b.EP_NUM = epnum;
-	USBn->HCC0_b.EP_DIR = in ? 1 : 0;
-	USBn->HCC0_b.LSD = (USB_ENUM_SPEED_LS == speed) ? 1 : 0;
-	USBn->HCC0_b.EP_TYPE = eptype;
-	USBn->HCC0_b.EC = 0;
-	USBn->HCC0_b.DA = devaddr;
-	USBn->HCC0_b.CE = 1;
-	return 0;
+    if (ch > 15)
+        return -1;
+    USBn->HCDMA0_b.ADDR = SET_HCDMA_DESC_ADDR(desc);
+    USBn->HCDMA0_b.CTD = ctd;
+    USBn->HCTSIZ0_b.PING = ping ? 1 : 0;
+    USBn->HCTSIZ0_b.NTD = ntd;
+    USBn->HCTSIZ0_b.PID = pid;
+    USBn->HCC0_b.MPS = mps;
+    USBn->HCC0_b.EP_NUM = epnum;
+    USBn->HCC0_b.EP_DIR = in ? 1 : 0;
+    USBn->HCC0_b.LSD = (USB_ENUM_SPEED_LS == speed) ? 1 : 0;
+    USBn->HCC0_b.EP_TYPE = eptype;
+    USBn->HCC0_b.EC = 0;
+    USBn->HCC0_b.DA = devaddr;
+    USBn->HCC0_b.CE = 1;
+    return 0;
 }
 
 int USB_hostCHnHalt(uint32_t ch)
 {
-	uint32_t hcchar;
-	USB_Type *USBn = (USB_Type *)(((char *)USB) + (ch * 0x20));
+    uint32_t hcchar;
+    USB_Type *USBn = (USB_Type *)(((char *)USB) + (ch * 0x20));
 
-	if (ch > 15)
-		return -1;
-	hcchar = USBn->HCC0;
-	hcchar |= (0x3 << 30);
-	USBn->HCC0 = hcchar;
-	return 0;
+    if (ch > 15)
+        return -1;
+    hcchar = USBn->HCC0;
+    hcchar |= (0x3 << 30);
+    USBn->HCC0 = hcchar;
+    return 0;
 }
 
 BOOL USB_hostPortDisable(BOOL dis)
 {
-	if (dis) {
-		USB_REG_HPRT hprt;
-		hprt.HPRT = 0;
-		hprt.HPRT_b.PE = 1;
-		USB_SET_REG_HPRT(&hprt, NULL);
-	}
-	return USB->__HPRT_b.PE ? FALSE : TRUE;
+    if (dis) {
+        USB_REG_HPRT hprt;
+        hprt.HPRT = 0;
+        hprt.HPRT_b.PE = 1;
+        USB_SET_REG_HPRT(&hprt, NULL);
+    }
+    return USB->__HPRT_b.PE ? FALSE : TRUE;
 }
 
 BOOL USB_roleIsHost()
 {
-	return USB->GINTSTS_b.CUR_MOD ? TRUE : FALSE;
+    return USB->GINTSTS_b.CUR_MOD ? TRUE : FALSE;
 }
 
 void USB_hostINT_enConn(BOOL en)
 {
-	USB->GINTEN_b.HP = en;
+    USB->GINTEN_b.HP = en;
 }
 
 BOOL USB_hostINT_isConn()
 {
-	return USB->GINTSTS_b.HP ? TRUE : FALSE;
+    return USB->GINTSTS_b.HP ? TRUE : FALSE;
 }
 
 BOOL USB_hostINT_isPCD()
 {
-	return USB->__HPRT_b.PCD ? TRUE : FALSE;
+    return USB->__HPRT_b.PCD ? TRUE : FALSE;
 }
 
 void USB_hostINT_clrPCD()
 {
-	USB_REG_HPRT hprt;
-	hprt.HPRT = 0;
-	hprt.HPRT_b.PCD = 1;
-	USB_SET_REG_HPRT(NULL, &hprt);
+    USB_REG_HPRT hprt;
+    hprt.HPRT = 0;
+    hprt.HPRT_b.PCD = 1;
+    USB_SET_REG_HPRT(NULL, &hprt);
 }
 
 BOOL USB_hostINT_isPEDC()
 {
-	return USB->__HPRT_b.PEDC ? TRUE : FALSE;
+    return USB->__HPRT_b.PEDC ? TRUE : FALSE;
 }
 
 void USB_hostINT_clrPEDC()
 {
-	USB_REG_HPRT hprt;
-	hprt.HPRT = 0;
-	hprt.HPRT_b.PEDC = 1;
-	USB_SET_REG_HPRT(NULL, &hprt);
+    USB_REG_HPRT hprt;
+    hprt.HPRT = 0;
+    hprt.HPRT_b.PEDC = 1;
+    USB_SET_REG_HPRT(NULL, &hprt);
 }
 
 int USB_hostINT_enDone(uint32_t ch, BOOL en)
 {
-	USB_Type *USBn = (USB_Type *)(((char *)USB) + (ch * 0x20));
+    USB_Type *USBn = (USB_Type *)(((char *)USB) + (ch * 0x20));
 
-	if (ch > 15)
-		return -1;
+    if (ch > 15)
+        return -1;
 
-	if (en) {
-		USB->GINTEN_b.HC = 1;
-		USB->HAINT_EN_b.EN |= BIT(ch);
-	} else
-		USB->HAINT_EN_b.EN &= ~BIT(ch);
+    if (en) {
+        USB->GINTEN_b.HC = 1;
+        USB->HAINT_EN_b.EN |= BIT(ch);
+    } else
+        USB->HAINT_EN_b.EN &= ~BIT(ch);
 
-	USBn->HCINT_EN0_b.TC = USBn->HCINT_EN0_b.CH_HALT = USBn->HCINT_EN0_b.BNA = en ? 1 : 0;
-	return 0;
+    USBn->HCINT_EN0_b.TC = USBn->HCINT_EN0_b.CH_HALT = USBn->HCINT_EN0_b.BNA = en ? 1 : 0;
+    return 0;
 }
 
 uint32_t USB_hostINT_isDone(uint32_t ch)
 {
-	uint32_t retval = 0;
+    uint32_t retval = 0;
 
-	if (ch > 15)
-		return 0;
+    if (ch > 15)
+        return 0;
 
-	if ((USB->GINTSTS_b.HC) && ((USB->HAINT & BIT(ch)))) {
-		USB_Type *USBn = (USB_Type *)(((char *)USB) + (ch * 0x20));
-		if (USBn->HCINT0_b.TC) {
-			USBn->HCINT0 = BIT(0);
-			retval |= 0x1;
-		}
-		if (USBn->HCINT0_b.BNA) {
-			USBn->HCINT0 = BIT(11);
-			retval |= 0x2;
-		}
-		if (USBn->HCINT0_b.CH_HALT) {
-			USBn->HCINT0 = BIT(1);
-			retval |= 0x4;
-		}
-		if (USBn->HCINT0_b.ETE) {
-			USBn->HCINT0 = BIT(12);
-			retval |= 0x8;
-		}
-	}
-	return retval;
+    if ((USB->GINTSTS_b.HC) && ((USB->HAINT & BIT(ch)))) {
+        USB_Type *USBn = (USB_Type *)(((char *)USB) + (ch * 0x20));
+        if (USBn->HCINT0_b.TC) {
+            USBn->HCINT0 = BIT(0);
+            retval |= 0x1;
+        }
+        if (USBn->HCINT0_b.BNA) {
+            USBn->HCINT0 = BIT(11);
+            retval |= 0x2;
+        }
+        if (USBn->HCINT0_b.CH_HALT) {
+            USBn->HCINT0 = BIT(1);
+            retval |= 0x4;
+        }
+        if (USBn->HCINT0_b.ETE) {
+            USBn->HCINT0 = BIT(12);
+            retval |= 0x8;
+        }
+    }
+    return retval;
 }
 
 uint32_t USB_hostINT_isPend(uint32_t ch)
 {
-	uint32_t retval = 0;
+    uint32_t retval = 0;
 
-	if (ch > 15)
-		return 0;
+    if (ch > 15)
+        return 0;
 
-	if ((USB->GINTSTS_b.HC) && ((USB->HAINT & BIT(ch)))) {
-		USB_Type *USBn = (USB_Type *)(((char *)USB) + (ch * 0x20));
-		retval = USBn->HCINT0;
-		USBn->HCINT0 = retval;
-	}
-	return retval;
+    if ((USB->GINTSTS_b.HC) && ((USB->HAINT & BIT(ch)))) {
+        USB_Type *USBn = (USB_Type *)(((char *)USB) + (ch * 0x20));
+        retval = USBn->HCINT0;
+        USBn->HCINT0 = retval;
+    }
+    return retval;
 }
 
 void USB_devInit()
 {
-	// If still has some int needed to be enable
-	USB->GINTEN_b.MODE_MIS = TRUE;
-	USB->GINTEN_b.OTG_INT = TRUE;
+    // If still has some int needed to be enable
+    USB->GINTEN_b.MODE_MIS = TRUE;
+    USB->GINTEN_b.OTG_INT = TRUE;
 
-	// DEVICE MODE
-	USB->GINTEN_b.RFNE = FALSE;					// REG_CS(0x018/*GINTMSK*/, BIT(5)/*NPTxFEmpMsk*/ | BIT(4)/*RxFLvlMsk*/, 0);
-	USB->GINTEN_b.NPTFE = FALSE;
-	USB->DCFG_b.DSPEED = 0;						// HS DEV
-	USB->DCFG_b.NZLSOH = 0;						// REG_CS(0x800/*DCFG*/, BIT(2)/*NZStsOUTHShk*/ | BIT(1) | BIT(0)/*DevSpd: HS*/, BIT(23)/*DescDMA*/ | BIT(13)/*EnDevOutNak*/);
-	USB->DCFG_b.EN_SG_DMA = 1;
-	USB->DCFG_b.EDON = 1;
-	USB->DCTL_b.SD = 0;
+    // DEVICE MODE
+    USB->GINTEN_b.RFNE = FALSE;                 // REG_CS(0x018/*GINTMSK*/, BIT(5)/*NPTxFEmpMsk*/ | BIT(4)/*RxFLvlMsk*/, 0);
+    USB->GINTEN_b.NPTFE = FALSE;
+    USB->DCFG_b.DSPEED = 0;                     // HS DEV
+    USB->DCFG_b.NZLSOH = 0;                     // REG_CS(0x800/*DCFG*/, BIT(2)/*NZStsOUTHShk*/ | BIT(1) | BIT(0)/*DevSpd: HS*/, BIT(23)/*DescDMA*/ | BIT(13)/*EnDevOutNak*/);
+    USB->DCFG_b.EN_SG_DMA = 1;
+    USB->DCFG_b.EDON = 1;
+    USB->DCTL_b.SD = 0;
 }
 
 USB_ENUM_SPEED USB_devGetEnumSpd()
 {
-	return (USB_ENUM_SPEED)USB->DSTS_b.SPEED;
+    return (USB_ENUM_SPEED)USB->DSTS_b.SPEED;
 }
 
 void USB_devSetAddress(uint32_t addr)
 {
-	USB->DCFG_b.DEVICE_ADDR = addr;
+    USB->DCFG_b.DEVICE_ADDR = addr;
 }
 
 void USB_devEP0out(uint32_t size, uint32_t pktcnt, uint32_t stpcnt, void *desc, BOOL snoop)
 {
-	USB->DOEPTSIZ0_b.SIZE = size;
-	USB->DOEPTSIZ0_b.PACKET_CNT = pktcnt;
-	USB->DOEPTSIZ0_b.SETUP_CNT = stpcnt;
-	USB->DOEPDMA0 = (uint32_t)(desc);
-	USB->DOEPCTL0_b.SNOOP = snoop;
-	USB->DOEPCTL0_b.CNAK = 1;
-	USB->DOEPCTL0_b.EPE = 1;					// REG_CS(0xB00/*DOEPCTL0*/, 0, BIT(31)/*EPEna*/);
+    USB->DOEPTSIZ0_b.SIZE = size;
+    USB->DOEPTSIZ0_b.PACKET_CNT = pktcnt;
+    USB->DOEPTSIZ0_b.SETUP_CNT = stpcnt;
+    USB->DOEPDMA0 = (uint32_t)(desc);
+    USB->DOEPCTL0_b.SNOOP = snoop;
+    USB->DOEPCTL0_b.CNAK = 1;
+    USB->DOEPCTL0_b.EPE = 1;                    // REG_CS(0xB00/*DOEPCTL0*/, 0, BIT(31)/*EPEna*/);
 }
 
 BOOL USB_devEP0in(uint32_t size, uint32_t pktcnt, void *desc, uint32_t mps/*8,16,32,64-byte*/)
 {
-	switch (mps) {
-		case 64:	mps = 0x0; break;
-		case 32:	mps = 0x1; break;
-		case 16:	mps = 0x2; break;
-		case 8:		mps = 0x3; break;
-		default:	return FALSE;
-	}
-	USB->DIEPTSIZ0_b.SIZE = size;
-	USB->DIEPTSIZ0_b.PACKET_CNT = pktcnt;
-	USB->DIEPDMA0 = (uint32_t)(desc);
-	USB->DIEPCTL0_b.MPS = mps;
-	USB->DIEPCTL0_b.TX_FIFO_NUM = 0;
-	USB->DIEPCTL0_b.CNAK = 1;
-	USB->DIEPCTL0_b.EPE = 1;					// REG_CS(0xB00/*DOEPCTL0*/, 0, BIT(31)/*EPEna*/);
-	return TRUE;
+    switch (mps) {
+        case 64:    mps = 0x0; break;
+        case 32:    mps = 0x1; break;
+        case 16:    mps = 0x2; break;
+        case 8:     mps = 0x3; break;
+        default:    return FALSE;
+    }
+    USB->DIEPTSIZ0_b.SIZE = size;
+    USB->DIEPTSIZ0_b.PACKET_CNT = pktcnt;
+    USB->DIEPDMA0 = (uint32_t)(desc);
+    USB->DIEPCTL0_b.MPS = mps;
+    USB->DIEPCTL0_b.TX_FIFO_NUM = 0;
+    USB->DIEPCTL0_b.CNAK = 1;
+    USB->DIEPCTL0_b.EPE = 1;                    // REG_CS(0xB00/*DOEPCTL0*/, 0, BIT(31)/*EPEna*/);
+    return TRUE;
 }
 
 void USB_devActEP1(const BOOL in, const uint32_t mps, USB_EP_TYPE type)
 {
-	if (in) {
-		USB->DIEPCTL1_b.MPS = mps;
-		USB->DIEPCTL1_b.EP_TYPE = type;
-		USB->DIEPCTL1_b.UAE = (mps != 0) ? 1 : 0;
-	} else {
-		USB->DOEPCTL1_b.MPS = mps;
-		USB->DOEPCTL1_b.EP_TYPE = type;
-		USB->DOEPCTL1_b.UAE = (mps != 0) ? 1 : 0;
-	}
+    if (in) {
+        USB->DIEPCTL1_b.MPS = mps;
+        USB->DIEPCTL1_b.EP_TYPE = type;
+        USB->DIEPCTL1_b.UAE = (mps != 0) ? 1 : 0;
+    } else {
+        USB->DOEPCTL1_b.MPS = mps;
+        USB->DOEPCTL1_b.EP_TYPE = type;
+        USB->DOEPCTL1_b.UAE = (mps != 0) ? 1 : 0;
+    }
 }
 
 void USB_devActEP2(const BOOL in, const uint32_t mps, USB_EP_TYPE type)
 {
-	if (in) {
-		USB->DIEPCTL2_b.MPS = mps;
-		USB->DIEPCTL2_b.EP_TYPE = type;
-		USB->DIEPCTL2_b.UAE = (mps != 0) ? 1 : 0;
-	} else {
-		USB->DOEPCTL2_b.MPS = mps;
-		USB->DOEPCTL2_b.EP_TYPE = type;
-		USB->DOEPCTL2_b.UAE = (mps != 0) ? 1 : 0;
-	}
+    if (in) {
+        USB->DIEPCTL2_b.MPS = mps;
+        USB->DIEPCTL2_b.EP_TYPE = type;
+        USB->DIEPCTL2_b.UAE = (mps != 0) ? 1 : 0;
+    } else {
+        USB->DOEPCTL2_b.MPS = mps;
+        USB->DOEPCTL2_b.EP_TYPE = type;
+        USB->DOEPCTL2_b.UAE = (mps != 0) ? 1 : 0;
+    }
 }
 
 void USB_devEP1in(uint32_t size, uint32_t pktcnt, uint32_t pid, void *desc)
 {
-	USB->DIEPTSIZ1_b.SIZE = size;
-	USB->DIEPTSIZ1_b.PACKET_CNT = pktcnt;
-	USB->DIEPDMA1 = (uint32_t)(desc);
-	USB->DIEPCTL1_b.CNAK = 1;
-	USB->DIEPCTL1_b.SET_D0_PID = (pid >> 0) & 0x1;
-	USB->DIEPCTL1_b.SET_D1_PID = (pid >> 1) & 0x1;
-	USB->DIEPCTL1_b.EPE = 1;
+    USB->DIEPTSIZ1_b.SIZE = size;
+    USB->DIEPTSIZ1_b.PACKET_CNT = pktcnt;
+    USB->DIEPDMA1 = (uint32_t)(desc);
+    USB->DIEPCTL1_b.CNAK = 1;
+    USB->DIEPCTL1_b.SET_D0_PID = (pid >> 0) & 0x1;
+    USB->DIEPCTL1_b.SET_D1_PID = (pid >> 1) & 0x1;
+    USB->DIEPCTL1_b.EPE = 1;
 }
 
 void USB_devEP1out(uint32_t size, uint32_t pktcnt, uint32_t pid, uint32_t stpcnt, void *desc, BOOL snoop)
 {
-	USB->DOEPTSIZ1_b.SIZE = size;
-	USB->DOEPTSIZ1_b.PACKET_CNT = pktcnt;
-	USB->DOEPTSIZ1_b.SETUPCNT_PID = stpcnt;
-	USB->DOEPDMA1 = (uint32_t)(desc);
-	USB->DOEPCTL1_b.EC = snoop;
-	USB->DOEPCTL1_b.CNAK = 1;
-	USB->DOEPCTL1_b.SET_D0_PID = (pid >> 0) & 0x1;
-	USB->DOEPCTL1_b.SET_D1_PID = (pid >> 1) & 0x1;
-	USB->DOEPCTL1_b.EPE = 1;
+    USB->DOEPTSIZ1_b.SIZE = size;
+    USB->DOEPTSIZ1_b.PACKET_CNT = pktcnt;
+    USB->DOEPTSIZ1_b.SETUPCNT_PID = stpcnt;
+    USB->DOEPDMA1 = (uint32_t)(desc);
+    USB->DOEPCTL1_b.EC = snoop;
+    USB->DOEPCTL1_b.CNAK = 1;
+    USB->DOEPCTL1_b.SET_D0_PID = (pid >> 0) & 0x1;
+    USB->DOEPCTL1_b.SET_D1_PID = (pid >> 1) & 0x1;
+    USB->DOEPCTL1_b.EPE = 1;
 }
 
 
 void USB_devEP2in(uint32_t size, uint32_t pktcnt, uint32_t pid, void *desc)
 {
-	USB->DIEPTSIZ2_b.SIZE = size;
-	USB->DIEPTSIZ2_b.PACKET_CNT = pktcnt;
-	USB->DIEPDMA2 = (uint32_t)(desc);
-	USB->DIEPCTL2_b.CNAK = 1;
-	USB->DIEPCTL2_b.SET_D0_PID = (pid >> 0) & 0x1;
-	USB->DIEPCTL2_b.SET_D1_PID = (pid >> 1) & 0x1;
-	USB->DIEPCTL2_b.EPE = 1;
+    USB->DIEPTSIZ2_b.SIZE = size;
+    USB->DIEPTSIZ2_b.PACKET_CNT = pktcnt;
+    USB->DIEPDMA2 = (uint32_t)(desc);
+    USB->DIEPCTL2_b.CNAK = 1;
+    USB->DIEPCTL2_b.SET_D0_PID = (pid >> 0) & 0x1;
+    USB->DIEPCTL2_b.SET_D1_PID = (pid >> 1) & 0x1;
+    USB->DIEPCTL2_b.EPE = 1;
 }
 
 void USB_devEP2out(uint32_t size, uint32_t pktcnt, uint32_t pid, uint32_t stpcnt, void *desc, BOOL snoop)
 {
-	USB->DOEPTSIZ2_b.SIZE = size;
-	USB->DOEPTSIZ2_b.PACKET_CNT = pktcnt;
-	USB->DOEPTSIZ2_b.SETUPCNT_PID = stpcnt;
-	USB->DOEPDMA2 = (uint32_t)(desc);
-	USB->DOEPCTL2_b.EC = snoop;
-	USB->DOEPCTL2_b.CNAK = 1;
-	USB->DOEPCTL2_b.SET_D0_PID = (pid >> 0) & 0x1;
-	USB->DOEPCTL2_b.SET_D1_PID = (pid >> 1) & 0x1;
-	USB->DOEPCTL2_b.EPE = 1;
+    USB->DOEPTSIZ2_b.SIZE = size;
+    USB->DOEPTSIZ2_b.PACKET_CNT = pktcnt;
+    USB->DOEPTSIZ2_b.SETUPCNT_PID = stpcnt;
+    USB->DOEPDMA2 = (uint32_t)(desc);
+    USB->DOEPCTL2_b.EC = snoop;
+    USB->DOEPCTL2_b.CNAK = 1;
+    USB->DOEPCTL2_b.SET_D0_PID = (pid >> 0) & 0x1;
+    USB->DOEPCTL2_b.SET_D1_PID = (pid >> 1) & 0x1;
+    USB->DOEPCTL2_b.EPE = 1;
 }
 
 void USB_devNAKhandshake(uint32_t ep, BOOL in, BOOL en)
 {
-	switch (ep) {
-	case 0:
-		if (in) {
-			if (en) USB->DIEPCTL0_b.SNAK = 1; else USB->DIEPCTL0_b.CNAK = 1;
-		} else {
-			if (en) USB->DOEPCTL0_b.SNAK = 1; else USB->DOEPCTL0_b.CNAK = 1;
-		}
-		break;
-	case 1:
-		if (in) {
-			if (en) USB->DIEPCTL1_b.SNAK = 1; else USB->DIEPCTL1_b.CNAK = 1;
-		} else {
-			if (en) USB->DOEPCTL1_b.SNAK = 1; else USB->DOEPCTL1_b.CNAK = 1;
-		}
-		break;
-	case 2:
-		if (in) {
-			if (en) USB->DIEPCTL2_b.SNAK = 1; else USB->DIEPCTL2_b.CNAK = 1;
-		} else {
-			if (en) USB->DOEPCTL2_b.SNAK = 1; else USB->DOEPCTL2_b.CNAK = 1;
-		}
-		break;
-	default:
-		break;
-	}
+    switch (ep) {
+    case 0:
+        if (in) {
+            if (en) USB->DIEPCTL0_b.SNAK = 1; else USB->DIEPCTL0_b.CNAK = 1;
+        } else {
+            if (en) USB->DOEPCTL0_b.SNAK = 1; else USB->DOEPCTL0_b.CNAK = 1;
+        }
+        break;
+    case 1:
+        if (in) {
+            if (en) USB->DIEPCTL1_b.SNAK = 1; else USB->DIEPCTL1_b.CNAK = 1;
+        } else {
+            if (en) USB->DOEPCTL1_b.SNAK = 1; else USB->DOEPCTL1_b.CNAK = 1;
+        }
+        break;
+    case 2:
+        if (in) {
+            if (en) USB->DIEPCTL2_b.SNAK = 1; else USB->DIEPCTL2_b.CNAK = 1;
+        } else {
+            if (en) USB->DOEPCTL2_b.SNAK = 1; else USB->DOEPCTL2_b.CNAK = 1;
+        }
+        break;
+    default:
+        break;
+    }
 }
 
 BOOL USB_devSTALLhandshake(uint32_t ep, BOOL in, BOOL en)
 {
-	BOOL retval = FALSE;
-	switch (ep) {
-	case 0:
-		if (in) {
-			retval = USB->DIEPCTL0_b.STALL;
-			USB->DIEPCTL0_b.STALL = en ? 1 : 0;
-		} else {
-			retval = USB->DOEPCTL0_b.STALL;
-			USB->DOEPCTL0_b.STALL = en ? 1 : 0;
-		}
-		break;
-	case 1:
-		if (in) {
-			retval = USB->DIEPCTL1_b.STALL;
-			USB->DIEPCTL1_b.STALL = en ? 1 : 0;
-		} else {
-			retval = USB->DOEPCTL1_b.STALL;
-			USB->DOEPCTL1_b.STALL = en ? 1 : 0;
-		}
-		break;
-	case 2:
-		if (in) {
-			retval = USB->DIEPCTL2_b.STALL;
-			USB->DIEPCTL2_b.STALL = en ? 1 : 0;
-		} else {
-			retval = USB->DOEPCTL2_b.STALL;
-			USB->DOEPCTL2_b.STALL = en ? 1 : 0;
-		}
-		break;
-	default:
-		break;
-	}
-	return retval;
+    BOOL retval = FALSE;
+    switch (ep) {
+    case 0:
+        if (in) {
+            retval = USB->DIEPCTL0_b.STALL;
+            USB->DIEPCTL0_b.STALL = en ? 1 : 0;
+        } else {
+            retval = USB->DOEPCTL0_b.STALL;
+            USB->DOEPCTL0_b.STALL = en ? 1 : 0;
+        }
+        break;
+    case 1:
+        if (in) {
+            retval = USB->DIEPCTL1_b.STALL;
+            USB->DIEPCTL1_b.STALL = en ? 1 : 0;
+        } else {
+            retval = USB->DOEPCTL1_b.STALL;
+            USB->DOEPCTL1_b.STALL = en ? 1 : 0;
+        }
+        break;
+    case 2:
+        if (in) {
+            retval = USB->DIEPCTL2_b.STALL;
+            USB->DIEPCTL2_b.STALL = en ? 1 : 0;
+        } else {
+            retval = USB->DOEPCTL2_b.STALL;
+            USB->DOEPCTL2_b.STALL = en ? 1 : 0;
+        }
+        break;
+    default:
+        break;
+    }
+    return retval;
 }
 
 void USB_devINT_enDone(uint32_t ep, BOOL in, BOOL en)
 {
-	if (in) {
-		USB->DIEPEN_b.TIMEOUT = en ? 1 : 0;
-		USB->DIEPEN_b.TC = en ? 1 : 0;
-		if (en) {
-			USB->GINTEN_b.IEP_INT = 1;
-			USB->DAINT_EN_b.IN_EN |= BIT(ep);
-		} else
-			USB->DAINT_EN_b.IN_EN &= ~BIT(ep);
-	} else {
-		USB->DOEPEN_b.SPD = en ? 1 : 0;
-		USB->DOEPEN_b.TC = en ? 1 : 0;
-		if (en) {
-			USB->GINTEN_b.OEP_INT = 1;
-			USB->DAINT_EN_b.OUT_EN |= BIT(ep);
-		} else
-			USB->DAINT_EN_b.OUT_EN &= ~BIT(ep);
-	}
+    if (in) {
+        USB->DIEPEN_b.TIMEOUT = en ? 1 : 0;
+        USB->DIEPEN_b.TC = en ? 1 : 0;
+        if (en) {
+            USB->GINTEN_b.IEP_INT = 1;
+            USB->DAINT_EN_b.IN_EN |= BIT(ep);
+        } else
+            USB->DAINT_EN_b.IN_EN &= ~BIT(ep);
+    } else {
+        USB->DOEPEN_b.SPD = en ? 1 : 0;
+        USB->DOEPEN_b.TC = en ? 1 : 0;
+        if (en) {
+            USB->GINTEN_b.OEP_INT = 1;
+            USB->DAINT_EN_b.OUT_EN |= BIT(ep);
+        } else
+            USB->DAINT_EN_b.OUT_EN &= ~BIT(ep);
+    }
 }
 
 uint32_t USB_devINT_isDone(uint32_t ep, BOOL in)
 {
-	int32_t retval = 0;
-	if (in) {
-		if (USB->GINTSTS_b.IEP_INT)
-		switch (ep) {
-		case 0:
-			if (USB->DIEPINT0_b.TC) {
-				retval |= 0x1;
-				USB->DIEPINT0 = BIT(0);
-			}
-			if (USB->DIEPINT0_b.BNA) {
-				retval |= 0x2;
-				USB->DIEPINT0 = BIT(9);
-			}
-			break;
-		case 1:
-			if (USB->DIEPINT1_b.TC) {
-				retval |= 0x1;
-				USB->DIEPINT1 = BIT(0);
-			}
-			if (USB->DIEPINT1_b.BNA) {
-				retval |= 0x2;
-				USB->DIEPINT1 = BIT(9);
-			}
-			break;
-		case 2:
-			if (USB->DIEPINT2_b.TC) {
-				retval |= 0x1;
-				USB->DIEPINT2 = BIT(0);
-			}
-			if (USB->DIEPINT2_b.BNA) {
-				retval |= 0x2;
-				USB->DIEPINT2 = BIT(9);
-			}
-		default:
-			break;
-		}
-	} else {
-		if (USB->GINTSTS_b.OEP_INT)
-		switch (ep) {
-		case 0:
-			if (USB->DOEPINT0_b.TC) {
-				retval |= 0x1;
-				USB->DOEPINT0 = BIT(0);
-			}
-			if (USB->DOEPINT0_b.SETUP) {
-				retval |= 0x4;
-				USB->DOEPINT0 = BIT(3);
-			}
-			break;
-		case 1:
-			if (USB->DOEPINT1_b.TC) {
-				retval |= 0x1;
-				USB->DOEPINT1 = BIT(0);
-			}
-			if (USB->DOEPINT1_b.BNA) {
-				retval |= 0x2;
-				USB->DOEPINT1 = BIT(9);
-			}
-			break;
-		case 2:
-			if (USB->DOEPINT2_b.TC) {
-				retval |= 0x1;
-				USB->DOEPINT2 = BIT(0);
-			}
-			if (USB->DOEPINT2_b.BNA) {
-				retval |= 0x2;
-				USB->DOEPINT2 = BIT(9);
-			}
-			break;
-		default:
-			break;
-		}
-	}
-	return retval;
+    int32_t retval = 0;
+    if (in) {
+        if (USB->GINTSTS_b.IEP_INT)
+        switch (ep) {
+        case 0:
+            if (USB->DIEPINT0_b.TC) {
+                retval |= 0x1;
+                USB->DIEPINT0 = BIT(0);
+            }
+            if (USB->DIEPINT0_b.BNA) {
+                retval |= 0x2;
+                USB->DIEPINT0 = BIT(9);
+            }
+            break;
+        case 1:
+            if (USB->DIEPINT1_b.TC) {
+                retval |= 0x1;
+                USB->DIEPINT1 = BIT(0);
+            }
+            if (USB->DIEPINT1_b.BNA) {
+                retval |= 0x2;
+                USB->DIEPINT1 = BIT(9);
+            }
+            break;
+        case 2:
+            if (USB->DIEPINT2_b.TC) {
+                retval |= 0x1;
+                USB->DIEPINT2 = BIT(0);
+            }
+            if (USB->DIEPINT2_b.BNA) {
+                retval |= 0x2;
+                USB->DIEPINT2 = BIT(9);
+            }
+        default:
+            break;
+        }
+    } else {
+        if (USB->GINTSTS_b.OEP_INT)
+        switch (ep) {
+        case 0:
+            if (USB->DOEPINT0_b.TC) {
+                retval |= 0x1;
+                USB->DOEPINT0 = BIT(0);
+            }
+            if (USB->DOEPINT0_b.SETUP) {
+                retval |= 0x4;
+                USB->DOEPINT0 = BIT(3);
+            }
+            break;
+        case 1:
+            if (USB->DOEPINT1_b.TC) {
+                retval |= 0x1;
+                USB->DOEPINT1 = BIT(0);
+            }
+            if (USB->DOEPINT1_b.BNA) {
+                retval |= 0x2;
+                USB->DOEPINT1 = BIT(9);
+            }
+            break;
+        case 2:
+            if (USB->DOEPINT2_b.TC) {
+                retval |= 0x1;
+                USB->DOEPINT2 = BIT(0);
+            }
+            if (USB->DOEPINT2_b.BNA) {
+                retval |= 0x2;
+                USB->DOEPINT2 = BIT(9);
+            }
+            break;
+        default:
+            break;
+        }
+    }
+    return retval;
 }
 
 void USB_INT_enOTG(BOOL en)
 {
-	USB->GINTEN_b.OTG_INT = en;
+    USB->GINTEN_b.OTG_INT = en;
 }
 
 BOOL USB_INT_isOTG()
 {
-	return USB->GINTSTS_b.OTG_INT ? TRUE : FALSE;
+    return USB->GINTSTS_b.OTG_INT ? TRUE : FALSE;
 }
 
 BOOL USB_INT_isOTGon(USB_INT_OTG otg)
 {
-	switch (otg) {
-	case USB_INT_OTG_SESEND:
-		return USB->GOTGINT_b.SES_END_DET ? TRUE : FALSE;
-		break;
-	case USB_INT_OTG_STANDAUP:
-		return USB->GOTGINT_b.A_DEV_TOUT_CHG ? TRUE : FALSE;
-		break;
-	case USB_INT_OTG_HNDETECT:
-		return USB->GOTGINT_b.HST_NEG_DET ? TRUE : FALSE;
-		break;
-	case USB_INT_OTG_HNSUCCHG:
-		return USB->GOTGINT_b.HST_NEG_SUC_STS_CHNG ? TRUE : FALSE;
-		break;
-	case USB_INT_OTG_KEEPAPP:
-		return USB->GOTGINT_b.DBNCE_DONE ? TRUE : FALSE;
-		break;
-	default:
-		break;
-	}
-	return FALSE;
+    switch (otg) {
+    case USB_INT_OTG_SESEND:
+        return USB->GOTGINT_b.SES_END_DET ? TRUE : FALSE;
+        break;
+    case USB_INT_OTG_STANDAUP:
+        return USB->GOTGINT_b.A_DEV_TOUT_CHG ? TRUE : FALSE;
+        break;
+    case USB_INT_OTG_HNDETECT:
+        return USB->GOTGINT_b.HST_NEG_DET ? TRUE : FALSE;
+        break;
+    case USB_INT_OTG_HNSUCCHG:
+        return USB->GOTGINT_b.HST_NEG_SUC_STS_CHNG ? TRUE : FALSE;
+        break;
+    case USB_INT_OTG_KEEPAPP:
+        return USB->GOTGINT_b.DBNCE_DONE ? TRUE : FALSE;
+        break;
+    default:
+        break;
+    }
+    return FALSE;
 }
 
 void USB_INT_clrOTGon(USB_INT_OTG otg)
 {
-	switch (otg) {
-	case USB_INT_OTG_SESEND:
-		USB->GOTGINT = BIT(2);
-		break;
- 	case USB_INT_OTG_STANDAUP:
-		USB->GOTGINT = BIT(18);
-		break;
-	case USB_INT_OTG_HNDETECT:
-		USB->GOTGINT = BIT(17);
-		break;
-	case USB_INT_OTG_HNSUCCHG:
-		USB->GOTGINT = BIT(9);
-		break;
-	case USB_INT_OTG_KEEPAPP:
-		USB->GOTGINT = BIT(19);
-		break;
-	default:
-		break;
-	}
+    switch (otg) {
+    case USB_INT_OTG_SESEND:
+        USB->GOTGINT = BIT(2);
+        break;
+    case USB_INT_OTG_STANDAUP:
+        USB->GOTGINT = BIT(18);
+        break;
+    case USB_INT_OTG_HNDETECT:
+        USB->GOTGINT = BIT(17);
+        break;
+    case USB_INT_OTG_HNSUCCHG:
+        USB->GOTGINT = BIT(9);
+        break;
+    case USB_INT_OTG_KEEPAPP:
+        USB->GOTGINT = BIT(19);
+        break;
+    default:
+        break;
+    }
 }
 
 void USB_INT_enGP(USB_INT_GP name, BOOL en)
 {
-	switch (name) {
-	case USB_INT_GP_HOST_DISC:
-		USB->GINTEN_b.DD = en ? 1 : 0;
-		break;
-	case USB_INT_GP_DEV_RESET:
-		USB->GINTEN_b.USB_RST = en ? 1 : 0;
-		break;
-	case USB_INT_GP_DEV_ENUMDONE:
-		USB->GINTEN_b.ENUM_DONE = en ? 1 : 0;
-		break;
-	case USB_INT_GP_DEV_SUSP:
-		USB->GINTEN_b.USB_SUS = en ? 1 : 0;
-		break;
-	case USB_INT_GP_DEV_EARLY:
-		USB->GINTEN_b.EARLY_SUS = en ? 1 : 0;
-		break;
-	case USB_INT_GP_SOF:
-		USB->GINTEN_b.SOF = en ? 1 : 0;
-		break;
-	case USB_INT_GP_MIS:
-		USB->GINTEN_b.MODE_MIS = en ? 1 : 0;
-		break;
-	case USB_INT_GP_IDCHG:
-		USB->GINTEN_b.CIDSC = en ? 1 : 0;
-		break;
-	case USB_INT_GP_SESSREQ:
-		USB->GINTEN_b.SR = en ? 1 : 0;
-		break;
-	default:
-		break;
-	}
+    switch (name) {
+    case USB_INT_GP_HOST_DISC:
+        USB->GINTEN_b.DD = en ? 1 : 0;
+        break;
+    case USB_INT_GP_DEV_RESET:
+        USB->GINTEN_b.USB_RST = en ? 1 : 0;
+        break;
+    case USB_INT_GP_DEV_ENUMDONE:
+        USB->GINTEN_b.ENUM_DONE = en ? 1 : 0;
+        break;
+    case USB_INT_GP_DEV_SUSP:
+        USB->GINTEN_b.USB_SUS = en ? 1 : 0;
+        break;
+    case USB_INT_GP_DEV_EARLY:
+        USB->GINTEN_b.EARLY_SUS = en ? 1 : 0;
+        break;
+    case USB_INT_GP_SOF:
+        USB->GINTEN_b.SOF = en ? 1 : 0;
+        break;
+    case USB_INT_GP_MIS:
+        USB->GINTEN_b.MODE_MIS = en ? 1 : 0;
+        break;
+    case USB_INT_GP_IDCHG:
+        USB->GINTEN_b.CIDSC = en ? 1 : 0;
+        break;
+    case USB_INT_GP_SESSREQ:
+        USB->GINTEN_b.SR = en ? 1 : 0;
+        break;
+    default:
+        break;
+    }
 }
 
 BOOL USB_INT_isGP(USB_INT_GP name)
 {
-	switch (name) {
-	case USB_INT_GP_HOST_DISC:
-		return USB->GINTSTS_b.DD ? TRUE : FALSE;
-		break;
-	case USB_INT_GP_DEV_RESET:
-		return USB->GINTSTS_b.USB_RST ? TRUE : FALSE;
-		break;
-	case USB_INT_GP_DEV_ENUMDONE:
-		return USB->GINTSTS_b.ENUM_DONE ? TRUE : FALSE;
-		break;
-	case USB_INT_GP_DEV_SUSP:
-		return USB->GINTSTS_b.USB_SUS ? TRUE : FALSE;
-		break;
-	case USB_INT_GP_DEV_EARLY:
-		return USB->GINTSTS_b.EARLY_SUS ? TRUE : FALSE;
-		break;
-	case USB_INT_GP_SOF:
-		return USB->GINTSTS_b.SOF ? TRUE : FALSE;
-		break;
-	case USB_INT_GP_MIS:
-		return USB->GINTSTS_b.MODE_MIS ? TRUE : FALSE;
-		break;
-	case USB_INT_GP_IDCHG:
-		return USB->GINTSTS_b.CIDSC ? TRUE : FALSE;
-		break;
-	case USB_INT_GP_SESSREQ:
-		return USB->GINTSTS_b.SR ? TRUE : FALSE;
-		break;
-	default:
-		break;
-	}
-	return FALSE;
+    switch (name) {
+    case USB_INT_GP_HOST_DISC:
+        return USB->GINTSTS_b.DD ? TRUE : FALSE;
+        break;
+    case USB_INT_GP_DEV_RESET:
+        return USB->GINTSTS_b.USB_RST ? TRUE : FALSE;
+        break;
+    case USB_INT_GP_DEV_ENUMDONE:
+        return USB->GINTSTS_b.ENUM_DONE ? TRUE : FALSE;
+        break;
+    case USB_INT_GP_DEV_SUSP:
+        return USB->GINTSTS_b.USB_SUS ? TRUE : FALSE;
+        break;
+    case USB_INT_GP_DEV_EARLY:
+        return USB->GINTSTS_b.EARLY_SUS ? TRUE : FALSE;
+        break;
+    case USB_INT_GP_SOF:
+        return USB->GINTSTS_b.SOF ? TRUE : FALSE;
+        break;
+    case USB_INT_GP_MIS:
+        return USB->GINTSTS_b.MODE_MIS ? TRUE : FALSE;
+        break;
+    case USB_INT_GP_IDCHG:
+        return USB->GINTSTS_b.CIDSC ? TRUE : FALSE;
+        break;
+    case USB_INT_GP_SESSREQ:
+        return USB->GINTSTS_b.SR ? TRUE : FALSE;
+        break;
+    default:
+        break;
+    }
+    return FALSE;
 }
 
 void USB_INT_clrGP(USB_INT_GP name)
 {
-	switch (name) {
-	case USB_INT_GP_HOST_DISC:
-		USB->GINTSTS = BIT(29);
-		break;
-	case USB_INT_GP_DEV_RESET:
-		USB->GINTSTS = BIT(12);
-		break;
-	case USB_INT_GP_DEV_ENUMDONE:
-		USB->GINTSTS = BIT(13);
-		break;
-	case USB_INT_GP_DEV_SUSP:
-		USB->GINTSTS = BIT(11);
-		break;
-	case USB_INT_GP_DEV_EARLY:
-		USB->GINTSTS = BIT(10);
-		break;
-	case USB_INT_GP_SOF:
-		USB->GINTSTS = BIT(3);
-		break;
-	case USB_INT_GP_MIS:
-		USB->GINTSTS = BIT(1);
-		break;
-	case USB_INT_GP_IDCHG:
-		USB->GINTSTS = BIT(28);
-		break;
-	case USB_INT_GP_SESSREQ:
-		USB->GINTSTS = BIT(30);
-		break;
-	default:
-		break;
-	}
+    switch (name) {
+    case USB_INT_GP_HOST_DISC:
+        USB->GINTSTS = BIT(29);
+        break;
+    case USB_INT_GP_DEV_RESET:
+        USB->GINTSTS = BIT(12);
+        break;
+    case USB_INT_GP_DEV_ENUMDONE:
+        USB->GINTSTS = BIT(13);
+        break;
+    case USB_INT_GP_DEV_SUSP:
+        USB->GINTSTS = BIT(11);
+        break;
+    case USB_INT_GP_DEV_EARLY:
+        USB->GINTSTS = BIT(10);
+        break;
+    case USB_INT_GP_SOF:
+        USB->GINTSTS = BIT(3);
+        break;
+    case USB_INT_GP_MIS:
+        USB->GINTSTS = BIT(1);
+        break;
+    case USB_INT_GP_IDCHG:
+        USB->GINTSTS = BIT(28);
+        break;
+    case USB_INT_GP_SESSREQ:
+        USB->GINTSTS = BIT(30);
+        break;
+    default:
+        break;
+    }
 }
 
 BOOL USB_otgControl(USB_OTG_CTL ctl, BOOL val)
 {
-	BOOL retval = FALSE;
-	switch (ctl) {
-	case USB_OTG_DEV_HNSUCC:
-		retval = USB->GOTGCTL_b.HST_NEG_SCS ? TRUE : FALSE;
-		break;
-	case USB_OTG_DEV_HNPREQ:
-		retval = USB->GOTGCTL_b.HNP_REQ ? TRUE : FALSE;
-		USB->GOTGCTL_b.HNP_REQ = val ? 1 : 0;
-		break;
-	case USB_OTG_HST_HNPENABLE:
-		retval = USB->GOTGCTL_b.HST_SET_HNP_EN ? TRUE : FALSE;
-		USB->GOTGCTL_b.HST_SET_HNP_EN = val ? 1 : 0;
-		break;
-	case USB_OTG_DEV_HNPENABLE:
-		retval = USB->GOTGCTL_b.DEV_HNP_EN ? TRUE : FALSE;
-		USB->GOTGCTL_b.DEV_HNP_EN = val ? 1 : 0;
-		break;
-	default:
-		break;
-	}
-	return retval;
+    BOOL retval = FALSE;
+    switch (ctl) {
+    case USB_OTG_DEV_HNSUCC:
+        retval = USB->GOTGCTL_b.HST_NEG_SCS ? TRUE : FALSE;
+        break;
+    case USB_OTG_DEV_HNPREQ:
+        retval = USB->GOTGCTL_b.HNP_REQ ? TRUE : FALSE;
+        USB->GOTGCTL_b.HNP_REQ = val ? 1 : 0;
+        break;
+    case USB_OTG_HST_HNPENABLE:
+        retval = USB->GOTGCTL_b.HST_SET_HNP_EN ? TRUE : FALSE;
+        USB->GOTGCTL_b.HST_SET_HNP_EN = val ? 1 : 0;
+        break;
+    case USB_OTG_DEV_HNPENABLE:
+        retval = USB->GOTGCTL_b.DEV_HNP_EN ? TRUE : FALSE;
+        USB->GOTGCTL_b.DEV_HNP_EN = val ? 1 : 0;
+        break;
+    default:
+        break;
+    }
+    return retval;
 }

--- a/bsp/CME_M7/StdPeriph_Driver/src/cmem7_wdg.c
+++ b/bsp/CME_M7/StdPeriph_Driver/src/cmem7_wdg.c
@@ -1,63 +1,63 @@
 /**
-	*****************************************************************************
-	* @file     cmem7_wdg.c
-	*
-	* @brief    CMEM7 watchdog source file
-	*
-	*
-	* @version  V1.0
-	* @date     3. September 2013
-	*
-	* @note               
-	*           
-	*****************************************************************************
-	* @attention
-	*
-	* THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
-	* WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
-	* TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT, 
-	* INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
-	* FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
-	* CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
-	*
-	* <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
-	*****************************************************************************
-	*/
-	
+    *****************************************************************************
+    * @file     cmem7_wdg.c
+    *
+    * @brief    CMEM7 watchdog source file
+    *
+    *
+    * @version  V1.0
+    * @date     3. September 2013
+    *
+    * @note
+    *
+    *****************************************************************************
+    * @attention
+    *
+    * THE PRESENT FIRMWARE WHICH IS FOR GUIDANCE ONLY AIMS AT PROVIDING CUSTOMERS
+    * WITH CODING INFORMATION REGARDING THEIR PRODUCTS IN ORDER FOR THEM TO SAVE
+    * TIME. AS A RESULT, CAPITAL-MICRO SHALL NOT BE HELD LIABLE FOR ANY DIRECT,
+    * INDIRECT OR CONSEQUENTIAL DAMAGES WITH RESPECT TO ANY CLAIMS ARISING
+    * FROM THE CONTENT OF SUCH FIRMWARE AND/OR THE USE MADE BY CUSTOMERS OF THE
+    * CODING INFORMATION CONTAINED HEREIN IN CONNECTION WITH THEIR PRODUCTS.
+    *
+    * <h2><center>&copy; COPYRIGHT 2013 Capital-micro </center></h2>
+    *****************************************************************************
+    */
+
 #include "cmem7_wdg.h"
 
 static uint32_t wdg_GetClock() {
-	return SYSTEM_CLOCK_FREQ / (1 << (GLOBAL_CTRL->CLK_SEL_0_b.WDG_CLK + 1));
+    return SYSTEM_CLOCK_FREQ / (1 << (GLOBAL_CTRL->CLK_SEL_0_b.WDG_CLK + 1));
 }
 
 void WDG_DeInit(void){
   SOFT_RESET->SOFTRST_b.WDT_n = 0;
-	SOFT_RESET->SOFTRST_b.WDT_n = 1;
+    SOFT_RESET->SOFTRST_b.WDT_n = 1;
 }
 
 void WDG_Init(uint8_t trigger, uint16_t ResetMillSecond) {
-	assert_param(IS_WDG_TRIGGER_MODE(trigger));
-	
-	WDG->INT_CTRL_b.TRIGGER_MODE = trigger;
-	WDG->LEN = ((uint64_t)wdg_GetClock()) * ResetMillSecond / 1000;
+    assert_param(IS_WDG_TRIGGER_MODE(trigger));
+
+    WDG->INT_CTRL_b.TRIGGER_MODE = trigger;
+    WDG->LEN = ((uint64_t)wdg_GetClock()) * ResetMillSecond / 1000;
 }
 
 void WDG_ITConfig(uint8_t Int, BOOL Enable) {
-	assert_param(IS_WDG_INT(Int));
-	
-	WDG->CTRL_b.INT_LEN = Int;
-	WDG->INT_CTRL_b.MASK = !Enable;
+    assert_param(IS_WDG_INT(Int));
+
+    WDG->CTRL_b.INT_LEN = Int;
+    WDG->INT_CTRL_b.MASK = !Enable;
 }
 
 BOOL WDG_GetITStatus() {
-	return (WDG->INT_STA_b.STA == 1) ? TRUE : FALSE;
+    return (WDG->INT_STA_b.STA == 1) ? TRUE : FALSE;
 }
 
 void WDG_ClearITPendingBit() {
-	WDG->INT_STA_b.STA = 1;
+    WDG->INT_STA_b.STA = 1;
 }
 
 void WDG_Cmd(BOOL Enable) {
-	WDG->CTRL_b.EN = Enable;
+    WDG->CTRL_b.EN = Enable;
 }
 

--- a/bsp/CME_M7/drivers/app_phy.c
+++ b/bsp/CME_M7/drivers/app_phy.c
@@ -107,7 +107,7 @@ BOOL phy_Init() {
             speed = 1000;
         }
 
-        printf("PHY runs in %dM speed %s duplex\n",
+        printf("PHY runs in %uM speed %s duplex\n",
             speed, (phy_GetDuplex() == PHY_DUPLEX_HALF) ? "half" : "full");
     }
 

--- a/bsp/Infineon/libraries/HAL_Drivers/drv_adc.c
+++ b/bsp/Infineon/libraries/HAL_Drivers/drv_adc.c
@@ -57,7 +57,7 @@ static rt_err_t ifx_adc_enabled(struct rt_adc_device *device, rt_uint32_t channe
 
         if (result != RT_EOK)
         {
-            LOG_E("ADC initialization failed. Error: %ld\n", (long unsigned int)result);
+            LOG_E("ADC initialization failed. Error: %llu\n", (long unsigned int)result);
             return -RT_ENOSYS;
         }
 
@@ -67,7 +67,7 @@ static rt_err_t ifx_adc_enabled(struct rt_adc_device *device, rt_uint32_t channe
 
         if (result != RT_EOK)
         {
-            LOG_E("ADC single ended channel initialization failed. Error: %ld\n", (long unsigned int)result);
+            LOG_E("ADC single ended channel initialization failed. Error: %llu\n", (long unsigned int)result);
             return -RT_ENOSYS;
         }
 
@@ -76,7 +76,7 @@ static rt_err_t ifx_adc_enabled(struct rt_adc_device *device, rt_uint32_t channe
 
         if (result != RT_EOK)
         {
-            printf("ADC configuration update failed. Error: %ld\n", (long unsigned int)result);
+            printf("ADC configuration update failed. Error: %llu\n", (long unsigned int)result);
             return -RT_ENOSYS;
         }
     }

--- a/components/net/at/at_socket/at_socket.c
+++ b/components/net/at/at_socket/at_socket.c
@@ -70,9 +70,9 @@ struct at_socket *at_get_socket(int socket)
     rt_slist_for_each(node, &_socket_list)
     {
         at_sock = rt_slist_entry(node, struct at_socket, list);
-        if (socket == at_sock->socket)
+        if (at_sock && socket == at_sock->socket)
         {
-            if (at_sock && at_sock->magic == AT_SOCKET_MAGIC)
+            if (at_sock->magic == AT_SOCKET_MAGIC)
             {
                 rt_hw_interrupt_enable(level);
                 return at_sock;
@@ -97,9 +97,9 @@ struct at_socket *at_get_base_socket(int base_socket)
     rt_slist_for_each(node, &_socket_list)
     {
         at_sock = rt_slist_entry(node, struct at_socket, list);
-        if (base_socket == (int)at_sock->user_data && at_sock->state != AT_SOCKET_LISTEN)
+        if (at_sock && base_socket == (int)at_sock->user_data && at_sock->state != AT_SOCKET_LISTEN)
         {
-            if (at_sock && at_sock->magic == AT_SOCKET_MAGIC)
+            if (at_sock->magic == AT_SOCKET_MAGIC)
             {
                 rt_hw_interrupt_enable(level);
                 return at_sock;
@@ -149,7 +149,7 @@ static int at_recvpkt_all_delete(rt_slist_t *rlist)
     {
         pkt = rt_slist_entry(node, struct at_recv_pkt, list);
         node = rt_slist_next(node);
-        if (pkt->buff)
+        if (pkt && pkt->buff)
         {
             rt_free(pkt->buff);
         }
@@ -176,7 +176,7 @@ static int at_recvpkt_node_delete(rt_slist_t *rlist, rt_slist_t *node)
     rt_slist_remove(rlist, node);
 
     pkt = rt_slist_entry(node, struct at_recv_pkt, list);
-    if (pkt->buff)
+    if (pkt && pkt->buff)
     {
         rt_free(pkt->buff);
     }
@@ -208,6 +208,8 @@ static size_t at_recvpkt_get(rt_slist_t *rlist, char *mem, size_t len)
 
         free_node = node;
         node = rt_slist_next(node);
+
+        if (!pkt) continue;
 
         page_pos = pkt->bfsz_totle - pkt->bfsz_index;
 
@@ -330,7 +332,7 @@ static int alloc_empty_socket(rt_slist_t *l)
     rt_slist_for_each(node, &_socket_list)
     {
         at_sock = rt_slist_entry(node, struct at_socket, list);
-        if(at_sock->socket != idx)
+        if(at_sock && at_sock->socket != idx)
             break;
         idx++;
         pre_node = node;
@@ -527,9 +529,9 @@ static int free_socket(struct at_socket *sock)
         rt_slist_for_each(node, &_socket_list)
         {
             at_sock = rt_slist_entry(node, struct at_socket, list);
-            if (sock->socket == at_sock->socket)
+            if (at_sock && sock->socket == at_sock->socket)
             {
-                if (at_sock && at_sock->magic == AT_SOCKET_MAGIC)
+                if (at_sock->magic == AT_SOCKET_MAGIC)
                 {
                     rt_slist_remove(&_socket_list, &at_sock->list);
                     break;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
在rt-thread\bsp\CME_M7\StdPeriph_Driver\src\cmem7_i2c.c中检测出存在未初始化变量dividor参与运算的可能，代码如下
```
static uint32_t i2c_GetClock(I2C0_Type* I2Cx) {
    uint32_t dividor;
    if ((uint32_t)I2Cx == (uint32_t)I2C0) {
        dividor = GLOBAL_CTRL->CLK_SEL_0_b.I2C0_CLK;
    } else if ((uint32_t)I2Cx == (uint32_t)I2C1) {
        dividor = GLOBAL_CTRL->CLK_SEL_0_b.I2C1_CLK;
    }

    return SYSTEM_CLOCK_FREQ / (1 << (dividor + 1));
}
```
分析该文件的判断分支有可能未对dividor进行赋值，导致以未赋值的变量参与返回值的运算，从而引发错误。

#### 你的解决方案是什么 (what is your solution)
使用项目中定义的宏函数assert_param对I2Cx进行检测，这样可以保证程序如果能成功地向下运行，那么I2Cx等于I2C1或I2C0
在判断分支之前对I2Cx地值增加初步检测，修改代码如下：
```
static uint32_t i2c_GetClock(I2C0_Type* I2Cx) {
    uint32_t dividor;
    assert_param(IS_I2C_ALL_PERIPH(I2Cx));

    if ((uint32_t)I2Cx == (uint32_t)I2C0) {
        dividor = GLOBAL_CTRL->CLK_SEL_0_b.I2C0_CLK;
    } else if ((uint32_t)I2Cx == (uint32_t)I2C1) {
        dividor = GLOBAL_CTRL->CLK_SEL_0_b.I2C1_CLK;
    }

    return SYSTEM_CLOCK_FREQ / (1 << (dividor + 1));
}
```
最后，注意到本文件中有许多处格式不规范，所以使用官方的格式化工具对该文件所在文件夹进行格式化调整
链接：https://github.com/mysterywolf/formatting
#### 在什么测试环境下测试通过 (what is the test environment)
all
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
