### PR TITLE
[tools] Add `--add-rtconfig` args for scons when you want to add macr…

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -317,6 +317,19 @@ def PrepareBuilding(env, root_directory, has_libcpu=False, remove_components = [
     if rtconfig.PLATFORM in ['gcc'] and str(env['LINKFLAGS']).find('nano.specs') != -1:
         env.AppendUnique(CPPDEFINES = ['_REENT_SMALL'])
 
+    add_rtconfig = GetOption('add_rtconfig')
+    if add_rtconfig:
+        add_rtconfig = add_rtconfig.split(',')
+        if isinstance(add_rtconfig, list):
+            for config in add_rtconfig:
+                if isinstance(config, str):
+                    AddDepend(add_rtconfig)
+                    env.Append(CFLAGS=' -D' + config, CXXFLAGS=' -D' + config, AFLAGS=' -D' + config)
+                else:
+                    print('add_rtconfig arguements are illegal!')
+        else:
+            print('add_rtconfig arguements are illegal!')
+
     if GetOption('genconfig'):
         from genconf import genconfig
         genconfig()
@@ -1049,3 +1062,4 @@ def PackageSConscript(package):
     from package import BuildPackage
 
     return BuildPackage(package)
+

--- a/tools/options.py
+++ b/tools/options.py
@@ -127,6 +127,10 @@ def AddOptions():
                 action = 'store_true',
                 default = False,
                 help = 'Don`t show pyconfig window')
+    AddOption('--add-rtconfig',
+                dest = 'add_rtconfig',
+                type = 'string',
+                help = 'Add macro definitions and scons depend at build time. It is similar to adding macro definitions in rtconfig.h')
     if platform.system() != 'Windows':
         AddOption('--menuconfig',
                     dest = 'menuconfig',


### PR DESCRIPTION
…o definitions build time.

## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

希望在 scons 构建时，可以动态添加宏定义

#### 你的解决方案是什么 (what is your solution)

增加 `scons --add-rtconfig=RT_USING_XX,RT_USING_YY` 命令，动态修改了构建环境下的 rtconfig 配置。此时的效果类似在 rtconfig.h 中增加了  `RT_USING_XX` 及 `RT_USING_YY` 宏定义的效果。

#### 在什么测试环境下测试通过 (what is the test environment)

本地项目中构建、下载、真机验证通过

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [X] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
