### PR TITLE
[HUST CSE][bsp]fix mismatched function types in rt_pin_ops for all drv_gpio.c

### DIFF
--- a/bsp/ESP32_C3/drivers/drv_gpio.c
+++ b/bsp/ESP32_C3/drivers/drv_gpio.c
@@ -15,20 +15,20 @@
 
 #ifdef RT_USING_PIN
 
-static void mcu_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void mcu_pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
 {
     gpio_set_level(pin, value);
     /*TODO:set gpio out put mode */
 }
 
-static int mcu_pin_read(rt_device_t dev, rt_base_t pin)
+static rt_int8_t mcu_pin_read(rt_device_t dev, rt_base_t pin)
 {
     int value;
     value = gpio_get_level(pin);
     return value;
 }
 
-static void mcu_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void mcu_pin_mode(rt_device_t dev, rt_base_t pin, rt_uint8_t mode)
 {
     gpio_config_t io_conf;
     io_conf.intr_type = GPIO_INTR_DISABLE;
@@ -45,22 +45,22 @@ static void mcu_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
 }
 
 
-static rt_err_t mcu_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                                   rt_uint32_t irq_mode, void (*hdr)(void *args), void *args)
+static rt_err_t mcu_pin_attach_irq(struct rt_device *device, rt_base_t pin,
+                                   rt_uint8_t irq_mode, void (*hdr)(void *args), void *args)
 {
 
     /*TODO: start irq handle */
     return RT_EOK;
 }
 
-static rt_err_t mcu_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t mcu_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
 {
     /*TODO:disable gpio irq handle */
     return RT_EOK;
 }
 
 static rt_err_t mcu_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                                   rt_uint32_t enabled)
+                                   rt_uint8_t enabled)
 {
     /*TODO:start irq handle */
     return RT_EOK;
@@ -72,7 +72,7 @@ const static struct rt_pin_ops _mcu_pin_ops =
     mcu_pin_write,
     mcu_pin_read,
     mcu_pin_attach_irq,
-    mcu_pin_dettach_irq,
+    mcu_pin_detach_irq,
     mcu_pin_irq_enable,
     RT_NULL,
 };

--- a/bsp/ESP32_C3/drivers/drv_gpio.c
+++ b/bsp/ESP32_C3/drivers/drv_gpio.c
@@ -50,7 +50,7 @@ static rt_err_t mcu_pin_attach_irq(struct rt_device *device, rt_base_t pin,
 {
 
     /*TODO: start irq handle */
-    return RT_EOK;
+    return -RT_ENOSYS;
 }
 
 static rt_err_t mcu_pin_detach_irq(struct rt_device *device, rt_int32_t pin)

--- a/bsp/ESP32_C3/drivers/drv_gpio.c
+++ b/bsp/ESP32_C3/drivers/drv_gpio.c
@@ -23,7 +23,7 @@ static void mcu_pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
 
 static rt_int8_t mcu_pin_read(rt_device_t dev, rt_base_t pin)
 {
-    int value;
+    rt_int8_t value;
     value = gpio_get_level(pin);
     return value;
 }

--- a/bsp/Vango/v85xx/drivers/drv_gpio.c
+++ b/bsp/Vango/v85xx/drivers/drv_gpio.c
@@ -120,7 +120,7 @@ static rt_base_t v85xx_pin_get(const char *name)
     return pin;
 }
 
-static void v85xx_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void v85xx_pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
 {
     GPIO_TypeDef *gpio_port;
     uint16_t gpio_pin;
@@ -140,7 +140,7 @@ static void v85xx_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     }
 }
 
-static int v85xx_pin_read(rt_device_t dev, rt_base_t pin)
+static rt_int8_t v85xx_pin_read(rt_device_t dev, rt_base_t pin)
 {
     GPIO_TypeDef *gpio_port;
     uint16_t gpio_pin;
@@ -161,7 +161,7 @@ static int v85xx_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-static void v85xx_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void v85xx_pin_mode(rt_device_t dev, rt_base_t pin, rt_uint8_t mode)
 {
     GPIO_InitType GPIO_InitStruct = {0};
 
@@ -219,8 +219,8 @@ rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
 }
 
 
-static rt_err_t v85xx_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                    rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t v85xx_pin_attach_irq(struct rt_device *device, rt_base_t pin,
+                    rt_uint8_t mode, void (*hdr)(void *args), void *args)
 {
     rt_base_t level;
     rt_int32_t irqindex = -1;
@@ -258,7 +258,7 @@ static rt_err_t v85xx_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
 
     return RT_EOK;
 }
-static rt_err_t v85xx_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t v85xx_pin_detach_irq(struct rt_device *device, rt_base_t pin)
 {
     rt_base_t level;
     rt_int32_t irqindex = -1;
@@ -288,7 +288,7 @@ static rt_err_t v85xx_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
 
     return RT_EOK;
 }
-static rt_err_t v85xx_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+static rt_err_t v85xx_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint8_t enabled)
 {
     const struct pin_irq_map *irqmap;
     rt_base_t level;

--- a/bsp/Vango/v85xxp/drivers/drv_gpio.c
+++ b/bsp/Vango/v85xxp/drivers/drv_gpio.c
@@ -121,7 +121,7 @@ static rt_base_t V85XXP_pin_get(const char *name)
     return pin;
 }
 
-static void V85XXP_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void V85XXP_pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
 {
     GPIO_Type *gpio_port;
     uint16_t gpio_pin;
@@ -141,7 +141,7 @@ static void V85XXP_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     }
 }
 
-static int V85XXP_pin_read(rt_device_t dev, rt_base_t pin)
+static rt_int8_t V85XXP_pin_read(rt_device_t dev, rt_base_t pin)
 {
     GPIO_Type *gpio_port;
     uint16_t gpio_pin;
@@ -162,7 +162,7 @@ static int V85XXP_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-static void V85XXP_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void V85XXP_pin_mode(rt_device_t dev, rt_base_t pin, rt_uint8_t mode)
 {
     GPIO_InitType GPIO_InitStruct = {0};
 
@@ -220,8 +220,8 @@ rt_inline rt_int32_t bit2bitno(rt_uint32_t bit)
 }
 
 
-static rt_err_t V85XXP_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                    rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t V85XXP_pin_attach_irq(struct rt_device *device, rt_base_t pin,
+                    rt_uint8_t mode, void (*hdr)(void *args), void *args)
 {
     rt_base_t level;
     rt_int32_t irqindex = -1;
@@ -259,7 +259,7 @@ static rt_err_t V85XXP_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
 
     return RT_EOK;
 }
-static rt_err_t V85XXP_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t V85XXP_pin_detach_irq(struct rt_device *device, rt_base_t pin)
 {
     rt_base_t level;
     rt_int32_t irqindex = -1;
@@ -289,7 +289,7 @@ static rt_err_t V85XXP_pin_detach_irq(struct rt_device *device, rt_int32_t pin)
 
     return RT_EOK;
 }
-static rt_err_t V85XXP_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+static rt_err_t V85XXP_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint8_t enabled)
 {
     const struct pin_irq_map *irqmap;
     rt_base_t level;

--- a/bsp/acm32/acm32f0x0-nucleo/drivers/drv_gpio.c
+++ b/bsp/acm32/acm32f0x0-nucleo/drivers/drv_gpio.c
@@ -175,7 +175,7 @@ static const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-static void acm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void acm32_pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
 {
     const struct pin_index *index;
 
@@ -188,7 +188,7 @@ static void acm32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     HAL_GPIO_WritePin(index->gpio, index->pin, (enum_PinState_t)value);
 }
 
-static int acm32_pin_read(rt_device_t dev, rt_base_t pin)
+static rt_int8_t acm32_pin_read(rt_device_t dev, rt_base_t pin)
 {
     int value;
     const struct pin_index *index;
@@ -206,7 +206,7 @@ static int acm32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-static void acm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void acm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_uint8_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -308,8 +308,8 @@ static void acm32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
 
 #define     PIN2INDEX(pin)      ((pin) % 16)
 
-static rt_err_t acm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                                     rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t acm32_pin_attach_irq(struct rt_device *device, rt_base_t pin,
+                                     rt_uint8_t mode, void (*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -348,7 +348,7 @@ static rt_err_t acm32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-static rt_err_t acm32_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t acm32_pin_dettach_irq(struct rt_device *device, rt_base_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -378,7 +378,7 @@ static rt_err_t acm32_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
 }
 
 static rt_err_t acm32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                                     rt_uint32_t enabled)
+                                     rt_uint8_t enabled)
 {
     const struct pin_index *index;
     struct pin_irq_map *irqmap;

--- a/bsp/acm32/acm32f4xx-nucleo/drivers/drv_gpio.c
+++ b/bsp/acm32/acm32f4xx-nucleo/drivers/drv_gpio.c
@@ -193,7 +193,7 @@ static const struct pin_index *get_pin(uint8_t pin)
     return index;
 };
 
-static void _pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void _pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
 {
     const struct pin_index *index;
 
@@ -206,7 +206,7 @@ static void _pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     HAL_GPIO_WritePin(index->gpio, index->pin, (enum_PinState_t)value);
 }
 
-static int _pin_read(rt_device_t dev, rt_base_t pin)
+static rt_int8_t _pin_read(rt_device_t dev, rt_base_t pin)
 {
     int value;
     const struct pin_index *index;
@@ -224,7 +224,7 @@ static int _pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-static void _pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void _pin_mode(rt_device_t dev, rt_base_t pin, rt_uint8_t mode)
 {
     const struct pin_index *index;
     GPIO_InitTypeDef GPIO_InitStruct;
@@ -280,8 +280,8 @@ static void _pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
 
 #define     PIN2INDEX(pin)      ((pin) % 16)
 
-static rt_err_t _pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                                     rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t _pin_attach_irq(struct rt_device *device, rt_base_t pin,
+                                     rt_uint8_t mode, void (*hdr)(void *args), void *args)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -320,7 +320,7 @@ static rt_err_t _pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-static rt_err_t _pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t _pin_dettach_irq(struct rt_device *device, rt_base_t pin)
 {
     const struct pin_index *index;
     rt_base_t level;
@@ -350,7 +350,7 @@ static rt_err_t _pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
 }
 
 static rt_err_t _pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                                     rt_uint32_t enabled)
+                                     rt_uint8_t enabled)
 {
     const struct pin_index *index;
     struct pin_irq_map *irqmap;

--- a/bsp/airm2m/air105/libraries/rt_drivers/drv_gpio.c
+++ b/bsp/airm2m/air105/libraries/rt_drivers/drv_gpio.c
@@ -52,7 +52,7 @@ static rt_base_t air105_pin_get(const char *name)
     return pin;
 }
 
-static void air105_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void air105_pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
 {
     if (pin < GPIO_MAX)
     {
@@ -60,7 +60,7 @@ static void air105_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     }
 }
 
-static int air105_pin_read(rt_device_t dev, rt_base_t pin)
+static rt_int8_t air105_pin_read(rt_device_t dev, rt_base_t pin)
 {
     if (pin < GPIO_MAX)
     {
@@ -72,7 +72,7 @@ static int air105_pin_read(rt_device_t dev, rt_base_t pin)
     }
 }
 
-static void air105_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void air105_pin_mode(rt_device_t dev, rt_base_t pin, rt_uint8_t mode)
 {
     if (pin >= GPIO_MAX)
     {
@@ -99,8 +99,8 @@ static void air105_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     }
 }
 
-static rt_err_t air105_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                                     rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t air105_pin_attach_irq(struct rt_device *device, rt_base_t pin,
+                                     rt_uint8_t mode, void (*hdr)(void *args), void *args)
 {
     rt_base_t level;
 
@@ -123,7 +123,7 @@ static rt_err_t air105_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-static rt_err_t air105_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t air105_pin_dettach_irq(struct rt_device *device, rt_base_t pin)
 {
     rt_base_t level;
     level = rt_hw_interrupt_disable();
@@ -136,7 +136,7 @@ static rt_err_t air105_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
 }
 
 static rt_err_t air105_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                                     rt_uint32_t enabled)
+                                     rt_uint8_t enabled)
 {
 
     rt_base_t level;

--- a/bsp/airm2m/air32f103/libraries/rt_drivers/drv_gpio.c
+++ b/bsp/airm2m/air32f103/libraries/rt_drivers/drv_gpio.c
@@ -140,7 +140,7 @@ static rt_base_t air32_pin_get(const char *name)
     return pin;
 }
 
-static void air32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void air32_pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
 {
     GPIO_TypeDef *gpio_port;
     uint16_t gpio_pin;
@@ -154,7 +154,7 @@ static void air32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     }
 }
 
-static int air32_pin_read(rt_device_t dev, rt_base_t pin)
+static rt_int8_t air32_pin_read(rt_device_t dev, rt_base_t pin)
 {
     GPIO_TypeDef *gpio_port;
     uint16_t gpio_pin;
@@ -170,7 +170,7 @@ static int air32_pin_read(rt_device_t dev, rt_base_t pin)
     return value;
 }
 
-static void air32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void air32_pin_mode(rt_device_t dev, rt_base_t pin, rt_uint8_t mode)
 {
     GPIO_InitTypeDef GPIO_InitStruct;
 
@@ -236,8 +236,8 @@ rt_inline const struct pin_irq_map *get_pin_irq_map(uint32_t pinbit)
     return &pin_irq_map[mapindex];
 };
 
-static rt_err_t air32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                                     rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t air32_pin_attach_irq(struct rt_device *device, rt_base_t pin,
+                                     rt_uint8_t mode, void (*hdr)(void *args), void *args)
 {
     rt_base_t level;
     rt_int32_t irqindex = -1;
@@ -276,7 +276,7 @@ static rt_err_t air32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
     return RT_EOK;
 }
 
-static rt_err_t air32_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t air32_pin_dettach_irq(struct rt_device *device, rt_base_t pin)
 {
     rt_base_t level;
     rt_int32_t irqindex = -1;
@@ -308,7 +308,7 @@ static rt_err_t air32_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
 }
 
 static rt_err_t air32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                                     rt_uint32_t enabled)
+                                     rt_uint8_t enabled)
 {
     const struct pin_irq_map *irqmap;
     rt_base_t level;

--- a/bsp/allwinner_tina/drivers/drv_gpio.c
+++ b/bsp/allwinner_tina/drivers/drv_gpio.c
@@ -431,7 +431,7 @@ static struct _pin_index pin_index[] =
     {66, GPIO_PORT_A, GPIO_PIN_0, PIN_MAGIC},
 };
 
-static void pin_mode(struct rt_device *dev, rt_base_t pin, rt_base_t mode)
+static void pin_mode(struct rt_device *dev, rt_base_t pin, rt_uint8_t mode)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {
@@ -442,7 +442,7 @@ static void pin_mode(struct rt_device *dev, rt_base_t pin, rt_base_t mode)
     gpio_set_func(pin_index[pin].pin_port, pin_index[pin].pin, mode);
 }
 
-static void pin_write(struct rt_device *dev, rt_base_t pin, rt_base_t value)
+static void pin_write(struct rt_device *dev, rt_base_t pin, rt_uint8_t value)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {
@@ -453,7 +453,7 @@ static void pin_write(struct rt_device *dev, rt_base_t pin, rt_base_t value)
     gpio_set_value(pin_index[pin].pin_port, pin_index[pin].pin, value);
 }
 
-static int pin_read(struct rt_device *device, rt_base_t pin)
+static rt_int8_t pin_read(struct rt_device *device, rt_base_t pin)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {
@@ -464,7 +464,7 @@ static int pin_read(struct rt_device *device, rt_base_t pin)
     return gpio_get_value(pin_index[pin].pin_port, pin_index[pin].pin);
 }
 
-static rt_err_t pin_attach_irq(struct rt_device *device, rt_int32_t pin, rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t pin_attach_irq(struct rt_device *device, rt_base_t pin, rt_uint8_t mode, void (*hdr)(void *args), void *args)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {
@@ -476,7 +476,7 @@ static rt_err_t pin_attach_irq(struct rt_device *device, rt_int32_t pin, rt_uint
     gpio_set_irq_type(pin_index[pin].pin_port, pin_index[pin].pin, mode);
     return RT_EOK;
 }
-static rt_err_t pin_detach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t pin_detach_irq(struct rt_device *device, rt_base_t pin)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {
@@ -489,7 +489,7 @@ static rt_err_t pin_detach_irq(struct rt_device *device, rt_int32_t pin)
     return RT_EOK;
 }
 
-rt_err_t pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+rt_err_t pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint8_t enabled)
 {
     if ((pin > PIN_NUM(pin_index)) || (pin_index[pin].magic != PIN_MAGIC))
     {

--- a/bsp/bluetrum/libraries/hal_drivers/drv_gpio.c
+++ b/bsp/bluetrum/libraries/hal_drivers/drv_gpio.c
@@ -99,21 +99,21 @@ static rt_base_t ab32_pin_get(const char *name)
     return pin;
 }
 
-static void ab32_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void ab32_pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
 {
     rt_uint8_t port = PIN_PORT(pin);
     rt_uint8_t gpio_pin  = pin - port_table[port].total_pin;
     hal_gpio_write(PORT_SFR(port), gpio_pin, (rt_uint8_t)value);
 }
 
-static int ab32_pin_read(rt_device_t dev, rt_base_t pin)
+static rt_int8_t ab32_pin_read(rt_device_t dev, rt_base_t pin)
 {
     rt_uint8_t port = PIN_PORT(pin);
     rt_uint8_t gpio_pin  = pin - port_table[port].total_pin;
     return hal_gpio_read(PORT_SFR(port), gpio_pin);
 }
 
-static void ab32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void ab32_pin_mode(rt_device_t dev, rt_base_t pin, rt_uint8_t mode)
 {
     struct gpio_init gpio_init;
     rt_uint8_t port = PIN_PORT(pin);
@@ -147,19 +147,19 @@ static void ab32_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     hal_gpio_init(PORT_SFR(port), &gpio_init);
 }
 
-static rt_err_t ab32_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
-                                     rt_uint32_t mode, void (*hdr)(void *args), void *args)
+static rt_err_t ab32_pin_attach_irq(struct rt_device *device, rt_base_t pin,
+                                     rt_uint8_t mode, void (*hdr)(void *args), void *args)
 {
     return -RT_ERROR;
 }
 
-static rt_err_t ab32_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t ab32_pin_dettach_irq(struct rt_device *device, rt_base_t pin)
 {
     return -RT_ERROR;
 }
 
 static rt_err_t ab32_pin_irq_enable(struct rt_device *device, rt_base_t pin,
-                                     rt_uint32_t enabled)
+                                     rt_uint8_t enabled)
 {
     return -RT_ERROR;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
经由[[HUST CSE][bsp] fix mismatched function types in rt_pin_ops](https://github.com/RT-Thread/rt-thread/pull/7161)为启发，当时只发现一个板子上的问题，故只修改了一个文件。然后发现除少部分drv_gpio.c文件变量类型正确无误外，下面所列出的文件均有类型不匹配的问题。
1. bsp/ESP32_C3/drivers/drv_gpio.c
2. bsp/Vango/v85xx/drivers/drv_gpio.c
3. bsp/Vango/v85xxp/drivers/drv_gpio.c
4. bsp/acm32/acm32f0x0-nucleo/drivers/drv_gpio.c
5. bsp/acm32/acm32f4xx-nucleo/drivers/drv_gpio.c
6. bsp/airm2m/air105/libraries/rt_drivers/drv_gpio.c
7. bsp/airm2m/air32f103/libraries/rt_drivers/drv_gpio.c
8. bsp/allwinner_tina/drivers/drv_gpio.c
9. bsp/bluetrum/libraries/hal_drivers/drv_gpio.c

#### 你的解决方案是什么 (what is your solution)
将drv_gpio.c的不匹配字段按照应有的类型做出一定的修改。

#### 在什么测试环境下测试通过 (what is the test environment)

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
