### PR TITLE
[HUST CSE]avoids the risk of a null pointer

### DIFF
--- a/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb-hal-cat1/source/cyhal_crc.c
+++ b/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb-hal-cat1/source/cyhal_crc.c
@@ -52,8 +52,7 @@ cy_rslt_t cyhal_crc_init(cyhal_crc_t *obj)
 
 void cyhal_crc_free(cyhal_crc_t *obj)
 {
-    CY_ASSERT(NULL != obj);
-    CY_ASSERT(obj->resource.type != CYHAL_RSC_CRYPTO);
+    CY_ASSERT(NULL != obj&&obj->resource.type != CYHAL_RSC_CRYPTO);
     _cyhal_crc_calc_free(obj->base);
     if (obj->resource.type != CYHAL_RSC_INVALID)
     {

--- a/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb-hal-cat1/source/cyhal_crc.c
+++ b/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb-hal-cat1/source/cyhal_crc.c
@@ -52,7 +52,8 @@ cy_rslt_t cyhal_crc_init(cyhal_crc_t *obj)
 
 void cyhal_crc_free(cyhal_crc_t *obj)
 {
-    CY_ASSERT(NULL != obj || obj->resource.type != CYHAL_RSC_CRYPTO);
+    CY_ASSERT(NULL != obj);
+    CY_ASSERT(obj->resource.type != CYHAL_RSC_CRYPTO);
     _cyhal_crc_calc_free(obj->base);
     if (obj->resource.type != CYHAL_RSC_INVALID)
     {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)
Either the condition 'NULL!=obj' is redundant or there is possible null pointer dereference: obj.
在判断断言时，若obj==NULL，或语句的右边为假，会进行或语句的左边obj->resource.type，故有错

此处给出文件路径：
bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb-hal-cat1/source/cyhal_crc.c

查看源码：
`CY_ASSERT(NULL != obj || obj->resource.type != CYHAL_RSC_CRYPTO);`


#### 你的解决方案是什么 (what is your solution)
将一个断言换成两个,避免空指针可能出现的bug
`CY_ASSERT(NULL != obj);
 CY_ASSERT(obj->resource.type != CYHAL_RSC_CRYPTO);`


#### 在什么测试环境下测试通过 (what is the test environment)
测试成功!


### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
