### PR TITLE
[HUST CSE][blob]Fix logical errors in if statements

### DIFF
--- a/bsp/hpmicro/libraries/hpm_sdk/soc/HPM6360/hpm_clock_drv.c
+++ b/bsp/hpmicro/libraries/hpm_sdk/soc/HPM6360/hpm_clock_drv.c
@@ -368,7 +368,7 @@ hpm_stat_t clock_set_dac_source(clock_name_t clock_name, clk_src_t src)
         return status_clk_invalid;
     }
 
-    if ((src != clk_dac_src_ana) || (src != clk_dac_src_ahb)) {
+    if ((src != clk_dac_src_ana) && (src != clk_dac_src_ahb)) {
         return status_clk_src_invalid;
     }
 
@@ -388,7 +388,7 @@ hpm_stat_t clock_set_i2s_source(clock_name_t clock_name, clk_src_t src)
         return status_clk_invalid;
     }
 
-    if ((src != clk_i2s_src_aud0) || (src != clk_i2s_src_aud1)) {
+    if ((src != clk_i2s_src_aud0) && (src != clk_i2s_src_aud1)) {
         return status_clk_src_invalid;
     }
 


### PR DESCRIPTION
**- 为什么提交这份PR** (why to submit this PR)**
在hpm_clock_drv.c文件中，发现两个判断Clock source是否有效的if语句存在着逻辑错误，从而导致无法对Clock source进行有效性验证。

文件的详细路径如下：
RT-Thread/rt-thread/blob/master/bsp/hpmicro/libraries/hpm_sdk/soc/HPM6360/hpm_clock_drv.c

具体的问题源于文件中第371行与391行，具体代码如下：
![2023-04-12_191737](https://user-images.githubusercontent.com/126075324/231488403-948dedcb-27a4-4771-867a-a947a2547ac5.jpg)
![2023-04-12_191721](https://user-images.githubusercontent.com/126075324/231488453-28ea7436-794b-4eae-9fa8-77633b335636.jpg)
可以看到在if语句中，使用||会导致逻辑错误，使得有效的src也会被认为是无效的。


**- 你的解决方案是什么 (what is your solution)**
将||改为&&，使得src在同时满足两个判断都不满足时才认为有效性验证不通过。
![image](https://user-images.githubusercontent.com/126075324/231491722-74a3eb76-4750-4580-9cf8-fa3f98867929.png)


**- 在什么测试环境下测试通过 (what is the test environment)**
all