### PR TITLE
[HUST-CSE]fix: fixed logical error when put format str

### DIFF
--- a/bsp/imxrt/libraries/MIMXRT1020/MIMXRT1021/utilities/debug_console_lite/fsl_debug_console.c
+++ b/bsp/imxrt/libraries/MIMXRT1020/MIMXRT1021/utilities/debug_console_lite/fsl_debug_console.c
@@ -972,22 +972,7 @@ static int DbgConsole_PrintfFormattedData(PUTCHAR_FUNC func_ptr, const char *fmt
 
 #if PRINTF_ADVANCED_ENABLE
                     dschar = false;
-                    if (0U != (flags_used & (uint32_t)kPRINTF_Zero))
-                    {
-                        if (0U != (flags_used & (uint32_t)kPRINTF_Pound))
-                        {
-                            (void)func_ptr('0');
-                            (void)func_ptr((use_caps ? 'X' : 'x'));
-                            count += 2;
-                            /*vlen += 2;*/
-                            dschar = true;
-                        }
-                        DbgConsole_PrintfPaddingCharacter('0', vlen, (int32_t)field_width, &count, func_ptr);
-                        vlen = (int32_t)field_width;
-                    }
-                    else
-                    {
-                        if (0U == (flags_used & (uint32_t)kPRINTF_Pound))
+                    if (0U != (flags_used & (uint32_t)kPRINTF_Minus))
                         {
                             if (0U != (flags_used & (uint32_t)kPRINTF_Pound))
                             {
@@ -1002,6 +987,21 @@ static int DbgConsole_PrintfFormattedData(PUTCHAR_FUNC func_ptr, const char *fmt
 
                                 dschar = true;
                             }
+                        }
+                    else
+                    {
+                        if (0U != (flags_used & (uint32_t)kPRINTF_Zero))
+                        {
+                            if (0U != (flags_used & (uint32_t)kPRINTF_Pound))
+                            {
+                                (void)func_ptr('0');
+                                (void)func_ptr((use_caps ? 'X' : 'x'));
+                                count += 2;
+                                /*vlen += 2;*/
+                               dschar = true;
+                            }
+                            DbgConsole_PrintfPaddingCharacter('0', vlen, (int32_t)field_width, &count, func_ptr);
+                            vlen = (int32_t)field_width;
                         }
                     }
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
https://github.com/RT-Thread/rt-thread/blob/master/bsp/imxrt/libraries/MIMXRT1020/MIMXRT1021/utilities/debug_console_lite/fsl_debug_console.c#L990
注意该处存在逻辑错误
#### 你的解决方案是什么 (what is your solution)
此行以下部分代码逻辑为：将输出格式化数字右对齐，并在存在‘#’flag时加上0x/0X前缀，根据宏定义使用的flag为：‘0’、‘+’、‘-’、‘ ’、‘#’以及其他代码逻辑可知格式化字符串中数字输出为类python风格，因此该处代码作用应当是判断是否使用了‘-’flag。修改后如下所示：
https://github.com/zb1tree/rt-thread/blob/master/bsp/imxrt/libraries/MIMXRT1020/MIMXRT1021/utilities/debug_console_lite/fsl_debug_console.c#:~:text=dschar%20%3D%20false%3B-,if%20(0U%20!%3D%20(flags_used%20%26%20(uint32_t)kPRINTF_Minus)),-%7B
另假设数字输出格式与python相同，则‘-’flag应当覆盖‘0’flag，据此我认为此处对flag判断顺序存在问题，将判断顺序修改如下：
https://github.com/zb1tree/rt-thread/blob/master/bsp/imxrt/libraries/MIMXRT1020/MIMXRT1021/utilities/debug_console_lite/fsl_debug_console.c#:~:text=dschar%20%3D%20false%3B-,if%20(0U%20!%3D%20(flags_used%20%26%20(uint32_t)kPRINTF_Minus)),%7D,-if%20((0U
#### 在什么测试环境下测试通过 (what is the test environment)
默认测试
]


### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo
### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
