### PR TITLE
修复瑞萨RA6M3的drv_gpio.c、drv_usart_v2.c的参数引用错误

### DIFF
--- a/bsp/renesas/libraries/HAL_Drivers/drv_gpio.c
+++ b/bsp/renesas/libraries/HAL_Drivers/drv_gpio.c
@@ -231,7 +231,7 @@ static rt_err_t ra_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_ui
 }
 
 static rt_err_t ra_pin_attach_irq(struct rt_device *device, rt_base_t pin,
-                                  rt_uint32_t mode, void (*hdr)(void *args), void *args)
+                                  rt_uint8_t   mode, void (*hdr)(void *args), void *args)
 {
 #ifdef R_ICU_H
     rt_int32_t irqx = ra_pin_get_irqx(pin);

--- a/bsp/renesas/libraries/HAL_Drivers/drv_gpio.c
+++ b/bsp/renesas/libraries/HAL_Drivers/drv_gpio.c
@@ -111,7 +111,7 @@ static void ra_pin_map_init(void)
 }
 #endif  /* R_ICU_H */
 
-static void ra_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
+static void ra_pin_mode(rt_device_t dev, rt_base_t pin, rt_uint8_t mode)
 {
     fsp_err_t err;
     /* Initialize the IOPORT module and configure the pins */
@@ -154,7 +154,7 @@ static void ra_pin_mode(rt_device_t dev, rt_base_t pin, rt_base_t mode)
     }
 }
 
-static void ra_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
+static void ra_pin_write(rt_device_t dev, rt_base_t pin, rt_uint8_t value)
 {
     bsp_io_level_t level = BSP_IO_LEVEL_HIGH;
 
@@ -168,7 +168,7 @@ static void ra_pin_write(rt_device_t dev, rt_base_t pin, rt_base_t value)
     R_BSP_PinAccessDisable();
 }
 
-static int ra_pin_read(rt_device_t dev, rt_base_t pin)
+static rt_int8_t ra_pin_read(rt_device_t dev, rt_base_t pin)
 {
     if ((pin > RA_MAX_PIN_VALUE) || (pin < RA_MIN_PIN_VALUE))
     {
@@ -178,7 +178,7 @@ static int ra_pin_read(rt_device_t dev, rt_base_t pin)
     return R_BSP_PinRead(pin);
 }
 
-static rt_err_t ra_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint32_t enabled)
+static rt_err_t ra_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_uint8_t enabled)
 {
 #ifdef R_ICU_H
     rt_err_t err;
@@ -230,7 +230,7 @@ static rt_err_t ra_pin_irq_enable(struct rt_device *device, rt_base_t pin, rt_ui
 #endif
 }
 
-static rt_err_t ra_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
+static rt_err_t ra_pin_attach_irq(struct rt_device *device, rt_base_t pin,
                                   rt_uint32_t mode, void (*hdr)(void *args), void *args)
 {
 #ifdef R_ICU_H
@@ -264,7 +264,7 @@ static rt_err_t ra_pin_attach_irq(struct rt_device *device, rt_int32_t pin,
 #endif
 }
 
-static rt_err_t ra_pin_dettach_irq(struct rt_device *device, rt_int32_t pin)
+static rt_err_t ra_pin_dettach_irq(struct rt_device *device, rt_base_t pin)
 {
 #ifdef R_ICU_H
     rt_int32_t irqx = ra_pin_get_irqx(pin);

--- a/bsp/renesas/libraries/HAL_Drivers/drv_usart_v2.c
+++ b/bsp/renesas/libraries/HAL_Drivers/drv_usart_v2.c
@@ -244,7 +244,7 @@ static int ra_uart_getc(struct rt_serial_device *serial)
     return RT_EOK;
 }
 
-static rt_ssize_t ra_uart_transmit(struct rt_serial_device     *serial,
+static rt_size_t ra_uart_transmit(struct rt_serial_device     *serial,
                                   rt_uint8_t           *buf,
                                   rt_size_t             size,
                                   rt_uint32_t           tx_flag)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
我在拉取ra6m3-ek源码，生成mdk5工程，进行编译时发现参数引用错误。

#### 你的解决方案是什么 (what is your solution)

经核对原型函数，修改参数引用的错误
#### 在什么测试环境下测试通过 (what is the test environment)
在RA6M3-EK开发板上测试了验证。
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ x] 代码是高质量的 Code in this PR is of high quality
- [x ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
