### PR TITLE
[HUST CSE] Fix: if语句的判断条件存在变量名错误

### DIFF
--- a/bsp/at32/libraries/rt_drivers/drv_qspi.c
+++ b/bsp/at32/libraries/rt_drivers/drv_qspi.c
@@ -449,7 +449,7 @@ rt_err_t at32_qspi_bus_attach_device(const char *bus_name, const char *device_na
         goto __exit;
     }
     cs_pin = (struct at32_hw_spi_cs *)rt_malloc(sizeof(struct at32_hw_spi_cs));
-    if (qspi_device == RT_NULL)
+    if (cs_pin == RT_NULL)
     {
         LOG_E("no memory, qspi bus attach device failed!");
         result = -RT_ENOMEM;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
在bsp/at32/libraries/rt_drivers/drv_qspi.c这个文件中，第444行申请qspi_device变量空间后，紧接着判断了是否申请成功，而在451行中申请cs_pin变量空间后，本应该判断这个变量是否申请成功，却继续判断qspi_device变量是否申请成功，如果cs_pin申请空间失败没有转入异常处理，后续就会发生错误，因此提交这份PR
#### 你的解决方案是什么 (what is your solution)
直接将if语句错误的变量名qspi_device替换为正确的cs_pin

#### 在什么测试环境下测试通过 (what is the test environment)
只修改了相应的变量名，测试一定会通过

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
