### PR TITLE
fix ipv6 compatibility issues

### DIFF
--- a/components/net/lwip/lwip-2.0.3/src/include/lwip/ip_addr.h
+++ b/components/net/lwip/lwip-2.0.3/src/include/lwip/ip_addr.h
@@ -373,7 +373,7 @@ extern const ip_addr_t ip_addr_broadcast;
 
 extern const ip_addr_t ip6_addr_any;
 
-/** 
+/**
  * @ingroup ip6addr
  * IP6_ADDR_ANY can be used as a fixed ip_addr_t
  * for the IPv6 wildcard address
@@ -399,6 +399,8 @@ extern const ip_addr_t ip6_addr_any;
 #else
 #define IP_ANY_TYPE    IP_ADDR_ANY
 #endif
+
+struct netif *lwip_ip4_route_src(const ip4_addr_t *dest, const ip4_addr_t *src);
 
 #ifdef __cplusplus
 }

--- a/components/net/lwip/lwip-2.1.2/src/include/lwip/ip_addr.h
+++ b/components/net/lwip/lwip-2.1.2/src/include/lwip/ip_addr.h
@@ -404,7 +404,7 @@ extern const ip_addr_t ip_addr_broadcast;
 
 extern const ip_addr_t ip6_addr_any;
 
-/** 
+/**
  * @ingroup ip6addr
  * IP6_ADDR_ANY can be used as a fixed ip_addr_t
  * for the IPv6 wildcard address
@@ -430,6 +430,8 @@ extern const ip_addr_t ip6_addr_any;
 #else
 #define IP_ANY_TYPE    IP_ADDR_ANY
 #endif
+
+struct netif *lwip_ip4_route_src(const ip4_addr_t *dest, const ip4_addr_t *src);
 
 #ifdef __cplusplus
 }

--- a/components/net/lwip/lwip-2.1.2/src/include/lwip/prot/ip6.h
+++ b/components/net/lwip/lwip-2.1.2/src/include/lwip/prot/ip6.h
@@ -200,7 +200,7 @@ PACK_STRUCT_END
 #define IP6_ROUT_SEG_LEFT(hdr) ((hdr)->_segments_left)
 
 /* Fragment header. */
-#define IP6_FRAG_HLEN    8
+#define IP6_FRAG_HLEN    12
 #define IP6_FRAG_OFFSET_MASK    0xfff8
 #define IP6_FRAG_MORE_FLAG      0x0001
 

--- a/components/net/lwip/port/ethernetif.c
+++ b/components/net/lwip/port/ethernetif.c
@@ -246,7 +246,11 @@ int lwip_netdev_ping(struct netdev *netif, const char *host, size_t data_len,
     local.sin_len = sizeof(local);
     local.sin_family = AF_INET;
     local.sin_port = 0;
+#ifndef NETDEV_USING_IPV6
     local.sin_addr.s_addr = (netif->ip_addr.addr);
+#else
+    local.sin_addr.s_addr = (netif->ip_addr.u_addr.ip4.addr);
+#endif
     lwip_bind(s, (struct sockaddr *)&local, sizeof(struct sockaddr_in));
 
     lwip_setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, sizeof(recv_timeout));

--- a/components/net/lwip/port/lwipopts.h
+++ b/components/net/lwip/port/lwipopts.h
@@ -585,7 +585,7 @@
 #endif
 
 /* MEMP_NUM_SYS_TIMEOUT: the number of simulateously active timeouts. */
-#define MEMP_NUM_SYS_TIMEOUT       (LWIP_TCP + IP_REASSEMBLY + LWIP_ARP + (2*LWIP_DHCP) + LWIP_AUTOIP + LWIP_IGMP + LWIP_DNS + 2*PPP_SUPPORT)
+#define MEMP_NUM_SYS_TIMEOUT       (LWIP_TCP + IP_REASSEMBLY + LWIP_ARP + (2*LWIP_DHCP) + LWIP_AUTOIP + LWIP_IGMP + LWIP_DNS + PPP_SUPPORT + (LWIP_IPV6 ? (1 + (2*LWIP_IPV6)) : 0))
 
 /*
  * LWIP_COMPAT_SOCKETS==1: Enable BSD-style sockets functions names.
@@ -642,8 +642,6 @@
 #else                                /* >= v2.1.2 */
 #define LWIP_HOOK_IP4_ROUTE_SRC(src, dest)  lwip_ip4_route_src(dest, src)
 #endif
-#include "lwip/ip_addr.h"
-struct netif *lwip_ip4_route_src(const ip4_addr_t *dest, const ip4_addr_t *src);
 #endif /* RT_USING_LWIP_VER_NUM >= 0x20000 */
 
 #endif /* __LWIPOPTS_H__ */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
在使用2.1.2版本lwip组件中，开启ipv6从编译到运行都遇到了问题，提供该修改策略。

#### 你的解决方案是什么 (what is your solution)
首先声明，这不是一个充分解决```ipv6```问题的```pr```，算是一份必要不充分的修改。
```
- #define IP6_FRAG_HLEN    8
+ #define IP6_FRAG_HLEN    12
```
这里的修改是为了应对不同架构硬件平台指针大小```size```差异，出现```ip6_frag.c line 115```断言。
```
//components/net/lwip/lwip-2.1.2/src/core/ipv6/ip6_frag.c line 115

#if !IPV6_FRAG_COPYHEADER
  LWIP_ASSERT("sizeof(struct ip6_reass_helper) <= IP6_FRAG_HLEN, set IPV6_FRAG_COPYHEADER to 1",
    sizeof(struct ip6_reass_helper) <= IP6_FRAG_HLEN);
#endif /* !IPV6_FRAG_COPYHEADER */
```
其余说明可以参考issues #6985 中我个人的评论。
如果想让ipv6功能跑起来，还需要在```components/net/lwip/port/lwipopts.h```考量下面这两行代码的处理方式，这边的问题同样在上述 issues #6985 中提及，鉴于还没来得及找到比较好的处理方式，暂未处理。

```c
//components/net/lwip/port/lwipopts.h line 645

#include "lwip/ip_addr.h"
struct netif *lwip_ip4_route_src(const ip4_addr_t *dest, const ip4_addr_t *src);
```
#### 在什么测试环境下测试通过 (what is the test environment)
将上述`components/net/lwip/port/lwipopts.h`中提及的两行代码注释掉，编译会出现警告，但是功能可以正常运行。
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
