### PR TITLE
[libcpu/aarch64] fix cache invalidate operation

### DIFF
--- a/components/mm/mm_page.c
+++ b/components/mm/mm_page.c
@@ -679,7 +679,7 @@ static void _install_page(rt_page_t mpr_head, rt_region_t region, void *insert_h
     shadow.start = region.start & ~shadow_mask;
     shadow.end = FLOOR(region.end, shadow_mask + 1);
 
-    if (shadow.end > UINT32_MAX)
+    if (shadow.end + PV_OFFSET > UINT32_MAX)
         _high_page_configured = 1;
 
     rt_page_t shad_head = addr_to_page(mpr_head, (void *)shadow.start);

--- a/libcpu/aarch64/common/cache.h
+++ b/libcpu/aarch64/common/cache.h
@@ -23,9 +23,13 @@ void rt_hw_cpu_dcache_invalidate(void *start_addr, unsigned long size);
 
 static inline void rt_hw_icache_invalidate_all(void)
 {
-    /* wait for any modification complete */
+    /* wait for any former modification to complete */
     __asm__ volatile ("dsb ishst");
-    __asm__ volatile ("ic iallu");
+
+    __asm__ volatile ("ic ialluis");
+    /* wait for ic to retire */
+    __asm__ volatile ("dsb nsh");
+    /* flush instruction pipeline */
     __asm__ volatile ("isb");
 }
 

--- a/libcpu/aarch64/common/cache.h
+++ b/libcpu/aarch64/common/cache.h
@@ -23,7 +23,7 @@ void rt_hw_cpu_dcache_invalidate(void *start_addr, unsigned long size);
 
 static inline void rt_hw_icache_invalidate_all(void)
 {
-    /* wait for any former modification to complete */
+    /* wait for previous modification to complete */
     __asm__ volatile ("dsb ishst");
 
     __asm__ volatile ("ic ialluis");


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

* `ic iallu` is replaced with `ic ialluis` because previous implementation is not working properly on cortex-a55
*  fix a misuse of va in `mm_page.c`

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
