### PR TITLE
使用realloc，malloc，calloc函数后没有类型转换

### DIFF
--- a/bsp/loongson/ls2kdev/drivers/ata/dwc_ahsata.c
+++ b/bsp/loongson/ls2kdev/drivers/ata/dwc_ahsata.c
@@ -995,7 +995,7 @@ static int ahci_init_one(int pdev)
     int rc;
     struct ahci_uc_priv *uc_priv = NULL;
 
-    uc_priv = malloc(sizeof(struct ahci_uc_priv));
+    uc_priv = (struct ahci_uc_priv*)malloc(sizeof(struct ahci_uc_priv));
     if (!uc_priv)
         return -ENOMEM;
 

--- a/bsp/simulator/drivers/board.c
+++ b/bsp/simulator/drivers/board.c
@@ -23,7 +23,7 @@
 rt_uint8_t *rt_hw_sram_init(void)
 {
     rt_uint8_t *heap;
-    heap = malloc(RT_HEAP_SIZE);
+    heap = (rt_uint8_t *)malloc(RT_HEAP_SIZE);
     if (heap == RT_NULL)
     {
         rt_kprintf("there is no memory in pc.");

--- a/bsp/simulator/drivers/dfs_win32.c
+++ b/bsp/simulator/drivers/dfs_win32.c
@@ -180,7 +180,7 @@ static int dfs_win32_open(struct dfs_file *file)
         strcat(file_path, "*.*");
         /* _findfirst will get '.' */
         /* save this pointer,will used by  dfs_win32_getdents*/
-        wdirp = rt_malloc(sizeof(WINDIR));
+        wdirp = (WINDIR *)rt_malloc(sizeof(WINDIR));
         RT_ASSERT(wdirp != NULL);
         if ((handle = _findfirst(file_path, &wdirp->finddata)) == -1)
         {

--- a/bsp/simulator/drivers/dfs_win32.c
+++ b/bsp/simulator/drivers/dfs_win32.c
@@ -358,7 +358,7 @@ static int dfs_win32_getdents(struct dfs_file *file, struct dirent *dirp, rt_uin
         {
             char* old_start = wdirp->start;
             long name_len = strlen(wdirp->finddata.name) + 1;
-            wdirp->start = realloc(wdirp->start, wdirp->end - wdirp->start + name_len);
+            wdirp->start = (WINDIR *)realloc(wdirp->start, wdirp->end - wdirp->start + name_len);
             wdirp->curr = wdirp->start + (wdirp->curr - old_start);
             wdirp->end = wdirp->curr + name_len;
             rt_strcpy(wdirp->curr, wdirp->finddata.name);

--- a/components/drivers/fdt/src/dtb_base.c
+++ b/components/drivers/fdt/src/dtb_base.c
@@ -401,7 +401,7 @@ int dtb_node_write_prop(const struct dtb_node *node, const char *propname, int l
         return -ENOENT;
 
     /* Property does not exist -> append new property */
-    new = malloc(sizeof(struct dtb_property));
+    new = (struct dtb_property*)malloc(sizeof(struct dtb_property));
     if (!new)
         return -ENOMEM;
 

--- a/components/drivers/fdt/src/dtb_get.c
+++ b/components/drivers/fdt/src/dtb_get.c
@@ -188,7 +188,7 @@ struct dtb_node *dtb_node_get_dtb_list(void *fdt)
 
     root_off = fdt_path_offset(fdt, "/");
 
-    if ((dtb_node_head->header = malloc(sizeof(struct dtb_header))) == NULL)
+    if ((dtb_node_head->header = (struct dtb_header*)malloc(sizeof(struct dtb_header))) == NULL)
     {
         fdt_exec_status = FDT_RET_NO_MEMORY;
         goto fail;
@@ -560,7 +560,7 @@ struct dtb_node *dtb_node_get_dtb_node_by_path(struct dtb_node *dtb_node, const 
     }
 
     pathname_sz = strlen(pathname) + 1;
-    pathname_clone = malloc(pathname_sz);
+    pathname_clone = (char *)malloc(pathname_sz);
     if (pathname_clone == NULL)
     {
         return NULL;

--- a/components/drivers/fdt/src/dtb_get.c
+++ b/components/drivers/fdt/src/dtb_get.c
@@ -176,7 +176,7 @@ struct dtb_node *dtb_node_get_dtb_list(void *fdt)
 
     if (paths_buf.ptr == NULL)
     {
-        paths_buf.ptr = malloc(FDT_DTB_ALL_NODES_PATH_SIZE);
+        paths_buf.ptr =(char *)malloc(FDT_DTB_ALL_NODES_PATH_SIZE);
         if (paths_buf.ptr == NULL)
         {
             fdt_exec_status = FDT_RET_NO_MEMORY;

--- a/components/drivers/fdt/src/dtb_get.c
+++ b/components/drivers/fdt/src/dtb_get.c
@@ -206,7 +206,7 @@ struct dtb_node *dtb_node_get_dtb_list(void *fdt)
             uint32_t off_mem_rsvmap = fdt_off_mem_rsvmap(fdt);
             struct fdt_reserve_entry *rsvmap = (struct fdt_reserve_entry *)((char *)fdt + off_mem_rsvmap);
 
-            ((struct dtb_header *)dtb_node_head->header)->memreserve = malloc(sizeof(struct dtb_memreserve) * memreserve_sz);
+            ((struct dtb_header *)dtb_node_head->header)->memreserve = (struct dtb_memreserve *)malloc(sizeof(struct dtb_memreserve) * memreserve_sz);
             if (dtb_node_head->header->memreserve == NULL)
             {
                 fdt_exec_status = FDT_RET_NO_MEMORY;

--- a/components/libc/cplusplus/cpp11/emutls.c
+++ b/components/libc/cplusplus/cpp11/emutls.c
@@ -188,7 +188,7 @@ emutls_get_address_array(uintptr_t index)
     {
         uintptr_t orig_size = array->size;
         uintptr_t new_size = emutls_new_data_array_size(index);
-        array = realloc(array, (new_size + 1) * sizeof(void *));
+        array = (emutls_address_array *)realloc(array, (new_size + 1) * sizeof(void *));
         if (array)
             memset(array->data + orig_size, 0,
                    (new_size - orig_size) * sizeof(void *));

--- a/components/libc/cplusplus/cpp11/emutls.c
+++ b/components/libc/cplusplus/cpp11/emutls.c
@@ -181,7 +181,7 @@ emutls_get_address_array(uintptr_t index)
     if (array == NULL)
     {
         uintptr_t new_size = emutls_new_data_array_size(index);
-        array = calloc(new_size + 1, sizeof(void *));
+        array = (emutls_address_array *)calloc(new_size + 1, sizeof(void *));
         emutls_check_array_set_size(array, new_size);
     }
     else if (index > array->size)

--- a/components/libc/cplusplus/cpp11/emutls.c
+++ b/components/libc/cplusplus/cpp11/emutls.c
@@ -61,7 +61,7 @@ static __inline void *emutls_memalign_alloc(size_t align, size_t size)
 #else
 #define EXTRA_ALIGN_PTR_BYTES (align - 1 + sizeof(void *))
     char *object;
-    if ((object = malloc(EXTRA_ALIGN_PTR_BYTES + size)) == NULL)
+    if ((object = (char *)malloc(EXTRA_ALIGN_PTR_BYTES + size)) == NULL)
         abort();
     base = (void *)(((uintptr_t)(object + EXTRA_ALIGN_PTR_BYTES)) & ~(uintptr_t)(align - 1));
 

--- a/examples/libc/ex4.c
+++ b/examples/libc/ex4.c
@@ -58,7 +58,7 @@ char * str_accumulate(const char * s)
   accu = (char *) pthread_getspecific(str_key);
   /* It's initially NULL, meaning that we must allocate the buffer first. */
   if (accu == NULL) {
-    accu = malloc(1024);
+    accu = (char *)malloc(1024);
     if (accu == NULL) return NULL;
     accu[0] = 0;
     /* Store the buffer pointer in the thread-specific data. */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
      有部分使用realloc，malloc，calloc函数后没有重新定义指针的情况

#### 你的解决方案是什么 (what is your solution)
       重新定义一次指针，改动了以下代码：
rt-thread-master/bsp/loongson/ls2kdev/drivers/ata/dwc_ahsata.c:    uc_priv = malloc(sizeof(struct ahci_uc_priv));	-> uc_priv = (struct ahci_uc_priv*)malloc(sizeof(struct ahci_uc_priv));
rt-thread-master/bsp/simulator/drivers/board.c:    heap = malloc(RT_HEAP_SIZE);	-> heap = (rt_uint8_t *)malloc(RT_HEAP_SIZE); 	-> heap = (rt_uint8_t *)malloc(RT_HEAP_SIZE);
rt-thread-master/bsp/simulator/drivers/dfs_win32.c:        wdirp->start = malloc(len); //not rt_malloc!	-> wdirp = (WINDIR *)rt_malloc(sizeof(WINDIR));
rt-thread-master/components/drivers/fdt/src/dtb_base.c:    new = malloc(sizeof(struct dtb_property));	-> new = (struct dtb_property*)malloc(sizeof(struct dtb_property));
rt-thread-master/components/drivers/fdt/src/dtb_get.c:        paths_buf.ptr = malloc(FDT_DTB_ALL_NODES_PATH_SIZE);	-> paths_buf.ptr = (char *)malloc(FDT_DTB_ALL_NODES_PATH_SIZE);
rt-thread-master/components/drivers/fdt/src/dtb_get.c:    if ((dtb_node_head->header = malloc(sizeof(struct dtb_header))) == NULL)	->if ((dtb_node_head->header = (struct dtb_header*)malloc(sizeof(struct dtb_header))) == NULL)
rt-thread-master/components/drivers/fdt/src/dtb_get.c:    pathname_clone = malloc(pathname_sz);	->pathname_clone = (char *)malloc(pathname_sz);
rt-thread-master/components/drivers/fdt/src/dtb_get.c:            ((struct dtb_header *)dtb_node_head->header)->memreserve = malloc(sizeof(struct dtb_memreserve) * memreserve_sz);	->((struct dtb_header *)dtb_node_head->header)->memreserve = (struct dtb_memreserve *)malloc(sizeof(struct dtb_memreserve) * memreserve_sz);
rt-thread-master/components/drivers/fdt/src/dtb_load.c:            if ((fdt = malloc(dtb_sz)) != NULL)	->if ((fdt =(size_t *)malloc(dtb_sz)) != NULL)
rt-thread-master/components/libc/cplusplus/cpp11/emutls.c:    if ((object = malloc(EXTRA_ALIGN_PTR_BYTES + size)) == NULL)	-> if ((object = (char *)malloc(EXTRA_ALIGN_PTR_BYTES + size)) == NULL)
rt-thread-master/examples/libc/ex4.c:    accu = malloc(1024);	-> accu = (char *)malloc(1024);
rt-thread-master/bsp/simulator/drivers/dfs_win32.c:            wdirp->start = realloc(wdirp->start, wdirp->end - wdirp->start + name_len);	-> wdirp->start = (WINDIR *)realloc(wdirp->start, wdirp->end - wdirp->start + name_len);
rt-thread-master/components/libc/cplusplus/cpp11/emutls.c:        array = realloc(array, (new_size + 1) * sizeof(void *));	-> array = (emutls_address_array *)realloc(array, (new_size + 1) * sizeof(void *));
rt-thread-master/components/libc/cplusplus/cpp11/emutls.c:        array = calloc(new_size + 1, sizeof(void *));	->array = (emutls_address_array *)calloc(new_size + 1, sizeof(void *));



       

#### 在什么测试环境下测试通过 (what is the test environment)

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
