### PR TITLE
[HUST CSE][bsp][fix] Fix potential buffer overflow vulnerability

### DIFF
--- a/bsp/simulator/pcap/pcap_netif.c
+++ b/bsp/simulator/pcap/pcap_netif.c
@@ -203,6 +203,13 @@ rt_err_t pcap_netif_tx( rt_device_t dev, struct pbuf* p)
     /* lock EMAC device */
     rt_sem_take(&sem_lock, RT_WAITING_FOREVER);
 
+    /* check if the total length of pbuf exceeds the size of buf */
+    if(p->tot_len > 2048)
+    {
+        rt_kprintf("Error sending the packet: send data exceed max len 2048\n");
+        return -RT_ERROR;
+    }
+
     /* copy data to tx buffer */
     q = p;
     ptr = (rt_uint8_t*)buf;

--- a/bsp/simulator/pcap/pcap_netif.c
+++ b/bsp/simulator/pcap/pcap_netif.c
@@ -26,6 +26,10 @@
 #include <rtthread.h>
 #include <netif/ethernetif.h>
 
+#define DBG_TAG    "pcap.netif"
+#define DBG_LVL    DBG_INFO
+#include <rtdbg.h>
+
 #define MAX_ADDR_LEN 6
 
 #define NETIF_DEVICE(netif) ((struct pcap_netif*)(netif))
@@ -206,7 +210,7 @@ rt_err_t pcap_netif_tx( rt_device_t dev, struct pbuf* p)
     /* check if the total length of pbuf exceeds the size of buf */
     if(p->tot_len > 2048)
     {
-        rt_kprintf("Error sending the packet: send data exceed max len 2048\n");
+        LOG_E("Sending the packet: send data exceed max len 2048!");
         return -RT_ERROR;
     }
 
@@ -226,7 +230,7 @@ rt_err_t pcap_netif_tx( rt_device_t dev, struct pbuf* p)
 
     if (res != 0)
     {
-        rt_kprintf("Error sending the packet: \n", pcap_geterr(tap));
+        LOG_E("Sending the packet: %s", pcap_geterr(tap));
         result = -RT_ERROR;
     }
 

--- a/bsp/simulator/pcap/pcap_netif.c
+++ b/bsp/simulator/pcap/pcap_netif.c
@@ -211,6 +211,7 @@ rt_err_t pcap_netif_tx( rt_device_t dev, struct pbuf* p)
     if(p->tot_len > 2048)
     {
         LOG_E("Sending the packet: send data exceed max len 2048!");
+        rt_sem_release(&sem_lock);
         return -RT_ERROR;
     }
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

bsp/simulator/pcap/pcap_netif.c 文件中的 pcap_netif_tx 函数中定义了 rt_uint8_t buf[2048] 数组，并在将函数参数 struct pbuf* p 形成的 pbuf 链表内的数据拷贝到这个 buf 数组中（见[pcap_netif_tx 函数相关代码](https://github.com/RT-Thread/rt-thread/blob/master/bsp/simulator/pcap/pcap_netif.c#L192-L214)）。

然而在 pcap_netif_tx 函数代码中并没有对参数 struct pbuf* p 形成的 pbuf 链表内的总数据长度进行检查。若按照当前代码的拷贝方式，在 pbuf 链表的总数据长度超过 2048 个字节后会引起缓冲区溢出，使得栈内其他数据被修改。

认为该函数存在潜在缓冲区溢出漏洞的原因是：

1. 在对仓库代码进行检索后，并未在可能调用该函数的相关代码中看到对输入参数 struct pbuf* p 形成的 pbuf 链表内的数据长度进行限制（例如在可能的函数调用关系“ethip6_ouput=>ethernet_output=>linkoutput(ethernetif_linkoutput)=>eth_tx(pcap_netif_tx)”中并没有发现对 pcap_netif_tx 函数输入参数 struct pbuf* p 形成的 pbuf 链表内的总数据长度的限制）。
2. 可以注意到和 pcap_netif_tx 函数类似作用的 bsp/allwinner/libraries/sunxi-hal/hal/source/gmac/hal_geth.c 文件下的 rt_geth_xmit 函数中对拷贝的 pbuf 链表总数据长度超过 2048 的情况进行了报错并 return -RT_ERROR; （见[hal_geth.c 相关代码](https://github.com/RT-Thread/rt-thread/blob/master/bsp/allwinner/libraries/sunxi-hal/hal/source/gmac/hal_geth.c#L326-L330)）说明输入参数 struct pbuf* p 形成的 pbuf 链表内的总数据长度可能超过 2048。

#### 你的解决方案是什么 (what is your solution)

仿照 pcap_netif_tx 函数对错误情况的处理（[rt_kprintf(错误信息) 并 result=-RT_ERROR](https://github.com/RT-Thread/rt-thread/blob/master/bsp/simulator/pcap/pcap_netif.c#L220-L224)）和类似函数 rt_geth_xmit 中对 pbuf 链表内总数据长度超过 2048 的处理（[printf(错误信息) 并 return -RT_ERROR](https://github.com/RT-Thread/rt-thread/blob/master/bsp/allwinner/libraries/sunxi-hal/hal/source/gmac/hal_geth.c#L326-L330)）。

在 pcap_netif_tx 函数中将 pbuf 内数据拷贝到 buf 数组前添加“ p->tot_len > 2048 则 rt_kprintf(错误信息) 并 return -RT_ERROR; ”的代码。

#### 在什么测试环境下测试通过 (what is the test environment)

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
