### PR TITLE
[HUST CSE]fix:修复了cy_ipc_bt.c中使用%ld打印unsigned int的问题

### DIFF
--- a/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb-pdl-cat1/drivers/source/cy_ipc_bt.c
+++ b/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb-pdl-cat1/drivers/source/cy_ipc_bt.c
@@ -155,7 +155,7 @@ void Cy_BTIPC_IRQ_Handler(cy_stc_ipc_bt_context_t *btIpcContext)
 #endif
             channelHPC = contextPtr->dlChannelHPC;
 
-            BTIPC_LOG_L1("on ch %ld\n",channelHPC);
+            BTIPC_LOG_L1("on ch %u\n",channelHPC);
 
             ipcPtr = Cy_IPC_Drv_GetIpcBaseAddress(channelHPC);
             Cy_IPC_Drv_ReadDDataValue(ipcPtr, mesg);
@@ -209,7 +209,7 @@ void Cy_BTIPC_IRQ_Handler(cy_stc_ipc_bt_context_t *btIpcContext)
 #endif
             channelHCI = contextPtr->dlChannelHCI;
 
-            BTIPC_LOG_L1("on ch %ld\n",channelHCI);
+            BTIPC_LOG_L1("on ch %u\n",channelHCI);
 
             ipcPtr = Cy_IPC_Drv_GetIpcBaseAddress(channelHCI);
             Cy_IPC_Drv_ReadDDataValue(ipcPtr, mesg);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
cy_ipc_bt.c中用占位符%ld打印unsigned int类型，会导致输出结果不正确，会输出负数或者其他未定义的行为
#### 你的解决方案是什么 (what is your solution)
解决方案为改成%u
#### 在什么测试环境下测试通过 (what is the test environment)
在测试环境下可通过
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
