### PR TITLE
[HUST CSE] Adjust the null pointer check and access orderPointer error

### DIFF
--- a/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb_shared/csdidac/cy_csdidac.c
+++ b/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb_shared/csdidac/cy_csdidac.c
@@ -570,8 +570,6 @@ cy_en_csdidac_status_t Cy_CSDIDAC_Restore(cy_stc_csdidac_context_t * context)
     cy_en_csdidac_status_t result = CY_CSDIDAC_HW_FAILURE;
     cy_en_csd_key_t mvKey;
     cy_en_csd_status_t initStatus = CY_CSD_LOCKED;
-    CSD_Type * ptrCsdBaseAdd = context->cfgCopy.base;
-    cy_stc_csd_context_t * ptrCsdCxt = context->cfgCopy.csdCxtPtr;
     cy_stc_csd_config_t csdCfg = CY_CSDIDAC_CSD_CONFIG_DEFAULT;
 
     /* The number of cycles of one for() loop. */
@@ -581,6 +579,8 @@ cy_en_csdidac_status_t Cy_CSDIDAC_Restore(cy_stc_csdidac_context_t * context)
 
     if (NULL != context)
     {
+        CSD_Type * ptrCsdBaseAdd = context->cfgCopy.base;
+        cy_stc_csd_context_t * ptrCsdCxt = context->cfgCopy.csdCxtPtr;
         /* Closes the IAIB switch if IDACs joined */
         if ((CY_CSDIDAC_JOIN == context->cfgCopy.configA) || (CY_CSDIDAC_JOIN == context->cfgCopy.configB))
         {

--- a/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb_shared/csdidac/cy_csdidac.c
+++ b/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb_shared/csdidac/cy_csdidac.c
@@ -779,13 +779,13 @@ cy_en_csdidac_status_t Cy_CSDIDAC_OutputEnableExt(
                 uint32_t idacCode,
                 cy_stc_csdidac_context_t * context)
 {
-    CSD_Type * ptrCsdBaseAdd = context->cfgCopy.base;
     uint32_t idacRegValue;
     uint32_t  interruptState;
     cy_en_csdidac_status_t retVal = CY_CSDIDAC_BAD_PARAM;
 
     if((NULL != context) && (CY_CSDIDAC_MAX_CODE >= idacCode))
     {
+        CSD_Type * ptrCsdBaseAdd = context->cfgCopy.base;
         if((true == Cy_CSDIDAC_IsIdacChoiceValid(outputCh, context->cfgCopy.configA, context->cfgCopy.configB)) &&
            (true == Cy_CSDIDAC_IsIdacPolarityValid(polarity)) &&
            (true == Cy_CSDIDAC_IsIdacLsbValid(lsbIndex)))

--- a/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb_shared/csdidac/cy_csdidac.c
+++ b/bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb_shared/csdidac/cy_csdidac.c
@@ -570,6 +570,8 @@ cy_en_csdidac_status_t Cy_CSDIDAC_Restore(cy_stc_csdidac_context_t * context)
     cy_en_csdidac_status_t result = CY_CSDIDAC_HW_FAILURE;
     cy_en_csd_key_t mvKey;
     cy_en_csd_status_t initStatus = CY_CSD_LOCKED;
+    CSD_Type * ptrCsdBaseAdd = NULL;
+    cy_stc_csd_context_t * ptrCsdCxt = NULL;
     cy_stc_csd_config_t csdCfg = CY_CSDIDAC_CSD_CONFIG_DEFAULT;
 
     /* The number of cycles of one for() loop. */
@@ -579,8 +581,8 @@ cy_en_csdidac_status_t Cy_CSDIDAC_Restore(cy_stc_csdidac_context_t * context)
 
     if (NULL != context)
     {
-        CSD_Type * ptrCsdBaseAdd = context->cfgCopy.base;
-        cy_stc_csd_context_t * ptrCsdCxt = context->cfgCopy.csdCxtPtr;
+        ptrCsdBaseAdd = context->cfgCopy.base;
+        ptrCsdCxt = context->cfgCopy.csdCxtPtr;
         /* Closes the IAIB switch if IDACs joined */
         if ((CY_CSDIDAC_JOIN == context->cfgCopy.configA) || (CY_CSDIDAC_JOIN == context->cfgCopy.configB))
         {
@@ -779,13 +781,14 @@ cy_en_csdidac_status_t Cy_CSDIDAC_OutputEnableExt(
                 uint32_t idacCode,
                 cy_stc_csdidac_context_t * context)
 {
+    CSD_Type * ptrCsdBaseAdd = NULL;
     uint32_t idacRegValue;
     uint32_t  interruptState;
     cy_en_csdidac_status_t retVal = CY_CSDIDAC_BAD_PARAM;
 
     if((NULL != context) && (CY_CSDIDAC_MAX_CODE >= idacCode))
     {
-        CSD_Type * ptrCsdBaseAdd = context->cfgCopy.base;
+        ptrCsdBaseAdd = context->cfgCopy.base;
         if((true == Cy_CSDIDAC_IsIdacChoiceValid(outputCh, context->cfgCopy.configA, context->cfgCopy.configB)) &&
            (true == Cy_CSDIDAC_IsIdacPolarityValid(polarity)) &&
            (true == Cy_CSDIDAC_IsIdacLsbValid(lsbIndex)))


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

在cy_csdidac.c中Cy_CSDIDAC_Restore函数中的指针变量ptrCsdBaseAdd和ptrCsdCxt，以及函数Cy_CSDIDAC_OutputEnableExt中指针变量ptrCsdBaseAdd访问在空指针判断之前进行，存在可能的空指针引用,进而引起程序异常退出。

```c
cy_en_csdidac_status_t Cy_CSDIDAC_Restore(cy_stc_csdidac_context_t * context)
{
    uint32_t watchdogCounter;

    cy_en_csdidac_status_t result = CY_CSDIDAC_HW_FAILURE;
    cy_en_csd_key_t mvKey;
    cy_en_csd_status_t initStatus = CY_CSD_LOCKED;
    CSD_Type * ptrCsdBaseAdd = context->cfgCopy.base;
    cy_stc_csd_context_t * ptrCsdCxt = context->cfgCopy.csdCxtPtr;
    cy_stc_csd_config_t csdCfg = CY_CSDIDAC_CSD_CONFIG_DEFAULT;
```

```c
cy_en_csdidac_status_t Cy_CSDIDAC_OutputEnableExt(
                cy_en_csdidac_choice_t outputCh,
                cy_en_csdidac_polarity_t polarity,
                cy_en_csdidac_lsb_t lsbIndex,
                uint32_t idacCode,
                cy_stc_csdidac_context_t * context)
{
    CSD_Type * ptrCsdBaseAdd = context->cfgCopy.base;
    uint32_t idacRegValue;
    uint32_t  interruptState;
    cy_en_csdidac_status_t retVal = CY_CSDIDAC_BAD_PARAM;

    if((NULL != context) && (CY_CSDIDAC_MAX_CODE >= idacCode))
    {
        if((true == Cy_CSDIDAC_IsIdacChoiceValid(outputCh, context->cfgCopy.configA, context->cfgCopy.configB)) &&
           (true == Cy_CSDIDAC_IsIdacPolarityValid(polarity)) &&
           (true == Cy_CSDIDAC_IsIdacLsbValid(lsbIndex)))
```

在此给出文件的详细路径如下：
bsp/Infineon/libraries/IFX_PSOC6_HAL/mtb_shared/csdidac/cy_csdidac.c

#### 你的解决方案是什么 (what is your solution)
修改顺序，使指针变量先进行空指针判断再进行访问

#### 在什么测试环境下测试通过 (what is the test environment)
ALL

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 