### PR TITLE
[HUST CSE] Adjust the null pointer check and access orderPointer error

### DIFF
--- a/components/vbus/vbus_chnx.c
+++ b/components/vbus/vbus_chnx.c
@@ -231,13 +231,13 @@ void rt_vbus_chnx_register_disconn(rt_device_t dev,
                                    rt_vbus_event_listener indi,
                                    void *ctx)
 {
-    struct rt_vbus_dev *vdev = dev->user_data;
+    if (dev && dev->user_data) {
+        struct rt_vbus_dev *vdev = dev->user_data;
+        RT_ASSERT(vdev->chnr != 0);
 
-    RT_ASSERT(vdev->chnr != 0);
-
-    if (vdev)
         rt_vbus_register_listener(vdev->chnr, RT_VBUS_EVENT_ID_DISCONN,
                                   indi, ctx);
+    }
 }
 
 #define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))

--- a/components/vbus/vbus_chnx.c
+++ b/components/vbus/vbus_chnx.c
@@ -231,7 +231,8 @@ void rt_vbus_chnx_register_disconn(rt_device_t dev,
                                    rt_vbus_event_listener indi,
                                    void *ctx)
 {
-    if (dev && dev->user_data) {
+    if (dev && dev->user_data)
+    {
         struct rt_vbus_dev *vdev = dev->user_data;
         RT_ASSERT(vdev->chnr != 0);
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
在vbus_chnx.c中rt_vbus_chnx_register_disconn函数中的指针变量dev以及vdev访问在空指针判断之前进行，存在可能的空指针引用,进而引起程序异常退出

#### 你的解决方案是什么 (what is your solution)
修改程序运行逻辑，使指针变量先进行空指针判断再进行访问

#### 在什么测试环境下测试通过 (what is the test environment)
ALL
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
