### PR TITLE
[components][drivers][sdio] Fix bugs in sdio driver

### DIFF
--- a/components/drivers/sdio/block_dev.c
+++ b/components/drivers/sdio/block_dev.c
@@ -5,7 +5,8 @@
  *
  * Change Logs:
  * Date           Author        Notes
- * 2011-07-25     weety     first version
+ * 2011-07-25     weety         first version
+ * 2023-05-06     hpmicro       avoid null dereference in function rt_mmcsd_blk_remove
  */
 
 #include <rtthread.h>
@@ -689,6 +690,18 @@ void rt_mmcsd_blk_remove(struct rt_mmcsd_card *card)
     rt_list_t *l, *n;
     struct mmcsd_blk_device *blk_dev;
 
+    if(card == RT_NULL)
+    {
+        LOG_E("card is null!");
+        return;
+    }
+
+    if(rt_list_isempty(&card->blk_devices))
+    {
+        LOG_E("card blk_devices is empty!");
+        return;
+    }
+
     for (l = (&blk_devices)->next, n = l->next; l != &blk_devices; l = n, n = n->next)
     {
         blk_dev = (struct mmcsd_blk_device *)rt_list_entry(l, struct mmcsd_blk_device, list);
@@ -699,7 +712,7 @@ void rt_mmcsd_blk_remove(struct rt_mmcsd_card *card)
             if (mounted_path)
             {
                 dfs_unmount(mounted_path);
-                LOG_D("unmount file system %s for device %s.\r\n", mounted_path, blk_dev->dev.parent.name);
+                LOG_D("unmount file system %s for device %s.", mounted_path, blk_dev->dev.parent.name);
             }
             rt_sem_delete(blk_dev->part.lock);
             rt_device_unregister(&blk_dev->dev);

--- a/components/drivers/sdio/mmcsd_core.c
+++ b/components/drivers/sdio/mmcsd_core.c
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author        Notes
  * 2011-07-25     weety         first version
+ * 2023-05-06     hpmicro       Fix the go_idle logic for SPI controller
  */
 
 #include <rtthread.h>
@@ -109,7 +110,7 @@ rt_int32_t mmcsd_go_idle(struct rt_mmcsd_host *host)
     rt_int32_t err;
     struct rt_mmcsd_cmd cmd;
 
-    if (!controller_is_spi(host))
+    if (controller_is_spi(host))
     {
         mmcsd_set_chip_select(host, MMCSD_CS_HIGH);
         rt_thread_mdelay(1);
@@ -125,7 +126,7 @@ rt_int32_t mmcsd_go_idle(struct rt_mmcsd_host *host)
 
     rt_thread_mdelay(1);
 
-    if (!controller_is_spi(host))
+    if (controller_is_spi(host))
     {
         mmcsd_set_chip_select(host, MMCSD_CS_IGNORE);
         rt_thread_mdelay(1);
@@ -778,4 +779,3 @@ int rt_mmcsd_core_init(void)
     return 0;
 }
 INIT_PREV_EXPORT(rt_mmcsd_core_init);
-


### PR DESCRIPTION
- Corrected the SPI CS control logic in mmcsd_go_idle function
- Corrected null de-reference issue in rt_mmcsd_blk_remove

## 拉取/合并请求描述：(PR description)

[

该问题在测试HPM6750EVKMINI开发板上外接TF-转eMMC卡的支持时发现。

该PR用于解决如下问题：
1： mmcsd_go_idle函数中对于SPI CS控制逻辑判断的问题，现在的实现中，判断逻辑是反的
2： rt_mmcsd_blk_remove()函数里当card->blk_devices列表为空时，出现了null de-reference的问题，该问题会导致SoC出现异常。
 - 复现方式：在基于RT-Thread V4.1.0 的 ART-PI BSP中可复现。（该问题是由 commit #6641 解决的那个bug触发的)

基于HPM6750EVKMINI开发板进行了测试，证明代码的改动有效。
]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [y] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [y] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [y] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [y] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [y] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [y] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [y] 代码是高质量的 Code in this PR is of high quality
- [y] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
