### PR TITLE
[components][libc][HUST CSE]消除了realloc函数导致内存泄漏的风险

### DIFF
--- a/components/libc/cplusplus/cpp11/emutls.c
+++ b/components/libc/cplusplus/cpp11/emutls.c
@@ -201,7 +201,6 @@ emutls_get_address_array(uintptr_t index)
             free(array);
             array = NULL;
         }
-            
         emutls_check_array_set_size(array, new_size);
     }
     return array;

--- a/components/libc/cplusplus/cpp11/emutls.c
+++ b/components/libc/cplusplus/cpp11/emutls.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2023, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -198,8 +198,11 @@ emutls_get_address_array(uintptr_t index)
         }
         else
         {
+            array_temp = (emutls_address_array *)calloc(new_size + 1, sizeof(void *));
+            emutls_check_array_set_size(array_temp, new_size);
+            memcpy(array_temp, array, (orig_size + 1) * sizeof(void *));
             free(array);
-            array = NULL;
+            array = array_temp;
         }
         emutls_check_array_set_size(array, new_size);
     }

--- a/components/libc/cplusplus/cpp11/emutls.c
+++ b/components/libc/cplusplus/cpp11/emutls.c
@@ -188,11 +188,20 @@ emutls_get_address_array(uintptr_t index)
     {
         uintptr_t orig_size = array->size;
         uintptr_t new_size = emutls_new_data_array_size(index);
-        array = (emutls_address_array *)realloc(array, (new_size + 1) * sizeof(void *));
+        emutls_address_array *array_temp = (emutls_address_array *)realloc(array, (new_size + 1) * sizeof(void *));
 
-        if (array)
+        if (array_temp)
+        {
+            array = array_temp;
             memset(array->data + orig_size, 0,
                    (new_size - orig_size) * sizeof(void *));
+        }
+        else
+        {
+            free(array);
+            array = NULL;
+        }
+            
         emutls_check_array_set_size(array, new_size);
     }
     return array;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
消除了一个可能由realloc函数引起内存泄漏的风险
https://github.com/RT-Thread/rt-thread/blob/master/components/libc/cplusplus/cpp11/emutls.c#L191
此处没有检查realloc函数的返回值
如果realloc函数的返回值为null，将直接导致array指针原来指向的内存泄漏

此处利用临时变量检查realloc的返回值
当realloc返回值不为null时继续进行程序原本的操作
当realloc返回值为null时，释放array指针指向的内存空间，并将array赋值为NULL

这次修改本地单独编译 emutls.c 会报 return 1，但是加入主函数之后编译正常
线上 Static code analysis / Static code analysis (pull_request)  也是报 return 1，不太清楚是为什么
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
