### PR TITLE
[components][rndis.c] add a checkout procedure after malloc to make sure allocating successfully

### DIFF
--- a/components/drivers/usb/usbdevice/class/rndis.c
+++ b/components/drivers/usb/usbdevice/class/rndis.c
@@ -1332,7 +1332,7 @@ ufunction_t rt_usbd_function_rndis_create(udevice_t device)
     rt_usbd_device_set_qualifier(device, &dev_qualifier);
     _rndis= rt_malloc(sizeof(struct rt_rndis_eth));
 
-    if(resp == RT_NULL)
+    if(_rndis == RT_NULL)
     {
         LOG_E("%s,%d: no memory!", __func__, __LINE__);
         return RT_NULL;

--- a/components/drivers/usb/usbdevice/class/rndis.c
+++ b/components/drivers/usb/usbdevice/class/rndis.c
@@ -1331,6 +1331,13 @@ ufunction_t rt_usbd_function_rndis_create(udevice_t device)
     cdc = rt_usbd_function_new(device, &_dev_desc, &ops);
     rt_usbd_device_set_qualifier(device, &dev_qualifier);
     _rndis= rt_malloc(sizeof(struct rt_rndis_eth));
+
+    if(resp == RT_NULL)
+    {
+        LOG_E("%s,%d: no memory!", __func__, __LINE__);
+        return RT_NULL;
+    }
+
     rt_memset(_rndis, 0, sizeof(struct rt_rndis_eth));
     cdc->user_data = _rndis;
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
发现在rndis.c文件中rt_usbd_function_rndis_create函数为变量_rndis分配了内存空间，但是未检查空间不足时分配失败的情况，因此存在潜在风险

#### 你的解决方案是什么 (what is your solution)
比对其他文件中对于malloc的后续处理步骤，添加了检查malloc结果的步骤，并在分配失败时打印日志并返回RT_NULL

#### 在什么测试环境下测试通过 (what is the test environment)
通过进行流程分析，并且只添加一个检查分支，不会导致测试不通过.
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
