### PR TITLE
[components/drivers] add result check for configure in `rt_spi_configure`

### DIFF
--- a/components/drivers/spi/spi_core.c
+++ b/components/drivers/spi/spi_core.c
@@ -116,7 +116,6 @@ rt_err_t rt_spi_configure(struct rt_spi_device        *device,
             {
                 /* current device is using, re-configure SPI bus */
                 result = device->bus->ops->configure(device, &device->config);
-
                 if (result != RT_EOK)
                 {
                     /* configure SPI bus failed */

--- a/components/drivers/spi/spi_core.c
+++ b/components/drivers/spi/spi_core.c
@@ -114,15 +114,26 @@ rt_err_t rt_spi_configure(struct rt_spi_device        *device,
         {
             if (device->bus->owner == device)
             {
-                device->bus->ops->configure(device, &device->config);
+                /* current device is using, re-configure SPI bus */
+                result = device->bus->ops->configure(device, &device->config);
+
+                if (result != RT_EOK)
+                {
+                    /* configure SPI bus failed */
+                    LOG_E("SPI device %s configuration failed", device->parent.parent.name);
+                }
             }
 
             /* release lock */
             rt_mutex_release(&(device->bus->lock));
         }
     }
+    else
+    {
+        result = RT_EOK;
+    }
 
-    return RT_EOK;
+    return result;
 }
 
 rt_err_t rt_spi_send_then_send(struct rt_spi_device *device,

--- a/components/drivers/spi/spi_core.c
+++ b/components/drivers/spi/spi_core.c
@@ -90,7 +90,7 @@ rt_err_t rt_spi_bus_attach_device(struct rt_spi_device *device,
 rt_err_t rt_spi_configure(struct rt_spi_device        *device,
                           struct rt_spi_configuration *cfg)
 {
-    rt_err_t result;
+    rt_err_t result = -RT_ERROR;
 
     RT_ASSERT(device != RT_NULL);
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

- 在 rt_spi_configure 中没有对配置结果做检查，建议补充上
- 偶然发现有人不是很明白这里为何，何时需要执行配置 (ref : https://blog.csdn.net/lilijianqun/article/details/103061547) , 故增加了一行注释说明一下
```DIFF
            if (device->bus->owner == device)
            {
+               /* current device is using, re-configure SPI bus */
                result = device->bus->ops->configure(device, &device->config);

                if (result != RT_EOK)
```

#### 你的解决方案是什么 (what is your solution)


#### 在什么测试环境下测试通过 (what is the test environment)

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
