### PR TITLE
Revert "[CI] ci 编译时先执行 scons --pyconfig-silent 后进行编译"

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -355,6 +355,6 @@ jobs:
           for bsp in $(echo $SRTT_BSP | tr ',' '\n'); do
             count=$((count+1))
             echo "Compiling BSP: ==$count=== $bsp ===="
-            pushd bsp/$bsp && scons --pyconfig-silent && pkgs --update && popd
+            pushd bsp/$bsp && pkgs --update && popd
             scons -C bsp/$bsp -j8
           done


### PR DESCRIPTION
Reverts RT-Thread/rt-thread#7383

scons --pyconfig-client 这个命令会由于没有menuconfig执行不成功，会导致后面的action路径出错。