### PR TITLE
[components][libc][posix] fix RT_NAME_MAX misspelled as NAME_MAX

### DIFF
--- a/components/libc/posix/ipc/mqueue.c
+++ b/components/libc/posix/ipc/mqueue.c
@@ -138,7 +138,7 @@ mqd_t mq_open(const char *name, int oflag, ...)
     /* lock posix mqueue list */
     rt_sem_take(&posix_mq_lock, RT_WAITING_FOREVER);
     int len = rt_strlen(name);
-    if (len > PATH_MAX || len > NAME_MAX)
+    if (len > PATH_MAX || len > RT_NAME_MAX)
     {
         rt_set_errno(ENAMETOOLONG);
         goto __return;

--- a/components/libc/posix/ipc/mqueue.c
+++ b/components/libc/posix/ipc/mqueue.c
@@ -159,9 +159,9 @@ mqd_t mq_open(const char *name, int oflag, ...)
     {
         va_start(arg, oflag);
         mode = (mode_t)va_arg(arg, unsigned int);
-        mode = mode;
+        mode = (mode_t)mode; /* self-assignment avoids compiler optimization */
         attr = (struct mq_attr *)va_arg(arg, struct mq_attr *);
-        attr = attr;
+        attr = (mode_t)attr; /* self-assignment avoids compiler optimization */
         va_end(arg);
 
         if (attr->mq_maxmsg <= 0)

--- a/components/libc/posix/ipc/mqueue.c
+++ b/components/libc/posix/ipc/mqueue.c
@@ -161,7 +161,7 @@ mqd_t mq_open(const char *name, int oflag, ...)
         mode = (mode_t)va_arg(arg, unsigned int);
         mode = (mode_t)mode; /* self-assignment avoids compiler optimization */
         attr = (struct mq_attr *)va_arg(arg, struct mq_attr *);
-        attr = (mode_t)attr; /* self-assignment avoids compiler optimization */
+        attr = (struct mq_attr *)attr; /* self-assignment avoids compiler optimization */
         va_end(arg);
 
         if (attr->mq_maxmsg <= 0)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
The related issue is #7485 
> error: 'PATH_MAX' and 'NAME_MAX' undeclared (first use in this function) 

It can be reproduced by following [Getting Started of QEMU (Ubuntu)](https://www.rt-thread.io/document/site/documentation/quick_start_qemu/quick_start_qemu_linux/)  

Execute `cd rt-thread/bsp/qemu-vexpress-a9` and `scons`, then you will get such compile error belows:  
```text
...
CC build/kernel/components/libc/posix/io/poll/select.o
CC build/kernel/components/libc/posix/io/stdio/libc.o
CC build/kernel/components/libc/posix/io/termios/termios.o
CC build/kernel/components/libc/posix/ipc/mqueue.o
/home/dylan/workspace/repos/rt-thread/components/libc/posix/ipc/mqueue.c: In function 'mq_open':
/home/dylan/workspace/repos/rt-thread/components/libc/posix/ipc/mqueue.c:141:33: error: 'NAME_MAX' undeclared (first use in this function)
     if (len > PATH_MAX || len > NAME_MAX)
                                 ^~~~~~~~
/home/dylan/workspace/repos/rt-thread/components/libc/posix/ipc/mqueue.c:141:33: note: each undeclared identifier is reported only once for each function it appears in
scons: *** [build/kernel/components/libc/posix/ipc/mqueue.o] Error 1
scons: building terminated because of errors.
```

The macro name `RT_NAME_MAX` misspelled as `NAME_MAX`.
`RT_NAME_MAX` was defined in `rt-thread/bsp/qemu-vexpress-a9/rtconfig.h`:
```c
  1 #ifndef RT_CONFIG_H__
  2 #define RT_CONFIG_H__
  3
  4 /* Automatically generated file; DO NOT EDIT. */
  5 /* RT-Thread Project Configuration */
  6
  7 /* RT-Thread Kernel */
  8
  9 #define RT_NAME_MAX 8  <----------------------------------------------------------
 10 #define RT_ALIGN_SIZE 8
 11 #define RT_THREAD_PRIORITY_256
 12 #define RT_THREAD_PRIORITY_MAX 256
 13 #define RT_TICK_PER_SECOND 100
...
```
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
