### PR TITLE
[components][net][lwip][port]  Fix next-hop finding in lwip_ip4_route_src.

### DIFF
--- a/components/net/lwip/port/sys_arch.c
+++ b/components/net/lwip/port/sys_arch.c
@@ -684,15 +684,15 @@ struct netif *lwip_ip4_route_src(const ip4_addr_t *dest, const ip4_addr_t *src)
             /* gateway matches on a non broadcast interface? (i.e. peer in a point to point interface) */
             if (src != NULL)
             {
-                if (ip4_addr_cmp(src, netif_ip4_addr(netif)))
+                if (ip4_addr_netcmp(src, netif_ip4_addr(netif), netif_ip4_netmask(netif)))
                 {
                     return netif;
                 }
             }
         }
     }
-    netif = netif_default;
-    return netif;
+
+    return netif_default;
 }
 #endif /* LWIP_HOOK_IP4_ROUTE_SRC */
 #endif /*LWIP_VERSION_MAJOR >= 2 */

--- a/components/net/lwip/port/sys_arch.c
+++ b/components/net/lwip/port/sys_arch.c
@@ -675,24 +675,24 @@ struct netif *lwip_ip4_route_src(const ip4_addr_t *dest, const ip4_addr_t *src)
 {
     struct netif *netif;
 
+    if (src == NULL)
+        return NULL;
+
     /* iterate through netifs */
     for (netif = netif_list; netif != NULL; netif = netif->next)
     {
         /* is the netif up, does it have a link and a valid address? */
         if (netif_is_up(netif) && netif_is_link_up(netif) && !ip4_addr_isany_val(*netif_ip4_addr(netif)))
         {
-            /* gateway matches on a non broadcast interface? (i.e. peer in a point to point interface) */
-            if (src != NULL)
+            /* source ip address equals netif's ip address? */
+            if (ip4_addr_cmp(src, netif_ip4_addr(netif)))
             {
-                if (ip4_addr_netcmp(src, netif_ip4_addr(netif), netif_ip4_netmask(netif)))
-                {
-                    return netif;
-                }
+                return netif;
             }
         }
     }
 
-    return netif_default;
+    return NULL;
 }
 #endif /* LWIP_HOOK_IP4_ROUTE_SRC */
 #endif /*LWIP_VERSION_MAJOR >= 2 */

--- a/components/net/netdev/src/netdev.c
+++ b/components/net/netdev/src/netdev.c
@@ -1178,37 +1178,33 @@ int netdev_cmd_ping(char* target_name, char *netdev_name, rt_uint32_t times, rt_
     if (netdev_name != RT_NULL)
     {
         netdev = netdev_get_by_name(netdev_name);
-        if (netdev == RT_NULL)
-        {
-            netdev = netdev_default;
-            rt_kprintf("ping: not found specified netif, using default netdev %s.\n", netdev->name);
-        }
-    }
-    else if (NETDEV_PING_IS_COMMONICABLE(netdev_default))
-    {
-        /* using default network interface device for ping */
-        netdev = netdev_default;
-    }
-    else
-    {
-        /* using first internet up status network interface device */
-        netdev = netdev_get_first_by_flags(NETDEV_FLAG_LINK_UP);
     }
 
     if (netdev == RT_NULL)
     {
-        rt_kprintf("ping: not found available network interface device.\n");
-        return -RT_ERROR;
+        netdev = netdev_default;
+        rt_kprintf("ping: not found specified netif, using default netdev %s.\n", netdev->name);
     }
-    else if (netdev->ops == RT_NULL || netdev->ops->ping == RT_NULL)
+
+    if (!NETDEV_PING_IS_COMMONICABLE(netdev))
     {
-        rt_kprintf("ping: network interface device(%s) not support ping feature.\n", netdev->name);
-        return -RT_ERROR;
-    }
-    else if (!netdev_is_up(netdev) || !netdev_is_link_up(netdev))
-    {
-        rt_kprintf("ping: network interface device(%s) status error.\n", netdev->name);
-        return -RT_ERROR;
+        /* using first internet up status network interface device */
+        netdev = netdev_get_first_by_flags(NETDEV_FLAG_LINK_UP);
+        if (netdev == RT_NULL)
+        {
+            rt_kprintf("ping: not found available network interface device.\n");
+            return -RT_ERROR;
+        }
+        else if (netdev->ops == RT_NULL || netdev->ops->ping == RT_NULL)
+        {
+            rt_kprintf("ping: network interface device(%s) not support ping feature.\n", netdev->name);
+            return -RT_ERROR;
+        }
+        else if (!netdev_is_up(netdev) || !netdev_is_link_up(netdev))
+        {
+            rt_kprintf("ping: network interface device(%s) status error.\n", netdev->name);
+            return -RT_ERROR;
+        }
     }
 
     for (index = 0; index < times; index++)

--- a/components/net/netdev/src/netdev.c
+++ b/components/net/netdev/src/netdev.c
@@ -1178,33 +1178,37 @@ int netdev_cmd_ping(char* target_name, char *netdev_name, rt_uint32_t times, rt_
     if (netdev_name != RT_NULL)
     {
         netdev = netdev_get_by_name(netdev_name);
+        if (netdev == RT_NULL)
+        {
+            netdev = netdev_default;
+            rt_kprintf("ping: not found specified netif, using default netdev %s.\n", netdev->name);
+        }
+    }
+    else if (NETDEV_PING_IS_COMMONICABLE(netdev_default))
+    {
+        /* using default network interface device for ping */
+        netdev = netdev_default;
+    }
+    else
+    {
+        /* using first internet up status network interface device */
+        netdev = netdev_get_first_by_flags(NETDEV_FLAG_LINK_UP);
     }
 
     if (netdev == RT_NULL)
     {
-        netdev = netdev_default;
-        rt_kprintf("ping: not found specified netif, using default netdev %s.\n", netdev->name);
+        rt_kprintf("ping: not found available network interface device.\n");
+        return -RT_ERROR;
     }
-
-    if (!NETDEV_PING_IS_COMMONICABLE(netdev))
+    else if (netdev->ops == RT_NULL || netdev->ops->ping == RT_NULL)
     {
-        /* using first internet up status network interface device */
-        netdev = netdev_get_first_by_flags(NETDEV_FLAG_LINK_UP);
-        if (netdev == RT_NULL)
-        {
-            rt_kprintf("ping: not found available network interface device.\n");
-            return -RT_ERROR;
-        }
-        else if (netdev->ops == RT_NULL || netdev->ops->ping == RT_NULL)
-        {
-            rt_kprintf("ping: network interface device(%s) not support ping feature.\n", netdev->name);
-            return -RT_ERROR;
-        }
-        else if (!netdev_is_up(netdev) || !netdev_is_link_up(netdev))
-        {
-            rt_kprintf("ping: network interface device(%s) status error.\n", netdev->name);
-            return -RT_ERROR;
-        }
+        rt_kprintf("ping: network interface device(%s) not support ping feature.\n", netdev->name);
+        return -RT_ERROR;
+    }
+    else if (!netdev_is_up(netdev) || !netdev_is_link_up(netdev))
+    {
+        rt_kprintf("ping: network interface device(%s) status error.\n", netdev->name);
+        return -RT_ERROR;
     }
 
     for (index = 0; index < times; index++)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[
Original implementation always return default netif to caller.

We should compare source IP address and netif IP address with netmask at the same time. 

Tested on multi-ethernet cards on Nuvoton platform.
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
