### PR TITLE
[libcpu] fix arm/cortex-a/start_gcc.S

### DIFF
--- a/libcpu/arm/cortex-a/start_gcc.S
+++ b/libcpu/arm/cortex-a/start_gcc.S
@@ -210,10 +210,9 @@ _rtthread_startup:
 
 .weak rt_asm_cpu_id 
 rt_asm_cpu_id:
-    mov r9, lr
     mrc p15, 0, r0, c0, c0, 5
     and r0, r0, #0xf
-    mov lr, r9
+    mov pc, lr
 
 stack_setup:
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

- 问题现象
arm/cortex-a/start_gcc.S 中stack_setup 函数中，当调用rt_asm_cpu_id 时会出现循环卡死的情况，修改前代码为
![1684226056396](https://github.com/RT-Thread/rt-thread/assets/31907499/7a124ecc-cf21-4dbb-9a7b-2503ab8742f2)
修改后的代码为：
![1684226201842](https://github.com/RT-Thread/rt-thread/assets/31907499/ba0f5ccf-3b5f-4db5-b033-1d56ac0514b4)

修改掉无效的lr 备份操作，由 ”mov pc, lr“ 指令从子程序返回到调用者。

- 测试方法：
目前已经在demo board 上进行测试，测试方法为屏蔽掉外部 rt_asm_cpu_id 强定义，使用默认weak函数


]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
