### PR TITLE
[HUST CSE][bsp][pico_malloc.c]Modify the code to check if rc is a nul…

### DIFF
--- a/bsp/raspberry-pico/libraries/pico-sdk/src/rp2_common/pico_malloc/pico_malloc.c
+++ b/bsp/raspberry-pico/libraries/pico-sdk/src/rp2_common/pico_malloc/pico_malloc.c
@@ -36,9 +36,15 @@ void *__wrap_malloc(size_t size) {
     mutex_exit(&malloc_mutex);
 #endif
 #ifdef PICO_DEBUG_MALLOC
-    if (!rc || ((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) {
-        printf("malloc %d %p->%p\n", (uint) size, rc, ((uint8_t *) rc) + size);
+    if (!rc) 
+    {
+        printf("calloc %d failed to allocate memory\n", (uint) (count * size));
+    } 
+    else if (((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) 
+    {
+        printf("calloc %d %p->%p\n", (uint) (count * size), rc, ((uint8_t *) rc) + size);
     }
+
 #endif
     check_alloc(rc, size);
     return rc;
@@ -53,7 +59,12 @@ void *__wrap_calloc(size_t count, size_t size) {
     mutex_exit(&malloc_mutex);
 #endif
 #ifdef PICO_DEBUG_MALLOC
-    if (!rc || ((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) {
+    if (!rc) 
+    {
+        printf("calloc %d failed to allocate memory\n", (uint) (count * size));
+    } 
+    else if (((uint8_t *)rc) + size > (uint8_t*)PICO_DEBUG_MALLOC_LOW_WATER) 
+    {
         printf("calloc %d %p->%p\n", (uint) (count * size), rc, ((uint8_t *) rc) + size);
     }
 #endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
    这段代码可能试图将空指针转换为 uint8_t* 类型并且尝试在这个指针的基础上进行加法操作。这种行为是未定义的，即其结果取决于具体的编译器和运行环境。在某些情况下，这可能导致程序崩溃。为了避免这种情况，最好在访问指针之前检查它是否为 NULL。

#### 你的解决方案是什么 (what is your solution)
    在这个修改后的版本中，我们首先检查 rc 是否为 NULL。如果 rc 是 NULL，我们打印一条消息说明 calloc 未能分配所需的内存。只有当 rc 不为 NULL 时，我们才会尝试进行指针运算并进行下一步的条件判断。这样就避免了在 rc 为 NULL 时进行未定义的指针运算。

#### 在什么测试环境下测试通过 (what is the test environment)
All
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [√ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [√ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [√ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [√ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [√ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [√ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [√ ] 代码是高质量的 Code in this PR is of high quality
- [√ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
