### PR TITLE
[ctime]解决clock_gettime计算出来的nsec超过1sec的问题

### DIFF
--- a/components/libc/compilers/common/ctime.c
+++ b/components/libc/compilers/common/ctime.c
@@ -678,7 +678,7 @@ int clock_gettime(clockid_t clockid, struct timespec *tp)
             tick = rt_tick_get(); /* get tick */
             tp->tv_sec  = _timevalue.tv_sec + tick / RT_TICK_PER_SECOND;
             tp->tv_nsec = (_timevalue.tv_usec + (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK) * 1000;
-            if(tp->tv_nsec>1000000000)
+            if(tp->tv_nsec > 1000000000ULL)
             {
                 tp->tv_nsec %= 1000000000ULL;
                 tp->tv_sec += 1;

--- a/components/libc/compilers/common/ctime.c
+++ b/components/libc/compilers/common/ctime.c
@@ -678,13 +678,12 @@ int clock_gettime(clockid_t clockid, struct timespec *tp)
             tick = rt_tick_get(); /* get tick */
             tp->tv_sec  = _timevalue.tv_sec + tick / RT_TICK_PER_SECOND;
             tp->tv_nsec = (_timevalue.tv_usec + (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK) * 1000;
-            rt_hw_interrupt_enable(level);
             if(tp->tv_nsec>1000000000)
             {
                 tp->tv_nsec %= 1000000000;
                 tp->tv_sec += 1;
             }
-
+            rt_hw_interrupt_enable(level);
         }
         break;
 #endif

--- a/components/libc/compilers/common/ctime.c
+++ b/components/libc/compilers/common/ctime.c
@@ -680,7 +680,7 @@ int clock_gettime(clockid_t clockid, struct timespec *tp)
             tp->tv_nsec = (_timevalue.tv_usec + (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK) * 1000;
             if(tp->tv_nsec>1000000000)
             {
-                tp->tv_nsec %= 1000000000;
+                tp->tv_nsec %= 1000000000ULL;
                 tp->tv_sec += 1;
             }
             rt_hw_interrupt_enable(level);

--- a/components/libc/compilers/common/ctime.c
+++ b/components/libc/compilers/common/ctime.c
@@ -679,6 +679,12 @@ int clock_gettime(clockid_t clockid, struct timespec *tp)
             tp->tv_sec  = _timevalue.tv_sec + tick / RT_TICK_PER_SECOND;
             tp->tv_nsec = (_timevalue.tv_usec + (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK) * 1000;
             rt_hw_interrupt_enable(level);
+            if(tp->tv_nsec>1000000000)
+            {
+                tp->tv_nsec %= 1000000000;
+                tp->tv_sec += 1;
+            }
+
         }
         break;
 #endif

--- a/components/libc/compilers/common/ctime.c
+++ b/components/libc/compilers/common/ctime.c
@@ -679,7 +679,7 @@ int clock_gettime(clockid_t clockid, struct timespec *tp)
             tp->tv_sec  = _timevalue.tv_sec + tick / RT_TICK_PER_SECOND;
             tp->tv_nsec = (_timevalue.tv_usec + (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK) * 1000U;
             rt_hw_interrupt_enable(level);
-            if(tp->tv_nsec > 1000000000ULL)
+            if (tp->tv_nsec > 1000000000ULL)
             {
                 tp->tv_nsec %= 1000000000ULL;
                 tp->tv_sec += 1;

--- a/components/libc/compilers/common/ctime.c
+++ b/components/libc/compilers/common/ctime.c
@@ -678,12 +678,12 @@ int clock_gettime(clockid_t clockid, struct timespec *tp)
             tick = rt_tick_get(); /* get tick */
             tp->tv_sec  = _timevalue.tv_sec + tick / RT_TICK_PER_SECOND;
             tp->tv_nsec = (_timevalue.tv_usec + (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK) * 1000U;
+            rt_hw_interrupt_enable(level);
             if(tp->tv_nsec > 1000000000ULL)
             {
                 tp->tv_nsec %= 1000000000ULL;
                 tp->tv_sec += 1;
             }
-            rt_hw_interrupt_enable(level);
         }
         break;
 #endif

--- a/components/libc/compilers/common/ctime.c
+++ b/components/libc/compilers/common/ctime.c
@@ -677,7 +677,7 @@ int clock_gettime(clockid_t clockid, struct timespec *tp)
             level = rt_hw_interrupt_disable();
             tick = rt_tick_get(); /* get tick */
             tp->tv_sec  = _timevalue.tv_sec + tick / RT_TICK_PER_SECOND;
-            tp->tv_nsec = (_timevalue.tv_usec + (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK) * 1000;
+            tp->tv_nsec = (_timevalue.tv_usec + (tick % RT_TICK_PER_SECOND) * MICROSECOND_PER_TICK) * 1000U;
             if(tp->tv_nsec > 1000000000ULL)
             {
                 tp->tv_nsec %= 1000000000ULL;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
解决clock_gettime计算出来的nsec超过1sec的问题

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
