### PR TITLE
【修改】mkdist.py 工程文件文件路径问题

### DIFF
--- a/tools/mkdist.py
+++ b/tools/mkdist.py
@@ -135,6 +135,21 @@ def bsp_update_kconfig(dist_dir):
                 line = line[0:position] + 'default "rt-thread"\n'
                 found = 0
             f.write(line)
+def bsp_update_project(dist_dir,project_name):
+    # change RTT_ROOT in *.ewp
+    source_ext=['.ewp','.uvprojx']
+    for  file_type in  source_ext:
+        file_path=os.path.join(dist_dir, project_name+file_type)
+        if not os.path.isfile(file_path):
+            continue
+
+        with open(file_path, 'r') as f:
+            data = f.readlines()
+        with open(file_path, 'w') as f:
+            for line in data:
+                if line.find('..\\..\\') != -1:
+                    line = line.replace('..\\..\\','rt-thread\\')
+                f.write(line)
 
 def bsp_update_kconfig_library(dist_dir):
     # change RTT_ROOT in Kconfig
@@ -369,6 +384,8 @@ def MkDist(program, BSP_ROOT, RTT_ROOT, Env, project_name, project_path):
     bsp_update_kconfig_library(dist_dir)
     # delete testcases in Kconfig
     bsp_update_kconfig_testcases(dist_dir)
+    # change RTT_ROOT in project
+    bsp_update_project(dist_dir,project_name)
 
     # make zip package
     if project_path == None:


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

为解决 scons --dist导出的 project工程 文件路径使用的仓库路径问题

#### 你的解决方案是什么 (what is your solution)

mkdist.py 文件中增加def bsp_update_project(dist_dir,project_name):
line = line.replace('..\\..\\','rt-thread\\')
将工程文件中的路径修改为当前工程路径

#### 在什么测试环境下测试通过 (what is the test environment)

 LPC4088工程 重新生成的 mdk与IAR工程中均测试通过

请注意：此次修改将影响全局
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[[formatting](https://github.com/mysterywolf/formatting)](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [[RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)