### PR TITLE
[bsp][stm32][spi] 优化DMA数据非字节对齐的处理流程

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -389,6 +389,16 @@ typedef int (*init_fn_t)(void);
 /**
  * @ingroup BasicDef
  *
+ * @def RT_IS_ALIGN(addr, align)
+ * Return true(1) or false(0).
+ *     RT_IS_ALIGN(128, 4) is judging whether 128 aligns with 4.
+ *     The result is 1, which means 128 aligns with 4.
+ */
+#define RT_IS_ALIGN(addr, align) (!(addr & (align - 1)))
+
+/**
+ * @ingroup BasicDef
+ *
  * @def RT_ALIGN(size, align)
  * Return the most contiguous size aligned at specified width. RT_ALIGN(13, 4)
  * would return 16.


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
- 根据建议,进行优化
> https://github.com/RT-Thread/rt-thread/pull/6741#discussion_r1220817019

#### 你的解决方案是什么 (what is your solution)
- 区分H7/F7情况下的SPI+DMA流程.
- 以支持单独使用TX_DMA和RX_DMA的情况.
#### 在什么测试环境下测试通过 (what is the test environment)
- STM32H750[ART-PI]
- KEIL V6 -OZ编译
- 使用SPI FLASH W25Q128,搭载littlefs文件系统测试
- 仅测试TXDMA和RXDMA开启情况.未测试单独开启TXDMA或者单独开启RXDMA的情况
测试图片传不上github >https://oss-club.rt-thread.org/uploads/20230607/cf0f422a1f56108ab381ddbc1c94e76a.png
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
