### PR TITLE
向 wch-riscv-bsp 添加 drv_common.c/.h 文件

### DIFF
--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_common.c
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_common.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2006-2023, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2023-06-14     muaxiaohei   first version
+ */
+
+#include <rtthread.h>
+#include "drv_common.h"
+
+void rt_hw_us_delay(rt_uint32_t us)
+{
+    uint64_t total_delay_ticks, us_ticks, start, now, delta, reload;
+
+    start = SysTick->CNT;
+    reload = SysTick->CMP;
+    us_ticks = SystemCoreClock / 8000000UL;
+    total_delay_ticks = (uint32_t)us * us_ticks;
+    RT_ASSERT(total_delay_ticks < reload);
+
+    do{
+        now = SysTick->CNT;
+        delta = start > now ? start - now : reload + start - now;
+    }while(delta < total_delay_ticks);
+}

--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_common.h
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_common.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2006-2023, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2023-06-14     muaxiaohei   first version
+ */
+
+#ifndef __DRV_COMMON_H__
+#define __DRV_COMMON_H__
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void rt_hw_us_delay(rt_uint32_t us);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

- 提供了`rt_hw_us_delay`，用以 us 延时。

#### 你的解决方案是什么 (what is your solution)

- 参考 arm 系列芯片的延时方案，实现 risc-v 系列芯片的 us 延时。

#### 在什么测试环境下测试通过 (what is the test environment)

- CH32V307VCT6 自制板卡。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[[formatting](https://github.com/mysterywolf/formatting)](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [[RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)