### PR TITLE
enable art-pi spi flash use elmfatfs

### DIFF
--- a/bsp/stm32/stm32h750-artpi/board/Kconfig
+++ b/bsp/stm32/stm32h750-artpi/board/Kconfig
@@ -107,7 +107,6 @@ menu "Onboard Peripheral Drivers"
     menuconfig BSP_USING_FS
         bool "Enable filesystem"
         select RT_USING_DFS
-        select RT_USING_DFS_ROMFS
         default n
         if BSP_USING_FS
             config BSP_USING_SDCARD_FS

--- a/bsp/stm32/stm32h750-artpi/board/Kconfig
+++ b/bsp/stm32/stm32h750-artpi/board/Kconfig
@@ -107,6 +107,7 @@ menu "Onboard Peripheral Drivers"
     menuconfig BSP_USING_FS
         bool "Enable filesystem"
         select RT_USING_DFS
+        select RT_USING_DFS_ROMFS
         default n
         if BSP_USING_FS
             config BSP_USING_SDCARD_FS

--- a/bsp/stm32/stm32h750-artpi/board/port/filesystem.c
+++ b/bsp/stm32/stm32h750-artpi/board/port/filesystem.c
@@ -119,7 +119,7 @@ static void sd_mount(void *parameter)
 
 int mount_init(void)
 {
-    #ifdef RT_USING_DFS_ROMFS 
+    #ifdef RT_USING_DFS_ROMFS
     if (dfs_mount(RT_NULL, "/", "rom", 0, &(romfs_root)) != 0)
     {
         LOG_E("rom mount to '/' failed!");
@@ -133,7 +133,7 @@ int mount_init(void)
     fal_init();
     #endif
 
-    #ifdef RT_USING_DFS_ROMFS 
+    #ifdef RT_USING_DFS_ROMFS
     flash_dev = fal_mtd_nor_device_create("filesystem");
 
     if (flash_dev)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

为 ART-PI 开发板添加如下功能：ART-Pi 外部 SPI Flash 使用 elmfatfs 文件系统

#### 你的解决方案是什么 (what is your solution)

原代码是先用 romfs 文件系统挂 /flash 和 /sdcard 两个目录，然后再用 littlefs 系统挂 flash 到 /flash下面

我想这样改：通过 RT_USING_DFS_ROMFS 和 RT_USING_DFS_ELMFAT 控制代码，如果开了elmfat，则会使 ART-Pi 外部 SPI Flash 使用 elmfatfs 文件系统，反之则功能和原代码相同，不影响原功能

修改后代码食用指南：

开启 DFS 以及 elmfatfs 文件系统，并将扇区改成 4096 （artpi 的板载外部 spi flash 的 sector 大小就是4096）。

![image](https://github.com/RT-Thread/rt-thread/assets/56245435/e572eec3-26bf-4aa8-b9ee-cd3c9a20a953)

开启 SPI Flash filesystem：

![image](https://github.com/RT-Thread/rt-thread/assets/56245435/23e3e1fe-14f5-4dff-b09d-d936154e2d62)

然后保存编译下载，即成功让外部 SPI Flash 使用 elmfatfs 文件系统：

![image](https://github.com/RT-Thread/rt-thread/assets/56245435/f845100a-6d70-40d4-8009-5b78b9a390bc)


#### 在什么测试环境下测试通过 (what is the test environment)
RT-Thread Version: latest
RT-Thread Env Version: 1.3.5
OS: Windows 10
IDE: Keil5

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
