### PR TITLE
fix: Static declaration of 'romfs_root' follows non-static declaratio…

### DIFF
--- a/bsp/stm32/stm32l475-atk-pandora/board/ports/drv_filesystem.c
+++ b/bsp/stm32/stm32l475-atk-pandora/board/ports/drv_filesystem.c
@@ -68,7 +68,7 @@ static const struct romfs_dirent _romfs_root[] =
 #endif
 };
 
-static const struct romfs_dirent romfs_root =
+const struct romfs_dirent romfs_root =
 {
     ROMFS_DIRENT_DIR, "/", (rt_uint8_t *)_romfs_root, sizeof(_romfs_root) / sizeof(_romfs_root[0])
 };


### PR DESCRIPTION
…n in dfs_romfs.h

## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
原版编译报错：Static declaration of 'romfs_root' follows non-static declaration in dfs_romfs.h

原因为：在`board/ports/drv_filesystem.c`71行用`static`定义了常量`romfs_root`，而在`rt-thread/components/dfs/dfs_v1/filesystems/romfs/dfs_romfs.h`29行，有它的外部引用：

```
extern const struct romfs_dirent romfs_root;
```

Original compilation error: Static declaration of 'romfs_ root' follows non-static declaration in dfs_romfs. h

The reason is: in 'board/ports/drv_filesystem.c' line 71 use `static` define `romfs_root`, while in `rt-thread/components/dfs/dfs_v1/filesystems/romfs/dfs_romfs.h` line 29, with its external reference:
```
extern const struct romfs_dirent romfs_root;
```

#### 你的解决方案是什么 (what is your solution)
在`drv_filesystem.c`中，不可以用static修饰这个常量，故去掉`static`关键字。

In  `board/ports/drv_filesystem.c`, it is not allowed to define this constant with static, so the `static` keyword must be removed.

#### 在什么测试环境下测试通过 (what is the test environment)
正点原子潘多拉开发板
stm32l475-atk-pandora
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
