### PR TITLE
[bsp][renesas] 修复SDHI尝试多块读取时只能读取到第一个块的问题

### DIFF
--- a/bsp/renesas/libraries/HAL_Drivers/drv_sdhi.c
+++ b/bsp/renesas/libraries/HAL_Drivers/drv_sdhi.c
@@ -94,6 +94,11 @@ rt_err_t command_send(sdhi_instance_ctrl_t *p_ctrl, struct rt_mmcsd_cmd *cmd)
                 cmd->cmd_code |= SDHI_CMD_DATA_DIR_READ;
             }
         }
+        if (data->blks > 1) 
+        {
+            cmd->cmd_code |= SDHI_BLK_TRANSFER;
+            cmd->cmd_code |= SDHI_BLK_NOT_AUTO_STOP;
+        }
     }
     p_ctrl->p_reg->SD_CMD = cmd->cmd_code;
 

--- a/bsp/renesas/libraries/HAL_Drivers/drv_sdhi.h
+++ b/bsp/renesas/libraries/HAL_Drivers/drv_sdhi.h
@@ -44,6 +44,7 @@
 #define SDHI_CMD_ADTC_EN (1 << 11)
 #define SDHI_CMD_DATA_DIR_READ (1 << 12)
 #define SDHI_BLK_TRANSFER (1 << 13)
+#define SDHI_BLK_NOT_AUTO_STOP (1 << 14)
 
 #define SDIO_MAX_FREQ 25000000
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修复瑞萨SDHI驱动中 "Multiple Block" 操作只有一个块有效的问题。


![image](https://github.com/RT-Thread/rt-thread/assets/34395906/73f7aefe-f454-44c0-9db6-570e97e276bf)

![image](https://github.com/RT-Thread/rt-thread/assets/34395906/174196eb-87a4-4e3c-9a7c-2a50137ca005)

在官方芯片手册中可以看到要完成 "Multiple Block" 操作需要给 SD_CMD 寄存器的 TRSTP 位置 1，同时由于驱动框架会主动发送CMD12 命令，所以 CMD12AT 需要写 1 来禁止自动发送 CMD12。


本修改在RT-Thread HMI Board 测试通过。
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
