### PR TITLE
[bsp][Infineon] Add I2C4 config for psoc6-evaluationkit

### DIFF
--- a/bsp/Infineon/libraries/HAL_Drivers/SConscript
+++ b/bsp/Infineon/libraries/HAL_Drivers/SConscript
@@ -23,7 +23,7 @@ if GetDepend(['RT_USING_I2C', 'RT_USING_I2C_BITOPS']):
         src += ['drv_soft_i2c.c']
 
 if GetDepend(['RT_USING_I2C']):
-    if GetDepend('BSP_USING_HW_I2C3') or GetDepend('BSP_USING_HW_I2C6'):
+    if GetDepend('BSP_USING_HW_I2C3') or GetDepend('BSP_USING_HW_I2C4') or GetDepend('BSP_USING_HW_I2C6'):
         src += ['drv_i2c.c']
 
 if GetDepend(['BSP_USING_SDIO1']):

--- a/bsp/Infineon/libraries/HAL_Drivers/drv_i2c.c
+++ b/bsp/Infineon/libraries/HAL_Drivers/drv_i2c.c
@@ -11,7 +11,7 @@
 #include "board.h"
 
 #if defined(RT_USING_I2C)
-#if defined(BSP_USING_HW_I2C3) || defined(BSP_USING_HW_I2C6)
+#if defined(BSP_USING_HW_I2C3) || defined(BSP_USING_HW_I2C4) || defined(BSP_USING_HW_I2C6)
 #include <rtdevice.h>
 
 #ifndef I2C3_CONFIG
@@ -22,7 +22,16 @@
         .sda_pin = BSP_I2C3_SDA_PIN, \
     }
 #endif /* I2C3_CONFIG */
-#endif
+
+#ifndef I2C4_CONFIG
+#define I2C4_CONFIG                  \
+    {                                \
+        .name = "i2c4",              \
+        .scl_pin = BSP_I2C4_SCL_PIN, \
+        .sda_pin = BSP_I2C4_SDA_PIN, \
+    }
+#endif /* I2C4_CONFIG */
+
 #ifndef I2C6_CONFIG
 #define I2C6_CONFIG                  \
     {                                \
@@ -32,10 +41,15 @@
     }
 #endif /* I2C6_CONFIG */
 
+#endif /* defined(BSP_USING_I2C1) || defined(BSP_USING_I2C2) */
+
 enum
 {
 #ifdef BSP_USING_HW_I2C3
     I2C3_INDEX,
+#endif
+#ifdef BSP_USING_HW_I2C4
+    I2C4_INDEX,
 #endif
 #ifdef BSP_USING_HW_I2C6
     I2C6_INDEX,
@@ -61,6 +75,10 @@ static struct ifx_i2c_config i2c_config[] =
     {
 #ifdef BSP_USING_HW_I2C3
         I2C3_CONFIG,
+#endif
+
+#ifdef BSP_USING_HW_I2C4
+        I2C4_CONFIG,
 #endif
 
 #ifdef BSP_USING_HW_I2C6
@@ -145,8 +163,7 @@ void HAL_I2C_Init(struct ifx_i2c *obj)
 
 int rt_hw_i2c_init(void)
 {
-    rt_err_t result;
-    cyhal_i2c_t mI2C;
+    rt_err_t result = RT_EOK;
 
     for (int i = 0; i < sizeof(i2c_config) / sizeof(i2c_config[0]); i++)
     {
@@ -156,8 +173,6 @@ int rt_hw_i2c_init(void)
         i2c_objs[i].mI2C_cfg.is_slave = false;
         i2c_objs[i].mI2C_cfg.address = 0;
         i2c_objs[i].mI2C_cfg.frequencyhal_hz = (400000UL);
-
-        i2c_objs[i].mI2C = mI2C;
 
         i2c_objs[i].i2c_bus.ops = &i2c_ops;
 
@@ -171,4 +186,4 @@ int rt_hw_i2c_init(void)
 }
 INIT_DEVICE_EXPORT(rt_hw_i2c_init);
 
-#endif /* defined(BSP_USING_I2C1) || defined(BSP_USING_I2C2) */
+#endif /* RT_USING_I2C */

--- a/bsp/Infineon/psoc6-evaluationkit-062S2/board/Kconfig
+++ b/bsp/Infineon/psoc6-evaluationkit-062S2/board/Kconfig
@@ -155,6 +155,20 @@ menu "On-chip Peripheral Drivers"
                         range 1 113
                         default 49
                 endif
+            config BSP_USING_HW_I2C4
+                bool "Enable I2C4 Bus (Arduino I2C)"
+                default n
+                if BSP_USING_HW_I2C4
+                    comment "Notice: P8_0 --> 64; P8_1 --> 65"
+                    config BSP_I2C4_SCL_PIN
+                        int "i2c4 SCL pin number"
+                        range 1 113
+                        default 64
+                    config BSP_I2C4_SDA_PIN
+                        int "i2c4 SDA pin number"
+                        range 1 113
+                        default 65
+                endif
             config BSP_USING_HW_I2C6
                 bool "Enable I2C6 Bus (User I2C)"
                 default n


### PR DESCRIPTION
## 为RTT PSoC开发板Arduino接口的I2C引脚添加了硬件I2C配置
Add Arduino I2C pin config for **PSoC™ 62 WITH CAPSENSE™ Evaluation Kit**

#### 为什么提交这份PR (why to submit this PR)
因为：
* RTT PSoC开发板的Arduino接口的I2C引脚与主控芯片的P8.0和P8.1相连
* 主控芯片的P8.0和P8.1可以通过引脚复用设置为硬件I2C功能
因此，添加了这两个引脚的硬件I2C配置之后，就可以使用Arduino扩展版；

#### 你的解决方案是什么 (what is your solution)
硬件I2C代码以及有了，加个配置就好了

#### 在什么测试环境下测试通过 (what is the test environment)
**PSoC™ 62 WITH CAPSENSE™ Evaluation Kit** 板子上测过了
