### PR TITLE
[libcpu][arc]修复arc架构线程切换bug

### DIFF
--- a/libcpu/arc/em/contex_gcc_mw.S
+++ b/libcpu/arc/em/contex_gcc_mw.S
@@ -9,7 +9,7 @@
 
 .global rt_interrupt_enter;
 .global rt_interrupt_leave;
-.global context_switch_reqflg;
+.global rt_thread_switch_interrupt_flag;
 .global rt_interrupt_from_thread;
 .global rt_interrupt_to_thread;
 .global exc_nest_count;
@@ -47,6 +47,7 @@ dispatcher:
 /* return routine when task dispatch happened in task context */
 dispatch_r:
     RESTORE_NONSCRATCH_REGS
+    RESTORE_R0_TO_R12
     j   [blink]
 
 /*
@@ -72,10 +73,13 @@ rt_hw_interrupt_enable:
     .global rt_hw_context_switch_interrupt
     .align 4
 rt_hw_context_switch_interrupt:
+    ld r2, [rt_thread_switch_interrupt_flag]
+    breq r2, 1, _reswitch    /* Check the flag, if it is 1, skip to reswitch */
+    mov r2, 1
+    st r2, [rt_thread_switch_interrupt_flag]
     st r0, [rt_interrupt_from_thread]
+_reswitch:
     st r1, [rt_interrupt_to_thread]
-    mov r0, 1
-    st r0, [context_switch_reqflg]
     j [blink]
 
 
@@ -87,6 +91,7 @@ rt_hw_context_switch_interrupt:
     .global rt_hw_context_switch
     .align 4
 rt_hw_context_switch:
+    SAVE_R0_TO_R12
     SAVE_NONSCRATCH_REGS
     mov r2, dispatch_r
     push r2
@@ -189,7 +194,7 @@ ret_exc:
     lr  r1, [AUX_IRQ_ACT] /* nest interrupt case */
     brne    r1, 0, ret_exc_1
 
-    ld  r0, [context_switch_reqflg]
+    ld  r0, [rt_thread_switch_interrupt_flag]
     brne    r0, 0, ret_exc_2
 ret_exc_1:  /* return from non-task context, interrupts or exceptions are nested */
     EXCEPTION_EPILOGUE
@@ -199,7 +204,7 @@ ret_exc_1:  /* return from non-task context, interrupts or exceptions are nested
 ret_exc_2:
     /* clear dispatch request */
     mov r0, 0
-    st  r0, [context_switch_reqflg]
+    st  r0, [rt_thread_switch_interrupt_flag]
 
     SAVE_CALLEE_REGS    /* save callee save registers */
 
@@ -304,7 +309,7 @@ ret_int:
     bclr    r2, r1, r3
     brne    r2, 0, ret_int_1
 
-    ld  r0, [context_switch_reqflg]
+    ld  r0, [rt_thread_switch_interrupt_flag]
     brne    r0, 0, ret_int_2
 ret_int_1:  /* return from non-task context */
     INTERRUPT_EPILOGUE
@@ -313,7 +318,7 @@ ret_int_1:  /* return from non-task context */
 ret_int_2:
     /* clear dispatch request */
     mov r0, 0
-    st  r0, [context_switch_reqflg]
+    st  r0, [rt_thread_switch_interrupt_flag]
 
     /* interrupt return by SW */
     lr  r10, [AUX_IRQ_ACT]

--- a/libcpu/arc/em/cpuport.c
+++ b/libcpu/arc/em/cpuport.c
@@ -16,7 +16,7 @@
 extern void start_r(void);
 
 
-rt_uint32_t context_switch_reqflg;
+rt_uint32_t rt_thread_switch_interrupt_flag;
 rt_uint32_t rt_interrupt_from_thread;
 rt_uint32_t rt_interrupt_to_thread;
 rt_uint32_t exc_nest_count;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
在实际项目中发现线程切换bug

#### 你的解决方案是什么 (what is your solution)
* 添加线程环境切换未保存的上下文  
* `context_switch_reqflg`改为`rt_thread_switch_interrupt_flag`  
* 在中断环境切换时增加rt_thread_switch_interrupt_flag`  标志位判断，防止中断嵌套时修改from的sp，进而破坏from线程的栈空间，或者栈溢出。  

#### 在什么测试环境下测试通过 (what is the test environment)
在windows下使用加特兰的Alps 雷达开发平台测试。  
]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
