### PR TITLE
[smart] fix possible memory leak

### DIFF
--- a/components/lwp/lwp.h
+++ b/components/lwp/lwp.h
@@ -106,6 +106,7 @@ struct rt_lwp
     pid_t tty_old_pgrp;
     pid_t session;
     rt_list_t t_grp;
+    rt_list_t timer; /* POSIX timer object binding to a process */
 
     int leader; /*boolean value for session group_leader*/
     struct dfs_fdtable fdt;
@@ -164,6 +165,9 @@ void lwp_aspace_switch(struct rt_thread *thread);
 void lwp_user_setting_save(rt_thread_t thread);
 void lwp_user_setting_restore(rt_thread_t thread);
 int lwp_setaffinity(pid_t pid, int cpu);
+
+/* ctime lwp API */
+int timer_list_free(rt_list_t *timer_list);
 
 #ifdef ARCH_MM_MMU
 struct __pthread {

--- a/components/lwp/lwp_pid.c
+++ b/components/lwp/lwp_pid.c
@@ -327,6 +327,7 @@ struct rt_lwp* lwp_new(void)
     lwp->session = -1;
     lwp->tty = RT_NULL;
     rt_list_init(&lwp->t_grp);
+    rt_list_init(&lwp->timer);
     lwp_user_object_lock_init(lwp);
     lwp->address_search_head = RT_NULL;
     rt_wqueue_init(&lwp->wait_queue);
@@ -502,6 +503,7 @@ void lwp_free(struct rt_lwp* lwp)
         }
     }
 
+    timer_list_free(&lwp->timer);
     lwp_pid_put(lwp_to_pid(lwp));
     rt_hw_interrupt_enable(level);
     rt_free(lwp);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

Memory leak will happen if user create a timer and exiting without calling to `timer_delete()`

#### 你的解决方案是什么 (what is your solution)

- Add timer management code for lwp, so it can recycle the timer on lwp defunct routine

#### 在什么测试环境下测试通过 (what is the test environment)

- POSIX app running on qemu-aarch64

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
