### PR TITLE
[libcpu/arm] fix race condition with ldrex,strex

### DIFF
--- a/components/lwp/arch/arm/cortex-a/lwp_arch.c
+++ b/components/lwp/arch/arm/cortex-a/lwp_arch.c
@@ -54,10 +54,13 @@ static struct rt_varea kuser_varea;
 
 void arch_kuser_init(rt_aspace_t aspace, void *vectors)
 {
-    const size_t kuser_size = 0x1000;
     int err;
-    extern char *__kuser_helper_start, *__kuser_helper_end;
-    int kuser_sz = __kuser_helper_end - __kuser_helper_start;
+    const size_t kuser_size = 0x1000;
+    extern char __kuser_helper_start[];
+    extern char __kuser_helper_end[];
+    rt_base_t start = (rt_base_t)__kuser_helper_start;
+    rt_base_t end = (rt_base_t)__kuser_helper_end;
+    int kuser_sz = end - start;
 
     err = rt_aspace_map_static(aspace, &kuser_varea, &vectors, kuser_size,
                                MMU_MAP_U_RO, MMF_MAP_FIXED | MMF_PREFETCH,

--- a/examples/utest/testcases/kernel/atomic_tc.c
+++ b/examples/utest/testcases/kernel/atomic_tc.c
@@ -134,10 +134,11 @@ static void ture_entry(void *parameter)
 static void test_atomic_add(void)
 {
     rt_thread_t thread;
-    int i;
+    size_t i;
     sem_t = rt_sem_create("atomic_sem", 0, RT_IPC_FLAG_PRIO);
 
-    count = 0;
+    rt_atomic_store(&count, 0);
+
     thread = rt_thread_create("t1", ture_entry, RT_NULL, THREAD_STACKSIZE, THREAD_PRIORITY, THREAD_TIMESLICE);
     rt_thread_startup(thread);
     thread = rt_thread_create("t2", ture_entry, RT_NULL, THREAD_STACKSIZE, THREAD_PRIORITY, THREAD_TIMESLICE);
@@ -149,7 +150,8 @@ static void test_atomic_add(void)
     {
         rt_sem_take(sem_t, RT_WAITING_FOREVER);
     }
-    uassert_true(count == 3000000);
+    i = rt_atomic_load(&count);
+    uassert_true(i == 3000000);
 }
 
 static rt_err_t utest_tc_init(void)

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -128,11 +128,11 @@ typedef rt_ubase_t                      rt_dev_t;       /**< Type for device */
 typedef rt_base_t                       rt_off_t;       /**< Type for offset */
 
 #if !defined(__cplusplus)
-#if defined(RT_USING_STDC_ATOMIC)
+#if defined(RT_USING_HW_ATOMIC)
+    typedef rt_base_t rt_atomic_t;
+#elif defined(RT_USING_STDC_ATOMIC)
     #include <stdatomic.h>
     typedef atomic_size_t rt_atomic_t;
-#elif defined(RT_USING_HW_ATOMIC)
-    typedef rt_base_t rt_atomic_t;
 #else
 
     /* To detect std atomic */

--- a/libcpu/aarch64/common/context_gcc.S
+++ b/libcpu/aarch64/common/context_gcc.S
@@ -377,7 +377,6 @@ vector_fiq:
 
 .globl vector_irq
 vector_irq:
-    CLREX
     SAVE_CONTEXT
     STP     X0, X1, [SP, #-0x10]!   /* X0 is thread sp */
 
@@ -391,10 +390,11 @@ vector_irq:
 
 .global rt_hw_context_switch_exit
 rt_hw_context_switch_exit:
+    CLREX
     MOV     X0, SP
     RESTORE_CONTEXT
 
-#else
+#else   /* RT_USING_SMP */
 
 /*
  * void rt_hw_context_switch_to(rt_ubase_t to);
@@ -402,6 +402,7 @@ rt_hw_context_switch_exit:
  */
 .globl rt_hw_context_switch_to
 rt_hw_context_switch_to:
+    CLREX
     LDR     X0, [X0]
     RESTORE_CONTEXT
 
@@ -413,7 +414,7 @@ rt_hw_context_switch_to:
  */
 .globl rt_hw_context_switch
 rt_hw_context_switch:
-
+    CLREX
     SAVE_CONTEXT_FROM_EL1
 
     MOV    X2, SP
@@ -430,6 +431,7 @@ rt_hw_context_switch:
 .globl rt_interrupt_to_thread
 .globl rt_hw_context_switch_interrupt
 rt_hw_context_switch_interrupt:
+    CLREX
     LDR     X6, =rt_thread_switch_interrupt_flag
     LDR     X7, [X6]
     CMP     X7, #1
@@ -506,7 +508,7 @@ vector_irq:
 vector_irq_exit:
     MOV     SP, X0
     RESTORE_CONTEXT_WITHOUT_MMU_SWITCH
-#endif
+#endif  /* RT_USING_SMP */
 
 // -------------------------------------------------
 

--- a/libcpu/arm/cortex-a/context_gcc.S
+++ b/libcpu/arm/cortex-a/context_gcc.S
@@ -40,6 +40,7 @@ rt_hw_interrupt_enable:
  */
 .globl rt_hw_context_switch_to
 rt_hw_context_switch_to:
+    clrex
     ldr sp, [r0]            @ get new task stack pointer
 
 #ifdef RT_USING_SMP
@@ -76,6 +77,7 @@ _guest_switch_lvl:
  */
 .globl rt_hw_context_switch
 rt_hw_context_switch:
+    clrex
     stmfd   sp!, {lr}       @ push pc (lr should be pushed in place of PC)
     stmfd   sp!, {r0-r12, lr}   @ push lr & register file
 
@@ -143,6 +145,7 @@ rt_hw_context_switch:
 .globl rt_interrupt_to_thread
 .globl rt_hw_context_switch_interrupt
 rt_hw_context_switch_interrupt:
+    clrex
 #ifdef RT_USING_SMP
     /* r0 :svc_mod context
      * r1 :addr of from_thread's sp

--- a/libcpu/arm/cortex-a/start_gcc.S
+++ b/libcpu/arm/cortex-a/start_gcc.S
@@ -408,8 +408,6 @@ vector_fiq:
 .globl vector_irq
 vector_irq:
 #ifdef RT_USING_SMP
-    clrex
-
     stmfd   sp!, {r0, r1}
     cps     #Mode_SVC
     mov     r0, sp          /* svc_sp */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

Fix the issue in https://github.com/RT-Thread/rt-thread/issues/7841

#### 你的解决方案是什么 (what is your solution)

Clear an existing tag on context switch, so local monitor can notice the race condition when executing exclusive store

#### 在什么测试环境下测试通过 (what is the test environment)

Tested on board qemu-vexpress-a9 with atomic_tc under `examples` directory

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
