### PR TITLE
[bsp][wch] fix UART IRQ declarion

### DIFF
--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_usart.c
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_usart.c
@@ -418,9 +418,9 @@ void USART3_IRQHandler(void)
 
 #ifdef BSP_USING_UART4
 #if defined (SOC_RISCV_SERIES_CH32V2)
-void USART4_IRQHandler(void) __attribute__((interrupt()));
+void UART4_IRQHandler(void) __attribute__((interrupt()));
 #else
-void USART4_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+void UART4_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 #endif
 void UART4_IRQHandler(void)
 {
@@ -434,9 +434,9 @@ void UART4_IRQHandler(void)
 
 #ifdef BSP_USING_UART5
 #if defined (SOC_RISCV_SERIES_CH32V2)
-void USART5_IRQHandler(void) __attribute__((interrupt()));
+void UART5_IRQHandler(void) __attribute__((interrupt()));
 #else
-void USART5_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+void UART5_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 #endif
 void UART5_IRQHandler(void)
 {
@@ -450,9 +450,9 @@ void UART5_IRQHandler(void)
 
 #ifdef BSP_USING_UART6
 #if defined (SOC_RISCV_SERIES_CH32V2)
-void USART6_IRQHandler(void) __attribute__((interrupt()));
+void UART6_IRQHandler(void) __attribute__((interrupt()));
 #else
-void USART6_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+void UART6_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 #endif
 void UART6_IRQHandler(void)
 {
@@ -466,9 +466,9 @@ void UART6_IRQHandler(void)
 
 #ifdef BSP_USING_UART7
 #if defined (SOC_RISCV_SERIES_CH32V2)
-void USART7_IRQHandler(void) __attribute__((interrupt()));
+void UART7_IRQHandler(void) __attribute__((interrupt()));
 #else
-void USART7_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+void UART7_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 #endif
 void UART7_IRQHandler(void)
 {
@@ -482,9 +482,9 @@ void UART7_IRQHandler(void)
 
 #ifdef BSP_USING_UART8
 #if defined (SOC_RISCV_SERIES_CH32V2)
-void USART8_IRQHandler(void) __attribute__((interrupt()));
+void UART8_IRQHandler(void) __attribute__((interrupt()));
 #else
-void USART8_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+void UART8_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
 #endif
 void UART8_IRQHandler(void)
 {


### PR DESCRIPTION
将UART4后的中断函数声明改为UART

## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
在CH32V307R1 BSP 发现使用UART4后的UART会发生中断函数跑飞，检查BSP库发现中断声明写为USART。
查阅数据手册，发现USART3后的4 5 6等等均为UART
[![pCXszkR.md.png](https://s1.ax1x.com/2023/07/25/pCXszkR.md.png)](https://imgse.com/i/pCXszkR)

#### 你的解决方案是什么 (what is your solution)
直接修改声明USART->UART

#### 在什么测试环境下测试通过 (what is the test environment)
已在CH32V307R1 上运行UART示例代码，可收发
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
