### PR TITLE
[smart] Fix bugs on lwp kill

### DIFF
--- a/components/lwp/arch/aarch64/cortex-a/lwp_arch.c
+++ b/components/lwp/arch/aarch64/cortex-a/lwp_arch.c
@@ -130,7 +130,6 @@ void *arch_signal_ucontext_restore(rt_base_t user_sp)
 
 void *arch_signal_ucontext_save(rt_base_t user_sp, siginfo_t *psiginfo,
                                 struct rt_hw_exp_stack *exp_frame,
-                                rt_base_t elr, rt_base_t spsr,
                                 lwp_sigset_t *save_sig_mask)
 {
     struct signal_ucontext *new_sp;
@@ -146,11 +145,6 @@ void *arch_signal_ucontext_save(rt_base_t user_sp, siginfo_t *psiginfo,
 
         /* exp frame is already aligned as AAPCS64 required */
         memcpy(&new_sp->frame, exp_frame, sizeof(*exp_frame));
-
-        /* fix the 3 fields in exception frame, so that memcpy will be fine */
-        new_sp->frame.pc = elr;
-        new_sp->frame.cpsr = spsr;
-        new_sp->frame.sp_el0 = user_sp;
 
         /* copy the save_sig_mask */
         memcpy(&new_sp->save_sigmask, save_sig_mask, sizeof(lwp_sigset_t));

--- a/components/lwp/arch/aarch64/cortex-a/lwp_arch.h
+++ b/components/lwp/arch/aarch64/cortex-a/lwp_arch.h
@@ -48,7 +48,6 @@ rt_inline void icache_invalid_all(void)
  */
 void *arch_signal_ucontext_save(rt_base_t user_sp, siginfo_t *psiginfo,
                                 struct rt_hw_exp_stack *exp_frame,
-                                rt_base_t elr, rt_base_t spsr,
                                 lwp_sigset_t *save_sig_mask);
 
 /**

--- a/components/lwp/arch/aarch64/cortex-a/lwp_gcc.S
+++ b/components/lwp/arch/aarch64/cortex-a/lwp_gcc.S
@@ -193,7 +193,7 @@ arch_syscall_exit:
     add sp, sp, #0x40
     RESTORE_FPU sp
 
-/* the sp is reset to the outer most level */
+/* the sp is reset to the outer most level, irq and fiq are disabled */
 START_POINT(arch_ret_to_user)
     /* save exception frame */
     SAVE_FPU sp
@@ -245,11 +245,18 @@ START_POINT(arch_ret_to_user)
 
     /**
      * push 2 dummy words to simulate a exception frame of interrupt
+     * @note in kernel state, the context switch dont saved the context
      */
-    add sp, sp, #-0x10
+    mrs x0, spsr_el1
+    mrs x1, elr_el1
+    stp x1, x0, [sp, #-0x10]!
     mov x0, sp
+    msr daifclr, #3
     bl lwp_thread_signal_catch
-    add sp, sp, #0x10
+    msr daifset, #3
+    ldp x1, x0, [sp], #0x10
+    msr spsr_el1, x0
+    msr elr_el1, x1
 
     /* check debug */
     /* restore exception frame */
@@ -405,7 +412,6 @@ arch_signal_quit:
     msr spsr_el1, x3
 
     ldp x29, x30, [sp], #0x10
-    // msr sp_el0, x29
 
     ldp x28, x29, [sp], #0x10
     msr fpcr, x28
@@ -452,12 +458,9 @@ arch_thread_signal_enter:
      * move exception frame to user stack
      */
     mrs x0, sp_el0
-    mrs x3, elr_el1
-    mov x5, x4
-    /** FIXME: spsr must restore from exception frame */
-    mrs x4, spsr_el1
+    mov x3, x4
 
-    /* arch_signal_ucontext_save(user_sp, psiginfo, exp_frame, elr, spsr, save_sig_mask); */
+    /* arch_signal_ucontext_save(user_sp, psiginfo, exp_frame, save_sig_mask); */
     bl arch_signal_ucontext_save
 
     dc cvau, x0
@@ -469,7 +472,16 @@ arch_thread_signal_enter:
      * @brief Prepare the environment for signal handler
      */
 
-    /** drop exp frame on kernel stack, reset kernel sp */
+    /** 
+     * reset the cpsr
+     * and drop exp frame on kernel stack, reset kernel sp
+     *
+     * @note Since we will reset spsr, but the reschedule will
+     * corrupt the spsr, we diable irq for a short period here
+     */
+    msr daifset, #3
+    ldr x1, [x20, #CONTEXT_OFFSET_SPSR_EL1]
+    msr spsr_el1, x1
     add sp, x20, #CONTEXT_SIZE
 
     /** reset user sp */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

##### Issues 1: lwp kill will not terminate process occasionally.

Previous implementation only allow main thread in a process to do the termination. If the termination is triggered by a sub-thread while main thread is suspended, the process will hang up forever.

##### Issues 2: sigtimedwait should reset the signal mask whlie suspended.

##### Issues 3: context switch will corrupt the SPSR

The user status may be corrupted during `rt_schedule()` because of this.

https://github.com/RT-Thread/rt-thread/blob/5c4b44f81e82d813bfd991e57d21c64ca3070a44/libcpu/aarch64/common/context_gcc.S#L147

#### 你的解决方案是什么 (what is your solution)

For issue 1:

In `lwp_termiante()`, each thread can race to terminate the process, which will set a flag to other threads to indicate a termination is pending and **request** all the threads to exit. Still, after every other threads exit, the main thread only will complete the remaining termination progress (setup return code, etc.)

For issue 3:

This patch bypass this through constructing the SPSR context explictly in stack frame of user exception. And restore it after re-schedule.

#### 在什么测试环境下测试通过 (what is the test environment)

A1000, QEMU aarch64

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
