### PR TITLE
[components][drivers][sdio] Fix minor issue in sdio driver

### DIFF
--- a/components/drivers/sdio/mmc.c
+++ b/components/drivers/sdio/mmc.c
@@ -307,7 +307,7 @@ out:
 }
 
 /*
- * Select the bus width amoung 4-bit and 8-bit(SDR).
+ * Select the bus width among 4-bit and 8-bit(SDR).
  * If the bus width is changed successfully, return the selected width value.
  * Zero is returned instead of error value if the wide width is not supported.
  */
@@ -337,22 +337,21 @@ static int mmc_select_bus_width(struct rt_mmcsd_card *card, rt_uint8_t *ext_csd)
         ddr = 2;
     }
     /*
-    * Unlike SD, MMC cards dont have a configuration register to notify
+    * Unlike SD, MMC cards don't have a configuration register to notify
     * supported bus width. So bus test command should be run to identify
-    * the supported bus width or compare the ext csd values of current
-    * bus width and ext csd values of 1 bit mode read earlier.
+    * the supported bus width or compare the EXT_CSD values of current
+    * bus width and EXT_CSD values of 1 bit mode read earlier.
     */
     for (idx = 0; idx < sizeof(bus_widths) / sizeof(rt_uint32_t); idx++)
     {
         /*
-        * Host is capable of 8bit transfer, then switch
-        * the device to work in 8bit transfer mode. If the
-        * mmc switch command returns error then switch to
-        * 4bit transfer mode. On success set the corresponding
-        * bus width on the host. Meanwhile, mmc core would
-        * bail out early if corresponding bus capable wasn't
-        * set by drivers.
-        */
+         * Determine BUS WIDTH mode according to the capability of host
+         */
+        if (((ext_csd_bits[idx][0] == EXT_CSD_BUS_WIDTH_8) && ((host->flags & MMCSD_BUSWIDTH_8) == 0)) ||
+            ((ext_csd_bits[idx][0] == EXT_CSD_BUS_WIDTH_4) && ((host->flags & MMCSD_BUSWIDTH_4) == 0)))
+        {
+            continue;
+        }
         bus_width = bus_widths[idx];
         if (bus_width == MMCSD_BUS_WIDTH_1)
         {
@@ -507,7 +506,7 @@ static int mmc_select_timing(struct rt_mmcsd_card *card)
     }
     else
     {
-        mmcsd_set_timing(card->host, MMCSD_TIMING_UHS_SDR50);
+        mmcsd_set_timing(card->host, MMCSD_TIMING_MMC_HS);
         mmcsd_set_clock(card->host, card->hs_max_data_rate);
     }
 


### PR DESCRIPTION
- Corrected the HIGH_SPEED timing setting
- Adjusted the bus_width setting logic
- Avoided potential null derefence issue in rt_mmcsd_blk_remove function

## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)


在测试mmc驱动时，发现了一些bug


#### 你的解决方案是什么 (what is your solution)

对照EMMC 5.1 规范以及当前mmc.h的结构体定义修改了代码逻辑

#### 在什么测试环境下测试通过 (what is the test environment)

当前的这份改动在先楫HPM6750EVKMINI和HPM6300EVK上做过测试。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
