### PR TITLE
[DFS_V1] 修复close失败后不释放fd导致内存被永久占用且无法释放

### DIFF
--- a/components/dfs/dfs_v1/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/dfs_v1/filesystems/elmfat/dfs_elm.c
@@ -491,11 +491,9 @@ int dfs_elm_close(struct dfs_file *file)
         RT_ASSERT(fd != RT_NULL);
 
         result = f_close(fd);
-        if (result == FR_OK)
-        {
-            /* release memory */
-            rt_free(fd);
-        }
+
+        /* release memory */
+        rt_free(fd);
     }
 
     return elm_result_to_dfs(result);

--- a/components/dfs/dfs_v1/src/dfs_file.c
+++ b/components/dfs/dfs_v1/src/dfs_file.c
@@ -309,13 +309,6 @@ int dfs_file_close(struct dfs_file *fd)
             result = vnode->fops->close(fd);
         }
 
-        /* close fd error, return */
-        if (result < 0)
-        {
-            dfs_fm_unlock();
-            return result;
-        }
-
         if (vnode->ref_count == 1)
         {
             /* remove from hash */

--- a/components/dfs/dfs_v1/src/dfs_posix.c
+++ b/components/dfs/dfs_v1/src/dfs_posix.c
@@ -146,6 +146,7 @@ int close(int fd)
     }
 
     result = dfs_file_close(d);
+    fd_release(fd);
 
     if (result < 0)
     {
@@ -153,8 +154,6 @@ int close(int fd)
 
         return -1;
     }
-
-    fd_release(fd);
 
     return 0;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
在项目运行过程中发现在打开一个文件并使用过 `write` 写入数据，此时若拔掉SD卡，`close` 必然返回失败，但是此时 `dfs` 的文件描述符并没有被释放，该内存将被永久占用，无法被释放。从而导致内存泄漏

#### 你的解决方案是什么 (what is your solution)
通过修改 `dfs` 的文件关闭逻辑，使其无论当前是否能够成功关闭，都会释放文件描述符（参考Linux 内核代码）。

#### 在什么测试环境下测试通过 (what is the test environment)
在 ART-PI 上测试通过
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
