### PR TITLE
[DFS_V1]修复 dfs_file_stat 一个 FATFS 根目录会失败的问题

### DIFF
--- a/components/dfs/dfs_v1/filesystems/elmfat/ff.c
+++ b/components/dfs/dfs_v1/filesystems/elmfat/ff.c
@@ -4746,7 +4746,7 @@ FRESULT f_stat (
 		res = follow_path(&dj, path);	/* Follow the file path */
 		if (res == FR_OK) {				/* Follow completed */
 			if (dj.fn[NSFLAG] & NS_NONAME) {	/* It is origin directory */
-				res = FR_INVALID_NAME;
+				fno->fattrib = AM_DIR;
 			} else {							/* Found an object */
 				if (fno) get_fileinfo(&dj, fno);
 			}

--- a/components/dfs/dfs_v1/src/dfs_file.c
+++ b/components/dfs/dfs_v1/src/dfs_file.c
@@ -584,44 +584,23 @@ int dfs_file_stat(const char *path, struct stat *buf)
         return -ENOENT;
     }
 
-    if ((fullpath[0] == '/' && fullpath[1] == '\0') ||
-        (dfs_subdir(fs->path, fullpath) == NULL))
+    if (fs->ops->stat == NULL)
     {
-        /* it's the root directory */
-        buf->st_dev   = 0;
-
-        buf->st_mode  = S_IRUSR | S_IRGRP | S_IROTH |
-                        S_IWUSR | S_IWGRP | S_IWOTH;
-        buf->st_mode |= S_IFDIR | S_IXUSR | S_IXGRP | S_IXOTH;
-
-        buf->st_size    = 0;
-        buf->st_mtime   = 0;
-
-        /* release full path */
         rt_free(fullpath);
+        LOG_E("the filesystem didn't implement this function");
 
-        return RT_EOK;
+        return -ENOSYS;
+    }
+    /* get the real file path and get file stat */
+    if (fs->ops->flags & DFS_FS_FLAG_FULLPATH)
+    {
+        result = fs->ops->stat(fs, fullpath, buf);
     }
     else
     {
-        if (fs->ops->stat == NULL)
-        {
-            rt_free(fullpath);
-            LOG_E("the filesystem didn't implement this function");
-
-            return -ENOSYS;
-        }
-        /* get the real file path and get file stat */
-        if (fs->ops->flags & DFS_FS_FLAG_FULLPATH)
-        {
-            result = fs->ops->stat(fs, fullpath, buf);
-        }
-        else
-        {
-            const char *subdir = dfs_subdir(fs->path, fullpath);
-            subdir = subdir ? subdir : "/";
-            result = fs->ops->stat(fs, subdir, buf);
-        }
+        const char *subdir = dfs_subdir(fs->path, fullpath);
+        subdir = subdir ? subdir : "/";
+        result = fs->ops->stat(fs, subdir, buf);
     }
 
     rt_free(fullpath);

--- a/components/dfs/dfs_v1/src/dfs_file.c
+++ b/components/dfs/dfs_v1/src/dfs_file.c
@@ -584,23 +584,44 @@ int dfs_file_stat(const char *path, struct stat *buf)
         return -ENOENT;
     }
 
-    if (fs->ops->stat == NULL)
+    if ((fullpath[0] == '/' && fullpath[1] == '\0') ||
+        (dfs_subdir(fs->path, fullpath) == NULL))
     {
-        rt_free(fullpath);
-        LOG_E("the filesystem didn't implement this function");
+        /* it's the root directory */
+        buf->st_dev   = 0;
 
-        return -ENOSYS;
-    }
-    /* get the real file path and get file stat */
-    if (fs->ops->flags & DFS_FS_FLAG_FULLPATH)
-    {
-        result = fs->ops->stat(fs, fullpath, buf);
+        buf->st_mode  = S_IRUSR | S_IRGRP | S_IROTH |
+                        S_IWUSR | S_IWGRP | S_IWOTH;
+        buf->st_mode |= S_IFDIR | S_IXUSR | S_IXGRP | S_IXOTH;
+
+        buf->st_size    = 0;
+        buf->st_mtime   = 0;
+
+        /* release full path */
+        rt_free(fullpath);
+
+        return RT_EOK;
     }
     else
     {
-        const char *subdir = dfs_subdir(fs->path, fullpath);
-        subdir = subdir ? subdir : "/";
-        result = fs->ops->stat(fs, subdir, buf);
+        if (fs->ops->stat == NULL)
+        {
+            rt_free(fullpath);
+            LOG_E("the filesystem didn't implement this function");
+
+            return -ENOSYS;
+        }
+        /* get the real file path and get file stat */
+        if (fs->ops->flags & DFS_FS_FLAG_FULLPATH)
+        {
+            result = fs->ops->stat(fs, fullpath, buf);
+        }
+        else
+        {
+            const char *subdir = dfs_subdir(fs->path, fullpath);
+            subdir = subdir ? subdir : "/";
+            result = fs->ops->stat(fs, subdir, buf);
+        }
     }
 
     rt_free(fullpath);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
在使用 ART-PI BSP 时发现启用 sdcard 文件系统后在终端输入 `ls` 会有如下显示：
![image](https://github.com/RT-Thread/rt-thread/assets/34395906/f7a55775-5b0d-465f-9e6f-af0d1c05f646)
sdcard 目录被识别成了 **BAD file**。实际上此时 `cd sdcard` 是正常可以进入的。并且内部的文件都能够正常查看。而且这个问题似乎是最近才出现的。

经排查发现这个问题是由这个PR引入的：
https://github.com/RT-Thread/rt-thread/pull/7887

该PR中删除了 `dfs_file.c` 中对当前是否是根目录的判断，导致无论是否是根目录都会进入 `fs->ops->stat` 的调用，进而调用到 `f_stat`，然而在目前版本的 FATFS 的 `f_stat` 在发现当前是根目录时会返回一个 `FR_INVALID_NAME` 的错误导致最终目录信息获取失败。

```c
FRESULT f_stat (
    const TCHAR* path,	/* Pointer to the file path */
    FILINFO* fno		/* Pointer to file information to return */
)
{
    FRESULT res;
    DIR dj;
    DEF_NAMBUF


    /* Get logical drive */
    res = mount_volume(&path, &dj.obj.fs, 0);
    if (res == FR_OK) {
        INIT_NAMBUF(dj.obj.fs);
        res = follow_path(&dj, path);	/* Follow the file path */
        if (res == FR_OK) {				/* Follow completed */
------->    if (dj.fn[NSFLAG] & NS_NONAME) {	/* It is origin directory */
                res = FR_INVALID_NAME;
            } else {							/* Found an object */
                if (fno) get_fileinfo(&dj, fno);
            }
        }
        FREE_NAMBUF();
    }

    LEAVE_FF(dj.obj.fs, res);
}

```

目前不是很清楚 #7887 在这方面的修改是否有必要的，如果有必要的话可能需要讨论一下上述问题的正确解决方案

#### 你的解决方案是什么 (what is your solution)

恢复之前 `dfs_file_stat` 中对根目录的单独处理逻辑

#### 在什么测试环境下测试通过 (what is the test environment)

ART-PI

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
