### PR TITLE
[serial_v2] 修复阻塞模式下中断发送的逻辑顺序问题与多线程下的竞态条件

### DIFF
--- a/components/drivers/serial/serial_v2.c
+++ b/components/drivers/serial/serial_v2.c
@@ -533,13 +533,14 @@ static rt_ssize_t _serial_fifo_tx_blocking_buf(struct rt_device        *dev,
                                                (rt_uint8_t *)buffer + offset,
                                                size);
 
-        offset += tx_fifo->put_size;
-        size -= tx_fifo->put_size;
         /* Call the transmit interface for transmission */
         serial->ops->transmit(serial,
                              (rt_uint8_t *)buffer + offset,
                              tx_fifo->put_size,
                              RT_SERIAL_TX_BLOCKING);
+                             
+        offset += tx_fifo->put_size;
+        size -= tx_fifo->put_size;
         /* Waiting for the transmission to complete */
         rt_completion_wait(&(tx_fifo->tx_cpt), RT_WAITING_FOREVER);
     }
@@ -598,7 +599,7 @@ static rt_ssize_t _serial_fifo_tx_nonblocking(struct rt_device        *dev,
         return length;
     }
 
-    /* If the activated mode is RT_FALSE, it means that serial device is transmitting,
+    /* If the activated mode is RT_TRUE, it means that serial device is transmitting,
      * where only the data in the ringbuffer and there is no need to call the transmit() API.
      * Note that this part of the code requires disable interrupts
      * to prevent multi thread reentrant */

--- a/components/drivers/serial/serial_v2.c
+++ b/components/drivers/serial/serial_v2.c
@@ -545,7 +545,7 @@ static rt_ssize_t _serial_fifo_tx_blocking_buf(struct rt_device        *dev,
         rt_completion_wait(&(tx_fifo->tx_cpt), RT_WAITING_FOREVER);
     }
     /* Finally Inactivate the tx->fifo */
-	tx_fifo->activated = RT_FALSE;
+    tx_fifo->activated = RT_FALSE;
 
     return length;
 }
@@ -1558,16 +1558,16 @@ void rt_hw_serial_isr(struct rt_serial_device *serial, int event)
                 if (serial->parent.tx_complete != RT_NULL)
                     serial->parent.tx_complete(&serial->parent, RT_NULL);
 
-                /* Maybe some datas left in the buffer still need to be sent in block mode. */
-				/* so tx_fifo->activated should be RT_TRUE */
+                /* Maybe some datas left in the buffer still need to be sent in block mode,
+                 * so tx_fifo->activated should be RT_TRUE */
                 if (serial->parent.open_flag & RT_SERIAL_TX_BLOCKING)
-				{				
+                {				
                     rt_completion_done(&(tx_fifo->tx_cpt));
-				}
-				else
-				{
-			    	tx_fifo->activated = RT_FALSE;
-				}
+                }
+                else
+                {
+                    tx_fifo->activated = RT_FALSE;
+                }
 
                 break;
             }

--- a/components/drivers/serial/serial_v2.c
+++ b/components/drivers/serial/serial_v2.c
@@ -538,7 +538,7 @@ static rt_ssize_t _serial_fifo_tx_blocking_buf(struct rt_device        *dev,
                              (rt_uint8_t *)buffer + offset,
                              tx_fifo->put_size,
                              RT_SERIAL_TX_BLOCKING);
-                             
+
         offset += tx_fifo->put_size;
         size -= tx_fifo->put_size;
         /* Waiting for the transmission to complete */
@@ -1561,7 +1561,7 @@ void rt_hw_serial_isr(struct rt_serial_device *serial, int event)
                 /* Maybe some datas left in the buffer still need to be sent in block mode,
                  * so tx_fifo->activated should be RT_TRUE */
                 if (serial->parent.open_flag & RT_SERIAL_TX_BLOCKING)
-                {				
+                {
                     rt_completion_done(&(tx_fifo->tx_cpt));
                 }
                 else


### PR DESCRIPTION
修复阻塞模式下中断发送的逻辑问题

## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

在开源之夏活动中申请了“在RT-Thread上实现稳定可靠的串口设备框架”项目，阅读源码的过程中发现了这些问题。

Commit1 ：[bug fix] 修复serial_v2逻辑问题
第一处修改理由:
一. 函数_serial_fifo_tx_blocking_buf中，需要将buffer中的数据复制到tx->fifo中，然后调用serial->ops->transmit（）进行发送，因为buffer的数量可能远大于tx->fifo的大小，因此需要多次发送。

 二. 该函数多次发送的正确流程应该是:   
(1.)将数据放入ringbuffer。
(2.)调用传输函数，启动中断发送
(3.)根据所发送数据的数量更新偏移量。(从而能够发送buffer中还未发送的数据)

三. 但是原版的代码的流程是 :      
(1.)将数据放入ringbuffer。
(2.)根据所发送数据的数量更新偏移量。
 (3.)调用传输函数，启动中断发送。
因此我认为源码代码逻辑有问题，跟正确的逻辑顺序相反。（注：offset初始值为0）

 四. 此处代码之所以没有发生恶性的bug，经过查证, 是因为传输函数serial->ops->transmit（）函数底层调用的是 
stm32_control()，此函数的目的是开启中断。因此，传输函数serial->ops->transmit(serial, (rt_uint8_t *)buffer + offset, 
tx_fifo ->put_size, RT_SERIAL_TX_BLOCKING)中关于buffer与偏移量的实参并没有发挥作用。正式因为这些参数没有发挥作用，传输 的逻辑的问题才没有让阻塞模式下的中断发送产生毁灭性的后果，但是我认为这个问题还是要改的，所以提了这个pr。
    
第二处修改理由：
 一. 这个很明显，注释写错了，tx->fifo为RT-TRUE时，表示该fifo已经被占用，而不是RT-FALSE；


Commit 2： [serial_v2] 修复多线程下阻塞模式中断发送bug：
修改理由：
一. 在阻塞模式下，中断发送的数据量可能远远大于发送缓存 tx->fifo, 因此可能需要多次发送。该函数_serial_fifo_tx_blocking_buf在最开始将tx_fifo->activated 设置为 RT_TRUE，标志发送缓存已经被使用，然后用while（size){..}来保证应用层的数据被完全发送完。在送过程中，先将数据拷贝到tx_fifo中，然后开始传输serial->ops->transmit。然后，当tx->fifo中的数据被发送完之后，中断处理函数会被调用。此时，问题就出现了，通过下面的代码我们可以发现，当tx_fifo的数据发送完后，第一步竟然是将tx_fifo->activated设置为FALSE。别忘了，阻塞模式的中断发送中，应用层的数据可是多于tx_fifo的，需要多次传输，可此时，还将工作的tx_fifo，其激活量竟然被标志FALSE，那么很明显，这个时候其他的现程就能通过同样调用_serial_fifo_tx_blocking_buf，来跟当然的现程来抢tx_fifo的使用权，这样就会出现混乱。在我的测试中，我发现两个发送的现程直接都卡死了，因此，我认为这是一个隐藏的bug，需要修复。

              if (tx_length == 0)
            {
		tx_fifo->activated = RT_FALSE;  <------错误在这里，它被提前设置为FLASE了，而且后面的代码再也没有讲其改为TRUE
                /* Trigger the transmit completion callback */
                if (serial->parent.tx_complete != RT_NULL)
                    serial->parent.tx_complete(&serial->parent, RT_NULL);
								
		/* Maybe some datas left in the buffer still need to be sent in block mode. */
		/* so tx_fifo->activated should be RT_TRUE */
                if (serial->parent.open_flag & RT_SERIAL_TX_BLOCKING)		
                    rt_completion_done(&(tx_fifo->tx_cpt));					
                break;
            }

#### 你的解决方案是什么 (what is your solution)

Commit1 ：[bug fix] 修复serial_v2逻辑问题
第一处修改：
  修正的错误的顺序
第二处修改：
  修正错误的注释
  
Commit 2： [serial_v2] 修复多线程下阻塞模式中断发送bug：
      因为中断处理函数rt_hw_serial_isr中，case RT_SERIAL_EVENT_TX_DONE 只有在阻塞模式下的中断发送和非阻塞模式下的中断发送调用会涉及到。而此次出bug的原因是，作者仅仅考虑的非阻塞模式下的情况，因为当tx->fifo中的数据被发送完，便可将其    tx_fifo->activated量设置为RT_FALSE，这种操作对于非阻塞模式下的发送，是完全没有问题的，因为非阻塞模式不会强制要求应用层缓冲区的数据必须发送完才能返回。原来的代码只是在阻塞模式下的发送中出现了提前将tx_fifo->activated量设置为FALSE的问题，对于此，我的修改是，如果不是阻塞模式，那么可以直接将tx_fifo->activated设置为RT_FALSE。如果是阻塞模式，那么不更改tx_fifo->activated的值，直到_serial_fifo_tx_blocking_buf函数执行完，到返回之前，再将tx_fifo->activated的值改为TRUE，以便其他的现程使用tx_fifo进行发送。



#### 在什么测试环境下测试通过 (what is the test environment)

在stm32L475潘多拉上通过了以上测试

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
