### PR TITLE
dfs_v2 tmpfs adds truncate functionality and unlink adaptations

### DIFF
--- a/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.h
+++ b/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.h
@@ -30,6 +30,7 @@ struct tmpfs_file
     struct tmpfs_sb *sb;       /* superblock ptr */
     rt_uint8_t      *data;     /* file date ptr */
     rt_size_t        size;     /* file size */
+    rt_bool_t       fre_memory;/* Whether to release memory upon close */
 };
 
 

--- a/components/dfs/dfs_v2/src/dfs_file.c
+++ b/components/dfs/dfs_v2/src/dfs_file.c
@@ -1082,7 +1082,7 @@ int dfs_file_unlink(const char *path)
                     rt_bool_t has_child = RT_FALSE;
 
                     has_child = dfs_mnt_has_child_mnt(mnt, fullpath);
-                    if (has_child == RT_FALSE && rt_atomic_load(&(dentry->ref_count)) == 1)
+                    if (has_child == RT_FALSE)
                     {
                         /* no child mnt point, unlink it */
                         ret = -RT_ERROR;

--- a/components/lwp/lwp_ipc.c
+++ b/components/lwp/lwp_ipc.c
@@ -18,6 +18,10 @@
 #include <dfs_file.h>
 #include <poll.h>
 
+#ifdef RT_USING_DFS_V2
+#include <dfs_dentry.h>
+#endif
+
 /**
  * the IPC channel states
  */
@@ -371,7 +375,6 @@ static void *_ipc_msg_get_file(int fd)
     if (!d->vnode)
         return RT_NULL;
 
-    d->vnode->ref_count++;
     return (void *)d;
 }
 
@@ -408,12 +411,15 @@ static int _ipc_msg_fd_new(void *file)
     d->fops = df->fops;
     d->mode = df->mode;
     d->dentry = df->dentry;
+    d->dentry->ref_count ++;
 #endif
 
     d->vnode = df->vnode;
     d->flags = df->flags;
     d->data = df->data;
     d->magic = df->magic;
+
+    d->vnode->ref_count ++;
 
     return fd;
 }


### PR DESCRIPTION
#### 为什么提交这份PR (why to submit this PR)
dfs_v2 下的 tmpfs 文件系统添加 truncate 功能以及 unlink 的适配

#### 在什么测试环境下测试通过 (what is the test environment)
qemu-virt64-aarch64

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
