### PR TITLE
[bsp][nuclei] fix "usb_conf.h not found"

### DIFF
--- a/bsp/nuclei/gd32vf103_rvstar/applications/usb_conf.h
+++ b/bsp/nuclei/gd32vf103_rvstar/applications/usb_conf.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2006-2020, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2023-09-25     XYZboom      fix usb_conf.h not found in nuclei-sdk after 0.3.8
+ */
+#ifndef __USB_CONF_H__
+#define __USB_CONF_H__
+
+#include <stddef.h>
+#include "gd32vf103.h"
+
+#define USE_USB_FS
+
+#ifdef USE_USB_FS
+#define USB_FS_CORE
+#endif
+
+#ifdef USE_USB_HS
+#define USB_HS_CORE
+#endif
+
+#ifdef USB_FS_CORE
+#define RX_FIFO_FS_SIZE                         128
+#define TX0_FIFO_FS_SIZE                        64
+#define TX1_FIFO_FS_SIZE                        128
+#define TX2_FIFO_FS_SIZE                        0
+#define TX3_FIFO_FS_SIZE                        0
+#define USB_RX_FIFO_FS_SIZE                     128
+#define USB_HTX_NPFIFO_FS_SIZE                  96
+#define USB_HTX_PFIFO_FS_SIZE                   96
+#endif /* USB_FS_CORE */
+
+#ifdef USB_HS_CORE
+#define RX_FIFO_HS_SIZE                          512
+#define TX0_FIFO_HS_SIZE                         128
+#define TX1_FIFO_HS_SIZE                         372
+#define TX2_FIFO_HS_SIZE                         0
+#define TX3_FIFO_HS_SIZE                         0
+#define TX4_FIFO_HS_SIZE                         0
+#define TX5_FIFO_HS_SIZE                         0
+
+#ifdef USE_ULPI_PHY
+#define USB_OTG_ULPI_PHY_ENABLED
+#endif
+
+#ifdef USE_EMBEDDED_PHY
+#define USB_OTG_EMBEDDED_PHY_ENABLED
+#endif
+
+#define USB_OTG_HS_INTERNAL_DMA_ENABLED
+#define USB_OTG_HS_DEDICATED_EP1_ENABLED
+#endif /* USB_HS_CORE */
+
+#ifndef USB_SOF_OUTPUT
+#define USB_SOF_OUTPUT                                     0
+#endif
+
+#ifndef USB_LOW_POWER
+#define USB_LOW_POWER                                      0
+#endif
+
+#ifndef USE_HOST_MODE
+#define  USE_DEVICE_MODE
+#endif
+
+#ifndef USB_FS_CORE
+#ifndef USB_HS_CORE
+#error "USB_HS_CORE or USB_FS_CORE should be defined"
+#endif
+#endif
+
+#ifndef USE_DEVICE_MODE
+#ifndef USE_HOST_MODE
+#error "USE_DEVICE_MODE or USE_HOST_MODE should be defined"
+#endif
+#endif
+
+#ifndef USE_USB_HS
+#ifndef USE_USB_FS
+#error "USE_USB_HS or USE_USB_FS should be defined"
+#endif
+#endif
+
+/****************** C Compilers dependant keywords ****************************/
+/* In HS mode and when the DMA is used, all variables and data structures dealing
+   with the DMA during the transaction process should be 4-bytes aligned */
+#ifdef USB_OTG_HS_INTERNAL_DMA_ENABLED
+#if defined   (__GNUC__)            /* GNU Compiler */
+#define __ALIGN_END __attribute__ ((aligned(4)))
+#define __ALIGN_BEGIN
+#endif                              /* __GNUC__ */
+#else
+#define __ALIGN_BEGIN
+#define __ALIGN_END
+#endif /* USB_OTG_HS_INTERNAL_DMA_ENABLED */
+
+#endif /* __USB_CONF_H__ */
+

--- a/bsp/nuclei/gd32vf103_rvstar/applications/usbd_conf.h
+++ b/bsp/nuclei/gd32vf103_rvstar/applications/usbd_conf.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2006-2020, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2023-09-25     XYZboom      fix usbd_conf.h not found in nuclei-sdk after 0.3.8
+ */
+#ifndef __USBD_CONF_H__
+#define __USBD_CONF_H__
+
+#include "usb_conf.h"
+
+#define USBD_CFG_MAX_NUM                    1
+#define USBD_ITF_MAX_NUM                    1
+
+#endif /* __USBD_CONF_H__ */
+

--- a/bsp/nuclei/gd32vf103_rvstar/applications/usbh_conf.h
+++ b/bsp/nuclei/gd32vf103_rvstar/applications/usbh_conf.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2006-2020, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2023-09-25     XYZboom      fix usbh_conf.h not found in nuclei-sdk after 0.3.8
+ */
+#ifndef __USBH_CONF_H__
+#define __USBH_CONF_H__
+
+#define USBH_MAX_EP_NUM                         2
+#define USBH_MAX_INTERFACES_NUM                 2
+#define USBH_MSC_MPS_SIZE                       0x200
+
+#endif /* __USBH_CONF_H__ */
+


### PR DESCRIPTION
Nuclei sdk requires the USB configuration header file to be completed by the application in versions after 0.3.8. see https://github.com/Nuclei-Software/nuclei-sdk/pull/54 and https://github.com/Nuclei-Software/nuclei-sdk/commit/43912c1a22faeaa02220c2dea8fbc17c13735091

## 拉取/合并请求描述：(PR description)

[
When compiling the code for Nuclei gd32vf103 rvstar, there were errors such as "usb_conf. h" where the USB configuration file could not be found. Upon inspection, it was found that Nuclei sdk removed the USB related configuration header files in version 0.3.8 and requested the application to configure it itself. In gd32vf103_ rvstar compilation test passed.
Reference: https://github.com/Nuclei-Software/nuclei-sdk/pull/54 And https://github.com/Nuclei-Software/nuclei-sdk/commit/43912c1a22faeaa02220c2dea8fbc17c13735091
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
