### PR TITLE
[smart] replace lwp_new() with lwp_create()

### DIFF
--- a/components/lwp/lwp.c
+++ b/components/lwp/lwp.c
@@ -1152,7 +1152,7 @@ pid_t lwp_execve(char *filename, int debug, int argc, char **argv, char **envp)
         return -EACCES;
     }
 
-    lwp = lwp_new();
+    lwp = lwp_create(LWP_CREATE_FLAG_ALLOC_PID);
 
     if (lwp == RT_NULL)
     {

--- a/components/lwp/lwp.h
+++ b/components/lwp/lwp.h
@@ -145,6 +145,7 @@ struct rt_lwp
     unsigned int asid;
 #endif
 };
+typedef struct rt_lwp *rt_lwp_t;
 
 struct rt_lwp *lwp_self(void);
 

--- a/components/lwp/lwp_pid.h
+++ b/components/lwp/lwp_pid.h
@@ -17,11 +17,16 @@
 extern "C" {
 #endif
 
+#define LWP_CREATE_FLAG_NONE        0x0000
+#define LWP_CREATE_FLAG_ALLOC_PID   0x0001  /* allocate pid on lwp object create */
+
 struct rt_lwp;
 
 struct lwp_avl_struct *lwp_get_pid_ary(void);
 
-struct rt_lwp* lwp_new(void);
+/* create a lwp object */
+struct rt_lwp* lwp_create(rt_base_t flags);
+
 void lwp_free(struct rt_lwp* lwp);
 
 int lwp_ref_inc(struct rt_lwp *lwp);

--- a/components/lwp/lwp_syscall.c
+++ b/components/lwp/lwp_syscall.c
@@ -2083,7 +2083,7 @@ sysret_t _sys_fork(void)
     void *user_stack = RT_NULL;
 
     /* new lwp */
-    lwp = lwp_new();
+    lwp = lwp_create(LWP_CREATE_FLAG_ALLOC_PID);
     if (!lwp)
     {
         SET_ERRNO(ENOMEM);
@@ -2685,15 +2685,13 @@ sysret_t sys_execve(const char *path, char *const argv[], char *const envp[])
     }
 
     /* alloc new lwp to operation */
-    new_lwp = (struct rt_lwp *)rt_malloc(sizeof(struct rt_lwp));
+    new_lwp = lwp_create(LWP_CREATE_FLAG_NONE);
     if (!new_lwp)
     {
         SET_ERRNO(ENOMEM);
         goto quit;
     }
-    rt_memset(new_lwp, 0, sizeof(struct rt_lwp));
-    new_lwp->ref = 1;
-    lwp_user_object_lock_init(new_lwp);
+
     ret = lwp_user_space_init(new_lwp, 0);
     if (ret != 0)
     {
@@ -2787,10 +2785,6 @@ sysret_t sys_execve(const char *path, char *const argv[], char *const envp[])
         lwp_aspace_switch(thread);
 
         rt_hw_interrupt_enable(level);
-
-        /* setup the signal, timer_list for the dummy lwp, so that is can be smoothly recycled */
-        lwp_signal_init(&new_lwp->signal);
-        rt_list_init(&new_lwp->timer);
 
         lwp_ref_dec(new_lwp);
         arch_start_umode(lwp->args,

--- a/examples/utest/testcases/mm/mm_lwp_tc.c
+++ b/examples/utest/testcases/mm/mm_lwp_tc.c
@@ -50,7 +50,7 @@ static void test_user_map_varea(void)
     const size_t buf_sz = ARCH_PAGE_SIZE * 4;
     struct rt_lwp *lwp;
     rt_varea_t varea;
-    lwp = lwp_new();
+    lwp = lwp_create(LWP_CREATE_FLAG_NONE);
 
     /* prepare environment */
     uassert_true(!!lwp);
@@ -74,7 +74,7 @@ static void test_user_map_varea_ext(void)
     const size_t buf_sz = ARCH_PAGE_SIZE * 4;
     struct rt_lwp *lwp;
     rt_varea_t varea;
-    lwp = lwp_new();
+    lwp = lwp_create(LWP_CREATE_FLAG_NONE);
 
     uassert_true(!!lwp);
     uassert_true(!lwp_user_space_init(lwp, 1));
@@ -104,7 +104,7 @@ static void test_user_accessible(void)
     /* Prepare Environment */
     char *test_address = (char *)(USER_STACK_VEND);
     struct rt_lwp *lwp;
-    lwp = lwp_new();
+    lwp = lwp_create(LWP_CREATE_FLAG_NONE);
     uassert_true(!!lwp);
     uassert_true(!lwp_user_space_init(lwp, 0));
 

--- a/examples/utest/testcases/mm/test_bst_adpt.h
+++ b/examples/utest/testcases/mm/test_bst_adpt.h
@@ -31,7 +31,7 @@ void test_bst_adpt(void)
     rt_mem_obj_t mem_obj;
 
     /* create aspace by lwp */
-    lwp = lwp_new();
+    lwp = lwp_create(LWP_CREATE_FLAG_NONE);
     uassert_true(!!lwp);
     uassert_true(!lwp_user_space_init(lwp, 0));
     aspace = lwp->aspace;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

Prev implementation of lwp_new() including the create of lwp object and the pid allocation. But not every lwp object need a pid. So this patch split out part of business in lwp_new() to lwp_create() to improve the maintainability.

#### 你的解决方案是什么 (what is your solution)


#### 在什么测试环境下测试通过 (what is the test environment)

QEMU aarch64 with ash, xargs to test if `fork()` & `execve()` is working properly

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
