### PR TITLE
Fix the problem that when dfs_v2 transmits fd, dentry or vnode does not exist

### DIFF
--- a/components/lwp/lwp_ipc.c
+++ b/components/lwp/lwp_ipc.c
@@ -407,19 +407,26 @@ static int _ipc_msg_fd_new(void *file)
         return -1;
     }
 
-#ifdef RT_USING_DFS_V2
-    d->fops = df->fops;
-    d->mode = df->mode;
-    d->dentry = df->dentry;
-    d->dentry->ref_count ++;
-#endif
-
     d->vnode = df->vnode;
     d->flags = df->flags;
     d->data = df->data;
     d->magic = df->magic;
 
-    d->vnode->ref_count ++;
+#ifdef RT_USING_DFS_V2
+    d->fops = df->fops;
+    d->mode = df->mode;
+    d->dentry = df->dentry;
+    if (d->dentry)
+        rt_atomic_add(&(d->dentry->ref_count), 1);
+
+    if (d->vnode)
+        rt_atomic_add(&(d->vnode->ref_count), 1);
+#else
+    if (d->vnode)
+        d->vnode->ref_count ++;
+#endif
+
+
 
     return fd;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
修复 dfs_v2 下传输 fd 时，dentry或者vnode不存在时出现的问题

#### 你的解决方案是什么 (what is your solution)
增加 dentry 和 vnode 的判断

#### 在什么测试环境下测试通过 (what is the test environment)
qemu-virt64-aarch64

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
