### PR TITLE
[smart] fixup: lwp_free()

### DIFF
--- a/components/lwp/lwp_pid.c
+++ b/components/lwp/lwp_pid.c
@@ -432,6 +432,7 @@ void lwp_free(struct rt_lwp* lwp)
 #ifdef ARCH_MM_MMU
     lwp_unmap_user_space(lwp);
 #endif
+    timer_list_free(&lwp->timer);
 
     level = rt_hw_interrupt_disable();
     /* for children */
@@ -513,7 +514,6 @@ void lwp_free(struct rt_lwp* lwp)
         }
     }
 
-    timer_list_free(&lwp->timer);
     lwp_pid_put(lwp_to_pid(lwp));
     rt_hw_interrupt_enable(level);
     rt_free(lwp);
@@ -713,6 +713,7 @@ pid_t waitpid(pid_t pid, int *status, int options)
         }
         (*lwp_node) = lwp->sibling;
         lwp->parent = RT_NULL;
+        lwp_pid_put(pid);
     }
 
 quit:


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

Recycling of timer in lwp_free() routine may not work because of the early return before the calling to `timer_list_free()`.

#### 你的解决方案是什么 (what is your solution)

Migrate the timer_list_free() ahead before early exit of sub-process.

#### 在什么测试环境下测试通过 (what is the test environment)

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
