### PR TITLE
[smart] fixup: syscall.c

### DIFF
--- a/components/lwp/lwp_syscall.c
+++ b/components/lwp/lwp_syscall.c
@@ -513,9 +513,9 @@ ssize_t sys_write(int fd, const void *buf, size_t nbyte)
 }
 
 /* syscall: "lseek" ret: "off_t" args: "int" "off_t" "int" */
-off_t sys_lseek(int fd, off_t offset, int whence)
+size_t sys_lseek(int fd, size_t offset, int whence)
 {
-    off_t ret = lseek(fd, offset, whence);
+    size_t ret = lseek(fd, offset, whence);
     return (ret < 0 ? GET_ERRNO() : ret);
 }
 
@@ -1303,7 +1303,7 @@ rt_base_t sys_brk(void *addr)
 }
 
 void *sys_mmap2(void *addr, size_t length, int prot,
-        int flags, int fd, off_t pgoffset)
+        int flags, int fd, size_t pgoffset)
 {
     return lwp_mmap2(addr, length, prot, flags, fd, pgoffset);
 }
@@ -6126,7 +6126,7 @@ sysret_t sys_epoll_pwait(int fd,
     return (ret < 0 ? GET_ERRNO() : ret);
 }
 
-sysret_t sys_ftruncate(int fd, off_t length)
+sysret_t sys_ftruncate(int fd, size_t length)
 {
     int ret;
 
@@ -6176,10 +6176,10 @@ sysret_t sys_reboot(int magic)
     return 0;
 }
 
-ssize_t sys_pread64(int fd, void *buf, int size, off_t offset)
+ssize_t sys_pread64(int fd, void *buf, int size, size_t offset)
 #ifdef RT_USING_DFS_V2
 {
-    ssize_t pread(int fd, void *buf, size_t len, off_t offset);
+    ssize_t pread(int fd, void *buf, size_t len, size_t offset);
 #ifdef ARCH_MM_MMU
     ssize_t ret = -1;
     void *kmem = RT_NULL;
@@ -6230,10 +6230,10 @@ ssize_t sys_pread64(int fd, void *buf, int size, off_t offset)
 }
 #endif
 
-ssize_t sys_pwrite64(int fd, void *buf, int size, off_t offset)
+ssize_t sys_pwrite64(int fd, void *buf, int size, size_t offset)
 #ifdef RT_USING_DFS_V2
 {
-    ssize_t pwrite(int fd, const void *buf, size_t len, off_t offset);
+    ssize_t pwrite(int fd, const void *buf, size_t len, size_t offset);
 #ifdef ARCH_MM_MMU
     ssize_t ret = -1;
     void *kmem = RT_NULL;

--- a/components/lwp/lwp_syscall.h
+++ b/components/lwp/lwp_syscall.h
@@ -48,7 +48,7 @@ void sys_exit(int value);
 sysret_t sys_exit_group(int status);
 ssize_t sys_read(int fd, void *buf, size_t nbyte);
 ssize_t sys_write(int fd, const void *buf, size_t nbyte);
-off_t sys_lseek(int fd, off_t offset, int whence);
+size_t sys_lseek(int fd, size_t offset, int whence);
 sysret_t sys_open(const char *name, int mode, ...);
 sysret_t sys_close(int fd);
 sysret_t sys_ioctl(int fd, unsigned long cmd, void* data);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

All `off_t` types will be cast to long during call to syscall(). Then interpreting it as an off_t type will be an error, especially for 32-bit architectures, since off_t is defined as off64_t in musl.

#### 你的解决方案是什么 (what is your solution)

Replace `off_t` with `size_t` in `lwp_syscall.c`

#### 在什么测试环境下测试通过 (what is the test environment)

QEMU vexpress-a9, aarch64

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
