### PR TITLE
fix busybox echo

### DIFF
--- a/bsp/qemu-virt64-aarch64/drivers/drv_uart.c
+++ b/bsp/qemu-virt64-aarch64/drivers/drv_uart.c
@@ -65,6 +65,9 @@ static rt_err_t uart_control(struct rt_serial_device *serial, int cmd, void *arg
         UART_IMSC(uart->hw_base) |= UARTIMSC_RXIM;
         rt_hw_interrupt_umask(uart->irqno);
         break;
+
+    default:
+        return -1;
     }
 
     return RT_EOK;

--- a/components/dfs/dfs_v2/src/dfs_file.c
+++ b/components/dfs/dfs_v2/src/dfs_file.c
@@ -1061,6 +1061,9 @@ int dfs_file_fcntl(int fd, int cmd, unsigned long arg)
         case F_SETLK:
         case F_SETLKW:
             break;
+        case F_DUPFD_CLOEXEC:
+            ret = -EINVAL;
+            break;
         default:
             ret = -EPERM;
             break;

--- a/components/dfs/dfs_v2/src/dfs_file.c
+++ b/components/dfs/dfs_v2/src/dfs_file.c
@@ -30,6 +30,8 @@
 
 #define MAX_RW_COUNT 0xfffc0000
 
+#define F_DUPFD_CLOEXEC 1030
+
 /*
  * rw_verify_area doesn't like huge counts. We limit
  * them to something that fits in "int" so that others

--- a/components/libc/compilers/common/extension/fcntl/msvc/fcntl.h
+++ b/components/libc/compilers/common/extension/fcntl/msvc/fcntl.h
@@ -63,6 +63,8 @@ extern "C" {
 
 #define F_GETOWNER_UIDS 17
 
+#define F_DUPFD_CLOEXEC 1030
+
 int open(const char *file, int flags, ...);
 int fcntl(int fildes, int cmd, ...);
 int creat(const char *path, mode_t mode);

--- a/components/libc/compilers/common/extension/fcntl/octal/fcntl.h
+++ b/components/libc/compilers/common/extension/fcntl/octal/fcntl.h
@@ -68,6 +68,8 @@ extern "C" {
 
 #define F_GETOWNER_UIDS 17
 
+#define F_DUPFD_CLOEXEC 1030
+
 int open(const char *file, int flags, ...);
 int fcntl(int fildes, int cmd, ...);
 int creat(const char *path, mode_t mode);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

The return value of ioctl for F_DUPFD_CLOEXEC has an error.

#### 你的解决方案是什么 (what is your solution)

Add case F_DUPFD_CLOEXEC, and return correct value.

#### 在什么测试环境下测试通过 (what is the test environment)

qemu aarch64

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
