### PR TITLE
[fix] Fix a netdev bug in lwip/core/netif.c

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -62,6 +62,7 @@ Change Log Since v5.0.1 Release
 * **net**
   * **sal/socket:** Fixed a BUG where calling closesocket interface triggered assertions when RT_DEBUG is enabled; Fixed duplicate free on allocated buffer.
   * **sal:** Fixed the IPv4 & v6 compiling issue.
+  * **lwip/core:** Fixed a BUG when getting an RT-Thread netdev by the lwip netif's name.
 * **ktime**
   * Added RT_USING_KTIME to Kconfig build.
   * Fixed some bugs with ktime.

--- a/components/net/lwip/lwip-1.4.1/README.md
+++ b/components/net/lwip/lwip-1.4.1/README.md
@@ -1,4 +1,10 @@
 Porting network interface device for RT-Thread in lwIP.
+
+Fix a bug in src/core/netif.c. The netif->name variable is a 2-byte char array, which may not end with '\0' and may cause a bug when it's directly passed to the function `netdev_get_by_name`. Use the newly added function `netif_get_netdev` to get a netdev object by netif's name.
+
+by windsgo 2023/10/30 11:03 AM
+18221102427@163.com
+
 The major jobs following RT-Thread Team. The RT-Thread network interface device need to synchronize some network status and address information in lwIP, so it need to make some changes in the lwIP netwrok status and address operations function.
 The specific changes are as follows:
 

--- a/components/net/lwip/lwip-1.4.1/src/core/netif.c
+++ b/components/net/lwip/lwip-1.4.1/src/core/netif.c
@@ -317,6 +317,35 @@ netif_find(char *name)
   return NULL;
 }
 
+#ifdef RT_USING_NETDEV
+/**
+ * @brief    This function will get network interface device
+ *           in network interface device list by network interface(netif).
+ * 
+ * @note     Do not use `netdev_get_by_name(netif->name)` to directly get a `netdev` object
+ *           by the name of network interface. Because `netif->name` is a 2-byte char array,
+ *           which may not end with '\0', causing the function `netdev_get_by_name()` to not
+ *           work correctly. Instead, use this function, which ensure the name passing to
+ *           `netdev_get_by_name()` is a string ended with '\0'.
+ * 
+ * @see      netdev_get_by_name()
+ *
+ * @param    netif the network interface used to find the network interface device 
+ *
+ * @return != NULL: network interface device object
+ *            NULL: get failed
+ */
+static struct netdev*
+netif_get_netdev(struct netif *netif)
+{
+  /* currently, sizeof(netif->name) should be 2 */
+  char temp[sizeof(netif->name) + 1] = {0}; /* one more byte to ensure the name is ended with '\0' */
+  rt_strncpy(temp, netif->name, sizeof(netif->name));
+
+  return netdev_get_by_name(temp);
+}
+#endif /* RT_USING_NETDEV */
+
 /**
  * Change the IP address of a network interface
  *
@@ -384,7 +413,7 @@ netif_set_ipaddr(struct netif *netif, ip_addr_t *ipaddr)
 
 #ifdef RT_USING_NETDEV
   /* rt-thread sal network interface device set IP address operations */
-  netdev_low_level_set_ipaddr(netdev_get_by_name(netif->name), (ip_addr_t *)ipaddr);
+  netdev_low_level_set_ipaddr(netif_get_netdev(netif), (ip_addr_t *)ipaddr);
 #endif /* RT_USING_NETDEV */
 }
 
@@ -409,7 +438,7 @@ netif_set_gw(struct netif *netif, ip_addr_t *gw)
 
 #ifdef RT_USING_NETDEV
   /* rt_thread network interface device set gateway address */
-  netdev_low_level_set_gw(netdev_get_by_name(netif->name), (ip_addr_t *)gw);
+  netdev_low_level_set_gw(netif_get_netdev(netif), (ip_addr_t *)gw);
 #endif /* RT_USING_NETDEV */
 }
 
@@ -438,7 +467,7 @@ netif_set_netmask(struct netif *netif, ip_addr_t *netmask)
 
 #ifdef RT_USING_NETDEV
   /* rt-thread network interface device set netmask address */
-  netdev_low_level_set_netmask(netdev_get_by_name(netif->name), (ip_addr_t *)netmask);
+  netdev_low_level_set_netmask(netif_get_netdev(netif), (ip_addr_t *)netmask);
 #endif /* RT_USING_NETDEV */
 }
 
@@ -501,7 +530,7 @@ void netif_set_up(struct netif *netif)
 
 #ifdef RT_USING_NETDEV
     /* rt-thread network interface device set up status */
-    netdev_low_level_set_status(netdev_get_by_name(netif->name), RT_TRUE);
+    netdev_low_level_set_status(netif_get_netdev(netif), RT_TRUE);
 #endif /* RT_USING_NETDEV */
   }
 }
@@ -531,7 +560,7 @@ void netif_set_down(struct netif *netif)
 
 #ifdef RT_USING_NETDEV
     /* rt-thread network interface device set down status */
-    netdev_low_level_set_status(netdev_get_by_name(netif->name), RT_FALSE);
+    netdev_low_level_set_status(netif_get_netdev(netif), RT_FALSE);
 #endif /* RT_USING_NETDEV */
   }
 }
@@ -600,7 +629,7 @@ void netif_set_link_up(struct netif *netif )
 
 #ifdef RT_USING_NETDEV
     /* rt-thread network interface device set link up status */
-    netdev_low_level_set_link_status(netdev_get_by_name(netif->name), RT_TRUE);
+    netdev_low_level_set_link_status(netif_get_netdev(netif), RT_TRUE);
 #endif /* RT_USING_NETDEV */
   }
 }
@@ -616,7 +645,7 @@ void netif_set_link_down(struct netif *netif )
 
 #ifdef RT_USING_NETDEV
     /* rt-thread network interface device set link down status */
-    netdev_low_level_set_link_status(netdev_get_by_name(netif->name), RT_FALSE);
+    netdev_low_level_set_link_status(netif_get_netdev(netif), RT_FALSE);
 #endif /* RT_USING_NETDEV */
   }
 }

--- a/components/net/lwip/lwip-2.0.3/README.md
+++ b/components/net/lwip/lwip-2.0.3/README.md
@@ -1,5 +1,10 @@
 Porting network interface device for RT-Thread in lwIP.
 
+Fix a bug in src/core/netif.c. The netif->name variable is a 2-byte char array, which may not end with '\0' and may cause a bug when it's directly passed to the function `netdev_get_by_name`. Use the newly added function `netif_get_netdev` to get a netdev object by netif's name.
+
+by windsgo 2023/10/30 11:03 AM
+18221102427@163.com
+
 The major jobs following RT-Thread Team. Only update the origin code of lwip 2.0.2 to lwip 2.0.3.
 And keep the difference between on the change of RT-Thread Team.
 

--- a/components/net/lwip/lwip-2.1.2/README.md
+++ b/components/net/lwip/lwip-2.1.2/README.md
@@ -9,6 +9,7 @@
 | :---- | :---- | :---- |
 | 2019-09-02 | MurphyZhao | 增加 lwip 2.1.2 移植说明 |
 | 2020-06-18 | xiangxistu | 增加部分 lwIP 2.1.2 移植说明 |
+| 2023-10-30 | windsgo | 增加src/core/netif.c的修复说明 |
 
 ## 修改内容
 
@@ -54,6 +55,7 @@
 
 - 在 `src/core/dns.c` 的 `dns_setserver` 函数中增加 RT-Thread netdev 相关的移植
 - 在 `src/core/netif.c` 中增加 RT-Thread netdev 相关的移植
+  - 增加`netif_get_netdev`函数，修复使用`netif->name`查询`netdev`可能产生的错误
 
 ### src/include
 

--- a/components/net/lwip/lwip-2.1.2/src/core/netif.c
+++ b/components/net/lwip/lwip-2.1.2/src/core/netif.c
@@ -459,6 +459,35 @@ netif_do_ip_addr_changed(const ip_addr_t *old_addr, const ip_addr_t *new_addr)
 #endif /* LWIP_RAW */
 }
 
+#ifdef RT_USING_NETDEV
+/**
+ * @brief    This function will get network interface device
+ *           in network interface device list by network interface(netif).
+ * 
+ * @note     Do not use `netdev_get_by_name(netif->name)` to directly get a `netdev` object
+ *           by the name of network interface. Because `netif->name` is a 2-byte char array,
+ *           which may not end with '\0', causing the function `netdev_get_by_name()` to not
+ *           work correctly. Instead, use this function, which ensure the name passing to
+ *           `netdev_get_by_name()` is a string ended with '\0'.
+ * 
+ * @see      netdev_get_by_name()
+ *
+ * @param    netif the network interface used to find the network interface device 
+ *
+ * @return != NULL: network interface device object
+ *            NULL: get failed
+ */
+static struct netdev*
+netif_get_netdev(struct netif *netif)
+{
+  /* currently, sizeof(netif->name) should be 2 */
+  char temp[sizeof(netif->name) + 1] = {0}; /* one more byte to ensure the name is ended with '\0' */
+  rt_strncpy(temp, netif->name, sizeof(netif->name));
+
+  return netdev_get_by_name(temp);
+}
+#endif /* RT_USING_NETDEV */
+
 #if LWIP_IPV4
 static int
 netif_do_set_ipaddr(struct netif *netif, const ip4_addr_t *ipaddr, ip_addr_t *old_addr)
@@ -491,7 +520,7 @@ netif_do_set_ipaddr(struct netif *netif, const ip4_addr_t *ipaddr, ip_addr_t *ol
 
 #ifdef RT_USING_NETDEV
   /* rt-thread sal network interface device set IP address operations */
-  netdev_low_level_set_ipaddr(netdev_get_by_name(netif->name), &netif->ip_addr);
+  netdev_low_level_set_ipaddr(netif_get_netdev(netif), &netif->ip_addr);
 #endif /* RT_USING_NETDEV */
 
     return 1; /* address changed */
@@ -557,7 +586,7 @@ netif_do_set_netmask(struct netif *netif, const ip4_addr_t *netmask, ip_addr_t *
 
 #ifdef RT_USING_NETDEV
   /* rt-thread network interface device set netmask address */
-  netdev_low_level_set_netmask(netdev_get_by_name(netif->name), &netif->netmask);
+  netdev_low_level_set_netmask(netif_get_netdev(netif), &netif->netmask);
 #endif /* RT_USING_NETDEV */
 
     return 1; /* netmask changed */
@@ -625,7 +654,7 @@ netif_do_set_gw(struct netif *netif, const ip4_addr_t *gw, ip_addr_t *old_gw)
 
 #ifdef RT_USING_NETDEV
     /* rt_thread network interface device set gateway address */
-    netdev_low_level_set_gw(netdev_get_by_name(netif->name), &netif->gw);
+    netdev_low_level_set_gw(netif_get_netdev(netif), &netif->gw);
 #endif /* RT_USING_NETDEV */
 
     return 1; /* gateway changed */
@@ -894,7 +923,7 @@ netif_set_up(struct netif *netif)
 
 #ifdef RT_USING_NETDEV
     /* rt-thread network interface device set up status */
-    netdev_low_level_set_status(netdev_get_by_name(netif->name), RT_TRUE);
+    netdev_low_level_set_status(netif_get_netdev(netif), RT_TRUE);
 #endif /* RT_USING_NETDEV */
   }
 }
@@ -978,7 +1007,7 @@ netif_set_down(struct netif *netif)
 
 #ifdef RT_USING_NETDEV
     /* rt-thread network interface device set down status */
-    netdev_low_level_set_status(netdev_get_by_name(netif->name), RT_FALSE);
+    netdev_low_level_set_status(netif_get_netdev(netif), RT_FALSE);
 #endif /* RT_USING_NETDEV */
   }
 }
@@ -1053,7 +1082,7 @@ netif_set_link_up(struct netif *netif)
 
 #ifdef RT_USING_NETDEV
     /* rt-thread network interface device set link up status */
-    netdev_low_level_set_link_status(netdev_get_by_name(netif->name), RT_TRUE);
+    netdev_low_level_set_link_status(netif_get_netdev(netif), RT_TRUE);
 #endif /* RT_USING_NETDEV */
   }
 }
@@ -1082,7 +1111,7 @@ netif_set_link_down(struct netif *netif)
 
 #ifdef RT_USING_NETDEV
     /* rt-thread network interface device set link down status */
-    netdev_low_level_set_link_status(netdev_get_by_name(netif->name), RT_FALSE);
+    netdev_low_level_set_link_status(netif_get_netdev(netif), RT_FALSE);
 #endif /* RT_USING_NETDEV */
   }
 }
@@ -1588,7 +1617,7 @@ netif_create_ip6_linklocal_address(struct netif *netif, u8_t from_mac_48bit)
 
 #ifdef RT_USING_NETDEV
     /* rt-thread network interface device set ipv6 address */
-    ip_addr_copy(netdev_get_by_name(netif->name)->ip6_addr[0], netif->ip6_addr[0]);
+    ip_addr_copy(netif_get_netdev(netif)->ip6_addr[0], netif->ip6_addr[0]);
 #endif /* RT_USING_NETDEV */
 
   /* Set address state. */
@@ -1636,7 +1665,7 @@ netif_add_ip6_address(struct netif *netif, const ip6_addr_t *ip6addr, s8_t *chos
       ip_addr_copy_from_ip6(netif->ip6_addr[i], *ip6addr);
 #ifdef RT_USING_NETDEV
       /* rt-thread network interface device set ipv6 address */
-      ip_addr_copy(netdev_get_by_name(netif->name)->ip6_addr[i], netif->ip6_addr[i]);
+      ip_addr_copy(netif_get_netdev(netif)->ip6_addr[i], netif->ip6_addr[i]);
 #endif /* RT_USING_NETDEV */
       ip6_addr_assign_zone(ip_2_ip6(&netif->ip6_addr[i]), IP6_UNICAST, netif);
       netif_ip6_addr_set_state(netif, i, IP6_ADDR_TENTATIVE);


### PR DESCRIPTION
Use netif->name to find netdev will cause a bug because the netif->name may not end with a '\0'. Write a new function to find netdev using netif's name to avoid this bug.

## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

根据`issue`[#7902](https://github.com/RT-Thread/rt-thread/issues/7902#issue-1832365354)的描述和排查，确定双网卡或多网卡情况下，存在通过名称查找`netdev`设备失败而导致在`ifconfig`中无法正确显示设备信息等问题，确认原因是`netif`类的`name`成员变量是一个`char[2]`数组，其可能不以`'\0'`字符结尾，导致函数`netdev_get_by_name()`查找失败。

#### 你的解决方案是什么 (what is your solution)

建立一个临时的字符数组，长度大于2（取`sizeof(netif->name) + 1`），将`netif->name`转换到这个临时字符数组，保证字符数组以`'\0'`结尾，再调用`netdev_get_by_name()`进行查询。

主要代码如下：
```c
static struct netdev*
netif_get_netdev(struct netif *netif)
{
  /* currently, sizeof(netif->name) should be 2 */
  char temp[sizeof(netif->name) + 1] = {0}; /* one more byte to ensure the name is ended with '\0' */
  rt_strncpy(temp, netif->name, sizeof(netif->name));

  return netdev_get_by_name(temp);
}

/* inside netif_xxx function */
...
#ifdef RT_USING_NETDEV
  /* rt-thread sal network interface device set IP address operations */
  netdev_low_level_set_ipaddr(netif_get_netdev(netif), &netif->ip_addr);
#endif /* RT_USING_NETDEV */
...
```

#### 在什么测试环境下测试通过 (what is the test environment)

与`issue`[#7902](https://github.com/RT-Thread/rt-thread/issues/7902#issue-1832365354)同环境：

芯片: `STM32F407IGT6`
RT-Thread版本:` 4.0.3`
lwip版本: `2.0.2` (RT-Thread自带)
工具链: `RT-Thread Studio 2.2.6 202211231640`

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
