### PR TITLE
[bsp][hc32]优化can驱动和pwm驱动

### DIFF
--- a/bsp/hc32/libraries/hc32_drivers/drv_adc.c
+++ b/bsp/hc32/libraries/hc32_drivers/drv_adc.c
@@ -151,14 +151,14 @@ static void _adc_internal_trigger1_set(adc_device *p_adc_dev)
     AOS_SetTriggerEventSrc(u32TriggerSel, p_adc_dev->init.internal_trig1_sel);
 }
 
-static rt_err_t _adc_enable(struct rt_adc_device *device, rt_uint32_t channel, rt_bool_t enabled)
+static rt_err_t _adc_enable(struct rt_adc_device *device, rt_int8_t channel, rt_bool_t enabled)
 {
     adc_device *p_adc_dev = rt_container_of(device, adc_device, rt_adc);
     ADC_ChCmd(p_adc_dev->instance, ADC_SEQ_A, channel, (en_functional_state_t)enabled);
     return 0;
 }
 
-static rt_err_t _adc_convert(struct rt_adc_device *device, rt_uint32_t channel, rt_uint32_t *value)
+static rt_err_t _adc_convert(struct rt_adc_device *device, rt_int8_t channel, rt_uint32_t *value)
 {
     rt_err_t rt_ret = -RT_ERROR;
 

--- a/bsp/hc32/libraries/hc32_drivers/drv_can.c
+++ b/bsp/hc32/libraries/hc32_drivers/drv_can.c
@@ -655,6 +655,7 @@ int rt_hw_can_init(void)
 
         /* register CAN device */
         rt_hw_board_can_init(g_can_dev_array[i].instance);
+        CAN_IntCmd(g_can_dev_array[i].instance, CAN_INT_ALL, DISABLE);
         rt_hw_can_register(&g_can_dev_array[i].rt_can,
                            g_can_dev_array[i].init.name,
                            &_can_ops,

--- a/bsp/hc32/libraries/hc32_drivers/drv_can.c
+++ b/bsp/hc32/libraries/hc32_drivers/drv_can.c
@@ -362,7 +362,7 @@ static rt_err_t _can_control(struct rt_can_device *can, int cmd, void *arg)
     return RT_EOK;
 }
 
-static int _can_sendmsg(struct rt_can_device *can, const void *buf, rt_uint32_t box_num)
+static rt_ssize_t _can_sendmsg(struct rt_can_device *can, const void *buf, rt_uint32_t box_num)
 {
     struct rt_can_msg *pmsg = (struct rt_can_msg *) buf;
     stc_can_tx_frame_t stc_tx_frame = {0};
@@ -398,7 +398,7 @@ static int _can_sendmsg(struct rt_can_device *can, const void *buf, rt_uint32_t 
     return RT_EOK;
 }
 
-static int _can_recvmsg(struct rt_can_device *can, void *buf, rt_uint32_t fifo)
+static rt_ssize_t _can_recvmsg(struct rt_can_device *can, void *buf, rt_uint32_t fifo)
 {
     int32_t ll_ret;
     struct rt_can_msg *pmsg;

--- a/bsp/hc32/libraries/hc32_drivers/drv_pwm_tmra.c
+++ b/bsp/hc32/libraries/hc32_drivers/drv_pwm_tmra.c
@@ -187,6 +187,48 @@ static rt_err_t drv_pwm_set(CM_TMRA_TypeDef *TMRAx, struct rt_pwm_configuration 
     return RT_EOK;
 }
 
+static rt_err_t drv_pwm_set_period(CM_TMRA_TypeDef *TMRAx, struct rt_pwm_configuration *configuration)
+{
+    rt_uint32_t u32clkFreq;
+    rt_uint64_t u64clk_ns;
+    rt_uint64_t u64val;
+    //
+    u32clkFreq = get_tmra_clk_freq(TMRAx);
+    u64clk_ns = (rt_uint64_t)1000000000ul / u32clkFreq;
+    u64val = (rt_uint64_t)configuration->period / u64clk_ns;
+    if ((configuration->period <= u64clk_ns) || (u64val > 0xFFFF))
+    {
+        // clk not match, need change div
+        uint32_t div_bit;
+        u32clkFreq = get_tmra_clk_freq_not_div(TMRAx);
+        u64clk_ns = (rt_uint64_t)1000000000ul / u32clkFreq;
+        u64val = (rt_uint64_t)configuration->period / u64clk_ns;
+        for (div_bit=0; div_bit<= 10; div_bit++)
+        {
+            if (u64val < 0xFFFF) break;
+            u64val /= 2;
+        }
+        if (div_bit > 10) return -RT_ERROR;
+        //
+        TMRA_SetClockDiv(TMRAx, div_bit << TMRA_BCSTR_CKDIV_POS);
+        u32clkFreq = get_tmra_clk_freq(TMRAx);
+        u64clk_ns = (rt_uint64_t)1000000000ul / u32clkFreq;
+    }
+    TMRA_SetPeriodValue(TMRAx, configuration->period / u64clk_ns);
+    return RT_EOK;
+}
+
+static rt_err_t drv_pwm_set_pulse(CM_TMRA_TypeDef *TMRAx, struct rt_pwm_configuration *configuration)
+{
+    rt_uint32_t u32clkFreq;
+    rt_uint64_t u64clk_ns;
+    //
+    u32clkFreq = get_tmra_clk_freq(TMRAx);
+    u64clk_ns = (rt_uint64_t)1000000000ul / u32clkFreq;
+    TMRA_SetCompareValue(TMRAx, configuration->channel, configuration->pulse / u64clk_ns);
+    return RT_EOK;
+}
+
 static rt_err_t drv_pwm_control(struct rt_device_pwm *device, int cmd, void *arg)
 {
     struct rt_pwm_configuration *configuration = (struct rt_pwm_configuration *)arg;
@@ -208,6 +250,10 @@ static rt_err_t drv_pwm_control(struct rt_device_pwm *device, int cmd, void *arg
         return drv_pwm_set(TMRAx, configuration);
     case PWM_CMD_GET:
         return drv_pwm_get(TMRAx, configuration);
+    case PWM_CMD_SET_PERIOD:
+        return drv_pwm_set_period(TMRAx, configuration);
+    case PWM_CMD_SET_PULSE:
+        return drv_pwm_set_pulse(TMRAx, configuration);
     default:
         return -RT_EINVAL;
     }

--- a/bsp/hc32/libraries/hc32_drivers/drv_pwm_tmra.c
+++ b/bsp/hc32/libraries/hc32_drivers/drv_pwm_tmra.c
@@ -160,13 +160,12 @@ static rt_err_t drv_pwm_set(CM_TMRA_TypeDef *TMRAx, struct rt_pwm_configuration 
     rt_uint32_t u32clkFreq;
     rt_uint64_t u64clk_ns;
     rt_uint64_t u64val;
-    //
     u32clkFreq = get_tmra_clk_freq(TMRAx);
     u64clk_ns = (rt_uint64_t)1000000000ul / u32clkFreq;
     u64val = (rt_uint64_t)configuration->period / u64clk_ns;
     if ((configuration->period <= u64clk_ns) || (u64val > 0xFFFF))
     {
-        // clk not match, need change div
+        /* clk not match, need change div */
         uint32_t div_bit;
         u32clkFreq = get_tmra_clk_freq_not_div(TMRAx);
         u64clk_ns = (rt_uint64_t)1000000000ul / u32clkFreq;
@@ -177,7 +176,6 @@ static rt_err_t drv_pwm_set(CM_TMRA_TypeDef *TMRAx, struct rt_pwm_configuration 
             u64val /= 2;
         }
         if (div_bit > 10) return -RT_ERROR;
-        //
         TMRA_SetClockDiv(TMRAx, div_bit << TMRA_BCSTR_CKDIV_POS);
         u32clkFreq = get_tmra_clk_freq(TMRAx);
         u64clk_ns = (rt_uint64_t)1000000000ul / u32clkFreq;
@@ -192,13 +190,12 @@ static rt_err_t drv_pwm_set_period(CM_TMRA_TypeDef *TMRAx, struct rt_pwm_configu
     rt_uint32_t u32clkFreq;
     rt_uint64_t u64clk_ns;
     rt_uint64_t u64val;
-    //
     u32clkFreq = get_tmra_clk_freq(TMRAx);
     u64clk_ns = (rt_uint64_t)1000000000ul / u32clkFreq;
     u64val = (rt_uint64_t)configuration->period / u64clk_ns;
     if ((configuration->period <= u64clk_ns) || (u64val > 0xFFFF))
     {
-        // clk not match, need change div
+        /* clk not match, need change div */
         uint32_t div_bit;
         u32clkFreq = get_tmra_clk_freq_not_div(TMRAx);
         u64clk_ns = (rt_uint64_t)1000000000ul / u32clkFreq;
@@ -209,7 +206,6 @@ static rt_err_t drv_pwm_set_period(CM_TMRA_TypeDef *TMRAx, struct rt_pwm_configu
             u64val /= 2;
         }
         if (div_bit > 10) return -RT_ERROR;
-        //
         TMRA_SetClockDiv(TMRAx, div_bit << TMRA_BCSTR_CKDIV_POS);
         u32clkFreq = get_tmra_clk_freq(TMRAx);
         u64clk_ns = (rt_uint64_t)1000000000ul / u32clkFreq;
@@ -222,7 +218,6 @@ static rt_err_t drv_pwm_set_pulse(CM_TMRA_TypeDef *TMRAx, struct rt_pwm_configur
 {
     rt_uint32_t u32clkFreq;
     rt_uint64_t u64clk_ns;
-    //
     u32clkFreq = get_tmra_clk_freq(TMRAx);
     u64clk_ns = (rt_uint64_t)1000000000ul / u32clkFreq;
     TMRA_SetCompareValue(TMRAx, configuration->channel, configuration->pulse / u64clk_ns);
@@ -235,7 +230,6 @@ static rt_err_t drv_pwm_control(struct rt_device_pwm *device, int cmd, void *arg
     struct hc32_pwm_tmra *pwm;
     pwm = rt_container_of(device, struct hc32_pwm_tmra, pwm_device);
     CM_TMRA_TypeDef *TMRAx = pwm->instance;
-
     switch (cmd)
     {
     case PWMN_CMD_ENABLE:
@@ -263,7 +257,6 @@ static rt_err_t _pwm_tmra_init(struct hc32_pwm_tmra *device)
 {
     CM_TMRA_TypeDef *TMRAx;
     uint32_t i;
-    //
     RT_ASSERT(device != RT_NULL);
     TMRAx = device->instance;
     TMRA_Init(TMRAx, &device->stcTmraInit);

--- a/bsp/hc32/libraries/hc32_drivers/drv_spi.c
+++ b/bsp/hc32/libraries/hc32_drivers/drv_spi.c
@@ -450,7 +450,6 @@ static rt_ssize_t hc32_spi_xfer(struct rt_spi_device *device, struct rt_spi_mess
         {
             recv_buf = (rt_uint8_t *)message->recv_buf + already_send_length;
         }
-        
         if (message->send_buf && message->recv_buf)
         {
             if ((spi_drv->spi_dma_flag & RT_DEVICE_FLAG_DMA_TX) && (spi_drv->spi_dma_flag & RT_DEVICE_FLAG_DMA_RX))

--- a/bsp/hc32/libraries/hc32_drivers/drv_spi.c
+++ b/bsp/hc32/libraries/hc32_drivers/drv_spi.c
@@ -392,7 +392,7 @@ static void hc32_spi_enable(CM_SPI_TypeDef *SPIx)
     }
 }
 
-static rt_uint32_t hc32_spi_xfer(struct rt_spi_device *device, struct rt_spi_message *message)
+static rt_ssize_t hc32_spi_xfer(struct rt_spi_device *device, struct rt_spi_message *message)
 {
     int32_t state;
     rt_size_t message_length, already_send_length;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
1. hc32驱动函数和rtt函数声明之间的参数类型不一致，在mdk编译时产生警告。
2. hc32的can设备，在注册时就把can中断使能了。导致can设备在打开前，就会产生中断。
3. hc32的pwm驱动，不支持PWM_CMD_SET_PERIOD和PWM_CMD_SET_PULSE指令，导致rt_pwm_set_pulse()函数返回失败。

#### 你的解决方案是什么 (what is your solution)
1. 修改hc32驱动函数参数类型和声明一致。
2. 注册can设备时主动禁止can中断，因为打开设备时会主动打开中断。
3. 修改pwm驱动，增加PWM_CMD_SET_PERIOD和PWM_CMD_SET_PULSE指令支持。

#### 在什么测试环境下测试通过 (what is the test environment)
硬件MCU为HC32F460.
rt-thread studio 2.2.6, GNU 10.2.1, 编译通过。
MDK 5.31.0.0, ArmClang V6.14, 编译通过。
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
