### PR TITLE
[kernel] 解决rt_slist_for_each_entry宏不能正常遍历slist链表中元素的问题

### DIFF
--- a/include/rtservice.h
+++ b/include/rtservice.h
@@ -280,9 +280,9 @@ rt_inline int rt_slist_isempty(rt_slist_t *l)
  * @param member the name of the list_struct within the struct.
  */
 #define rt_slist_for_each_entry(pos, head, member) \
-    for (pos = rt_slist_entry((head)->next, typeof(*pos), member); \
-         &pos->member != (RT_NULL); \
-         pos = rt_slist_entry(pos->member.next, typeof(*pos), member))
+    for (pos = ((head)->next == (RT_NULL) ? (RT_NULL) : rt_slist_entry((head)->next, typeof(*pos), member)); \
+         pos != (RT_NULL) && &pos->member != (RT_NULL); \
+         pos = (pos->member.next == (RT_NULL) ? (RT_NULL) : rt_slist_entry(pos->member.next, typeof(*pos), member)))
 
 /**
  * rt_slist_first_entry - get the first element from a slist


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
【转移Gitee提交PR https://gitee.com/rtthread/rt-thread/pulls/644 】
[
[virteman](https://gitee.com/virteman)-virteman virteman create on 2023-10-11 17:33
拉取/合并请求描述：
[
因rt_slist_for_each_entry宏不能正常调用，在实际开发中去循环再调用rt_slist_entry很不简洁，所以修改了rt_slist_for_each_entry宏中关于链表next的判空处理。目前相关代码在GD32系统的MCU上均能正常工作，相关应用也在生产产品中使用大半年了。
]

]

#### 为什么提交这份PR (why to submit this PR)


#### 你的解决方案是什么 (what is your solution)


#### 在什么测试环境下测试通过 (what is the test environment)

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
