### PR TITLE
fix aarch64 backtrace print.

### DIFF
--- a/src/kservice.c
+++ b/src/kservice.c
@@ -93,7 +93,7 @@ rt_weak void rt_hw_cpu_shutdown(void)
 
 rt_weak rt_err_t rt_hw_backtrace_frame_get(rt_thread_t thread, struct rt_hw_backtrace_frame *frame)
 {
-    LOG_W("not implemented");
+    LOG_W("%s is not implemented", __func__);
     return -RT_ENOSYS;
 }
 

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -1575,7 +1575,7 @@ rt_err_t rt_backtrace_frame(struct rt_hw_backtrace_frame *frame)
 {
     long nesting = 0;
 
-    rt_kprintf("please use: addr2line -e rtthread.elf -a -f");
+    rt_kprintf("please use: addr2line -e rtthread.elf -a -f\n");
 
     while (nesting < RT_BACKTRACE_LEVEL_MAX_NR)
     {

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -99,7 +99,7 @@ rt_weak rt_err_t rt_hw_backtrace_frame_get(rt_thread_t thread, struct rt_hw_back
 
 rt_weak rt_err_t rt_hw_backtrace_frame_unwind(rt_thread_t thread, struct rt_hw_backtrace_frame *frame)
 {
-    LOG_W("not implemented");
+    LOG_W("%s is not implemented", __func__);
     return -RT_ENOSYS;
 }
 

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -93,13 +93,13 @@ rt_weak void rt_hw_cpu_shutdown(void)
 
 rt_weak rt_err_t rt_hw_backtrace_frame_get(rt_thread_t thread, struct rt_hw_backtrace_frame *frame)
 {
-    LOG_W("%s: not implemented");
+    LOG_W("not implemented");
     return -RT_ENOSYS;
 }
 
 rt_weak rt_err_t rt_hw_backtrace_frame_unwind(rt_thread_t thread, struct rt_hw_backtrace_frame *frame)
 {
-    LOG_W("%s: not implemented");
+    LOG_W("not implemented");
     return -RT_ENOSYS;
 }
 
@@ -1565,7 +1565,7 @@ rt_weak rt_err_t rt_backtrace(void)
 #else /* otherwise not implemented */
 rt_weak rt_err_t rt_backtrace(void)
 {
-    LOG_W("%s: not implemented");
+    rt_kprintf("not implemented\n");
     return -RT_ENOSYS;
 }
 #endif
@@ -1573,18 +1573,19 @@ rt_weak rt_err_t rt_backtrace(void)
 rt_err_t rt_backtrace_frame(struct rt_hw_backtrace_frame *frame)
 {
     long nesting = 0;
-    LOG_RAW("please use: addr2line -e rtthread.elf -a -f");
+
+    rt_kprintf("please use: addr2line -e rtthread.elf -a -f");
 
     while (nesting < RT_BACKTRACE_LEVEL_MAX_NR)
     {
-        LOG_RAW(" 0x%lx", (rt_ubase_t)frame->pc);
+        rt_kprintf(" 0x%lx", (rt_ubase_t)frame->pc);
         if (rt_hw_backtrace_frame_unwind(rt_thread_self(), frame))
         {
             break;
         }
         nesting++;
     }
-    LOG_RAW("\n");
+    rt_kprintf("\n");
     return RT_EOK;
 }
 
@@ -1619,7 +1620,7 @@ static void cmd_backtrace(int argc, char** argv)
     {
         if (argc == 1)
         {
-            LOG_RAW("[INFO] No thread specified\n"
+            rt_kprintf("[INFO] No thread specified\n"
                 "[HELP] You can use commands like: backtrace %p\n"
                 "Printing backtrace of calling stack...\n",
                 rt_thread_self());
@@ -1628,7 +1629,7 @@ static void cmd_backtrace(int argc, char** argv)
         }
         else
         {
-            LOG_RAW("please use: backtrace [thread_address]\n");
+            rt_kprintf("please use: backtrace [thread_address]\n");
             return;
         }
     }
@@ -1636,18 +1637,18 @@ static void cmd_backtrace(int argc, char** argv)
     pid = strtoul(argv[1], &end_ptr, 0);
     if (end_ptr == argv[1])
     {
-        LOG_RAW("Invalid input: %s\n", argv[1]);
+        rt_kprintf("Invalid input: %s\n", argv[1]);
         return ;
     }
 
     if (pid && rt_object_get_type((void *)pid) == RT_Object_Class_Thread)
     {
         rt_thread_t target = (rt_thread_t)pid;
-        LOG_RAW("backtrace %s(0x%lx), from %s\n", target->parent.name, pid, argv[1]);
+        rt_kprintf("backtrace %s(0x%lx), from %s\n", target->parent.name, pid, argv[1]);
         rt_backtrace_thread(target);
     }
     else
-        LOG_RAW("Invalid pid: %ld\n", pid);
+        rt_kprintf("Invalid pid: %ld\n", pid);
 }
 MSH_CMD_EXPORT_ALIAS(cmd_backtrace, backtrace, print backtrace of a thread);
 

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -1565,7 +1565,8 @@ rt_weak rt_err_t rt_backtrace(void)
 #else /* otherwise not implemented */
 rt_weak rt_err_t rt_backtrace(void)
 {
-    rt_kprintf("not implemented\n");
+   /* LOG_W cannot work under this environment */
+    rt_kprintf("%s is not implemented\n", __func__);
     return -RT_ENOSYS;
 }
 #endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
修复aarch64上backtrace打印接口，LOG_X接口在异步ulog环境下不能正常看到trace信息，所以修改为rt_kprintf直接输出。
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
