### PR TITLE
[fal] Add blocks mechanism to fal.

### DIFF
--- a/components/fal/inc/fal_def.h
+++ b/components/fal/inc/fal_def.h
@@ -73,6 +73,16 @@ if (!(EXPR))                                                                   \
 #define FAL_DEV_NAME_MAX 24
 #endif
 
+#ifndef FAL_DEV_BLK_MAX
+#define FAL_DEV_BLK_MAX 6
+#endif
+
+struct flash_blk
+{
+    size_t size;
+    size_t count;
+};
+
 struct fal_flash_dev
 {
     char name[FAL_DEV_NAME_MAX];
@@ -95,6 +105,7 @@ struct fal_flash_dev
        1(nor flash)/ 8(stm32f2/f4)/ 32(stm32f1)/ 64(stm32l4)
        0 will not take effect. */
     size_t write_gran;
+    struct flash_blk blocks[FAL_DEV_BLK_MAX];
 };
 typedef struct fal_flash_dev *fal_flash_dev_t;
 

--- a/components/fal/src/fal_flash.c
+++ b/components/fal/src/fal_flash.c
@@ -27,7 +27,7 @@ static uint8_t init_ok = 0;
  */
 int fal_flash_init(void)
 {
-    size_t i;
+    size_t i, j, offset;
 
     if (init_ok)
     {
@@ -47,6 +47,17 @@ int fal_flash_init(void)
         log_d("Flash device | %*.*s | addr: 0x%08lx | len: 0x%08x | blk_size: 0x%08x |initialized finish.",
                 FAL_DEV_NAME_MAX, FAL_DEV_NAME_MAX, device_table[i]->name, device_table[i]->addr, device_table[i]->len,
                 device_table[i]->blk_size);
+        offset = 0;
+        for (j = 0; j < FAL_DEV_BLK_MAX; j ++)
+        {
+            const struct flash_blk *blk = &device_table[i]->blocks[j];
+            size_t blk_len = blk->count * blk->size;
+            if (blk->count == 0 || blk->size == 0)
+                break;
+            log_d("                  blk%2d | addr: 0x%08lx | len: 0x%08x | blk_size: 0x%08x |initialized finish.",
+                    j, device_table[i]->addr + offset, blk_len, blk->size);
+            offset += blk_len;
+        }
     }
 
     init_ok = 1;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

原来的fal对 flash不均匀分布的flash不友好，比如stm32. 明明是一块地址连续的 flash，需要注册出来3个flash设备，fal的分区还不能跨 flash 使用。导致app分区只能放在 128K起始的地址上，造成flash的浪费
#### 你的解决方案是什么 (what is your solution)
为 fal 添加 blocks 机制，支持添加特殊的 block 定义。
使用方式如下，添加了具体的flash的blocks定义，4个16K的blk，1个64K，7个128K。

```c
const struct fal_flash_dev stm32_onchip_flash =
{
    "onchip",
    STM32_FLASH_START_ADRESS,
    (1024 * 1024),
    (16 * 1024),
    {
        NULL,
        fal_flash_read,
        fal_flash_write,
        fal_flash_erase,
    },
    8,
    {
        { .size = 0x4000, .count = 4 },
        { .size = 0x10000, .count = 1 },
        { .size = 0x20000, .count = 7 },
        { 0 },
    },
};
```

#### 在什么测试环境下测试通过 (what is the test environment)

在 星火1号上测试通过。

![image](https://github.com/RT-Thread/rt-thread/assets/25633294/f6b3d881-8138-4a6f-a5e1-d1f695b581c5)
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
