### PR TITLE
[bsp][stm32] 修复 encoder驱动 编码器数值的计算问题

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drv_pulse_encoder.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drv_pulse_encoder.c
@@ -143,7 +143,7 @@ rt_int32_t pulse_encoder_get_count(struct rt_pulse_encoder_device *pulse_encoder
 {
     struct stm32_pulse_encoder_device *stm32_device;
     stm32_device = (struct stm32_pulse_encoder_device*)pulse_encoder;
-    return (rt_int32_t)((rt_int16_t)__HAL_TIM_GET_COUNTER(&stm32_device->tim_handler) + stm32_device->over_under_flowcount * AUTO_RELOAD_VALUE);
+    return (rt_int32_t)((rt_int16_t)__HAL_TIM_GET_COUNTER(&stm32_device->tim_handler) + stm32_device->over_under_flowcount * (AUTO_RELOAD_VALUE + 1));
 }
 
 rt_err_t pulse_encoder_control(struct rt_pulse_encoder_device *pulse_encoder, rt_uint32_t cmd, void *args)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

文件 drv_pulse_encoder.c 中
```
rt_int32_t pulse_encoder_get_count(struct rt_pulse_encoder_device *pulse_encoder)
{
    struct stm32_pulse_encoder_device *stm32_device;
    stm32_device = (struct stm32_pulse_encoder_device*)pulse_encoder;
    return (rt_int32_t)((rt_int16_t)__HAL_TIM_GET_COUNTER(&stm32_device->tim_handler) + stm32_device->over_under_flowcount * AUTO_RELOAD_VALUE);
}
```
对编码器数值的计算可能存在问题：
```
(rt_int32_t)((rt_int16_t)__HAL_TIM_GET_COUNTER(&stm32_device->tim_handler) + stm32_device->over_under_flowcount * AUTO_RELOAD_VALUE);
```

##### 验证

```
rt_device_read(dev, 0, (void *)&pulse_value, 1);
```

|CNT|OV|测试结果|预期结果|
|-|-|-|-|
|0x0000|0|0|0|
|0x7FFF|-1|0|-1|
|0x7FFF|0|32767|32767|
|0x0000|1|32767|32768|

#### 你的解决方案是什么 (what is your solution)

其中`AUTO_RELOAD_VALUE`为重装载值:0x7FFF， 作为乘数应当+1

#### 请提供验证的bsp和config (provide the config and bsp) 

未使用特定的BSP包，仅在测试工程中使用了 rt_device 驱动框架以及 bsp/stm32/libraries/HAL_Drivers 相关驱动。在以STM32F407ZET6为MCU的板子上测试，程序按预期正常工作。

测试时相关的rtconfig.h配置：
```
#define RT_USING_PULSE_ENCODER
#define SOC_SERIES_STM32F4
#define BSP_USING_PULSE_ENCODER2
```

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

~~- BSP:~~

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

~~- .config:~~

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

~~- action:~~

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
