### PR TITLE
ch32_drivers: call rt_hw_pin_init in rt_hw_i2c_init explicitly

### DIFF
--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_gpio.c
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_gpio.c
@@ -576,6 +576,5 @@ int rt_hw_pin_init(void)
 
     return rt_device_pin_register("pin", &_ch32_pin_ops, RT_NULL);
 }
-INIT_BOARD_EXPORT(rt_hw_pin_init);
 
 #endif /* BSP_USING_GPIO */

--- a/bsp/wch/risc-v/ch32v103r-evt/board/board.c
+++ b/bsp/wch/risc-v/ch32v103r-evt/board/board.c
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 #include "drv_usart.h"
+#include "drv_gpio.h"
 
 #include <rthw.h>
 #include <rtthread.h>
@@ -75,6 +76,10 @@ void rt_hw_board_init()
     /* System Tick Configuration, systick clock is HCLK/8 */
     _SysTick_Config(SystemCoreClock / 8 / RT_TICK_PER_SECOND);
     /* Call components board initial (use INIT_BOARD_EXPORT()) */
+#ifdef RT_USING_PIN
+    /* pin must initialized before i2c */
+    rt_hw_pin_init();
+#endif
 #ifdef RT_USING_COMPONENTS_INIT
     rt_components_board_init();
 #endif

--- a/bsp/wch/risc-v/ch32v208w-r0/board/board.c
+++ b/bsp/wch/risc-v/ch32v208w-r0/board/board.c
@@ -11,6 +11,7 @@
 #include "board.h"
 #include <stdint.h>
 #include "drv_usart.h"
+#include "drv_gpio.h"
 #include <rthw.h>
 #include <rtthread.h>
 
@@ -61,6 +62,10 @@ void rt_hw_board_init()
 #endif
 #ifdef RT_USING_CONSOLE
     rt_console_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif
+#ifdef RT_USING_PIN
+    /* pin must initialized before i2c */
+    rt_hw_pin_init();
 #endif
     /* Call components board initial (use INIT_BOARD_EXPORT()) */
 #ifdef RT_USING_COMPONENTS_INIT

--- a/bsp/wch/risc-v/ch32v307v-r1/board/board.c
+++ b/bsp/wch/risc-v/ch32v307v-r1/board/board.c
@@ -11,6 +11,7 @@
 #include "board.h"
 #include <stdint.h>
 #include "drv_usart.h"
+#include "drv_gpio.h"
 #include <rthw.h>
 #include <rtthread.h>
 
@@ -47,6 +48,10 @@ void rt_hw_board_init()
 #endif
 #ifdef RT_USING_CONSOLE
     rt_console_set_device(RT_CONSOLE_DEVICE_NAME);
+#endif
+#ifdef RT_USING_PIN
+    /* pin must initialized before i2c */
+    rt_hw_pin_init();
 #endif
     /* Call components board initial (use INIT_BOARD_EXPORT()) */
 #ifdef RT_USING_COMPONENTS_INIT


### PR DESCRIPTION
Fix #8325

## 拉取/合并请求描述：(PR description)

<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

在Linux下构建项目时，`rt_hw_i2c_init`先于`rt_hw_pin_init`被调用，导致崩溃。

#### 你的解决方案是什么 (what is your solution)

在`rt_hw_i2c_init`中显式调用`rt_hw_pin_init`，确保`pin`模块先于`i2c`模块初始化。

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:  在私有的BSP上验证过(version 4.1.1)，master分支未测试

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
