### PR TITLE
[bsp][rk3568] 修改串口波特率

### DIFF
--- a/bsp/rockchip/rk3568/driver/drv_uart.c
+++ b/bsp/rockchip/rk3568/driver/drv_uart.c
@@ -307,7 +307,7 @@ int rt_hw_uart_init(void)
     struct serial_configure config = RT_SERIAL_CONFIG_DEFAULT;
     RT_UNUSED(value);
 
-    config.baud_rate = 115200;
+    config.baud_rate = 1500000;
 
 #define BSP_INSTALL_UART_DEVICE(no)     \
     uart = &_uart##no##_device;         \


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)
https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R5S/zh 文档中，串口波特率为 1500000，所以将原先的115200改为1500000

#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP: rockchip/rk3568

- .config:

- action:

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
