### PR TITLE
[kservice] MT-safe console support (kprintf/kputs)

### DIFF
--- a/components/utilities/Kconfig
+++ b/components/utilities/Kconfig
@@ -15,7 +15,7 @@ config RT_USING_RYM
         default y
     endif
 
-config RT_USING_ULOG
+menuconfig RT_USING_ULOG
     bool "Enable ulog"
     default n
 

--- a/components/utilities/ulog/backend/console_be.c
+++ b/components/utilities/ulog/backend/console_be.c
@@ -22,20 +22,7 @@ static struct ulog_backend console = { 0 };
 void ulog_console_backend_output(struct ulog_backend *backend, rt_uint32_t level, const char *tag, rt_bool_t is_raw,
         const char *log, rt_size_t len)
 {
-#ifdef RT_USING_DEVICE
-    rt_device_t dev = rt_console_get_device();
-
-    if (dev == RT_NULL)
-    {
-        rt_hw_console_output(log);
-    }
-    else
-    {
-        rt_device_write(dev, 0, log, len);
-    }
-#else
-    rt_hw_console_output(log);
-#endif
+    rt_kputs(log);
 
 }
 

--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -191,7 +191,7 @@ static void output_unlock(void)
     }
 
     /* If the scheduler is started and in thread context */
-    if (rt_interrupt_get_nest() == 0 && rt_thread_self() != RT_NULL)
+    if (rt_scheduler_is_available())
     {
         rt_mutex_release(&ulog.output_locker);
     }
@@ -212,7 +212,7 @@ static void output_lock(void)
     }
 
     /* If the scheduler is started and in thread context */
-    if (rt_interrupt_get_nest() == 0 && rt_thread_self() != RT_NULL)
+    if (rt_scheduler_is_available())
     {
         rt_mutex_take(&ulog.output_locker, RT_WAITING_FOREVER);
     }

--- a/examples/utest/testcases/kernel/Kconfig
+++ b/examples/utest/testcases/kernel/Kconfig
@@ -65,4 +65,8 @@ config UTEST_HOOKLIST_TC
     select RT_USING_HOOKLIST
     default n
 
+config UTEST_MTSAFE_KPRINT_TC
+    bool "mtsafe kprint test"
+    default n
+
 endmenu

--- a/examples/utest/testcases/kernel/SConscript
+++ b/examples/utest/testcases/kernel/SConscript
@@ -47,6 +47,9 @@ if GetDepend(['UTEST_ATOMIC_TC']):
 if GetDepend(['UTEST_HOOKLIST_TC']):
     src += ['hooklist_tc.c']
 
+if GetDepend(['UTEST_MTSAFE_KPRINT_TC']):
+    src += ['mtsafe_kprint_tc.c']
+
 group = DefineGroup('utestcases', src, depend = ['RT_USING_UTESTCASES'], CPPPATH = CPPPATH)
 
 Return('group')

--- a/examples/utest/testcases/kernel/mtsafe_kprint_tc.c
+++ b/examples/utest/testcases/kernel/mtsafe_kprint_tc.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2006-2023, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2023-12-25     Shell        the first version
+ */
+#include <rtthread.h>
+#include "utest.h"
+
+#define TEST_LOOP_TIMES 20
+
+static struct rt_semaphore _thr_exit_sem;
+
+static void _thread_entry(void *param)
+{
+    for (size_t i = 0; i < TEST_LOOP_TIMES; i++)
+    {
+        rt_kprintf("This is thread %p\n", rt_thread_self());
+        rt_thread_mdelay(1);
+    }
+
+    rt_sem_release(&_thr_exit_sem);
+    return;
+}
+
+#define TEST_THREAD_COUNT 16
+
+static void mtsafe_kprint_tc(void)
+{
+    for (size_t i = 0; i < TEST_THREAD_COUNT; i++)
+    {
+        rt_thread_t new_thread =
+            rt_thread_create(
+                "test",
+                _thread_entry,
+                NULL,
+                UTEST_THR_STACK_SIZE,
+                UTEST_THR_PRIORITY,
+                100);
+        rt_thread_startup(new_thread);
+    }
+
+    for (size_t i = 0; i < TEST_THREAD_COUNT; i++)
+    {
+        rt_sem_take(&_thr_exit_sem, RT_WAITING_FOREVER);
+    }
+}
+
+static rt_err_t utest_tc_init(void)
+{
+    rt_sem_init(&_thr_exit_sem, "test", 0, RT_IPC_FLAG_PRIO);
+    return RT_EOK;
+}
+
+static rt_err_t utest_tc_cleanup(void)
+{
+    rt_sem_detach(&_thr_exit_sem);
+    return RT_EOK;
+}
+
+static void testcase(void)
+{
+    UTEST_UNIT_RUN(mtsafe_kprint_tc);
+}
+UTEST_TC_EXPORT(testcase, "testcases.kernel.mtsafe_kprint", utest_tc_init, utest_tc_cleanup, 10);

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -707,6 +707,11 @@ int rt_snprintf(char *buf, rt_size_t size, const char *format, ...);
 #if defined(RT_USING_DEVICE) && defined(RT_USING_CONSOLE)
 rt_device_t rt_console_set_device(const char *name);
 rt_device_t rt_console_get_device(void);
+#ifdef RT_USING_THREDSAFE_PRINTF
+    rt_thread_t rt_console_current_user(void);
+#else
+    rt_inline void *rt_console_current_user(void) { return RT_NULL; }
+#endif /* RT_USING_THREDSAFE_PRINTF */
 #endif /* defined(RT_USING_DEVICE) && defined(RT_USING_CONSOLE) */
 
 rt_err_t rt_get_errno(void);

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -417,6 +417,10 @@ config RT_USING_INTERRUPT_INFO
     help
         Add name and counter information for interrupt trace.
 
+config RT_USING_THREDSAFE_PRINTF
+    bool "Enable thread safe kernel print service"
+    default y if RT_USING_SMP && RT_USING_SMART
+
 config RT_USING_CONSOLE
     bool "Using console for rt_kprintf"
     default y
@@ -429,6 +433,7 @@ if RT_USING_CONSOLE
     config RT_CONSOLE_DEVICE_NAME
         string "the device name for console"
         default "uart1"
+
 endif
 
 config RT_VER_NUM

--- a/tools/ci/cpp_check.py
+++ b/tools/ci/cpp_check.py
@@ -23,7 +23,7 @@ class CPPCheck:
         logging.info("Start to static code analysis.")
         check_result = True
         for file in file_list_filtered:
-            result = subprocess.run(['cppcheck', '-DRTM_EXPORT', '--enable=warning', 'performance', 'portability', '--inline-suppr', '--error-exitcode=1', '--force', file], stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+            result = subprocess.run(['cppcheck', '-DRTM_EXPORT', '-DMSH_CMD_EXPORT(a,b)=', '--enable=warning', 'performance', 'portability', '--inline-suppr', '--error-exitcode=1', '--force', file], stdout = subprocess.PIPE, stderr = subprocess.PIPE)
             logging.info(result.stdout.decode())
             logging.info(result.stderr.decode())
             if result.stderr:


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

- avoid data race in rt_kputs/kprintf and ulog service

BEFORE

```text
ThThiTis is ts is thread 0xffff0000004hhr6e3a0eis ia
sd  thre0adxf 0xfffffff0000000000046e046e33a0a
0
ThisTh iiss  Thtisih thrs is terhad 0xfffread f0ea0This is thread x0xffffd000000000f 0xf004fff4ff00006613af0100468
00313a8
a8
read 0s46This  isd This isatis et8 thhhr
reaxeffd 0xffff000ad 0xffThis000000470970
This 0is0 thread0000000 467230
is xft467hreafff00Thd 0xffff0000003f5220
i0220
s is 0th0046TrThhisf68 ieias8
 thread 0xd s0ff isxfThis ff ti0ffhres0f0 t000a0d 0x000468f00468518hr51fff
8
0000ead 000xf46Th5fff000Thfis is thr0is i07804e
s6a t3978
dhr 0Thisead is thr 0xexad 0fffffxfff0ffff000000469800
000000046009800
00469800
```

AFTER

```text
This is thread 0xffff000000462690
This is thread 0xffff0000004732c0
This is thread 0xffff000000463be0
This is thread 0xffff000000470cf0
This is thread 0xffff0000003f6508
This is thread 0xffff000000463978
This is thread 0xffff000000469b80
This is thread 0xffff000000469b80
This is thread 0xffff00000046d438
This is thread 0xffff000000463978
This is thread 0xffff0000003f6508
This is thread 0xffff000000470cf0
This is thread 0xffff000000463be0
This is thread 0xffff0000004732c0
This is thread 0xffff000000462690
This is thread 0xffff0000004745a8
This is thread 0xffff0000003f5220
This is thread 0xffff00000046e720
This is thread 0xffff0000004613a8
This is thread 0xffff00000046fa08
This is thread 0xffff00000046c150
This is thread 0xffff000000471fd8
This is thread 0xffff00000046ae68
```

#### 你的解决方案是什么 (what is your solution)

#### 请提供验证的bsp和config (provide the config and bsp) 

This feature had been tested with utest which is also inside this patch, and in conditions of exception, ISR, normal thread context.

- BSP: rpi4b, qemu aarch64

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
