### PR TITLE
[fixup] check NULL pointer before access

### DIFF
--- a/bsp/qemu-virt64-aarch64/applications/main.c
+++ b/bsp/qemu-virt64-aarch64/applications/main.c
@@ -9,10 +9,11 @@
  */
 
 #include <stdio.h>
+#include <rtthread.h>
 
 int main(void)
 {
-    printf("hello rt-thread\n");
+    rt_kprintf("hello rt-thread\n");
 
     return 0;
 }

--- a/bsp/qemu-virt64-aarch64/drivers/secondary_cpu.c
+++ b/bsp/qemu-virt64-aarch64/drivers/secondary_cpu.c
@@ -14,6 +14,10 @@
 #include "mmu.h"
 #include "gtimer.h"
 
+#ifdef BSP_USING_GICV3
+#include <gicv3.h>
+#endif
+
 #ifdef RT_USING_SMP
 
 extern unsigned long MMUTable[];
@@ -28,6 +32,10 @@ void rt_hw_secondary_cpu_bsp_start(void)
     rt_hw_vector_init();
 
     arm_gic_cpu_init(0, 0);
+
+#ifdef BSP_USING_GICV3
+    arm_gic_redist_init(0, 0);
+#endif /* BSP_USING_GICV3 */
 
     // local timer init
     rt_hw_gtimer_init();

--- a/components/mm/mm_aspace.c
+++ b/components/mm/mm_aspace.c
@@ -1278,7 +1278,7 @@ int rt_aspace_load_page(rt_aspace_t aspace, void *addr, rt_size_t npage)
 
     if (!varea)
     {
-        LOG_W("%s: varea not exist", __func__);
+        LOG_W("%s: varea not exist(addr=%p)", __func__, addr);
         err = -RT_ENOENT;
     }
     else if ((char *)addr >= end || (rt_size_t)addr & ARCH_PAGE_MASK ||

--- a/libcpu/aarch64/common/backtrace.c
+++ b/libcpu/aarch64/common/backtrace.c
@@ -85,7 +85,7 @@ rt_err_t rt_hw_backtrace_frame_unwind(rt_thread_t thread, struct rt_hw_backtrace
     if (fp && !((long)fp & 0x7))
     {
 #ifdef RT_USING_SMART
-        if (thread->lwp)
+        if (thread && thread->lwp)
         {
             rt_lwp_t lwp = thread->lwp;
             void *this_lwp = lwp_self();

--- a/libcpu/aarch64/common/gicv3.c
+++ b/libcpu/aarch64/common/gicv3.c
@@ -468,7 +468,7 @@ rt_uint64_t arm_gic_get_interface_prior_mask(rt_uint64_t index)
 
 void arm_gic_set_binary_point(rt_uint64_t index, rt_uint64_t binary_point)
 {
-    index = index;
+    RT_UNUSED(index);
     binary_point &= 0x7;
 
     SET_GICV3_REG(ICC_BPR1_EL1, binary_point);
@@ -625,13 +625,18 @@ rt_uint64_t arm_gic_get_high_pending_irq(rt_uint64_t index)
 rt_uint64_t arm_gic_get_interface_id(rt_uint64_t index)
 {
     rt_uint64_t ret = 0;
+    rt_base_t level;
+    int cpuid;
 
     RT_ASSERT(index < ARM_GIC_MAX_NR);
 
-    if (_gic_table[index].cpu_hw_base != RT_NULL)
+    level = rt_hw_local_irq_disable();
+    cpuid = rt_hw_cpu_id();
+    if (_gic_table[index].cpu_hw_base[cpuid] != RT_NULL)
     {
-        ret = GIC_CPU_IIDR(_gic_table[index].cpu_hw_base);
+        ret = GIC_CPU_IIDR(_gic_table[index].cpu_hw_base[cpuid]);
     }
+    rt_hw_local_irq_enable(level);
 
     return ret;
 }

--- a/libcpu/aarch64/common/gicv3.c
+++ b/libcpu/aarch64/common/gicv3.c
@@ -81,24 +81,24 @@ static unsigned int _gic_max_irq;
 #define ICC_ASGI1R_EL1  "S3_0_C12_C11_6"
 
 /* Macro to access the Distributor Control Register (GICD_CTLR) */
-#define GICD_CTLR_RWP       (1 << 31)
-#define GICD_CTLR_E1NWF     (1 << 7)
-#define GICD_CTLR_DS        (1 << 6)
-#define GICD_CTLR_ARE_NS    (1 << 5)
-#define GICD_CTLR_ARE_S     (1 << 4)
-#define GICD_CTLR_ENGRP1S   (1 << 2)
-#define GICD_CTLR_ENGRP1NS  (1 << 1)
-#define GICD_CTLR_ENGRP0    (1 << 0)
+#define GICD_CTLR_RWP       (1U << 31)
+#define GICD_CTLR_E1NWF     (1U << 7)
+#define GICD_CTLR_DS        (1U << 6)
+#define GICD_CTLR_ARE_NS    (1U << 5)
+#define GICD_CTLR_ARE_S     (1U << 4)
+#define GICD_CTLR_ENGRP1S   (1U << 2)
+#define GICD_CTLR_ENGRP1NS  (1U << 1)
+#define GICD_CTLR_ENGRP0    (1U << 0)
 
 /* Macro to access the Redistributor Control Register (GICR_CTLR) */
-#define GICR_CTLR_UWP       (1 << 31)
-#define GICR_CTLR_DPG1S     (1 << 26)
-#define GICR_CTLR_DPG1NS    (1 << 25)
-#define GICR_CTLR_DPG0      (1 << 24)
-#define GICR_CTLR_RWP       (1 << 3)
-#define GICR_CTLR_IR        (1 << 2)
-#define GICR_CTLR_CES       (1 << 1)
-#define GICR_CTLR_EnableLPI (1 << 0)
+#define GICR_CTLR_UWP       (1U << 31)
+#define GICR_CTLR_DPG1S     (1U << 26)
+#define GICR_CTLR_DPG1NS    (1U << 25)
+#define GICR_CTLR_DPG0      (1U << 24)
+#define GICR_CTLR_RWP       (1U << 3)
+#define GICR_CTLR_IR        (1U << 2)
+#define GICR_CTLR_CES       (1U << 1)
+#define GICR_CTLR_EnableLPI (1U << 0)
 
 /* Macro to access the Generic Interrupt Controller Interface (GICC) */
 #define GIC_CPU_CTRL(hw_base)               HWREG32((hw_base) + 0x00U)
@@ -162,7 +162,7 @@ static unsigned int _gic_max_irq;
 
 int arm_gic_get_active_irq(rt_uint64_t index)
 {
-    int irq;
+    rt_base_t irq;
 
     RT_ASSERT(index < ARM_GIC_MAX_NR);
 
@@ -178,7 +178,7 @@ void arm_gic_ack(rt_uint64_t index, int irq)
     RT_ASSERT(irq >= 0);
 
     __DSB();
-    SET_GICV3_REG(ICC_EOIR1_EL1, irq);
+    SET_GICV3_REG(ICC_EOIR1_EL1, (rt_base_t)irq);
 }
 
 void arm_gic_mask(rt_uint64_t index, int irq)
@@ -397,7 +397,7 @@ void arm_gic_set_priority(rt_uint64_t index, int irq, rt_uint64_t priority)
         rt_int32_t cpu_id = rt_hw_cpu_id();
 
         mask = GIC_RDISTSGI_IPRIORITYR(_gic_table[index].redist_hw_base[cpu_id], irq);
-        mask &= ~(0xff << ((irq % 4) * 8));
+        mask &= ~(0xffUL << ((irq % 4) * 8));
         mask |= ((priority & 0xff) << ((irq % 4) * 8));
         GIC_RDISTSGI_IPRIORITYR(_gic_table[index].redist_hw_base[cpu_id], irq) = mask;
     }
@@ -478,7 +478,7 @@ rt_uint64_t arm_gic_get_binary_point(rt_uint64_t index)
 {
     rt_uint64_t binary_point;
 
-    index = index;
+    RT_UNUSED(index);
     GET_GICV3_REG(ICC_BPR1_EL1, binary_point);
     return binary_point;
 }
@@ -616,7 +616,7 @@ rt_uint64_t arm_gic_get_high_pending_irq(rt_uint64_t index)
     rt_uint64_t irq;
     RT_ASSERT(index < ARM_GIC_MAX_NR);
 
-    index = index;
+    RT_UNUSED(index);
     GET_GICV3_REG(ICC_HPPIR1_EL1, irq);
 
     return irq;
@@ -862,7 +862,7 @@ int arm_gic_cpu_init(rt_uint64_t index, rt_uint64_t cpu_base)
     value = arm_gic_get_system_register_enable_mask(index);
     value |= (1 << 0);
     arm_gic_set_system_register_enable_mask(index, value);
-    SET_GICV3_REG(ICC_CTLR_EL1, 0);
+    SET_GICV3_REG(ICC_CTLR_EL1, 0l);
 
     arm_gic_set_interface_prior_mask(index, 0xff);
 

--- a/libcpu/aarch64/common/setup.c
+++ b/libcpu/aarch64/common/setup.c
@@ -390,8 +390,10 @@ void rt_hw_common_setup(void)
 
         for (int i = 0; i < mem_region_nr; ++i, ++mem_region)
         {
-            if (mem_region != page_region)
+            if (mem_region != page_region && mem_region->name)
             {
+                mem_region->start -= PV_OFFSET;
+                mem_region->end -= PV_OFFSET;
                 rt_page_install(*mem_region);
             }
         }

--- a/src/scheduler_mp.c
+++ b/src/scheduler_mp.c
@@ -1255,8 +1255,15 @@ rt_uint16_t rt_critical_level(void)
 
     current_thread = rt_cpu_self()->current_thread;
 
-    /* the necessary memory barrier is done on irq_(dis|en)able */
-    critical_lvl = RT_SCHED_CTX(current_thread).critical_lock_nest;
+    if (current_thread)
+    {
+        /* the necessary memory barrier is done on irq_(dis|en)able */
+        critical_lvl = RT_SCHED_CTX(current_thread).critical_lock_nest;
+    }
+    else
+    {
+        critical_lvl = 0;
+    }
 
     rt_hw_local_irq_enable(level);
     return critical_lvl;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

- Fix NULL pointer access
- gtimer init failed when enable gicv3

#### 你的解决方案是什么 (what is your solution)

- check NULL pointer before access
- using virtual address for `rt_page_install()`
- add `arm_gic_redist_init(0, 0)` for qemu secondary bootup
- using `rt_kprintf` instead of `printf`

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
