### PR TITLE
[bsp][stm32] eth driver support phy YT8512C

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_eth.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_eth.c
@@ -500,7 +500,11 @@ static void phy_monitor_thread_entry(void *parameter)
             EthHandle.Init.PhyAddress = i;
             HAL_ETH_ReadPHYRegister(&EthHandle, PHY_ID1_REG, (uint32_t *)&temp);
 
+#ifdef PHY_USING_YT8512C
+            if (temp != 0xFFFF)
+#else
             if (temp != 0xFFFF && temp != 0x00)
+#endif /* PHY_USING_YT8512C */
             {
                 phy_addr = i;
                 break;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

问题复现：

Issue[#8611](https://github.com/RT-Thread/rt-thread/issues/8611)

对于drv_eth.h，看了最新的代码，3个月前有人提交了PR，我们的方案是一样的，在drv_eth.h增加相关的宏定义：

    ```c
    #elif defined(PHY_USING_YT8512C)
    /*  The PHY interrupt source flag register. */
    #define PHY_INTERRUPT_FLAG_REG      0x13U
    /*  The PHY interrupt mask register. */
    #define PHY_INTERRUPT_MASK_REG      0x12U
    /*  The PHY auto nego and link change mask. */
    #define PHY_INT_MASK                (1<<15)|(3<<10)
    /*  The PHY status register. */
    #define PHY_Status_REG              0x11U
    #define PHY_100M_MASK               (1<<14)
    #define PHY_FULL_DUPLEX_MASK        (1<<13)
    #define PHY_Status_SPEED_10M(sr)    (!PHY_Status_SPEED_100M(sr))
    #define PHY_Status_SPEED_100M(sr)   ((sr) & PHY_100M_MASK)
    #define PHY_Status_FULL_DUPLEX(sr)  ((sr) & PHY_FULL_DUPLEX_MASK)
    #endif /* defined(PHY_USING_LAN8720A) || defined(PHY_USING_LAN8742A) */
    ```

问题分析：

取消drv_eth.c的`#define DRV_DEBUG`，然后临时增加几行调试代码查看寄存器的值：

```c
static void phy_monitor_thread_entry(void *parameter)
{
    ...
        /* phy search */
        rt_uint32_t i, temp, temp2;
        for (i = 0; i <= 0x1F; i++)
        {
            EthHandle.Init.PhyAddress = i;
            HAL_ETH_ReadPHYRegister(&EthHandle, PHY_ID1_REG, (uint32_t *)&temp);
            LOG_D("HAL_ETH_ReadPHYRegister PHY_ID1_REG, PhyAddress: %d, value: 0x%04X", i, temp);
            HAL_ETH_ReadPHYRegister(&EthHandle, PHY_ID2_REG, (uint32_t *)&temp2);
            LOG_D("HAL_ETH_ReadPHYRegister PHY_ID2_REG, PhyAddress: %d, value: 0x%04X", i, temp2);
            if (temp != 0xFFFF && temp != 0x00)
            {
                phy_addr = i;
                break;
            }
        }
    ...
}
```

运行结果如下：

```
[D/drv.emac] HAL_ETH_ReadPHYRegister PHY_ID1_REG, PhyAddress: 0, value: 0x0000
[D/drv.emac] HAL_ETH_ReadPHYRegister PHY_ID2_REG, PhyAddress: 0, value: 0x0128

[D/drv.emac] HAL_ETH_ReadPHYRegister PHY_ID1_REG, PhyAddress: 1, value: 0x1FFF
[D/drv.emac] HAL_ETH_ReadPHYRegister PHY_ID2_REG, PhyAddress: 1, value: 0xFFFF

[D/drv.emac] Found a phy, address:0x01
```

**开发板上的PHY地址应为0，芯片的PHY_ID1_REG和PHY_ID2_REG分别为`0x0000`和`0x0128`。**

查看[YT8512C的手册](https://atta.szlcsc.com/upload/public/pdf/source/20210528/C2685350_B3A10D8A8451598E13B3D6712CBA036F.pdf)第33页，确实如此：

![image](https://github.com/RT-Thread/rt-thread/assets/45103434/b34898f5-d6cc-43b5-a6b7-5a882a651083)

#### 你的解决方案是什么 (what is your solution)

对于YT8512C，允许PHY_ID1_REG寄存器值为0：

```c
static void phy_monitor_thread_entry(void *parameter)
{
    ...
#ifdef PHY_USING_YT8512C
            if (temp != 0xFFFF)
#else
            if (temp != 0xFFFF && temp != 0x00)
#endif /* PHY_USING_YT8512C */
    ...
```

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
