### PR TITLE
[bsp][CV1800B] fix cv1800b polarity reversal error

### DIFF
--- a/bsp/cvitek/drivers/drv_pwm.c
+++ b/bsp/cvitek/drivers/drv_pwm.c
@@ -31,7 +31,7 @@ static void cvi_pwm_set_config(rt_ubase_t reg_base, struct rt_pwm_configuration 
 {
     unsigned long long duty_clk, period_clk;
 
-    cvi_pwm_set_polarity_low_ch(reg_base, (cfg->channel & PWM_MAX_CH));
+    cvi_pwm_set_polarity_high_ch(reg_base, (cfg->channel & PWM_MAX_CH));
 
     duty_clk = (cfg->pulse * count_unit) / NSEC_COUNT;
     cvi_pwm_set_high_period_ch(reg_base, (cfg->channel & PWM_MAX_CH), duty_clk);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

现在PWM驱动输出与目标输出极性相反。

CV1800B 芯片支持PWM信号输出并支持极性反转。当POLARITY寄存器设置为1时HLPERIOD寄存器代表高电平拍数，当POLARITY寄存器设置为0时HLPERIOD寄存器代表低电平拍数。目前cvi_pwm_set_config()中将POLARITY设为0，代表HLPERIOD存储的为低电平拍数，而在用户调用时，通常会认为pulse为高电平占用的时间。所以造成了极性与目标不一致的现象。

#### 你的解决方案是什么 (what is your solution)

在cvi_pwm_set_config()中将POLARITY配置为高电平。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
- .config:
- action:
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
