### PR TITLE
[wlan] Add the wlan join scan function

### DIFF
--- a/components/drivers/Kconfig
+++ b/components/drivers/Kconfig
@@ -811,6 +811,10 @@ menuconfig RT_USING_WIFI
                 bool "MSH command Enable"
                 default y
 
+            config RT_WLAN_JOIN_SCAN_BY_MGNT
+                bool "Enable wlan join scan"
+                default y
+
             config RT_WLAN_AUTO_CONNECT_ENABLE
                 bool "Auto connect Enable"
                 select RT_WLAN_CFG_ENABLE

--- a/components/drivers/wlan/wlan_mgnt.c
+++ b/components/drivers/wlan/wlan_mgnt.c
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-08-06     tyx          the first version
+ * 2023-12-12     Evlers       Add the wlan join scan function
  */
 
 #include <rthw.h>
@@ -858,7 +859,7 @@ static void rt_wlan_join_scan_callback(int event, struct rt_wlan_buff *buff, voi
             info->ssid.len == tgt_info->ssid.len)
     {
         /*Get the rssi the max ap*/
-        if(info->rssi > tgt_info->rssi)
+        if((info->rssi > tgt_info->rssi) || (tgt_info->rssi == 0))
         {
             tgt_info->security  = info->security;
             tgt_info->band      = info->band;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
- 添加`RT_WLAN_JOIN_SCAN_BY_MGNT`配置支持
- 另外在`rt_wlan_connect`函数中使用了`INVALID_INFO`宏清除`rssi`为`0`，而在`rt_wlan_join_scan_callback`函数中未判断`rssi`属于无效的状态导致无法copy新的`WiFi信息`到`目标WiFi信息`

#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:已在自己的开发板上做了测试
```
 \ | /
- RT -     Thread Operating System
 / | \     5.0.2 build Mar 23 2024 23:37:31
 2006 - 2022 Copyright by RT-Thread team
lwIP-2.0.3 initialized!
[I/SFUD] Found a Winbond flash chip. Size is 16777216 bytes.
[I/SFUD] norflash0 flash device initialized successfully.
[I/SFUD] Probe SPI flash norflash0 by SPI device spi10 success.
[D/FAL] (fal_flash_init:47) Flash device |                norflash0 | addr: 0x00000000 | len: 0x01000000 | blk_size: 0x00001000 |initialized finish.
[I/FAL] ==================== FAL partition table ====================
[I/FAL] | name         | flash_dev |   offset   |    length  |
[I/FAL] -------------------------------------------------------------
[I/FAL] | whd_firmware | norflash0 | 0x00000000 | 0x00070000 |
[I/FAL] | whd_clm      | norflash0 | 0x00070000 | 0x00008000 |
[I/FAL] | bt_image     | norflash0 | 0x00080000 | 0x00080000 |
[I/FAL] | download     | norflash0 | 0x00100000 | 0x00200000 |
[I/FAL] | easyflash    | norflash0 | 0x00300000 | 0x00100000 |
[I/FAL] | filesystem   | norflash0 | 0x00400000 | 0x00c00000 |
[I/FAL] =============================================================
[I/FAL] RT-Thread Flash Abstraction Layer initialize success.
[Flash] (..\offline-packages\easyflash\src\ef_env.c:1818) ENV start address is 0x00000000, size is 8192 bytes.
[Flash] EasyFlash V4.1.0 is initialize success.
[Flash] You can get the latest version on https://github.com/armink/EasyFlash .
[I/sal.skt] Socket Abstraction Layer initialize success.
WLAN MAC Address : 2C:B0:FD:A2:2E:26
WLAN Firmware    : wl0: Mar 28 2021 22:55:55 version 7.45.98.117 (dc5d9c4 CY) FWID 01-d36e8386
WLAN CLM         : API: 12.2 Data: 9.10.39 Compiler: 1.29.4 ClmImport: 1.36.3 Creation: 2021-03-28 22:47:33
WHD VERSION      : 3.0.0.22316 : v3.0.0 : ARM CLANG 5060960 : 2023-12-04 07:24:34 -0600
[I/WLAN.dev] wlan init success
[I/WLAN.lwip] eth device init ok name:w0
[I/WLAN.dev] wlan init success
[I/WLAN.lwip] eth device init ok name:w1
[I/FAL] The FAL block device (filesystem) created successfully
msh />[I/SDIO] SD card capacity 15558144 KB.
found part[0], begin: 1048576, size: 14.856GB
[I/filesystem] sd card mount to '/sdcard'
[I/WLAN.mgnt] wifi connect success ssid:EvlerHome
[I/WLAN.lwip] Got IP address : 192.168.0.169
[I/ntp] Get local time from NTP server: Sat Mar 23 23:41:50 2024
```

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
