### PR TITLE
[wlan] add the wlan join scan function

### DIFF
--- a/components/drivers/Kconfig
+++ b/components/drivers/Kconfig
@@ -811,6 +811,10 @@ menuconfig RT_USING_WIFI
                 bool "MSH command Enable"
                 default y
 
+            config RT_WLAN_JOIN_SCAN_BY_MGNT
+                bool "Enable wlan join scan"
+                default y
+
             config RT_WLAN_AUTO_CONNECT_ENABLE
                 bool "Auto connect Enable"
                 select RT_WLAN_CFG_ENABLE

--- a/components/drivers/wlan/wlan_mgnt.c
+++ b/components/drivers/wlan/wlan_mgnt.c
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-08-06     tyx          the first version
+ * 2023-12-12     Evlers       add the wlan join scan function
  */
 
 #include <rthw.h>
@@ -858,7 +859,7 @@ static void rt_wlan_join_scan_callback(int event, struct rt_wlan_buff *buff, voi
             info->ssid.len == tgt_info->ssid.len)
     {
         /*Get the rssi the max ap*/
-        if(info->rssi > tgt_info->rssi)
+        if((info->rssi > tgt_info->rssi) || (tgt_info->rssi == 0))
         {
             tgt_info->security  = info->security;
             tgt_info->band      = info->band;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
- 添加`RT_WLAN_JOIN_SCAN_BY_MGNT`配置支持（该功能在c代码中是支持的，但是没有这个宏定义的支持）
- 另外在`rt_wlan_connect`函数中使用了`INVALID_INFO`宏清除`rssi`为`0`，而在`rt_wlan_join_scan_callback`函数中未判断`rssi`属于无效的状态导致无法copy新的`WiFi信息`到`目标WiFi信息`
以下是未修复时的现象:
```shell
# 在连接前手动确认ap是否存在
msh />wifi scan
             SSID                      MAC            security    rssi chn Mbps
------------------------------- -----------------  -------------- ---- --- ----
WirelessNet                     04:9f:ca:98:a8:e0  WPA2_MIXED_PSK -79    1  144
111111                          ec:26:ca:eb:c0:84  WPA2_AES_PSK   -68    1  450
405                             ec:26:ca:fa:c0:d2  WPA2_AES_PSK   -77    1  450
Xiaomi_9535                     a4:39:b3:b1:95:36  WPA2_MIXED_PSK -90    2  144
EvlerHome                       c8:ea:f8:eb:cd:6e  WPA2_AES_PSK   -54    5  300

# 连接AP (在连接前无法匹配扫描到的ap信息)
msh />wifi join EvlerHome xyf.97512
[W/WLAN.mgnt] F:rt_wlan_connect L:932 not find ap! ssid:EvlerHome,info.ssid.len=9

```

#### 你的解决方案是什么 (what is your solution)
在`rt_wlan_join_scan_callback`函数中添加无效的rssi值的判断，然后再进行信号强度的对比


#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:已在自己的开发板上做了测试
```shell
# 连接不存在的AP
msh />wifi join test 12345678
[W/WLAN.mgnt] F:rt_wlan_connect L:933 not find ap! ssid:test,info.ssid.len=4

# 连接存在的AP
msh />wifi join EvlerHome xxxxxxxx
[I/WLAN.mgnt] wifi connect success ssid:EvlerHome
msh />[I/WLAN.lwip] Got IP address : 192.168.0.169
```

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
