### PR TITLE
[wlan][cmd] fixed a duplicate issue with the wifi scan command

### DIFF
--- a/components/drivers/wlan/wlan_cmd.c
+++ b/components/drivers/wlan/wlan_cmd.c
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-08-13     tyx          the first version
+ * 2024-03-24     Evlers       fixed a duplicate issue with the wifi scan command
  */
 
 #include <rtthread.h>
@@ -388,6 +389,7 @@ static void user_ap_info_callback(int event, struct rt_wlan_buff *buff, void *pa
     struct rt_wlan_info *info = RT_NULL;
     int index = 0;
     int ret = RT_EOK;
+    rt_uint32_t last_num = scan_result.num;
 
     RT_ASSERT(event == RT_WLAN_EVT_SCAN_REPORT);
     RT_ASSERT(buff != RT_NULL);
@@ -404,8 +406,12 @@ static void user_ap_info_callback(int event, struct rt_wlan_buff *buff, void *pa
                  scan_filter->ssid.len == info->ssid.len &&
                  rt_memcmp(&scan_filter->ssid.val[0], &info->ssid.val[0], scan_filter->ssid.len) == 0))
         {
-            /*Print the info*/
-            print_ap_info(info,index);
+            /*Check whether a new ap is added*/
+            if (last_num < scan_result.num)
+            {
+                /*Print the info*/
+                print_ap_info(info,index);
+            }
 
             index++;
             *((int *)(parameter)) = index;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
在执行`wifi scan`命令时，扫描出来的结果会重复打印，我测试在`lts-v4.1.x`是不存在这个问题的。
重复打印的问题如下：
```shell
msh />wifi scan
             SSID                      MAC            security    rssi chn Mbps
------------------------------- -----------------  -------------- ---- --- ----
EvlerHome                       c8:ea:f8:eb:cd:6e  WPA2_AES_PSK   -48    5  300
EvlerHome                       c8:ea:f8:eb:cd:6e  WPA2_AES_PSK   -47    5  300
ES-650733                       58:48:49:05:84:5d  WPA2_AES_PSK   -86    9   72
TP-LINK_403                     b8:f8:83:af:4c:61  WPA2_AES_PSK   -67   11  450
TP-LINK_403                     b8:f8:83:af:4c:61  WPA2_AES_PSK   -69   11  450
312                             20:6b:e7:81:fc:1b  WPA2_AES_PSK   -62   11  450
EvlerHome                       c8:ea:f8:eb:cd:6e  WPA2_AES_PSK   -46    5  300
EvlerHome                       c8:ea:f8:eb:cd:6e  WPA2_AES_PSK   -46    5  300
YXKJ                            48:5f:08:b2:f6:1d  WPA2_AES_PSK   -76    6  300
                                f8:9a:78:73:73:4d  WPA2_AES_PSK   -91    6  300
Xiaomi_404                      5c:02:14:63:62:5a  WPA2_MIXED_PSK -90    9  144
312                             20:6b:e7:81:fc:1b  WPA2_AES_PSK   -62   11  450
TP-LINK_403                     b8:f8:83:af:4c:61  WPA2_AES_PSK   -67   11  450
111111                          ec:26:ca:eb:c0:84  WPA2_AES_PSK   -70    1  450
111111                          ec:26:ca:eb:c0:84  WPA2_AES_PSK   -70    1  450
ChinaNet-5sD3                   bc:5d:a3:8c:84:56  WPA2_MIXED_PSK -76    4  144
```

#### 你的解决方案是什么 (what is your solution)
在将扫描结果保存到`cached (wifi_scan_result_cache)` 之前，先读取扫描结果的数量，然后再存入`cached`，利用`cached`的查重机制检查数量是否增加新的ap。
在`wifi_scan_result_cache`函数完成后，如果`scan_result.num`有增加，说明该ap属于新扫描到的ap，此时再将该`ap信息`打印出来。
以下是修复后的效果：
```shell
msh />wifi scan
             SSID                      MAC            security    rssi chn Mbps
------------------------------- -----------------  -------------- ---- --- ----
EvlerHome                       c8:ea:f8:eb:cd:6e  WPA2_AES_PSK   -46    5  300
ES-650733                       58:48:49:05:84:5d  WPA2_AES_PSK   -84    9   72
TP-LINK_403                     b8:f8:83:af:4c:61  WPA2_AES_PSK   -66   11  450
312                             20:6b:e7:81:fc:1b  WPA2_AES_PSK   -60   11  450
YXKJ                            48:5f:08:b2:f6:1d  WPA2_AES_PSK   -73    6  300
Xiaomi_404                      5c:02:14:63:62:5a  WPA2_MIXED_PSK -71    9  144
406                             6c:b1:58:f7:3b:3b  WPA2_AES_PSK   -91   12  300
ChinaNet-5sD3                   bc:5d:a3:8c:84:56  WPA2_MIXED_PSK -85    1  144
111111                          ec:26:ca:eb:c0:84  WPA2_AES_PSK   -67    1  450
405                             ec:26:ca:fa:c0:d2  WPA2_AES_PSK   -76    1  450
110-2                           3c:cd:57:75:c3:bc  WPA2_MIXED_PSK -85    1  300
Xiaomi_301                      c8:bf:4c:db:9e:2a  WPA2_MIXED_PSK -78    4  300
```

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
