### PR TITLE
modified:   components/libc/posix/delay/delay.c			Added comments for …

### DIFF
--- a/components/libc/posix/delay/delay.c
+++ b/components/libc/posix/delay/delay.c
@@ -12,36 +12,68 @@
 #include <rtthread.h>
 #include <rthw.h>
 
+/**
+ * @brief    Delays the execution of the current thread for the specified number of milliseconds.
+ *
+ * @param    msecs The number of milliseconds to sleep.
+ */
 void msleep(unsigned int msecs)
 {
     rt_thread_mdelay(msecs);
 }
 RTM_EXPORT(msleep);
 
+/**
+ * @brief    Delays the execution of the current thread for the specified number of seconds.
+ *
+ * @param    seconds The number of seconds to sleep.
+ */
 void ssleep(unsigned int seconds)
 {
     msleep(seconds * 1000);
 }
 RTM_EXPORT(ssleep);
 
+/**
+ * @brief    Delays the execution of the current thread for the specified number of milliseconds.
+ *
+ * @param    msecs The number of milliseconds to delay.
+ */
 void mdelay(unsigned long msecs)
 {
     rt_hw_us_delay(msecs * 1000);
 }
 RTM_EXPORT(mdelay);
 
+/**
+ * @brief    Delays the execution of the current thread for the specified number of microseconds.
+ *
+ * @param    usecs The number of microseconds to delay.
+ */
 void udelay(unsigned long usecs)
 {
     rt_hw_us_delay(usecs);
 }
 RTM_EXPORT(udelay);
 
+/**
+ * @brief    Delays the execution of the current thread for approximately one microsecond.
+ *
+ * @param    nsecs This parameter is ignored.
+ */
 void ndelay(unsigned long nsecs)
 {
     rt_hw_us_delay(1);
 }
 RTM_EXPORT(ndelay);
 
+/**
+ * @brief    Delays the execution of the current thread for the specified number of seconds.
+ *
+ * @param    seconds The number of seconds to sleep.
+ *
+ * @return   Returns 0 on success.
+ */
 unsigned int sleep(unsigned int seconds)
 {
     if (rt_thread_self() != RT_NULL)
@@ -61,6 +93,13 @@ unsigned int sleep(unsigned int seconds)
 }
 RTM_EXPORT(sleep);
 
+/**
+ * @brief    Delays the execution of the current thread for the specified number of microseconds.
+ *
+ * @param    usec The number of microseconds to sleep.
+ *
+ * @return   Returns 0 on success.
+ */
 int usleep(useconds_t usec)
 {
     if (rt_thread_self() != RT_NULL)

--- a/components/libc/posix/signal/posix_signal.c
+++ b/components/libc/posix/signal/posix_signal.c
@@ -229,6 +229,16 @@ int raise(int sig)
 }
 
 #include <sys/types.h>
+/**
+ * @brief    Sends a signal to the caller.
+ *
+ * This function sends the signal specified by @p sig to the caller.
+ *
+ * @param    sig The signal to be sent.
+ *           This should be one of the standard signal macros such as SIGUSR1, SIGUSR2, etc.
+ *
+ * @return   Returns 0 on success. If an error occurs, -1 is returned and errno is set appropriately.
+ */
 int sigqueue (pid_t pid, int signo, const union sigval value)
 {
     /* no support, signal queue */

--- a/components/libc/posix/signal/posix_signal.h
+++ b/components/libc/posix/signal/posix_signal.h
@@ -18,40 +18,40 @@ extern "C" {
 #include <sys/signal.h>
 
 enum rt_signal_value{
-    SIG1 = SIGHUP,
-    SIG2 = SIGINT,
-    SIG3 = SIGQUIT,
-    SIG4 = SIGILL,
-    SIG5 = SIGTRAP,
-    SIG6 = SIGABRT,
-    SIG7 = SIGEMT,
-    SIG8 = SIGFPE,
-    SIG9 = SIGKILL,
-    SIG10 = SIGBUS,
-    SIG11 = SIGSEGV,
-    SIG12 = SIGSYS,
-    SIG13 = SIGPIPE,
-    SIG14 = SIGALRM,
-    SIG15 = SIGTERM,
-    SIG16 = SIGURG,
-    SIG17 = SIGSTOP,
-    SIG18 = SIGTSTP,
-    SIG19 = SIGCONT,
-    SIG20 = SIGCHLD,
-    SIG21 = SIGTTIN,
-    SIG22 = SIGTTOU,
-    SIG23 = SIGPOLL,
-    SIG24 = 24, // SIGXCPU,
-    SIG25 = 25, // SIGXFSZ,
-    SIG26 = 26, // SIGVTALRM,
-    SIG27 = 27, // SIGPROF,
-    SIG28 = SIGWINCH,
-    SIG29 = 29, // SIGLOST,
-    SIG30 = SIGUSR1,
-    SIG31 = SIGUSR2,
-    SIGRT_MIN = 27, // SIGRTMIN,
-    SIGRT_MAX = 31, // SIGRTMAX,
-    SIGMAX = NSIG,
+    SIG1  = SIGHUP,  // Hangup detected on controlling terminal or death of controlling process
+    SIG2  = SIGINT,  // Interrupt from keyboard
+    SIG3  = SIGQUIT, // Quit from keyboard
+    SIG4  = SIGILL,  // Illegal instruction
+    SIG5  = SIGTRAP, // Trace trap
+    SIG6  = SIGABRT, // Abort signal from abort(3)
+    SIG7  = SIGEMT,  // Emulator trap
+    SIG8  = SIGFPE,  // Floating-point exception
+    SIG9  = SIGKILL, // Kill signal
+    SIG10 = SIGBUS,  // Bus error
+    SIG11 = SIGSEGV, // Segmentation fault
+    SIG12 = SIGSYS,  // Bad system call
+    SIG13 = SIGPIPE, // Broken pipe
+    SIG14 = SIGALRM, // Timer signal from alarm(2)
+    SIG15 = SIGTERM, // Termination signal
+    SIG16 = SIGURG,  // Urgent condition on socket
+    SIG17 = SIGSTOP, // Stop executing (cannot be caught or ignored)
+    SIG18 = SIGTSTP, // Stop signal from keyboard to suspend execution
+    SIG19 = SIGCONT, // Continue if stopped
+    SIG20 = SIGCHLD, // Child status has changed
+    SIG21 = SIGTTIN, // Background read from control terminal attempted by background process
+    SIG22 = SIGTTOU, // Background write to control terminal attempted by background process
+    SIG23 = SIGPOLL, // Pollable event
+    SIG24 = 24,      // SIGXCPU: CPU time limit exceeded
+    SIG25 = 25,      // SIGXFSZ: File size limit exceeded
+    SIG26 = 26,      // SIGVTALRM: Virtual timer expired
+    SIG27 = 27,      // SIGPROF: Profiling timer expired
+    SIG28 = SIGWINCH,// Window size changed
+    SIG29 = 29,      // SIGLOST
+    SIG30 = SIGUSR1, // User-defined signal 1
+    SIG31 = SIGUSR2, // User-defined signal 2
+    SIGRT_MIN = 27, // SIGRTMIN: Minimum real-time signal number
+    SIGRT_MAX = 31, // SIGRTMAX: Maximum real-time signal number
+    SIGMAX    = NSIG // Number of signals (total)
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
    modified:   components/libc/posix/delay/delay.c                 Added comments for all functions in this file
    modified:   components/libc/posix/signal/posix_signal.c         Add comments to the sigqueue function, although it does not have an internal implementation
    modified:   components/libc/posix/signal/posix_signal.h         Added detailed explanation to all members of the rt_signal_value enumeration

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
