### PR TITLE
improve phy interface driver

### DIFF
--- a/components/drivers/include/drivers/phy.h
+++ b/components/drivers/include/drivers/phy.h
@@ -55,11 +55,11 @@ typedef rt_int32_t rt_phy_status;
 struct rt_phy_ops
 {
     rt_phy_status (*init)(void *object, rt_uint32_t phy_addr, rt_uint32_t src_clock_hz);
-    rt_phy_status (*read)(rt_uint32_t reg, rt_uint32_t *data);
-    rt_phy_status (*write)(rt_uint32_t reg, rt_uint32_t data);
-    rt_phy_status (*loopback)(rt_uint32_t mode, rt_uint32_t speed, rt_bool_t enable);
-    rt_phy_status (*get_link_status)(rt_bool_t *status);
-    rt_phy_status (*get_link_speed_duplex)(rt_uint32_t *speed, rt_uint32_t *duplex);
+    rt_phy_status (*read)(rt_phy_t *phy, rt_uint32_t reg, rt_uint32_t *data);
+    rt_phy_status (*write)(rt_phy_t *phy, rt_uint32_t reg, rt_uint32_t data);
+    rt_phy_status (*loopback)(rt_phy_t *phy, rt_uint32_t mode, rt_uint32_t speed, rt_bool_t enable);
+    rt_phy_status (*get_link_status)(rt_phy_t *phy, rt_bool_t *status);
+    rt_phy_status (*get_link_speed_duplex)(rt_phy_t *phy, rt_uint32_t *speed, rt_uint32_t *duplex);
 };
 
 rt_err_t rt_hw_phy_register(struct rt_phy_device *phy, const char *name);


### PR DESCRIPTION
Current issue:
The current rt_phy_ops API can not specify phy in multi-phy case

Solution:
Add one parameter phy to specify phy instance

