### PR TITLE
[fal]修正类型不匹配

### DIFF
--- a/components/fal/src/fal_rtt.c
+++ b/components/fal/src/fal_rtt.c
@@ -212,7 +212,7 @@ struct fal_mtd_nor_device
     const struct fal_partition     *fal_part;
 };
 
-static rt_ssize_t mtd_nor_dev_read(struct rt_mtd_nor_device* device, rt_off_t offset, rt_uint8_t* data, rt_uint32_t length)
+static rt_ssize_t mtd_nor_dev_read(struct rt_mtd_nor_device* device, rt_off_t offset, rt_uint8_t* data, rt_size_t length)
 {
     int ret = 0;
     struct fal_mtd_nor_device *part = (struct fal_mtd_nor_device*) device;
@@ -233,7 +233,7 @@ static rt_ssize_t mtd_nor_dev_read(struct rt_mtd_nor_device* device, rt_off_t of
     return ret;
 }
 
-static rt_ssize_t mtd_nor_dev_write(struct rt_mtd_nor_device* device, rt_off_t offset, const rt_uint8_t* data, rt_uint32_t length)
+static rt_ssize_t mtd_nor_dev_write(struct rt_mtd_nor_device* device, rt_off_t offset, const rt_uint8_t* data, rt_size_t length)
 {
     int ret = 0;
     struct fal_mtd_nor_device *part;
@@ -255,7 +255,7 @@ static rt_ssize_t mtd_nor_dev_write(struct rt_mtd_nor_device* device, rt_off_t o
     return ret;
 }
 
-static rt_err_t mtd_nor_dev_erase(struct rt_mtd_nor_device* device, rt_off_t offset, rt_uint32_t length)
+static rt_err_t mtd_nor_dev_erase(struct rt_mtd_nor_device* device, rt_off_t offset, rt_size_t length)
 {
     int ret = 0;
     struct fal_mtd_nor_device *part;
@@ -265,7 +265,7 @@ static rt_err_t mtd_nor_dev_erase(struct rt_mtd_nor_device* device, rt_off_t off
 
     ret = fal_partition_erase(part->fal_part, offset, length);
 
-    if ((rt_uint32_t)ret != length || ret < 0)
+    if (ret != (int)length || ret < 0)
     {
         return -RT_ERROR;
     }
@@ -277,10 +277,10 @@ static rt_err_t mtd_nor_dev_erase(struct rt_mtd_nor_device* device, rt_off_t off
 
 static const struct rt_mtd_nor_driver_ops _ops =
 {
-    RT_NULL,
-    mtd_nor_dev_read,
-    mtd_nor_dev_write,
-    mtd_nor_dev_erase,
+    RT_NULL,           /* read_id */
+    mtd_nor_dev_read,  /* read */
+    mtd_nor_dev_write, /* write*/
+    mtd_nor_dev_erase, /* erase_block */
 };
 
 /**


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
打开文件系统后,出现编译警告:
```
CC build\kernel\components\fal\src\fal_rtt.o
E:\Project\rt-thread\components\fal\src\fal_rtt.c:281:5: warning: initialization of 'rt_ssize_t (*)(struct rt_mtd_nor_device *, rt_off_t,  rt_uint8_t *, rt_size_t)' {aka 'int (*)(struct rt_mtd_nor_device *, long int,  unsigned char *, unsigned int)'} from incompatible pointer type 'rt_ssize_t (*)(struct rt_mtd_nor_device *, rt_off_t,  rt_uint8_t *, rt_uint32_t)' {aka 'int (*)(struct rt_mtd_nor_device *, long int,  unsigned char *, long unsigned int)'} [-Wincompatible-pointer-types]
  281 |     mtd_nor_dev_read,
      |     ^~~~~~~~~~~~~~~~
E:\Project\rt-thread\components\fal\src\fal_rtt.c:281:5: note: (near initialization for '_ops.read')
E:\Project\rt-thread\components\fal\src\fal_rtt.c:282:5: warning: initialization of 'rt_ssize_t (*)(struct rt_mtd_nor_device *, rt_off_t,  const rt_uint8_t *, rt_size_t)' {aka 'int (*)(struct rt_mtd_nor_device *, long int,  const unsigned char *, unsigned int)'} from incompatible pointer type 'rt_ssize_t (*)(struct rt_mtd_nor_device *, rt_off_t,  const rt_uint8_t *, rt_uint32_t)' {aka 'int (*)(struct rt_mtd_nor_device *, long int,  const unsigned char *, long unsigned int)'} [-Wincompatible-pointer-types]
  282 |     mtd_nor_dev_write,
      |     ^~~~~~~~~~~~~~~~~
E:\Project\rt-thread\components\fal\src\fal_rtt.c:282:5: note: (near initialization for '_ops.write')
E:\Project\rt-thread\components\fal\src\fal_rtt.c:283:5: warning: initialization of 'rt_err_t (*)(struct rt_mtd_nor_device *, rt_off_t,  rt_size_t)' {aka 'long int (*)(struct rt_mtd_nor_device *, long int,  unsigned int)'} from incompatible pointer type 'rt_err_t (*)(struct rt_mtd_nor_device *, rt_off_t,  rt_uint32_t)' {aka 'long int (*)(struct rt_mtd_nor_device *, long int,  long unsigned int)'} [-Wincompatible-pointer-types]
  283 |     mtd_nor_dev_erase,
      |     ^~~~~~~~~~~~~~~~~
E:\Project\rt-thread\components\fal\src\fal_rtt.c:283:5: note: (near initialization for '_ops.erase_block')
```

#### 为什么提交这份PR (why to submit this PR)


#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 
- BSP: bsp\stm32\stm32l475-atk-pandora
- .config:
 选中 `Enable File System` - `Enable SDCARD(FATFS)` 
<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
