### PR TITLE
[fix] 添加创建线程函数时间片参数检查

### DIFF
--- a/src/thread.c
+++ b/src/thread.c
@@ -343,6 +343,7 @@ rt_err_t rt_thread_init(struct rt_thread *thread,
     /* parameter check */
     RT_ASSERT(thread != RT_NULL);
     RT_ASSERT(stack_start != RT_NULL);
+    RT_ASSERT(tick != 0);
 
     /* initialize thread object */
     rt_object_init((rt_object_t)thread, RT_Object_Class_Thread, name);
@@ -512,6 +513,9 @@ rt_thread_t rt_thread_create(const char *name,
                              rt_uint8_t  priority,
                              rt_uint32_t tick)
 {
+    /* parameter check */
+    RT_ASSERT(tick != 0);
+
     struct rt_thread *thread;
     void *stack_start;
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[问题]  创建相同优先级的线程，线程时间片设置为0，在rt_tick_increase中会将该线程的时间片变为最大
若存在俩个线程使用轮询的方式调度，则首先启动的线程会长时间占用CPU
[解决办法]  在创建线程时添加对时间片的断言检查
[测试环境]  art-pi + MDK5
