### PR TITLE
[bsp][cvitek] 修正PIN设备的控制宏

### DIFF
--- a/bsp/cvitek/drivers/SConscript
+++ b/bsp/cvitek/drivers/SConscript
@@ -18,7 +18,7 @@ elif GetDepend('BOARD_TYPE_MILKV_DUO') or GetDepend('BOARD_TYPE_MILKV_DUO_SPINOR
 CPPPATH += [cwd + r'/libraries']
 CPPPATH += [cwd + r'/libraries/' + CHIP_TYPE]
 
-if GetDepend('BSP_USING_CV180X'):
+if GetDepend('BSP_USING_CV18XX'):
     src += ['drv_gpio.c']
 
 if GetDepend('BSP_USING_I2C'):


### PR DESCRIPTION
- 问题：PIN设备未初始化
- 原因：`BSP_USING_CV18XX`仅在scons脚本中使用，Kconfig中不存在
- 修正：改为Kconfig中存在的宏： `BSP_USING_CV180X`
- 验证平台：`milkv-duo`