### PR TITLE
[libcpu] fix function replaced by macro

### DIFF
--- a/libcpu/arm/cortex-m7/cpu_cache.c
+++ b/libcpu/arm/cortex-m7/cpu_cache.c
@@ -17,6 +17,8 @@
 /* The L1-caches on all CortexÂ®-M7s are divided into lines of 32 bytes. */
 #define L1CACHE_LINESIZE_BYTE       (32)
 
+#ifdef RT_USING_CACHE
+
 void rt_hw_cpu_icache_enable(void)
 {
     SCB_EnableICache();
@@ -89,3 +91,6 @@ void rt_hw_cpu_dcache_ops(int ops, void* addr, int size)
         RT_ASSERT(0);
     }
 }
+
+#endif /* RT_USING_CACHE */
+


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

在未使能 `RT_USING_CACHE` 时，`cpu_cache.c` 的函数定义会被替换为空，加上宏开关解决这个问题

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
