### PR TITLE
[bsp][stm32] fix bugs of i2c hardware drivers, test on STM32F429IGTx

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/i2c_hard_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/i2c_hard_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2024-02-06     Dyyt587   first version
+ * 2024-04-23     Zeidan    Add I2Cx_xx_DMA_CONFIG
  */
 #ifndef __I2C_HARD_CONFIG_H__
 #define __I2C_HARD_CONFIG_H__
@@ -32,6 +33,15 @@ extern "C" {
 
 #ifdef BSP_I2C1_TX_USING_DMA
 #ifndef I2C1_TX_DMA_CONFIG
+#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
+#define I2C1_TX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C1_TX_DMA_RCC,                 \
+        .Instance = I2C1_TX_DMA_INSTANCE,           \
+        .dma_irq = I2C1_TX_DMA_IRQ,                 \
+        .channel = I2C1_TX_DMA_CHANNEL              \
+    }
+#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
 #define I2C1_TX_DMA_CONFIG                          \
     {                                               \
         .dma_rcc = I2C1_TX_DMA_RCC,                 \
@@ -39,11 +49,21 @@ extern "C" {
         .dma_irq = I2C1_TX_DMA_IRQ,                 \
         .request = DMA_REQUEST_I2C1_TX              \
     }
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
 #endif /* I2C1_TX_DMA_CONFIG */
 #endif /* BSP_I2C1_TX_USING_DMA */
 
 #ifdef BSP_I2C1_RX_USING_DMA
 #ifndef I2C1_RX_DMA_CONFIG
+#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
+#define I2C1_RX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C1_RX_DMA_RCC,                 \
+        .Instance = I2C1_RX_DMA_INSTANCE,           \
+        .dma_irq = I2C1_RX_DMA_IRQ,                 \
+        .channel = I2C1_RX_DMA_CHANNEL,             \
+    }
+#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
 #define I2C1_RX_DMA_CONFIG                          \
     {                                               \
         .dma_rcc = I2C1_RX_DMA_RCC,                 \
@@ -51,6 +71,7 @@ extern "C" {
         .dma_irq = I2C1_RX_DMA_IRQ,                 \
         .request = DMA_REQUEST_I2C1_RX              \
     }
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
 #endif /* I2C1_RX_DMA_CONFIG */
 #endif /* BSP_I2C1_RX_USING_DMA */
 
@@ -70,6 +91,15 @@ extern "C" {
 
 #ifdef BSP_I2C2_TX_USING_DMA
 #ifndef I2C2_TX_DMA_CONFIG
+#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
+#define I2C2_TX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C2_TX_DMA_RCC,                 \
+        .Instance = I2C2_TX_DMA_INSTANCE,           \
+        .dma_irq = I2C2_TX_DMA_IRQ,                 \
+        .channel = I2C2_TX_DMA_CHANNEL,             \
+    }
+#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
 #define I2C2_TX_DMA_CONFIG                          \
     {                                               \
         .dma_rcc = I2C2_TX_DMA_RCC,                 \
@@ -77,11 +107,21 @@ extern "C" {
         .dma_irq = I2C2_TX_DMA_IRQ,                 \
         .request = DMA_REQUEST_I2C2_TX              \
     }
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
 #endif /* I2C2_TX_DMA_CONFIG */
 #endif /* BSP_I2C2_TX_USING_DMA */
 
 #ifdef BSP_I2C2_RX_USING_DMA
 #ifndef I2C2_RX_DMA_CONFIG
+#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
+#define I2C2_RX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C2_RX_DMA_RCC,                 \
+        .Instance = I2C2_RX_DMA_INSTANCE,           \
+        .dma_irq = I2C2_RX_DMA_IRQ,                 \
+        .channel = I2C2_RX_DMA_CHANNEL,             \
+    }
+#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
 #define I2C2_RX_DMA_CONFIG                          \
     {                                               \
         .dma_rcc = I2C2_RX_DMA_RCC,                 \
@@ -89,6 +129,7 @@ extern "C" {
         .dma_irq = I2C2_RX_DMA_IRQ,                 \
         .request = DMA_REQUEST_I2C2_RX              \
     }
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
 #endif /* I2C2_RX_DMA_CONFIG */
 #endif /* BSP_I2C2_RX_USING_DMA */
 
@@ -108,6 +149,15 @@ extern "C" {
 
 #ifdef BSP_I2C3_TX_USING_DMA
 #ifndef I2C3_TX_DMA_CONFIG
+#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
+#define I2C3_TX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C3_TX_DMA_RCC,                 \
+        .Instance = I2C3_TX_DMA_INSTANCE,           \
+        .dma_irq = I2C3_TX_DMA_IRQ,                 \
+        .channel = I2C3_TX_DMA_CHANNEL,             \
+    }
+#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
 #define I2C3_TX_DMA_CONFIG                          \
     {                                               \
         .dma_rcc = I2C3_TX_DMA_RCC,                 \
@@ -115,11 +165,21 @@ extern "C" {
         .dma_irq = I2C3_TX_DMA_IRQ,                 \
         .request = DMA_REQUEST_I2C3_TX              \
     }
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
 #endif /* I2C3_TX_DMA_CONFIG */
 #endif /* BSP_I2C3_TX_USING_DMA */
 
 #ifdef BSP_I2C3_RX_USING_DMA
 #ifndef I2C3_RX_DMA_CONFIG
+#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
+#define I2C3_RX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C3_RX_DMA_RCC,                 \
+        .Instance = I2C3_RX_DMA_INSTANCE,           \
+        .dma_irq = I2C3_RX_DMA_IRQ,                 \
+        .channel = I2C3_RX_DMA_CHANNEL,             \
+    }
+#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
 #define I2C3_RX_DMA_CONFIG                          \
     {                                               \
         .dma_rcc = I2C3_RX_DMA_RCC,                 \
@@ -127,6 +187,7 @@ extern "C" {
         .dma_irq = I2C3_RX_DMA_IRQ,                 \
         .request = DMA_REQUEST_I2C3_RX              \
     }
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
 #endif /* I2C3_RX_DMA_CONFIG */
 #endif /* BSP_I2C3_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
@@ -203,11 +203,11 @@ static rt_ssize_t stm32_i2c_master_xfer(struct rt_i2c_bus_device *bus,
                                                                                                                                                          : "nuknown mode");
             if ((i2c_obj->i2c_dma_flag & I2C_USING_RX_DMA_FLAG) && (msg->len >= DMA_TRANS_MIN_LEN))
             {
-                ret = HAL_I2C_Master_Seq_Receive_DMA(handle, msg->addr, msg->buf, msg->len, mode);
+                ret = HAL_I2C_Master_Seq_Receive_DMA(handle, (msg->addr<<1), msg->buf, msg->len, mode);
             }
             else
             {
-                ret = HAL_I2C_Master_Seq_Receive_IT(handle, msg->addr, msg->buf, msg->len, mode);
+                ret = HAL_I2C_Master_Seq_Receive_IT(handle, (msg->addr<<1), msg->buf, msg->len, mode);
             }
             if (ret != RT_EOK)
             {
@@ -228,11 +228,11 @@ static rt_ssize_t stm32_i2c_master_xfer(struct rt_i2c_bus_device *bus,
                                                                                                                                                          : "nuknown mode");
             if ((i2c_obj->i2c_dma_flag & I2C_USING_TX_DMA_FLAG) && (msg->len >= DMA_TRANS_MIN_LEN))
             {
-                ret = HAL_I2C_Master_Seq_Transmit_DMA(handle, msg->addr, msg->buf, msg->len, mode);
+                ret = HAL_I2C_Master_Seq_Transmit_DMA(handle, (msg->addr<<1), msg->buf, msg->len, mode);
             }
             else
             {
-                ret = HAL_I2C_Master_Seq_Transmit_IT(handle, msg->addr, msg->buf, msg->len, mode);
+                ret = HAL_I2C_Master_Seq_Transmit_IT(handle, (msg->addr<<1), msg->buf, msg->len, mode);
             }
             if (ret != RT_EOK)
             {
@@ -263,11 +263,11 @@ static rt_ssize_t stm32_i2c_master_xfer(struct rt_i2c_bus_device *bus,
                                                                                                                                                    : "nuknown mode");
         if ((i2c_obj->i2c_dma_flag & I2C_USING_RX_DMA_FLAG) && (msg->len >= DMA_TRANS_MIN_LEN))
         {
-            ret = HAL_I2C_Master_Seq_Receive_DMA(handle, msg->addr, msg->buf, msg->len, mode);
+            ret = HAL_I2C_Master_Seq_Receive_DMA(handle, (msg->addr<<1), msg->buf, msg->len, mode);
         }
         else
         {
-            ret = HAL_I2C_Master_Seq_Receive_IT(handle, msg->addr, msg->buf, msg->len, mode);
+            ret = HAL_I2C_Master_Seq_Receive_IT(handle,(msg->addr<<1), msg->buf, msg->len, mode);
         }
         if (ret != RT_EOK)
         {
@@ -287,11 +287,11 @@ static rt_ssize_t stm32_i2c_master_xfer(struct rt_i2c_bus_device *bus,
                                                                                                                                                    : "nuknown mode");
         if ((i2c_obj->i2c_dma_flag & I2C_USING_TX_DMA_FLAG) && (msg->len >= DMA_TRANS_MIN_LEN))
         {
-            ret = HAL_I2C_Master_Seq_Transmit_DMA(handle, msg->addr, msg->buf, msg->len, mode);
+            ret = HAL_I2C_Master_Seq_Transmit_DMA(handle, (msg->addr<<1), msg->buf, msg->len, mode);
         }
         else
         {
-            ret = HAL_I2C_Master_Seq_Transmit_IT(handle, msg->addr, msg->buf, msg->len, mode);
+            ret = HAL_I2C_Master_Seq_Transmit_IT(handle, (msg->addr<<1), msg->buf, msg->len, mode);
         }
         if (ret != RT_EOK)
         {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
我在STM32F429IGTx设备上使用硬件i2c驱动程序师遇到以下几个问题：
1. 语法错误：drv_hard_i2c.c 行67、68中i2c_handle未正常替换过来，估计是上个版本对变量重命名后因为宏定义忽略了此处修改；
2. 语法错误：drv_hard_i2c.c 行326中缺少一个"}"导致编译出错；
3. 初始化i2c设备过程中对双地址选项进行设置时（i2c_handle->Init.OwnAddress2Masks = I2C_OA2_NOMASK），STM32F4系列SOC没有这个配置定义，于是我直接将双地址模式关闭了（i2c_handle->Init.DualAddressMode = I2C_DUALADDRESS_DISABLE）；
4. 初始化i2c设备（DMA方式）过程中发现i2c_hard_config.h文件中未定义DMA通道配置；
5. i2c设备传输过程中，发现i2c从机收不到数据，i2c主机也收不到数据，最终问题定位至HAL_I2C_Master_Seq_Receive_xx、HAL_I2C_Master_Seq_Transmit_xx系列接口调用中，传参将设备地址左移了一位(msg->addr<<1)，不太理解这个做法，个人认定是个bug，感觉上层传过来的i2c从机设备地址不应进行修改，应直接透传；

主要补丁如下：
1. 修复硬件i2c驱动代码中语法错误（drv_hard_i2c.c行67、68、326）；
2. 关闭默认i2c双地址模式（drv_hard_i2c.c行75：I2C_DUALADDRESS_DISABLE）；
3. 修改硬件i2c调用HAL库传输接口从机设备地址传参，原代码中从机设备地址传参为：(msg->addr<<1)，修改为：msg->addr（drv_hard_i2c.c行206、210、231、235、266、270、290、294）；
4. 添加硬件i2c驱动配置文件DMA相关配置项，增加对SOC_SERIES_STM32F2、SOC_SERIES_STM32F4、SOC_SERIES_STM32F7系列芯片配置DMA_CHANNEL的适配；

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
