### PR TITLE
[drivers][ofw] Fixed fdt_scan_memory() memory adjustment bug

### DIFF
--- a/components/drivers/ofw/fdt.c
+++ b/components/drivers/ofw/fdt.c
@@ -476,6 +476,19 @@ static rt_err_t fdt_scan_memory(void)
             }
 
             /*
+             *  +--------+                                    +--------+
+             *  | memory |                                    | memory |
+             *  +--------+  +----------+        +----------+  +--------+
+             *              | reserved |        | reserved |
+             *              +----------+        +----------+
+             */
+            if (res_region->start >= region->end || res_region->end <= region->start)
+            {
+                /* No adjustments needed */
+                continue;
+            }
+
+            /*
              * case 0:                      case 1:
              *  +------------------+             +----------+
              *  |      memory      |             |  memory  |
@@ -490,53 +503,49 @@ static rt_err_t fdt_scan_memory(void)
              *                 | reserved |  | reserved |
              *                 +----------+  +----------+
              */
-
-            /* case 0 */
-            if (res_region->start > region->start && res_region->end < region->end)
+            if (res_region->start > region->start)
             {
-                rt_size_t new_size = region->end - res_region->end;
-
-                region->end = res_region->start;
-
-                /* Commit part next block */
-                err = commit_memregion(region->name, res_region->end, new_size, RT_FALSE);
-
-                if (!err)
+                if (res_region->end < region->end)
                 {
-                    ++no;
+                    /* case 0 */
+                    rt_size_t new_size = region->end - res_region->end;
 
-                    /* Scan again */
-                    region = &_memregion[0];
-                    --region;
+                    region->end = res_region->start;
+
+                    /* Commit part next block */
+                    err = commit_memregion(region->name, res_region->end, new_size, RT_FALSE);
+
+                    if (!err)
+                    {
+                        ++no;
+
+                        /* Scan again */
+                        region = &_memregion[0];
+                        --region;
+
+                        break;
+                    }
+                }
+                else
+                {
+                    /* case 2 */
+                    region->end = res_region->start;
+                }
+            }
+            else
+            {
+                if (res_region->end < region->end)
+                {
+                    /* case 3 */
+                    region->start = res_region->end;
+                }
+                else
+                {
+                    /* case 1 */
+                    region->name = RT_NULL;
 
                     break;
                 }
-
-                continue;
-            }
-
-            /* case 1 */
-            if (res_region->start <= region->start && res_region->end >= region->end)
-            {
-                region->name = RT_NULL;
-
-                break;
-            }
-
-            /* case 2 */
-            if (res_region->start <= region->end && res_region->end >= region->end)
-            {
-                region->end = res_region->start;
-
-                continue;
-            }
-
-            /* case 3 */
-            if (res_region->start <= region->start && res_region->end >= region->start)
-            {
-                region->start = res_region->end;
-
-                continue;
             }
         }
     }

--- a/components/drivers/ofw/fdt.c
+++ b/components/drivers/ofw/fdt.c
@@ -492,17 +492,14 @@ static rt_err_t fdt_scan_memory(void)
              */
 
             /* case 0 */
-            if (res_region->start >= region->start && res_region->end <= region->end)
+            if (res_region->start > region->start && res_region->end < region->end)
             {
                 rt_size_t new_size = region->end - res_region->end;
 
                 region->end = res_region->start;
 
                 /* Commit part next block */
-                if (new_size)
-                {
-                    err = commit_memregion(region->name, res_region->end, new_size, RT_FALSE);
-                }
+                err = commit_memregion(region->name, res_region->end, new_size, RT_FALSE);
 
                 if (!err)
                 {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

在调用fdt_scan_memory对设备树的内存进行解析后，会根据保留内存对整个内存重新做出一些调整。如下图(添加了一些打印信息)：

![image](https://github.com/RT-Thread/rt-thread/assets/64183082/6ef2112e-c4b1-471f-8c96-afde8c4052b7)

如图所示，调整后出现了一个起始地址等于结束地址的一个无效mem_region。

```
[I/rtdm.ofw]   (NULL)           [0x00000000441581a0, 0x00000000441581a0]
```

排查发现是对case 0情况的判断条件不妥。

```
/*
             * case 0:                      case 1:
             *  +------------------+             +----------+
             *  |      memory      |             |  memory  |
             *  +---+----------+---+         +---+----------+---+
             *      | reserved |             |     reserved     |
             *      +----------+             +---+----------+---+
             *
             * case 2:                      case 3:
             *  +------------------+                +------------------+
             *  |      memory      |                |      memory      |
             *  +--------------+---+------+  +------+---+--------------+
             *                 | reserved |  | reserved |
             *                 +----------+  +----------+
             */
```

如果出现了一个res_region->start = region->start 和 res_region->end < region->end 的情况。

```
+------------------+
|      memory      |
+----------+-------+
| reserved |    
+----------+    
```

按照目前的代码，是符合case 0 情况的，那么这里调整后会出现两个mem_region，其中一个的起始地址等于结束地址。显然这是不合理的，对于这种情况，直接走case 3 情况处理即可。而且这里这个mem_region将会在下一次遍历为mem_region->name赋值为RT_NULL，那这样做其实也是会影响外层for循环的执行的(for (no = 0; region->name; ++region){})。

这里我做了一个验证，我故意多commit了几个内存保留区域（基于qemu-virt64-aarch64）。

![image](https://github.com/RT-Thread/rt-thread/assets/64183082/b18d3cc3-59e6-447b-b903-088a326d1477)

结果，并没有为0x46000000~0x46001000这段空间进行调整，肯定是不符合要求的。

![image](https://github.com/RT-Thread/rt-thread/assets/64183082/6d408e6d-bad5-4e9a-a002-b2b1ae2a40aa)

按照我目前pr的修改方式，可以解决这个问题。

![image](https://github.com/RT-Thread/rt-thread/assets/64183082/a81859f3-4cf0-4e71-8656-1c586c31b4ac)

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
