### PR TITLE
[mem]When using SLAB, calls to memcheck and memtrace will be abnormal

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -630,9 +630,9 @@ static int memtrace(int argc, char **argv)
         /* show memory information */
         rt_kprintf("\nmemory heap address:\n");
         rt_kprintf("name    : %s\n", m->parent.parent.name);
-        rt_kprintf("total   : 0x%d\n", m->parent.total);
-        rt_kprintf("used    : 0x%d\n", m->parent.used);
-        rt_kprintf("max_used: 0x%d\n", m->parent.max);
+        rt_kprintf("total   : %d\n", m->parent.total);
+        rt_kprintf("used    : %d\n", m->parent.used);
+        rt_kprintf("max_used: %d\n", m->parent.max);
         rt_kprintf("heap_ptr: 0x%08x\n", m->heap_ptr);
         rt_kprintf("lfree   : 0x%08x\n", m->lfree);
         rt_kprintf("heap_end: 0x%08x\n", m->heap_end);

--- a/src/mem.c
+++ b/src/mem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2022, RT-Thread Development Team
+ * Copyright (c) 2006-2024, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -565,9 +565,16 @@ static int memcheck(int argc, char *argv[])
         object = rt_list_entry(node, struct rt_object, list);
         /* find the specified object */
         if (name != RT_NULL && rt_strncmp(name, object->name, RT_NAME_MAX) != 0)
+        {
             continue;
+        }
         /* mem object */
         m = (struct rt_small_mem *)object;
+        if(rt_strncmp(m->parent.algorithm, "small", RT_NAME_MAX) != 0)
+        {
+            continue;
+        }
+
         /* check mem */
         for (mem = (struct rt_small_mem_item *)m->heap_ptr; mem != m->heap_end; mem = (struct rt_small_mem_item *)&m->heap_ptr[mem->next])
         {
@@ -611,9 +618,15 @@ static int memtrace(int argc, char **argv)
         object = rt_list_entry(node, struct rt_object, list);
         /* find the specified object */
         if (name != RT_NULL && rt_strncmp(name, object->name, RT_NAME_MAX) != 0)
+        {
             continue;
+        }
         /* mem object */
         m = (struct rt_small_mem *)object;
+        if(rt_strncmp(m->parent.algorithm, "small", RT_NAME_MAX) != 0)
+        {
+            continue;
+        }
         /* show memory information */
         rt_kprintf("\nmemory heap address:\n");
         rt_kprintf("name    : %s\n", m->parent.parent.name);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
当使用SLAB时，控制台调用memcheck和memtrace的将会异常

#### 你的解决方案是什么 (what is your solution)
memcheck和memtrace时判断当前内存算法为小内存算法才去执行判断逻辑

#### 请提供验证的bsp和config (provide the config and bsp) 
- BSP:bsp/stm32/stm32H750

- .config:
CONFIG_RT_USING_SLAB_AS_HEAP=y
or
CONFIG_RT_USING_SMALL_MEM_AS_HEAP=y

- 验证使用SLAB算法时,memcheck和memtrace不打印不生效不执行
- 验证使用small mem算法时,memcheck和memtrace生效
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
