### PR TITLE
[bsp][gd32] 修复串口驱动中由于可能的中断嵌套而导致RB索引异常的问题

### DIFF
--- a/bsp/gd32/arm/libraries/gd32_drivers/drv_usart_v2.c
+++ b/bsp/gd32/arm/libraries/gd32_drivers/drv_usart_v2.c
@@ -233,13 +233,15 @@ static void dma_recv_isr (struct rt_serial_device *serial)
 {
     struct gd32_uart *uart;
     rt_size_t recv_len, counter;
+    rt_base_t level;
 
     RT_ASSERT(serial != RT_NULL);
     uart = rt_container_of(serial, struct gd32_uart, serial);
 
     recv_len = 0;
+    
+    level = rt_hw_interrupt_disable();
     counter = dma_transfer_number_get(uart->dma.rx.periph, uart->dma.rx.channel);
-
     if (counter <= uart->dma.last_index)
     {
         recv_len = uart->dma.last_index - counter;
@@ -248,10 +250,11 @@ static void dma_recv_isr (struct rt_serial_device *serial)
     {
         recv_len = serial->config.rx_bufsz + uart->dma.last_index - counter;
     }
+    uart->dma.last_index = counter;
+    rt_hw_interrupt_enable(level);
 
     if (recv_len)
     {
-        uart->dma.last_index = counter;
         rt_hw_serial_isr(serial, RT_SERIAL_EVENT_RX_DMADONE | (recv_len << 8));
     }
 }

--- a/bsp/gd32/arm/libraries/gd32_drivers/drv_usart_v2.c
+++ b/bsp/gd32/arm/libraries/gd32_drivers/drv_usart_v2.c
@@ -239,7 +239,6 @@ static void dma_recv_isr (struct rt_serial_device *serial)
     uart = rt_container_of(serial, struct gd32_uart, serial);
 
     recv_len = 0;
-    
     level = rt_hw_interrupt_disable();
     counter = dma_transfer_number_get(uart->dma.rx.periph, uart->dma.rx.channel);
     if (counter <= uart->dma.last_index)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
`dma_recv_isr` 的中断调用源有两个：
1. 串口 IDLE 中断
2. DMA 完成半完成中断

因此，如果同时使能了这两个中断，并且中断优先级不同的情况下（目前这是默认情况），一旦出现中断嵌套并且出现嵌套的位置为 `recv_len` 计算后（并且 `recv_len` 不为零），那么就会出现其中一个中断处理已经准备携带不为零的 `recv_len`  进入 `rt_hw_serial_isr`（进入后会更新 RB 索引），但被另一个中断打断，并且这个嵌套的中断同样会计算出与上一个中断同样的 `recv_len` 并进入 `rt_hw_serial_isr` 更新 RB 索引，可以预见这种情况下 RB 索引会被更新两次，从而出现数据异常。并且这个异常一旦出现，数据将永久错位无法自动恢复。

#### 你的解决方案是什么 (what is your solution)

使用开关中断来创建一个临界区，保护 `recv_len` 在计算过程中不会出现重入，这样即使出现中断在计算前出现嵌套并触发两次计算，由于第一次计算时已经更新了 `uart->dma.last_index`，第二次计算时 `recv_len` 会为零，自然也就不会进入 `rt_hw_serial_isr` 从而出现 RB 索引更新两次的情况。

#### 请提供验证的bsp和config (provide the config and bsp) 
GD32450Z-EVAL

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:  bsp/gd32/arm/gd32450z-eval

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
