### PR TITLE
[drivers][ofw] fix ofw_alias_scan() bug

### DIFF
--- a/components/drivers/ofw/base.c
+++ b/components/drivers/ofw/base.c
@@ -1051,7 +1051,7 @@ rt_err_t ofw_alias_scan(void)
 
     rt_ofw_foreach_prop(np, prop)
     {
-        int id = 0, rate = 1;
+        int id = 0;
         struct alias_info *info;
         const char *name = prop->name, *end;
 
@@ -1066,17 +1066,17 @@ rt_err_t ofw_alias_scan(void)
             continue;
         }
 
-        end = name + rt_strlen(name) - 1;
+        end = name + rt_strlen(name);
 
-        while (*end && !(*end >= '0' && *end <= '9') && end > name)
+        while (*(end - 1) && (*(end - 1) >= '0' && *(end - 1) <= '9') && end > name)
         {
             --end;
         }
 
         while (*end && (*end >= '0' && *end <= '9'))
         {
-            id += (*end - '0') * rate;
-            rate *= 10;
+            id *= 10;
+            id += (*end - '0');
 
             ++end;
         }
@@ -1093,7 +1093,7 @@ rt_err_t ofw_alias_scan(void)
 
         info->id = id;
         info->tag = name;
-        info->tag_len = end - name - 1;
+        info->tag_len = end - name;
         info->np = tmp;
 
         rt_list_insert_after(&_aliases_nodes, &info->list);

--- a/components/drivers/ofw/base.c
+++ b/components/drivers/ofw/base.c
@@ -1053,7 +1053,7 @@ rt_err_t ofw_alias_scan(void)
     {
         int id = 0;
         struct alias_info *info;
-        const char *name = prop->name, *end;
+        const char *name = prop->name, *end, *id_start;
 
         /* Maybe the bootloader will set the name, or other nodes reference the aliases */
         if (!rt_strcmp(name, "name") || !rt_strcmp(name, "phandle"))
@@ -1073,12 +1073,13 @@ rt_err_t ofw_alias_scan(void)
             --end;
         }
 
-        while (*end && (*end >= '0' && *end <= '9'))
+        id_start = end;
+        while (*id_start && (*id_start >= '0' && *id_start <= '9'))
         {
             id *= 10;
-            id += (*end - '0');
+            id += (*id_start - '0');
 
-            ++end;
+            ++id_start;
         }
 
         info = rt_malloc(sizeof(*info));


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

处理设备树中aliases节点对于id的解析逻辑存在问题。

假设存在如下设备树aliases节点：

```dts
aliases {
    serial123 = &pl011;
    serial12  = &pl011;
    serial1 = &pl011;
    serial = &pl011;
};
```

对应的id解析出来应该是123、12、1、0.

目前代码的解析结果：

![image](https://github.com/RT-Thread/rt-thread/assets/64183082/38eebe4f-91a7-401f-a458-fbaa41a30df4)

修改代码后的解析结果：

![image](https://github.com/RT-Thread/rt-thread/assets/64183082/6d385707-ea11-4398-9dea-4e2909594c89)

#### 你的解决方案是什么 (what is your solution)

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:

qemu-virt64-aarch64

- .config:

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
