### PR TITLE
[arm64] add hw thread self

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -740,8 +740,10 @@ struct rt_cpu
         struct rt_thread        *current_thread;
 
         rt_uint8_t              irq_switch_flag:1;
-        rt_uint8_t              critical_switch_flag:1;
         rt_uint8_t              sched_lock_flag:1;
+#ifndef ARCH_USING_HW_THREAD_SELF
+        rt_uint8_t              critical_switch_flag:1;
+#endif /* ARCH_USING_HW_THREAD_SELF */
 
         rt_uint8_t              current_priority;
         rt_list_t               priority_table[RT_THREAD_PRIORITY_MAX];

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -765,9 +765,18 @@ struct rt_cpu
     struct rt_cpu_usage_stats   cpu_stat;
 #endif
 };
-typedef struct rt_cpu *rt_cpu_t;
+
+#else /* !RT_USING_SMP */
+struct rt_cpu
+{
+    struct rt_thread            *current_thread;
+};
 
 #endif /* RT_USING_SMP */
+
+typedef struct rt_cpu *rt_cpu_t;
+/* Noted: As API to reject writing to this variable from application codes */
+#define rt_current_thread rt_thread_self()
 
 struct rt_thread;
 

--- a/include/rtsched.h
+++ b/include/rtsched.h
@@ -56,6 +56,10 @@ struct rt_sched_thread_ctx
     rt_uint8_t                  sched_flag_locked:1;    /**< calling thread have the scheduler locked */
     rt_uint8_t                  sched_flag_ttmr_set:1;  /**< thread timer is start */
 
+#ifdef ARCH_USING_HW_THREAD_SELF
+    rt_uint8_t                  critical_switch_flag:1; /**< critical switch pending */
+#endif /* ARCH_USING_HW_THREAD_SELF */
+
 #ifdef RT_USING_SMP
     rt_uint8_t                  bind_cpu;               /**< thread is bind to cpu */
     rt_uint8_t                  oncpu;                  /**< process on cpu */
@@ -138,6 +142,8 @@ rt_bool_t rt_sched_is_locked(void);
 
 #define RT_SCHED_DEBUG_IS_LOCKED
 #define RT_SCHED_DEBUG_IS_UNLOCKED
+
+extern struct rt_thread *rt_current_thread;
 #endif /* RT_USING_SMP */
 
 /**

--- a/include/rtsched.h
+++ b/include/rtsched.h
@@ -142,8 +142,6 @@ rt_bool_t rt_sched_is_locked(void);
 
 #define RT_SCHED_DEBUG_IS_LOCKED
 #define RT_SCHED_DEBUG_IS_UNLOCKED
-
-extern struct rt_thread *rt_current_thread;
 #endif /* RT_USING_SMP */
 
 /**
@@ -176,6 +174,7 @@ rt_err_t rt_sched_thread_timer_stop(struct rt_thread *thread);
 rt_err_t rt_sched_thread_timer_start(struct rt_thread *thread);
 void rt_sched_insert_thread(struct rt_thread *thread);
 void rt_sched_remove_thread(struct rt_thread *thread);
+struct rt_thread *rt_sched_thread_self(void);
 
 #endif /* defined(__RT_KERNEL_SOURCE__) || defined(__RT_IPC_SOURCE__) */
 

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -669,6 +669,12 @@ rt_err_t  rt_device_control(rt_device_t dev, int cmd, void *arg);
 void rt_interrupt_enter(void);
 void rt_interrupt_leave(void);
 
+/**
+ * CPU object
+ */
+struct rt_cpu *rt_cpu_self(void);
+struct rt_cpu *rt_cpu_index(int index);
+
 #ifdef RT_USING_SMP
 
 /*
@@ -678,9 +684,6 @@ void rt_interrupt_leave(void);
 rt_base_t rt_cpus_lock(void);
 void rt_cpus_unlock(rt_base_t level);
 void rt_cpus_lock_status_restore(struct rt_thread *thread);
-
-struct rt_cpu *rt_cpu_self(void);
-struct rt_cpu *rt_cpu_index(int index);
 
 #ifdef RT_USING_DEBUG
     rt_base_t rt_cpu_get_id(void);

--- a/libcpu/Kconfig
+++ b/libcpu/Kconfig
@@ -14,6 +14,8 @@ if ARCH_ARMV8 && ARCH_CPU_64BIT
         default y
     config ARCH_USING_GENERIC_CPUID
         bool "Using generic cpuid implemenation"
+        select ARCH_USING_HW_THREAD_SELF
+        default y if RT_USING_OFW
         default n
     endmenu
 endif
@@ -268,5 +270,9 @@ config ARCH_HOST_SIMULATOR
     bool
 
 config ARCH_CPU_STACK_GROWS_UPWARD
+    bool
+    default n
+
+config ARCH_USING_HW_THREAD_SELF
     bool
     default n

--- a/libcpu/aarch64/common/context_gcc.S
+++ b/libcpu/aarch64/common/context_gcc.S
@@ -29,12 +29,19 @@ rt_thread_switch_interrupt_flag: .zero  8
 
 .text
 
+/**
+ * #ifdef RT_USING_OFW
+ * void rt_hw_cpu_id_set(long cpuid)
+ * #else
+ * void rt_hw_cpu_id_set(void)
+ * #endif
+ */
 .type rt_hw_cpu_id_set, @function
 rt_hw_cpu_id_set:
 #ifdef ARCH_USING_GENERIC_CPUID
-    .globl rt_hw_cpu_id_set
+    .globl  rt_hw_cpu_id_set
 #else /* !ARCH_USING_GENERIC_CPUID */
-    .weak rt_hw_cpu_id_set
+    .weak   rt_hw_cpu_id_set
 #endif /* ARCH_USING_GENERIC_CPUID */
 
 #ifndef RT_USING_OFW
@@ -45,11 +52,11 @@ rt_hw_cpu_id_set:
     and     x0, x0, #15
 #endif /* !RT_USING_OFW */
 
-#ifdef ARCH_USING_GENERIC_CPUID
+#ifdef ARCH_USING_HW_THREAD_SELF
     msr     tpidrro_el0, x0
-#else
+#else /* !ARCH_USING_HW_THREAD_SELF */
     msr     tpidr_el1, x0
-#endif
+#endif /* ARCH_USING_HW_THREAD_SELF */
     ret
 
 /*

--- a/libcpu/aarch64/common/context_gcc.S
+++ b/libcpu/aarch64/common/context_gcc.S
@@ -8,6 +8,7 @@
  * 2021-05-18     Jesven       the first version
  * 2023-06-24     WangXiaoyao  Support backtrace for user thread
  * 2024-01-06     Shell        Fix barrier on irq_disable/enable
+ * 2024-01-18     Shell        fix implicit dependency of cpuid management
  */
 
 #ifndef __ASSEMBLY__
@@ -27,15 +28,28 @@ rt_thread_switch_interrupt_flag: .zero  8
 #endif
 
 .text
-.weak rt_hw_cpu_id_set
+
 .type rt_hw_cpu_id_set, @function
 rt_hw_cpu_id_set:
-    mrs x0, mpidr_el1           /* MPIDR_EL1: Multi-Processor Affinity Register */
+#ifdef ARCH_USING_GENERIC_CPUID
+    .globl rt_hw_cpu_id_set
+#else /* !ARCH_USING_GENERIC_CPUID */
+    .weak rt_hw_cpu_id_set
+#endif /* ARCH_USING_GENERIC_CPUID */
+
+#ifndef RT_USING_OFW
+    mrs     x0, mpidr_el1           /* MPIDR_EL1: Multi-Processor Affinity Register */
 #ifdef ARCH_ARM_CORTEX_A55
-    lsr x0, x0, #8
+    lsr     x0, x0, #8
+#endif /* ARCH_ARM_CORTEX_A55 */
+    and     x0, x0, #15
+#endif /* !RT_USING_OFW */
+
+#ifdef ARCH_USING_GENERIC_CPUID
+    msr     tpidrro_el0, x0
+#else
+    msr     tpidr_el1, x0
 #endif
-    and x0, x0, #15
-    msr tpidr_el1, x0
     ret
 
 /*

--- a/libcpu/aarch64/common/cpu.c
+++ b/libcpu/aarch64/common/cpu.c
@@ -232,6 +232,24 @@ int rt_hw_cpu_boot_secondary(int num_cpus, rt_uint64_t *cpu_hw_ids, struct cpu_o
 #endif /*RT_USING_SMP*/
 
 /**
+ * Generic hw-cpu-id
+ */
+#ifdef ARCH_USING_GENERIC_CPUID
+
+int rt_hw_cpu_id(void)
+{
+#if RT_CPUS_NR > 1
+    long cpuid;
+    __asm__ volatile("mrs %0, tpidrro_el0":"=r"(cpuid));
+    return cpuid;
+#else
+    return 0;
+#endif /* RT_CPUS_NR > 1 */
+}
+
+#endif /* ARCH_USING_GENERIC_CPUID */
+
+/**
  * @addtogroup ARM CPU
  */
 /*@{*/

--- a/libcpu/aarch64/cortex-a/entry_point.S
+++ b/libcpu/aarch64/cortex-a/entry_point.S
@@ -95,7 +95,6 @@ _start:
 
     /* Save cpu stack */
     get_phy stack_top, .boot_cpu_stack_top
-
     /* Save cpu id temp */
 #ifdef ARCH_USING_HW_THREAD_SELF
     msr     tpidrro_el0, xzr

--- a/libcpu/aarch64/cortex-a/entry_point.S
+++ b/libcpu/aarch64/cortex-a/entry_point.S
@@ -7,6 +7,7 @@
  * 2020-01-15     bigmagic     the first version
  * 2020-08-10     SummerGift   support clang compiler
  * 2023-04-29     GuEe-GUI     support kernel's ARM64 boot header
+ * 2024-01-18     Shell        fix implicit dependency of cpuid management
  */
 
 #ifndef __ASSEMBLY__
@@ -94,7 +95,12 @@ _start:
 
     /* Save cpu stack */
     get_phy stack_top, .boot_cpu_stack_top
+
     /* Save cpu id temp */
+#ifdef ARCH_USING_HW_THREAD_SELF
+    msr     tpidrro_el0, xzr
+    /* Save thread self */
+#endif /* ARCH_USING_HW_THREAD_SELF */
     msr     tpidr_el1, xzr
 
     bl      init_cpu_el
@@ -149,11 +155,10 @@ _secondary_cpu_entry:
 
     /* Get cpu id success */
     sub     x0, x2, #1
-    msr     tpidr_el1, x0           /* Save cpu id global */
-#else
-    bl      rt_hw_cpu_id_set
-    mrs     x0, tpidr_el1
 #endif /* RT_USING_OFW */
+    /* Save cpu id global */
+    bl      rt_hw_cpu_id_set
+    bl      rt_hw_cpu_id
 
     /* Set current cpu's stack top */
     sub     x0, x0, #1

--- a/src/cpu_up.c
+++ b/src/cpu_up.c
@@ -6,9 +6,13 @@
  * Change Logs:
  * Date           Author       Notes
  * 2024-04-19     Shell        Fixup UP irq spinlock
+ * 2024-05-22     Shell        Add UP cpu object and
+ *                             maintain the rt_current_thread inside it
  */
 #include <rthw.h>
 #include <rtthread.h>
+
+static struct rt_cpu _cpu;
 
 /**
  * @brief   Initialize a static spinlock object.
@@ -79,4 +83,26 @@ void rt_spin_unlock_irqrestore(struct rt_spinlock *lock, rt_base_t level)
     RT_SPIN_UNLOCK_DEBUG(lock, critical_level);
     rt_exit_critical_safe(critical_level);
     rt_hw_interrupt_enable(level);
+}
+
+/**
+ * @brief   This fucntion will return current cpu object.
+ *
+ * @return  Return a pointer to the current cpu object.
+ */
+struct rt_cpu *rt_cpu_self(void)
+{
+    return &_cpu;
+}
+
+/**
+ * @brief   This fucntion will return the cpu object corresponding to index.
+ *
+ * @param   index is the index of target cpu object.
+ *
+ * @return  Return a pointer to the cpu object corresponding to index.
+ */
+struct rt_cpu *rt_cpu_index(int index)
+{
+    return index == 0 ? &_cpu : RT_NULL;
 }

--- a/src/scheduler_mp.c
+++ b/src/scheduler_mp.c
@@ -1331,22 +1331,5 @@ rt_err_t rt_sched_thread_bind_cpu(struct rt_thread *thread, int cpu)
     return RT_EOK;
 }
 
-rt_thread_t rt_sched_thread_self(void)
-{
-#ifdef ARCH_USING_HW_THREAD_SELF
-    return rt_hw_thread_self();
-
-#else /* !ARCH_USING_HW_THREAD_SELF */
-    rt_thread_t self;
-    rt_base_t lock;
-
-    lock = rt_hw_local_irq_disable();
-    self = rt_cpu_self()->current_thread;
-    rt_hw_local_irq_enable(lock);
-
-    return self;
-#endif /* ARCH_USING_HW_THREAD_SELF */
-}
-
 /**@}*/
 /**@endcond*/

--- a/src/scheduler_mp.c
+++ b/src/scheduler_mp.c
@@ -33,6 +33,7 @@
  * 2023-12-10     xqyjlj       use rt_hw_spinlock
  * 2024-01-05     Shell        Fixup of data racing in rt_critical_level
  * 2024-01-18     Shell        support rt_sched_thread of scheduling status for better mt protection
+ * 2024-01-18     Shell        support rt_hw_thread_self to improve overall performance
  */
 
 #include <rtthread.h>
@@ -98,6 +99,14 @@ static struct rt_spinlock _mp_scheduler_lock;
         SCHEDULER_EXIT_CRITICAL(_curthr);  \
         rt_hw_local_irq_enable(level);     \
     } while (0)
+
+#ifdef ARCH_USING_HW_THREAD_SELF
+#define CRITICAL_SWITCH_FLAG(pcpu, curthr) (RT_SCHED_CTX(curthr).critical_switch_flag)
+
+#else /* !ARCH_USING_HW_THREAD_SELF */
+#define CRITICAL_SWITCH_FLAG(pcpu, curthr) ((pcpu)->critical_switch_flag)
+
+#endif /* ARCH_USING_HW_THREAD_SELF */
 
 static rt_uint32_t rt_thread_ready_priority_group;
 #if RT_THREAD_PRIORITY_MAX > 32
@@ -749,7 +758,7 @@ rt_err_t rt_sched_unlock_n_resched(rt_sched_lock_level_t level)
         /* leaving critical region of global context since we can't schedule */
         SCHEDULER_CONTEXT_UNLOCK(pcpu);
 
-        pcpu->critical_switch_flag = 1;
+        CRITICAL_SWITCH_FLAG(pcpu, current_thread) = 1;
         error = -RT_ESCHEDLOCKED;
 
         SCHEDULER_EXIT_CRITICAL(current_thread);
@@ -757,7 +766,7 @@ rt_err_t rt_sched_unlock_n_resched(rt_sched_lock_level_t level)
     else
     {
         /* flush critical switch flag since a scheduling is done */
-        pcpu->critical_switch_flag = 0;
+        CRITICAL_SWITCH_FLAG(pcpu, current_thread) = 0;
 
         /* pick the highest runnable thread, and pass the control to it */
         to_thread = _prepare_context_switch_locked(cpu_id, pcpu, current_thread);
@@ -828,7 +837,7 @@ void rt_schedule(void)
     /* whether caller had locked the local scheduler already */
     if (RT_SCHED_CTX(current_thread).critical_lock_nest > 1)
     {
-        pcpu->critical_switch_flag = 1;
+        CRITICAL_SWITCH_FLAG(pcpu, current_thread) = 1;
 
         SCHEDULER_EXIT_CRITICAL(current_thread);
 
@@ -837,7 +846,7 @@ void rt_schedule(void)
     else
     {
         /* flush critical switch flag since a scheduling is done */
-        pcpu->critical_switch_flag = 0;
+        CRITICAL_SWITCH_FLAG(pcpu, current_thread) = 0;
         pcpu->irq_switch_flag = 0;
 
         /**
@@ -912,13 +921,13 @@ void rt_scheduler_do_irq_switch(void *context)
     /* whether caller had locked the local scheduler already */
     if (RT_SCHED_CTX(current_thread).critical_lock_nest > 1)
     {
-        pcpu->critical_switch_flag = 1;
+        CRITICAL_SWITCH_FLAG(pcpu, current_thread) = 1;
         SCHEDULER_EXIT_CRITICAL(current_thread);
     }
     else if (rt_atomic_load(&(pcpu->irq_nest)) == 0)
     {
         /* flush critical & irq switch flag since a scheduling is done */
-        pcpu->critical_switch_flag = 0;
+        CRITICAL_SWITCH_FLAG(pcpu, current_thread) = 0;
         pcpu->irq_switch_flag = 0;
 
         SCHEDULER_CONTEXT_LOCK(pcpu);
@@ -1056,6 +1065,9 @@ void rt_sched_post_ctx_switch(struct rt_thread *thread)
     }
     /* safe to access since irq is masked out */
     pcpu->current_thread = thread;
+#ifdef ARCH_USING_HW_THREAD_SELF
+    rt_hw_thread_set_self(thread);
+#endif /* ARCH_USING_HW_THREAD_SELF */
 }
 
 #ifdef RT_DEBUGING_CRITICAL
@@ -1096,14 +1108,28 @@ void rt_exit_critical_safe(rt_base_t critical_level)
 #endif /* RT_DEBUGING_CRITICAL */
 RTM_EXPORT(rt_exit_critical_safe);
 
+#ifdef ARCH_USING_HW_THREAD_SELF
+#define FREE_THREAD_SELF(lvl)
+
+#else /* !ARCH_USING_HW_THREAD_SELF */
+#define FREE_THREAD_SELF(lvl)        \
+    do                               \
+    {                                \
+        rt_hw_local_irq_enable(lvl); \
+    } while (0)
+
+#endif /* ARCH_USING_HW_THREAD_SELF */
+
 /**
  * @brief This function will lock the thread scheduler.
  */
 rt_base_t rt_enter_critical(void)
 {
-    rt_base_t level;
     rt_base_t critical_level;
     struct rt_thread *current_thread;
+
+#ifndef ARCH_USING_HW_THREAD_SELF
+    rt_base_t level;
     struct rt_cpu *pcpu;
 
     /* disable interrupt */
@@ -1118,12 +1144,22 @@ rt_base_t rt_enter_critical(void)
         return -RT_EINVAL;
     }
 
+#else /* !ARCH_USING_HW_THREAD_SELF */
+
+    current_thread = rt_hw_thread_self();
+    if (!current_thread)
+    {
+        /* scheduler unavailable */
+        return -RT_EINVAL;
+    }
+
+#endif /* ARCH_USING_HW_THREAD_SELF */
+
     /* critical for local cpu */
     RT_SCHED_CTX(current_thread).critical_lock_nest++;
     critical_level = RT_SCHED_CTX(current_thread).critical_lock_nest;
 
-    /* enable interrupt */
-    rt_hw_local_irq_enable(level);
+    FREE_THREAD_SELF(level);
 
     return critical_level;
 }
@@ -1134,9 +1170,11 @@ RTM_EXPORT(rt_enter_critical);
  */
 void rt_exit_critical(void)
 {
-    rt_base_t level;
     struct rt_thread *current_thread;
     rt_bool_t need_resched;
+
+#ifndef ARCH_USING_HW_THREAD_SELF
+    rt_base_t level;
     struct rt_cpu *pcpu;
 
     /* disable interrupt */
@@ -1150,6 +1188,15 @@ void rt_exit_critical(void)
         return;
     }
 
+#else /* !ARCH_USING_HW_THREAD_SELF */
+
+    current_thread = rt_hw_thread_self();
+    if (!current_thread)
+    {
+        return;
+    }
+#endif /* ARCH_USING_HW_THREAD_SELF */
+
     /* the necessary memory barrier is done on irq_(dis|en)able */
     RT_SCHED_CTX(current_thread).critical_lock_nest--;
 
@@ -1157,11 +1204,10 @@ void rt_exit_critical(void)
     if (RT_SCHED_CTX(current_thread).critical_lock_nest == 0)
     {
         /* is there any scheduling request unfinished? */
-        need_resched = pcpu->critical_switch_flag;
-        pcpu->critical_switch_flag = 0;
+        need_resched = CRITICAL_SWITCH_FLAG(pcpu, current_thread);
+        CRITICAL_SWITCH_FLAG(pcpu, current_thread) = 0;
 
-        /* enable interrupt */
-        rt_hw_local_irq_enable(level);
+        FREE_THREAD_SELF(level);
 
         if (need_resched)
             rt_schedule();
@@ -1171,8 +1217,7 @@ void rt_exit_critical(void)
         /* each exit_critical is strictly corresponding to an enter_critical */
         RT_ASSERT(RT_SCHED_CTX(current_thread).critical_lock_nest > 0);
 
-        /* enable interrupt */
-        rt_hw_local_irq_enable(level);
+        FREE_THREAD_SELF(level);
     }
 }
 RTM_EXPORT(rt_exit_critical);

--- a/src/scheduler_up.c
+++ b/src/scheduler_up.c
@@ -48,7 +48,7 @@ rt_uint8_t rt_thread_ready_table[32];
 
 extern volatile rt_uint8_t rt_interrupt_nest;
 static rt_int16_t rt_scheduler_lock_nest;
-struct rt_thread *rt_current_thread = RT_NULL;
+static struct rt_thread *rt_current_thread = RT_NULL;
 rt_uint8_t rt_current_priority;
 
 #if defined(RT_USING_HOOK) && defined(RT_HOOK_USING_FUNC_PTR)
@@ -562,6 +562,11 @@ RTM_EXPORT(rt_critical_level);
 rt_err_t rt_sched_thread_bind_cpu(struct rt_thread *thread, int cpu)
 {
     return -RT_EINVAL;
+}
+
+rt_thread_t rt_sched_thread_self(void)
+{
+    return rt_current_thread;
 }
 
 /**@}*/

--- a/src/scheduler_up.c
+++ b/src/scheduler_up.c
@@ -48,7 +48,7 @@ rt_uint8_t rt_thread_ready_table[32];
 
 extern volatile rt_uint8_t rt_interrupt_nest;
 static rt_int16_t rt_scheduler_lock_nest;
-static struct rt_thread *rt_current_thread = RT_NULL;
+struct rt_thread *rt_current_thread = RT_NULL;
 rt_uint8_t rt_current_priority;
 
 #if defined(RT_USING_HOOK) && defined(RT_HOOK_USING_FUNC_PTR)

--- a/src/scheduler_up.c
+++ b/src/scheduler_up.c
@@ -48,7 +48,6 @@ rt_uint8_t rt_thread_ready_table[32];
 
 extern volatile rt_uint8_t rt_interrupt_nest;
 static rt_int16_t rt_scheduler_lock_nest;
-struct rt_thread *rt_current_thread = RT_NULL;
 rt_uint8_t rt_current_priority;
 
 #if defined(RT_USING_HOOK) && defined(RT_HOOK_USING_FUNC_PTR)
@@ -175,7 +174,7 @@ void rt_system_scheduler_start(void)
 
     to_thread = _scheduler_get_highest_priority_thread(&highest_ready_priority);
 
-    rt_current_thread = to_thread;
+    rt_cpu_self()->current_thread = to_thread;
 
     rt_sched_remove_thread(to_thread);
     RT_SCHED_CTX(to_thread).stat = RT_THREAD_RUNNING;
@@ -203,6 +202,8 @@ void rt_schedule(void)
     rt_base_t level;
     struct rt_thread *to_thread;
     struct rt_thread *from_thread;
+    /* using local variable to avoid unecessary function call */
+    struct rt_thread *curr_thread = rt_thread_self();
 
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
@@ -219,15 +220,16 @@ void rt_schedule(void)
 
             to_thread = _scheduler_get_highest_priority_thread(&highest_ready_priority);
 
-            if ((RT_SCHED_CTX(rt_current_thread).stat & RT_THREAD_STAT_MASK) == RT_THREAD_RUNNING)
+            if ((RT_SCHED_CTX(curr_thread).stat & RT_THREAD_STAT_MASK) == RT_THREAD_RUNNING)
             {
-                if (RT_SCHED_PRIV(rt_current_thread).current_priority < highest_ready_priority)
+                if (RT_SCHED_PRIV(curr_thread).current_priority < highest_ready_priority)
                 {
-                    to_thread = rt_current_thread;
+                    to_thread = curr_thread;
                 }
-                else if (RT_SCHED_PRIV(rt_current_thread).current_priority == highest_ready_priority && (RT_SCHED_CTX(rt_current_thread).stat & RT_THREAD_STAT_YIELD_MASK) == 0)
+                else if (RT_SCHED_PRIV(curr_thread).current_priority == highest_ready_priority
+                         && (RT_SCHED_CTX(curr_thread).stat & RT_THREAD_STAT_YIELD_MASK) == 0)
                 {
-                    to_thread = rt_current_thread;
+                    to_thread = curr_thread;
                 }
                 else
                 {
@@ -235,12 +237,12 @@ void rt_schedule(void)
                 }
             }
 
-            if (to_thread != rt_current_thread)
+            if (to_thread != curr_thread)
             {
                 /* if the destination thread is not the same as current thread */
                 rt_current_priority = (rt_uint8_t)highest_ready_priority;
-                from_thread         = rt_current_thread;
-                rt_current_thread   = to_thread;
+                from_thread                   = curr_thread;
+                rt_cpu_self()->current_thread = to_thread;
 
                 RT_OBJECT_HOOK_CALL(rt_scheduler_hook, (from_thread, to_thread));
 
@@ -282,11 +284,11 @@ void rt_schedule(void)
 #ifdef RT_USING_SIGNALS
                     /* check stat of thread for signal */
                     level = rt_hw_interrupt_disable();
-                    if (RT_SCHED_CTX(rt_current_thread).stat & RT_THREAD_STAT_SIGNAL_PENDING)
+                    if (RT_SCHED_CTX(curr_thread).stat & RT_THREAD_STAT_SIGNAL_PENDING)
                     {
                         extern void rt_thread_handle_sig(rt_bool_t clean_state);
 
-                        RT_SCHED_CTX(rt_current_thread).stat &= ~RT_THREAD_STAT_SIGNAL_PENDING;
+                        RT_SCHED_CTX(curr_thread).stat &= ~RT_THREAD_STAT_SIGNAL_PENDING;
 
                         rt_hw_interrupt_enable(level);
 
@@ -310,8 +312,8 @@ void rt_schedule(void)
             }
             else
             {
-                rt_sched_remove_thread(rt_current_thread);
-                RT_SCHED_CTX(rt_current_thread).stat = RT_THREAD_RUNNING | (RT_SCHED_CTX(rt_current_thread).stat & ~RT_THREAD_STAT_MASK);
+                rt_sched_remove_thread(curr_thread);
+                RT_SCHED_CTX(curr_thread).stat = RT_THREAD_RUNNING | (RT_SCHED_CTX(curr_thread).stat & ~RT_THREAD_STAT_MASK);
             }
         }
     }
@@ -562,11 +564,6 @@ RTM_EXPORT(rt_critical_level);
 rt_err_t rt_sched_thread_bind_cpu(struct rt_thread *thread, int cpu)
 {
     return -RT_EINVAL;
-}
-
-rt_thread_t rt_sched_thread_self(void)
-{
-    return rt_current_thread;
 }
 
 /**@}*/

--- a/src/thread.c
+++ b/src/thread.c
@@ -348,6 +348,30 @@ rt_err_t rt_thread_init(struct rt_thread *thread,
 }
 RTM_EXPORT(rt_thread_init);
 
+#ifdef RT_USING_SMP
+static rt_thread_t _mp_thread_self(void)
+{
+#ifdef ARCH_USING_HW_THREAD_SELF
+    return rt_hw_thread_self();
+
+#else /* !ARCH_USING_HW_THREAD_SELF */
+    rt_thread_t self;
+    rt_base_t lock;
+
+    lock = rt_hw_local_irq_disable();
+    self = rt_cpu_self()->current_thread;
+    rt_hw_local_irq_enable(lock);
+
+    return self;
+#endif /* ARCH_USING_HW_THREAD_SELF */
+}
+#define THREAD_SELF _mp_thread_self()
+
+#else /* !RT_USING_SMP */
+#define THREAD_SELF rt_current_thread
+
+#endif /* RT_USING_SMP */
+
 /**
  * @brief   This function will return self thread object.
  *
@@ -355,20 +379,7 @@ RTM_EXPORT(rt_thread_init);
  */
 rt_thread_t rt_thread_self(void)
 {
-#ifdef RT_USING_SMP
-    rt_base_t lock;
-    rt_thread_t self;
-
-    lock = rt_hw_local_irq_disable();
-    self = rt_cpu_self()->current_thread;
-    rt_hw_local_irq_enable(lock);
-    return self;
-
-#else /* !RT_USING_SMP */
-    extern rt_thread_t rt_current_thread;
-
-    return rt_current_thread;
-#endif /* RT_USING_SMP */
+    return THREAD_SELF;
 }
 RTM_EXPORT(rt_thread_self);
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -348,30 +348,6 @@ rt_err_t rt_thread_init(struct rt_thread *thread,
 }
 RTM_EXPORT(rt_thread_init);
 
-#ifdef RT_USING_SMP
-static rt_thread_t _mp_thread_self(void)
-{
-#ifdef ARCH_USING_HW_THREAD_SELF
-    return rt_hw_thread_self();
-
-#else /* !ARCH_USING_HW_THREAD_SELF */
-    rt_thread_t self;
-    rt_base_t lock;
-
-    lock = rt_hw_local_irq_disable();
-    self = rt_cpu_self()->current_thread;
-    rt_hw_local_irq_enable(lock);
-
-    return self;
-#endif /* ARCH_USING_HW_THREAD_SELF */
-}
-#define THREAD_SELF _mp_thread_self()
-
-#else /* !RT_USING_SMP */
-#define THREAD_SELF rt_current_thread
-
-#endif /* RT_USING_SMP */
-
 /**
  * @brief   This function will return self thread object.
  *
@@ -379,7 +355,7 @@ static rt_thread_t _mp_thread_self(void)
  */
 rt_thread_t rt_thread_self(void)
 {
-    return THREAD_SELF;
+    return rt_sched_thread_self();
 }
 RTM_EXPORT(rt_thread_self);
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -355,7 +355,22 @@ RTM_EXPORT(rt_thread_init);
  */
 rt_thread_t rt_thread_self(void)
 {
-    return rt_sched_thread_self();
+#ifndef RT_USING_SMP
+    return rt_cpu_self()->current_thread;
+
+#elif defined (ARCH_USING_HW_THREAD_SELF)
+    return rt_hw_thread_self();
+
+#else /* !ARCH_USING_HW_THREAD_SELF */
+    rt_thread_t self;
+    rt_base_t lock;
+
+    lock = rt_hw_local_irq_disable();
+    self = rt_cpu_self()->current_thread;
+    rt_hw_local_irq_enable(lock);
+
+    return self;
+#endif /* ARCH_USING_HW_THREAD_SELF */
 }
 RTM_EXPORT(rt_thread_self);
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

This patch introduces hardware-based thread self-identification
for the AArch64 architecture. It optimizes thread management by
using hardware registers to store and access the current thread's
pointer, reducing overhead and improving overall performance.

#### 你的解决方案是什么 (what is your solution)

Changes include:
- Added `ARCH_USING_HW_THREAD_SELF` configuration option.
- Modified `rtdef.h`, `rtsched.h` to conditionally include
  `critical_switch_flag` based on the new config.
- Updated context management in `context_gcc.S`, `cpuport.h`
  to support hardware-based thread self.
- Enhanced `scheduler_mp.c` and `thread.c` to leverage the new
  hardware thread self feature.

These modifications ensure better scheduling and thread handling,
particularly in multi-core environments, by minimizing the
software overhead associated with thread management.

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: orangepi cm4 in UP; SMP,single-core; SMP, quad-core

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
