### PR TITLE
[DM/feature] Simple NUMA (Non-Uniform Memory Access)

### DIFF
--- a/components/drivers/core/SConscript
+++ b/components/drivers/core/SConscript
@@ -8,7 +8,7 @@ if GetDepend(['RT_USING_DEV_BUS']) or GetDepend(['RT_USING_DM']):
     src = src + ['bus.c']
 
 if GetDepend(['RT_USING_DM']):
-    src = src + ['dm.c', 'driver.c', 'platform.c']
+    src = src + ['dm.c', 'driver.c', 'numa.c', 'platform.c']
 
     if GetDepend(['RT_USING_DFS']):
         src += ['mnt.c'];

--- a/components/drivers/core/numa.c
+++ b/components/drivers/core/numa.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2006-2023, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2023-09-24     GuEe-GUI     the first version
+ */
+
+#include <rtthread.h>
+#include <rtdevice.h>
+
+#define DBG_TAG "rtdm.numa"
+#define DBG_LVL DBG_INFO
+#include <rtdbg.h>
+
+#include <drivers/pic.h>
+
+struct numa_memory
+{
+    rt_list_t list;
+
+    int nid;
+    rt_uint64_t start;
+    rt_uint64_t end;
+
+    union
+    {
+        void *ofw_node;
+    };
+};
+
+static rt_bool_t numa_enabled = RT_FALSE;
+static int cpu_numa_map[RT_CPUS_NR] rt_section(".bss.noclean.numa");
+static rt_list_t numa_memory_nodes rt_section(".bss.noclean.numa");
+
+int rt_numa_cpu_id(int cpuid)
+{
+    if (!numa_enabled)
+    {
+        return -RT_ENOSYS;
+    }
+
+    return cpuid < RT_ARRAY_SIZE(cpu_numa_map) ? cpu_numa_map[cpuid] : -RT_EINVAL;
+}
+
+int rt_numa_device_id(struct rt_device *dev)
+{
+    rt_uint32_t nid = (rt_uint32_t)-RT_ENOSYS;
+
+    if (!numa_enabled)
+    {
+        return nid;
+    }
+
+    return rt_dm_dev_prop_read_u32(dev, "numa-node-id", &nid) ? : (int)nid;
+}
+
+rt_err_t rt_numa_memory_affinity(rt_uint64_t phy_addr, rt_bitmap_t *out_affinity)
+{
+    struct numa_memory *nm;
+
+    if (!out_affinity)
+    {
+        return -RT_EINVAL;
+    }
+
+    if (!numa_enabled)
+    {
+        /* Default to CPU#0 */
+        RT_IRQ_AFFINITY_SET(out_affinity, 0);
+
+        return RT_EOK;
+    }
+
+    rt_memset(out_affinity, 0, sizeof(*out_affinity) * RT_BITMAP_LEN(RT_CPUS_NR));
+
+    rt_list_for_each_entry(nm, &numa_memory_nodes, list)
+    {
+        if (phy_addr >= nm->start && phy_addr < nm->end)
+        {
+            for (int i = 0; i < RT_ARRAY_SIZE(cpu_numa_map); ++i)
+            {
+                if (cpu_numa_map[i] == nm->nid)
+                {
+                    RT_IRQ_AFFINITY_SET(out_affinity, i);
+                }
+            }
+
+            return RT_EOK;
+        }
+    }
+
+    return -RT_EEMPTY;
+}
+
+#ifdef RT_USING_OFW
+static int numa_ofw_init(void)
+{
+    int i = 0;
+    rt_uint32_t nid;
+    const char *numa_conf;
+    struct rt_ofw_node *np = RT_NULL;
+
+    numa_conf = rt_ofw_bootargs_select("numa=", 0);
+
+    if (!numa_conf || rt_strcmp(numa_conf, "on"))
+    {
+        return (int)RT_EOK;
+    }
+
+    numa_enabled = RT_TRUE;
+
+    for (int i = 0; i < RT_ARRAY_SIZE(cpu_numa_map); ++i)
+    {
+        cpu_numa_map[i] = -RT_ENOSYS;
+    }
+
+    rt_list_init(&numa_memory_nodes);
+
+    rt_ofw_foreach_cpu_node(np)
+    {
+        rt_ofw_prop_read_u32(np, "numa-node-id", (rt_uint32_t *)&cpu_numa_map[i]);
+
+        if (++i >= RT_CPUS_NR)
+        {
+            break;
+        }
+    }
+
+    rt_ofw_foreach_node_by_type(np, "memory")
+    {
+        if (!rt_ofw_prop_read_u32(np, "numa-node-id", &nid))
+        {
+            int mem_nr = rt_ofw_get_address_count(np);
+
+            for (i = 0; i < mem_nr; ++i)
+            {
+                rt_uint64_t addr, size;
+                struct numa_memory *nm;
+
+                if (rt_ofw_get_address(np, i, &addr, &size))
+                {
+                    continue;
+                }
+
+                nm = rt_malloc(sizeof(*nm));
+
+                if (!nm)
+                {
+                    LOG_E("No memory to record NUMA[%d] memory[%p, %p] info",
+                            nid, addr, addr + size);
+
+                    return (int)-RT_ENOMEM;
+                }
+
+                nm->start = addr;
+                nm->end = addr + size;
+                nm->ofw_node = np;
+
+                rt_list_init(&nm->list);
+                rt_list_insert_before(&numa_memory_nodes, &nm->list);
+            }
+        }
+    }
+
+    return 0;
+}
+INIT_CORE_EXPORT(numa_ofw_init);
+#endif /* RT_USING_OFW */

--- a/components/drivers/include/drivers/core/numa.h
+++ b/components/drivers/include/drivers/core/numa.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2006-2023, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2023-09-24     GuEe-GUI     the first version
+ */
+
+#ifndef __RT_DM_NUMA_H__
+#define __RT_DM_NUMA_H__
+
+#include <rthw.h>
+#include <rtthread.h>
+
+#include <bitmap.h>
+
+/* NUMA: Non-Uniform Memory Access */
+
+int rt_numa_cpu_id(int cpuid);
+int rt_numa_device_id(struct rt_device *dev);
+rt_err_t rt_numa_memory_affinity(rt_uint64_t phy_addr, rt_bitmap_t *out_affinity);
+
+#endif /* __RT_DM_NUMA_H__ */

--- a/components/drivers/include/rtdevice.h
+++ b/components/drivers/include/rtdevice.h
@@ -41,6 +41,7 @@ extern "C" {
 
 #ifdef RT_USING_DM
 #include "drivers/core/dm.h"
+#include "drivers/core/numa.h"
 #include "drivers/platform.h"
 
 #ifdef RT_USING_OFW


### PR DESCRIPTION
[
For some CPU memory access devices, that the drivers will find memory and CPU affinity to config device.

Make a way to found the best affinity memory for current CPU (if platform have NUMA memory) or ask the
developers to take care of the memory affinity when driver access a memory:

```c
rt_err_t msi_affinity_init(struct rt_pic_irq *pirq, struct rt_pci_msi_desc *desc, bitmap_t *cpumasks)
{
        rt_uint64_t data_address;

        /* Get MSI/MSI-X write data adddress */
        data_address = desc->msg.address_hi;
        data_address <<= 32;
        data_address |= desc->msg.address_lo;

        /* Prepare affinity */
        cpumasks = pirq->affinity;
        rt_numa_memory_affinity(data_address, cpumasks);

        /* Config affinity */
        return rt_pic_irq_set_affinity(irq, cpumasks);
}
```
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
