### PR TITLE
[smart] update sched_setaffinity() to use thread(task) ID

### DIFF
--- a/components/lwp/lwp.h
+++ b/components/lwp/lwp.h
@@ -249,7 +249,7 @@ void lwp_user_setting_restore(rt_thread_t thread);
 void lwp_uthread_ctx_save(void *ctx);
 void lwp_uthread_ctx_restore(void);
 
-int lwp_setaffinity(pid_t pid, int cpu);
+int lwp_setaffinity(int tid, int cpu);
 
 pid_t exec(char *filename, int debug, int argc, char **argv);
 

--- a/components/lwp/lwp_pid.c
+++ b/components/lwp/lwp_pid.c
@@ -1600,35 +1600,25 @@ static void _resr_cleanup(struct rt_lwp *lwp)
     }
 }
 
-static int _lwp_setaffinity(pid_t pid, int cpu)
+static int _lwp_setaffinity(int tid, int cpu)
 {
-    struct rt_lwp *lwp;
+    rt_thread_t thread;
     int ret = -1;
 
-    lwp_pid_lock_take();
-    lwp = lwp_from_pid_locked(pid);
+    thread = lwp_tid_get_thread_and_inc_ref(tid);
 
-    if (lwp)
+    if (thread)
     {
 #ifdef RT_USING_SMP
-        rt_list_t *list;
-
-        lwp->bind_cpu = cpu;
-        for (list = lwp->t_grp.next; list != &lwp->t_grp; list = list->next)
-        {
-            rt_thread_t thread;
-
-            thread = rt_list_entry(list, struct rt_thread, sibling);
-            rt_thread_control(thread, RT_THREAD_CTRL_BIND_CPU, (void *)(rt_size_t)cpu);
-        }
+        rt_thread_control(thread, RT_THREAD_CTRL_BIND_CPU, (void *)(rt_ubase_t)cpu);
 #endif
         ret = 0;
     }
-    lwp_pid_lock_release();
+    lwp_tid_dec_ref(thread);
     return ret;
 }
 
-int lwp_setaffinity(pid_t pid, int cpu)
+int lwp_setaffinity(int tid, int cpu)
 {
     int ret;
 
@@ -1638,7 +1628,7 @@ int lwp_setaffinity(pid_t pid, int cpu)
         cpu = RT_CPUS_NR;
     }
 #endif
-    ret = _lwp_setaffinity(pid, cpu);
+    ret = _lwp_setaffinity(tid, cpu);
     return ret;
 }
 

--- a/components/lwp/lwp_syscall.c
+++ b/components/lwp/lwp_syscall.c
@@ -5426,6 +5426,12 @@ sysret_t sys_sched_setaffinity(pid_t pid, size_t size, void *set)
         if (CPU_ISSET_S(i, size, kset))
         {
             kmem_put(kset);
+
+            /**
+             * yes it's tricky.
+             * But when we talk about 'pid' from GNU libc, it's the 'task-id'
+             * aka 'thread->tid' known in kernel.
+             */
             return lwp_setaffinity(pid, i);
         }
     }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

Correct `sched_setaffinity()` to use the thread IDs (TIDs) instead of
process IDs (PIDs). The previous implementation used PIDs, which
caused issues since affinity settings need to be applied at the
thread level.

As the manual documented, the signature is:

>        int sched_setaffinity(pid_t pid, size_t cpusetsize,
>                             const cpu_set_t *mask);

Yes, it's tricky, the identification passing in is called **'PID'**.
But when we talk about 'pid' from GNU libc, it's the **'task-id'**,
aka, `thread->tid` known in kernel.

#### 你的解决方案是什么 (what is your solution)

Changes were made by updating the function signatures and logic
in `lwp.h`, `lwp_pid.c`, and `lwp_syscall.c` to accept TIDs. Specifically,
the `lwp_setaffinity` function and related internal functions now
operate using thread IDs and adjust thread affinity settings accordingly.

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
