### PR TITLE
[DM/feature] Implement PIC irq state { get; set }

### DIFF
--- a/components/drivers/include/drivers/pic.h
+++ b/components/drivers/include/drivers/pic.h
@@ -75,6 +75,12 @@ struct rt_pic_ops
     int         (*irq_alloc_msi)(struct rt_pic *pic, struct rt_pci_msi_desc *msi_desc);
     void        (*irq_free_msi)(struct rt_pic *pic, int irq);
 
+#define RT_IRQ_STATE_PENDING    0
+#define RT_IRQ_STATE_ACTIVE     1
+#define RT_IRQ_STATE_MASKED     2
+    rt_err_t    (*irq_set_state)(struct rt_pic *pic, int hwirq, int type, rt_bool_t state);
+    rt_err_t    (*irq_get_state)(struct rt_pic *pic, int hwirq, int type, rt_bool_t *out_state);
+
     int         (*irq_map)(struct rt_pic *pic, int hwirq, rt_uint32_t mode);
     rt_err_t    (*irq_parse)(struct rt_pic *pic, struct rt_ofw_cell_args *args, struct rt_pic_irq *out_pirq);
 
@@ -188,6 +194,11 @@ rt_err_t rt_pic_irq_get_affinity(int irq, rt_bitmap_t *out_affinity);
 rt_err_t rt_pic_irq_set_triger_mode(int irq, rt_uint32_t mode);
 rt_uint32_t rt_pic_irq_get_triger_mode(int irq);
 void rt_pic_irq_send_ipi(int irq, rt_bitmap_t *cpumask);
+
+rt_err_t rt_pic_irq_set_state_raw(struct rt_pic *pic, int hwirq, int type, rt_bool_t state);
+rt_err_t rt_pic_irq_get_state_raw(struct rt_pic *pic, int hwirq, int type, rt_bool_t *out_state);
+rt_err_t rt_pic_irq_set_state(int irq, int type, rt_bool_t state);
+rt_err_t rt_pic_irq_get_state(int irq, int type, rt_bool_t *out_state);
 
 void rt_pic_irq_parent_enable(struct rt_pic_irq *pirq);
 void rt_pic_irq_parent_disable(struct rt_pic_irq *pirq);

--- a/components/drivers/pic/pic-gicv3.c
+++ b/components/drivers/pic/pic-gicv3.c
@@ -187,6 +187,14 @@ static void *gicv3_hwirq_reg_base(int hwirq, rt_uint32_t offset, rt_uint32_t *in
     return base + gicv3_hwirq_convert_offset_index(hwirq, offset, index);
 }
 
+static rt_bool_t gicv3_hwirq_peek(int hwirq, rt_uint32_t offset)
+{
+    rt_uint32_t index;
+    void *base = gicv3_hwirq_reg_base(hwirq, offset, &index);
+
+    return !!HWREG32(base + (index / 32) * 4);
+}
+
 static void gicv3_hwirq_poke(int hwirq, rt_uint32_t offset)
 {
     rt_uint32_t index;
@@ -600,6 +608,79 @@ static void gicv3_irq_send_ipi(struct rt_pic_irq *pirq, rt_bitmap_t *cpumask)
 #undef __mpidr_to_sgi_affinity
 }
 
+static rt_err_t gicv3_irq_set_state(struct rt_pic *pic, int hwirq, int type, rt_bool_t state)
+{
+    rt_err_t err = RT_EOK;
+    rt_uint32_t offset = 0;
+
+    if (hwirq >= 8192)
+    {
+        type = -1;
+    }
+
+    switch (type)
+    {
+    case RT_IRQ_STATE_PENDING:
+        offset = state ? GICD_ISPENDR : GICD_ICPENDR;
+        break;
+    case RT_IRQ_STATE_ACTIVE:
+        offset = state ? GICD_ISACTIVER : GICD_ICACTIVER;
+        break;
+    case RT_IRQ_STATE_MASKED:
+        if (state)
+        {
+            struct rt_pic_irq pirq = {};
+
+            pirq.hwirq = hwirq;
+            gicv3_irq_mask(&pirq);
+        }
+        else
+        {
+            offset = GICD_ISENABLER;
+        }
+        break;
+    default:
+        err = -RT_EINVAL;
+        break;
+    }
+
+    if (!err && offset)
+    {
+        gicv3_hwirq_poke(hwirq, offset);
+    }
+
+    return err;
+}
+
+static rt_err_t gicv3_irq_get_state(struct rt_pic *pic, int hwirq, int type, rt_bool_t *out_state)
+{
+    rt_err_t err = RT_EOK;
+    rt_uint32_t offset = 0;
+
+    switch (type)
+    {
+    case RT_IRQ_STATE_PENDING:
+        offset = GICD_ISPENDR;
+        break;
+    case RT_IRQ_STATE_ACTIVE:
+        offset = GICD_ISACTIVER;
+        break;
+    case RT_IRQ_STATE_MASKED:
+        offset = GICD_ISENABLER;
+        break;
+    default:
+        err = -RT_EINVAL;
+        break;
+    }
+
+    if (!err)
+    {
+        *out_state = gicv3_hwirq_peek(hwirq, offset);
+    }
+
+    return err;
+}
+
 static int gicv3_irq_map(struct rt_pic *pic, int hwirq, rt_uint32_t mode)
 {
     struct rt_pic_irq *pirq;
@@ -716,6 +797,8 @@ const static struct rt_pic_ops gicv3_ops =
     .irq_set_affinity = gicv3_irq_set_affinity,
     .irq_set_triger_mode = gicv3_irq_set_triger_mode,
     .irq_send_ipi = gicv3_irq_send_ipi,
+    .irq_set_state = gicv3_irq_set_state,
+    .irq_get_state = gicv3_irq_get_state,
     .irq_map = gicv3_irq_map,
     .irq_parse = gicv3_irq_parse,
 };


### PR DESCRIPTION
[
There are some common state for irq:
1. Pending: IRQ was triggered, but software not ACK.
2. Active: IRQ was ACK, but not EOI.
3. Masked: IRQ was masked or umasked.

We  supported the ARM GICv2/v3 to make a example.
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
