### PR TITLE
解决ktime部分函数计算时unsigned long溢出

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,7 +23,7 @@ AlignConsecutiveBitFields:
   AlignCompound: true
   PadOperators: true
 AlignConsecutiveDeclarations:
-  Enabled: false
+  Enabled: true
   AcrossEmptyLines: false
   AcrossComments: false
   AlignCompound: false

--- a/components/drivers/ktime/inc/ktime.h
+++ b/components/drivers/ktime/inc/ktime.h
@@ -18,7 +18,7 @@
 
 #include "rtthread.h"
 
-#define RT_KTIME_RESMUL (1000000UL)
+#define RT_KTIME_RESMUL (1000000ULL)
 
 struct rt_ktime_hrtimer
 {
@@ -69,14 +69,14 @@ rt_uint64_t rt_ktime_cputimer_getres(void);
  *
  * @return frequency
  */
-rt_uint64_t rt_ktime_cputimer_getfrq(void);
+unsigned long rt_ktime_cputimer_getfrq(void);
 
 /**
  * @brief Get cputimer the value of the cnt counter
  *
  * @return cnt
  */
-rt_uint64_t rt_ktime_cputimer_getcnt(void);
+unsigned long rt_ktime_cputimer_getcnt(void);
 
 /**
  * @brief Get cputimer the cnt value corresponding to 1 os tick
@@ -103,14 +103,14 @@ rt_uint64_t rt_ktime_hrtimer_getres(void);
  *
  * @return frequency
  */
-rt_uint64_t rt_ktime_hrtimer_getfrq(void);
+unsigned long rt_ktime_hrtimer_getfrq(void);
 
 /**
  * @brief Get hrtimer the value of the cnt counter
  *
  * @return cnt
  */
-rt_uint64_t rt_ktime_hrtimer_getcnt(void);
+unsigned long rt_ktime_hrtimer_getcnt(void);
 
 /**
  * @brief set hrtimer timeout, when timeout, the timer callback will call timeout

--- a/components/drivers/ktime/inc/ktime.h
+++ b/components/drivers/ktime/inc/ktime.h
@@ -24,7 +24,7 @@ struct rt_ktime_hrtimer
 {
     struct rt_object     parent; /**< inherit from rt_object */
     rt_list_t            row;
-    void                 *parameter;
+    void                *parameter;
     unsigned long        init_cnt;
     unsigned long        timeout_cnt;
     rt_err_t             error;
@@ -62,21 +62,21 @@ rt_err_t rt_ktime_boottime_get_ns(struct timespec *ts);
  *
  * @return (resolution * RT_KTIME_RESMUL)
  */
-unsigned long rt_ktime_cputimer_getres(void);
+rt_uint64_t rt_ktime_cputimer_getres(void);
 
 /**
  * @brief Get cputimer frequency
  *
  * @return frequency
  */
-unsigned long rt_ktime_cputimer_getfrq(void);
+rt_uint64_t rt_ktime_cputimer_getfrq(void);
 
 /**
  * @brief Get cputimer the value of the cnt counter
  *
  * @return cnt
  */
-unsigned long rt_ktime_cputimer_getcnt(void);
+rt_uint64_t rt_ktime_cputimer_getcnt(void);
 
 /**
  * @brief Get cputimer the cnt value corresponding to 1 os tick
@@ -96,21 +96,21 @@ void rt_ktime_cputimer_init(void);
  *
  * @return (resolution * RT_KTIME_RESMUL)
  */
-unsigned long rt_ktime_hrtimer_getres(void);
+rt_uint64_t rt_ktime_hrtimer_getres(void);
 
 /**
  * @brief Get hrtimer frequency
  *
  * @return frequency
  */
-unsigned long rt_ktime_hrtimer_getfrq(void);
+rt_uint64_t rt_ktime_hrtimer_getfrq(void);
 
 /**
  * @brief Get hrtimer the value of the cnt counter
  *
  * @return cnt
  */
-unsigned long rt_ktime_hrtimer_getcnt(void);
+rt_uint64_t rt_ktime_hrtimer_getcnt(void);
 
 /**
  * @brief set hrtimer timeout, when timeout, the timer callback will call timeout

--- a/components/drivers/ktime/src/aarch64/cputimer.c
+++ b/components/drivers/ktime/src/aarch64/cputimer.c
@@ -11,19 +11,19 @@
 #include "gtimer.h"
 #include "ktime.h"
 
-static volatile unsigned long _init_cnt = 0;
+static volatile rt_uint64_t _init_cnt = 0;
 
-unsigned long rt_ktime_cputimer_getres(void)
+rt_uint64_t rt_ktime_cputimer_getres(void)
 {
-    return ((1000UL * 1000 * 1000) * RT_KTIME_RESMUL) / rt_hw_get_gtimer_frq();
+    return ((1000ULL * 1000 * 1000) * RT_KTIME_RESMUL) / rt_hw_get_gtimer_frq();
 }
 
-unsigned long rt_ktime_cputimer_getfrq(void)
+rt_uint64_t rt_ktime_cputimer_getfrq(void)
 {
     return rt_hw_get_gtimer_frq();
 }
 
-unsigned long rt_ktime_cputimer_getcnt(void)
+rt_uint64_t rt_ktime_cputimer_getcnt(void)
 {
     return rt_hw_get_cntpct_val() - _init_cnt;
 }

--- a/components/drivers/ktime/src/aarch64/cputimer.c
+++ b/components/drivers/ktime/src/aarch64/cputimer.c
@@ -11,19 +11,19 @@
 #include "gtimer.h"
 #include "ktime.h"
 
-static volatile rt_uint64_t _init_cnt = 0;
+static volatile unsigned long _init_cnt = 0;
 
 rt_uint64_t rt_ktime_cputimer_getres(void)
 {
     return ((1000ULL * 1000 * 1000) * RT_KTIME_RESMUL) / rt_hw_get_gtimer_frq();
 }
 
-rt_uint64_t rt_ktime_cputimer_getfrq(void)
+unsigned long rt_ktime_cputimer_getfrq(void)
 {
     return rt_hw_get_gtimer_frq();
 }
 
-rt_uint64_t rt_ktime_cputimer_getcnt(void)
+unsigned long rt_ktime_cputimer_getcnt(void)
 {
     return rt_hw_get_cntpct_val() - _init_cnt;
 }

--- a/components/drivers/ktime/src/boottime.c
+++ b/components/drivers/ktime/src/boottime.c
@@ -10,16 +10,16 @@
 
 #include "ktime.h"
 
-#define __KTIME_MUL ((1000UL * 1000 * 1000) / RT_TICK_PER_SECOND)
+#define __KTIME_MUL ((1000ULL * 1000 * 1000) / RT_TICK_PER_SECOND)
 
 rt_weak rt_err_t rt_ktime_boottime_get_us(struct timeval *tv)
 {
     RT_ASSERT(tv != RT_NULL);
 
-    unsigned long ns = (rt_ktime_cputimer_getcnt() * rt_ktime_cputimer_getres()) / RT_KTIME_RESMUL;
+    rt_uint64_t ns = (rt_ktime_cputimer_getcnt() * rt_ktime_cputimer_getres()) / RT_KTIME_RESMUL;
 
-    tv->tv_sec  = ns / (1000UL * 1000 * 1000);
-    tv->tv_usec = (ns % (1000UL * 1000 * 1000)) / 1000;
+    tv->tv_sec  = ns / (1000ULL * 1000 * 1000);
+    tv->tv_usec = (ns % (1000ULL * 1000 * 1000)) / 1000;
 
     return RT_EOK;
 }
@@ -28,9 +28,9 @@ rt_weak rt_err_t rt_ktime_boottime_get_s(time_t *t)
 {
     RT_ASSERT(t != RT_NULL);
 
-    unsigned long ns = (rt_ktime_cputimer_getcnt() * rt_ktime_cputimer_getres()) / RT_KTIME_RESMUL;
+    rt_uint64_t ns = (rt_ktime_cputimer_getcnt() * rt_ktime_cputimer_getres()) / RT_KTIME_RESMUL;
 
-    *t = ns / (1000UL * 1000 * 1000);
+    *t = ns / (1000ULL * 1000 * 1000);
 
     return RT_EOK;
 }
@@ -39,10 +39,10 @@ rt_weak rt_err_t rt_ktime_boottime_get_ns(struct timespec *ts)
 {
     RT_ASSERT(ts != RT_NULL);
 
-    unsigned long ns = (rt_ktime_cputimer_getcnt() * rt_ktime_cputimer_getres()) / RT_KTIME_RESMUL;
+    rt_uint64_t ns = (rt_ktime_cputimer_getcnt() * rt_ktime_cputimer_getres()) / RT_KTIME_RESMUL;
 
-    ts->tv_sec  = ns / (1000UL * 1000 * 1000);
-    ts->tv_nsec = ns % (1000UL * 1000 * 1000);
+    ts->tv_sec  = ns / (1000ULL * 1000 * 1000);
+    ts->tv_nsec = ns % (1000ULL * 1000 * 1000);
 
     return RT_EOK;
 }

--- a/components/drivers/ktime/src/cputimer.c
+++ b/components/drivers/ktime/src/cputimer.c
@@ -10,17 +10,17 @@
 
 #include "ktime.h"
 
-rt_weak unsigned long rt_ktime_cputimer_getres(void)
+rt_weak rt_uint64_t rt_ktime_cputimer_getres(void)
 {
-    return ((1000UL * 1000 * 1000) * RT_KTIME_RESMUL) / RT_TICK_PER_SECOND;
+    return ((1000ULL * 1000 * 1000) * RT_KTIME_RESMUL) / RT_TICK_PER_SECOND;
 }
 
-rt_weak unsigned long rt_ktime_cputimer_getfrq(void)
+rt_weak rt_uint64_t rt_ktime_cputimer_getfrq(void)
 {
     return RT_TICK_PER_SECOND;
 }
 
-rt_weak unsigned long rt_ktime_cputimer_getcnt(void)
+rt_weak rt_uint64_t rt_ktime_cputimer_getcnt(void)
 {
     return rt_tick_get();
 }

--- a/components/drivers/ktime/src/cputimer.c
+++ b/components/drivers/ktime/src/cputimer.c
@@ -15,12 +15,12 @@ rt_weak rt_uint64_t rt_ktime_cputimer_getres(void)
     return ((1000ULL * 1000 * 1000) * RT_KTIME_RESMUL) / RT_TICK_PER_SECOND;
 }
 
-rt_weak rt_uint64_t rt_ktime_cputimer_getfrq(void)
+rt_weak unsigned long rt_ktime_cputimer_getfrq(void)
 {
     return RT_TICK_PER_SECOND;
 }
 
-rt_weak rt_uint64_t rt_ktime_cputimer_getcnt(void)
+rt_weak unsigned long rt_ktime_cputimer_getcnt(void)
 {
     return rt_tick_get();
 }

--- a/components/drivers/ktime/src/risc-v/virt64/cputimer.c
+++ b/components/drivers/ktime/src/risc-v/virt64/cputimer.c
@@ -10,19 +10,19 @@
 
 #include "ktime.h"
 
-static volatile rt_uint64_t _init_cnt = 0;
+static volatile unsigned long _init_cnt = 0;
 
 rt_uint64_t rt_ktime_cputimer_getres(void)
 {
     return ((1000ULL * 1000 * 1000) * RT_KTIME_RESMUL) / CPUTIME_TIMER_FREQ;
 }
 
-rt_uint64_t rt_ktime_cputimer_getfrq(void)
+unsigned long rt_ktime_cputimer_getfrq(void)
 {
     return CPUTIME_TIMER_FREQ;
 }
 
-rt_uint64_t rt_ktime_cputimer_getcnt(void)
+unsigned long rt_ktime_cputimer_getcnt(void)
 {
     unsigned long time_elapsed;
     __asm__ __volatile__("rdtime %0" : "=r"(time_elapsed));

--- a/components/drivers/ktime/src/risc-v/virt64/cputimer.c
+++ b/components/drivers/ktime/src/risc-v/virt64/cputimer.c
@@ -10,19 +10,19 @@
 
 #include "ktime.h"
 
-static volatile unsigned long _init_cnt = 0;
+static volatile rt_uint64_t _init_cnt = 0;
 
-unsigned long rt_ktime_cputimer_getres(void)
+rt_uint64_t rt_ktime_cputimer_getres(void)
 {
-    return ((1000UL * 1000 * 1000) * RT_KTIME_RESMUL) / CPUTIME_TIMER_FREQ;
+    return ((1000ULL * 1000 * 1000) * RT_KTIME_RESMUL) / CPUTIME_TIMER_FREQ;
 }
 
-unsigned long rt_ktime_cputimer_getfrq(void)
+rt_uint64_t rt_ktime_cputimer_getfrq(void)
 {
     return CPUTIME_TIMER_FREQ;
 }
 
-unsigned long rt_ktime_cputimer_getcnt(void)
+rt_uint64_t rt_ktime_cputimer_getcnt(void)
 {
     unsigned long time_elapsed;
     __asm__ __volatile__("rdtime %0" : "=r"(time_elapsed));


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

ktime部分函数中，计算时间所需的分辨率、振动频率等使用了unsigned long类型，但是该类型在计算会存在溢出。

#### 你的解决方案是什么 (what is your solution)

将存在溢出的unsigned long变量类型修改为rt_uint64_t

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:  qemu

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
