### PR TITLE
[fix][misc][adc] 修复 ADC 电压转换的计算错误

### DIFF
--- a/components/drivers/misc/adc.c
+++ b/components/drivers/misc/adc.c
@@ -184,7 +184,7 @@ rt_int16_t rt_adc_voltage(rt_adc_device_t dev, rt_int8_t channel)
 
     /*read the value and convert to voltage*/
     dev->ops->convert(dev, channel, &value);
-    voltage = value * vref / (1 << resolution);
+    voltage = value * vref / ((1 << resolution) - 1);
 
 _voltage_exit:
     return voltage;
@@ -285,6 +285,7 @@ static int adc(int argc, char **argv)
         rt_kprintf("adc read <channel>      - read adc value on the channel\n");
         rt_kprintf("adc disable <channel>   - disable adc channel\n");
         rt_kprintf("adc enable <channel>    - enable adc channel\n");
+        rt_kprintf("adc voltage <channel>   - read voltage on the channel\n");
 
         result = -RT_ERROR;
     }


### PR DESCRIPTION
计算式：
`voltage = value * vref / (1 << resolution);`
因为 ADC 实际的最大值是 `((1 << resolution) - 1)`
所以应该改为：
`voltage = value * vref / ((1 << resolution) - 1);`

增加 'adc voltage' 命令的帮助信息。