### PR TITLE
fix DeprecationWarning: invalid escape sequence.

### DIFF
--- a/tools/gcc.py
+++ b/tools/gcc.py
@@ -252,11 +252,11 @@ def GCCResult(rtconfig, str):
             if re.search('union[ \t]+sigval', line):
                 have_sigval = 1
 
-            if re.search('char\* version', line):
-                version = re.search(r'\"([^"]+)\"', line).groups()[0]
+            if re.search(r'char\* version', line):
+                version = re.search(r'([^"]+)', line).groups()[0]
 
-            if re.findall('iso_c_visible = [\d]+', line):
-                stdc = re.findall('[\d]+', line)[0]
+            if re.findall(r'iso_c_visible = [\d]+', line):
+                stdc = re.findall(r'[\d]+', line)[0]
 
             if re.findall('pthread_create', line):
                 posix_thread = 1


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
在linux平台python3使用scons编译的时候会对转义字符报警告，本次提交旨在解决消除编译时候产生的警告。

#### 为什么提交这份PR (why to submit this PR)

为了scons编译时不再产生警告

#### 你的解决方案是什么 (what is your solution)

在 Python 中，正则表达式字符串通常包含许多反斜杠 (\) 来转义特殊字符。为了避免这些反斜杠被 Python 自身的字符串解析器误解，可以使用原始字符串（raw string）表示法。原始字符串通过在字符串前面加一个 r 来表示，它告诉 Python 不要处理反斜杠，这样反斜杠就直接传递给正则表达式解析器。

#### 请提供验证的bsp和config (provide the config and bsp) 

本地开发阶段发现的问题，bsp不会提交到当前库当中

- BSP:

无

- .config:

无

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
