### PR TITLE
[DM/MISC] Add error No for ptr

### DIFF
--- a/components/drivers/include/drivers/misc.h
+++ b/components/drivers/include/drivers/misc.h
@@ -54,6 +54,12 @@
 
 #define rt_offsetof(s, field)   ((rt_size_t)&((s *)0)->field)
 
+#define rt_err_ptr(err)         ((void *)(rt_base_t)(err))
+#define rt_ptr_err(ptr)         ((rt_err_t)(rt_base_t)(ptr))
+#define rt_is_err_value(ptr)    ((rt_ubase_t)(void *)(ptr) >= (rt_ubase_t)-4095)
+#define rt_is_err(ptr)          rt_is_err_value(ptr)
+#define rt_is_err_or_null(ptr)  (!(ptr) || rt_is_err_value((rt_ubase_t)(ptr)))
+
 #define rt_upper_32_bits(n)     ((rt_uint32_t)(((n) >> 16) >> 16))
 #define rt_lower_32_bits(n)     ((rt_uint32_t)((n) & 0xffffffff))
 #define rt_upper_16_bits(n)     ((rt_uint16_t)((n) >> 16))


### PR DESCRIPTION
[
When the driver request a API gets RT_NULL which return value is ptr, they could not know **why** get a RT_NULL.

some API return RT_NULL, is not error internal maybe, it just not supported for this platform, but the driver still could work ok, the API can return (RT_NULL + -RT_EEMPTY) to driver.

on the other hand, the driver can do more behaviors by error No.
When the API return the -RT_EBUSY, driver can wait for a moment and retry. 
When the API return the -RT_ENOSYS, driver can try the next mode or request's name.
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
