### PR TITLE
[Feature] 添加kconfiglib全面支持，放弃kconfig-frontends

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,4 +1,4 @@
-source "$RTT_DIR/src/Kconfig"
-source "$RTT_DIR/libcpu/Kconfig"
-source "$RTT_DIR/components/Kconfig"
-source "$RTT_DIR/examples/utest/testcases/Kconfig"
+rsource "src/Kconfig"
+rsource "libcpu/Kconfig"
+rsource "components/Kconfig"
+rsource "examples/utest/testcases/Kconfig"

--- a/bsp/CME_M7/Kconfig
+++ b/bsp/CME_M7/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_CME_M7
     bool

--- a/bsp/ESP32_C3/Kconfig
+++ b/bsp/ESP32_C3/Kconfig
@@ -1,20 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "drivers/Kconfig"

--- a/bsp/Infineon/libraries/templates/PSOC62/Kconfig
+++ b/bsp/Infineon/libraries/templates/PSOC62/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/Infineon/libraries/templates/XMC7200D/Kconfig
+++ b/bsp/Infineon/libraries/templates/XMC7200D/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/Infineon/psoc6-cy8ckit-062-BLE/Kconfig
+++ b/bsp/Infineon/psoc6-cy8ckit-062-BLE/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/Infineon/psoc6-cy8ckit-062-WIFI-BT/Kconfig
+++ b/bsp/Infineon/psoc6-cy8ckit-062-WIFI-BT/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/Infineon/psoc6-cy8ckit-062S2-43012/Kconfig
+++ b/bsp/Infineon/psoc6-cy8ckit-062S2-43012/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/Infineon/psoc6-cy8ckit-062s4/Kconfig
+++ b/bsp/Infineon/psoc6-cy8ckit-062s4/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/Infineon/psoc6-cy8cproto-062S3-4343W/Kconfig
+++ b/bsp/Infineon/psoc6-cy8cproto-062S3-4343W/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/Infineon/psoc6-evaluationkit-062S2/Kconfig
+++ b/bsp/Infineon/psoc6-evaluationkit-062S2/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/Infineon/xmc7200-kit_xmc7200_evk/Kconfig
+++ b/bsp/Infineon/xmc7200-kit_xmc7200_evk/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/Vango/v85xx/Kconfig
+++ b/bsp/Vango/v85xx/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default: "rt-thread"
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_SERIES_V85XX
     bool

--- a/bsp/Vango/v85xxp/Kconfig
+++ b/bsp/Vango/v85xxp/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default: "rt-thread"
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_SERIES_V85XXP
     bool

--- a/bsp/acm32/acm32f0x0-nucleo/Kconfig
+++ b/bsp/acm32/acm32f0x0-nucleo/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_SERIES_ACM32F0
     bool
@@ -25,5 +16,5 @@ config SOC_SERIES_ACM32F0
     select RT_USING_USER_MAIN
     default y
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"
 

--- a/bsp/acm32/acm32f4xx-nucleo/Kconfig
+++ b/bsp/acm32/acm32f4xx-nucleo/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"
 

--- a/bsp/airm2m/air105/Kconfig
+++ b/bsp/airm2m/air105/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/airm2m/air32f103/Kconfig
+++ b/bsp/airm2m/air32f103/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/allwinner/d1/Kconfig
+++ b/bsp/allwinner/d1/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config BOARD_allwinnerd1
     bool
@@ -39,5 +30,5 @@ config __STACKSIZE__
     int "stack size for interrupt"
     default 4096
 
-source "../libraries/drivers/Kconfig"
-source "../libraries/Kconfig"
+rsource "../libraries/drivers/Kconfig"
+rsource "../libraries/Kconfig"

--- a/bsp/allwinner/d1s/Kconfig
+++ b/bsp/allwinner/d1s/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config BOARD_allwinnerd1s
     bool
@@ -39,5 +30,5 @@ config __STACKSIZE__
     int "stack size for interrupt"
     default 4096
 
-source "../libraries/drivers/Kconfig"
-source "../libraries/Kconfig"
+rsource "../libraries/drivers/Kconfig"
+rsource "../libraries/Kconfig"

--- a/bsp/allwinner/libraries/Kconfig
+++ b/bsp/allwinner/libraries/Kconfig
@@ -3,16 +3,16 @@ menuconfig RT_USING_SUNXI_HAL
     default n
 
 if RT_USING_SUNXI_HAL
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/uart/Kconfig"
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/ccmu/Kconfig"
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/dma/Kconfig"
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/gpio/Kconfig"
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/disp2/Kconfig"
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/sdmmc/Kconfig"
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/spi/Kconfig"
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/twi/Kconfig"
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/g2d_rcq/Kconfig"
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/usb/Kconfig"
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/ce/Kconfig"
-    source "$BSP_DIR/../libraries/sunxi-hal/hal/source/efuse/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/uart/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/ccmu/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/dma/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/gpio/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/disp2/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/sdmmc/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/spi/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/twi/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/g2d_rcq/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/usb/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/ce/Kconfig"
+    source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/efuse/Kconfig"
 endif

--- a/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/Kconfig
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/Kconfig
@@ -171,20 +171,20 @@ config DISP2_SUNXI_BOOT_COLORBAR
 menu "LCD panels select"
     depends on DISP2_SUNXI
 
-source "$BSP_DIR/../libraries/sunxi-hal/hal/source/disp2/disp/lcd/Kconfig"
+source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/disp2/disp/lcd/Kconfig"
 endmenu
 
 
 menu "Display engine feature select"
     depends on DISP2_SUNXI
 
-source "$BSP_DIR/../libraries/sunxi-hal/hal/source/disp2/disp/Kconfig"
+source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/disp2/disp/Kconfig"
 endmenu
 
 menu "Soc and board select"
     depends on DISP2_SUNXI
 
-source "$BSP_DIR/../libraries/sunxi-hal/hal/source/disp2/soc/Kconfig"
+source "$(BSP_DIR)/../libraries/sunxi-hal/hal/source/disp2/soc/Kconfig"
 endmenu
 
 endmenu

--- a/bsp/allwinner/libraries/sunxi-hal/hal/source/sound/Kconfig
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/source/sound/Kconfig
@@ -3,7 +3,7 @@ menuconfig DRIVERS_SOUND
     default y
 
 if DRIVERS_SOUND
-source "drivers/hal/source/sound/codecs/Kconfig"
-source "drivers/hal/source/sound/platform/Kconfig"
-source "drivers/hal/source/sound/component/Kconfig"
+rsource "codecs/Kconfig"
+rsource "platform/Kconfig"
+rsource "component/Kconfig"
 endif # SOUND

--- a/bsp/allwinner_tina/Kconfig
+++ b/bsp/allwinner_tina/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_TINA
     bool
@@ -29,4 +20,4 @@ config SOC_TINA
     select RT_USING_USER_MAIN
     default y
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"

--- a/bsp/amebaz/Kconfig
+++ b/bsp/amebaz/Kconfig
@@ -1,33 +1,21 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$ENV_DIR/tools/scripts/cmds/Kconfig"
-source "$BSP_DIR/libraries/Kconfig"
-source "$BSP_DIR/drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+osource "$ENV_DIR/tools/scripts/cmds/Kconfig"
+source "$(BSP_DIR)/libraries/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"
 
 config SOC_AMEBAZ
     bool

--- a/bsp/apm32/apm32e103ze-evalboard/Kconfig
+++ b/bsp/apm32/apm32e103ze-evalboard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apm32/apm32e103ze-tinyboard/Kconfig
+++ b/bsp/apm32/apm32e103ze-tinyboard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apm32/apm32f030r8-miniboard/Kconfig
+++ b/bsp/apm32/apm32f030r8-miniboard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apm32/apm32f051r8-evalboard/Kconfig
+++ b/bsp/apm32/apm32f051r8-evalboard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apm32/apm32f072vb-miniboard/Kconfig
+++ b/bsp/apm32/apm32f072vb-miniboard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apm32/apm32f091vc-miniboard/Kconfig
+++ b/bsp/apm32/apm32f091vc-miniboard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apm32/apm32f103vb-miniboard/Kconfig
+++ b/bsp/apm32/apm32f103vb-miniboard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apm32/apm32f103xe-minibroard/Kconfig
+++ b/bsp/apm32/apm32f103xe-minibroard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apm32/apm32f107vc-evalboard/Kconfig
+++ b/bsp/apm32/apm32f107vc-evalboard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apm32/apm32f407ig-minibroard/Kconfig
+++ b/bsp/apm32/apm32f407ig-minibroard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apm32/apm32f407zg-evalboard/Kconfig
+++ b/bsp/apm32/apm32f407zg-evalboard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apm32/apm32s103vb-miniboard/Kconfig
+++ b/bsp/apm32/apm32s103vb-miniboard/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/apollo2/Kconfig
+++ b/bsp/apollo2/Kconfig
@@ -1,30 +1,18 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_APOLLO2
     bool

--- a/bsp/asm9260t/Kconfig
+++ b/bsp/asm9260t/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_AT91SAM926
     bool

--- a/bsp/at32/at32a403a-start/Kconfig
+++ b/bsp/at32/at32a403a-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32a423-start/Kconfig
+++ b/bsp/at32/at32a423-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32f402-start/Kconfig
+++ b/bsp/at32/at32f402-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32f403a-start/Kconfig
+++ b/bsp/at32/at32f403a-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32f405-start/Kconfig
+++ b/bsp/at32/at32f405-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32f407-start/Kconfig
+++ b/bsp/at32/at32f407-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32f413-start/Kconfig
+++ b/bsp/at32/at32f413-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32f415-start/Kconfig
+++ b/bsp/at32/at32f415-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32f421-start/Kconfig
+++ b/bsp/at32/at32f421-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32f423-start/Kconfig
+++ b/bsp/at32/at32f423-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32f425-start/Kconfig
+++ b/bsp/at32/at32f425-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32f435-start/Kconfig
+++ b/bsp/at32/at32f435-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/at32f437-start/Kconfig
+++ b/bsp/at32/at32f437-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/at32/tools/sdk_dist.py
+++ b/bsp/at32/tools/sdk_dist.py
@@ -1,8 +1,10 @@
 import os
 import sys
 import shutil
+
 cwd_path = os.getcwd()
 sys.path.append(os.path.join(os.path.dirname(cwd_path), 'rt-thread', 'tools'))
+
 
 def bsp_update_kconfig_library(dist_dir):
     # change RTT_ROOT in Kconfig
@@ -12,15 +14,11 @@ def bsp_update_kconfig_library(dist_dir):
     with open(os.path.join(dist_dir, 'Kconfig'), 'r') as f:
         data = f.readlines()
     with open(os.path.join(dist_dir, 'Kconfig'), 'w') as f:
-        found = 0
         for line in data:
-            if line.find('RTT_ROOT') != -1:
-                found = 1
-            if line.find('../libraries') != -1 and found:
-                position = line.find('../libraries')
-                line = line[0:position] + 'libraries/Kconfig"\n'
-                found = 0
+            if line.find('source') != -1 and line.find('../libraries') != -1:
+                line = line.replace('../libraries', 'libraries')
             f.write(line)
+
 
 # BSP dist function
 def dist_do_building(BSP_ROOT, dist_dir):
@@ -30,8 +28,10 @@ def dist_do_building(BSP_ROOT, dist_dir):
     print("=> copy at32 bsp library")
     library_dir = os.path.join(dist_dir, 'libraries')
     library_path = os.path.join(os.path.dirname(BSP_ROOT), 'libraries')
-    bsp_copy_files(os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE),
-                   os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE))
+    bsp_copy_files(
+        os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE),
+        os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE),
+    )
 
     print("=> copy bsp drivers")
     bsp_copy_files(os.path.join(library_path, 'rt_drivers'), os.path.join(library_dir, 'rt_drivers'))

--- a/bsp/at91/at91sam9260/Kconfig
+++ b/bsp/at91/at91sam9260/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_AT91SAM926
     bool

--- a/bsp/at91/at91sam9g45/Kconfig
+++ b/bsp/at91/at91sam9g45/Kconfig
@@ -1,30 +1,18 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_AT91SAM9G45
     bool
@@ -34,5 +22,5 @@ config SOC_AT91SAM9G45
     select RT_USING_USER_MAIN
     default y
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"
 

--- a/bsp/avr32/at32uc3a0256/Kconfig
+++ b/bsp/avr32/at32uc3a0256/Kconfig
@@ -1,30 +1,18 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 menu "Hardware Drivers Config"
 

--- a/bsp/avr32/at32uc3b0256/Kconfig
+++ b/bsp/avr32/at32uc3b0256/Kconfig
@@ -1,30 +1,18 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 menu "Hardware Drivers Config"
 

--- a/bsp/beaglebone/Kconfig
+++ b/bsp/beaglebone/Kconfig
@@ -1,30 +1,18 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example: default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_AM335X
     bool

--- a/bsp/bluetrum/ab32vg1-ab-prougen/Kconfig
+++ b/bsp/bluetrum/ab32vg1-ab-prougen/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config BOARD_BLUETRUM_EVB
     bool

--- a/bsp/bm3803/Kconfig
+++ b/bsp/bm3803/Kconfig
@@ -1,30 +1,18 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example: default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_BM3803
     bool

--- a/bsp/bouffalo_lab/bl60x/Kconfig
+++ b/bsp/bouffalo_lab/bl60x/Kconfig
@@ -1,26 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config LIBRARIES_DIR
-    string
-    option env="LIBRARIES_DIR"
-    default "../libraries"
+LIBRARIES_DIR := ../libraries
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
-source "$LIBRARIES_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
+source "$(LIBRARIES_DIR)/Kconfig"

--- a/bsp/bouffalo_lab/bl61x/Kconfig
+++ b/bsp/bouffalo_lab/bl61x/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
+rsource "../libraries/Kconfig"

--- a/bsp/bouffalo_lab/bl70x/Kconfig
+++ b/bsp/bouffalo_lab/bl70x/Kconfig
@@ -1,26 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config LIBRARIES_DIR
-    string
-    option env="LIBRARIES_DIR"
-    default "../libraries"
+LIBRARIES_DIR := ../libraries
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
-source "$LIBRARIES_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
+source "$(LIBRARIES_DIR)/Kconfig"

--- a/bsp/bouffalo_lab/bl808/d0/Kconfig
+++ b/bsp/bouffalo_lab/bl808/d0/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config __STACKSIZE__
     int "stack size for interrupt"

--- a/bsp/bouffalo_lab/bl808/lp/Kconfig
+++ b/bsp/bouffalo_lab/bl808/lp/Kconfig
@@ -1,26 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config LIBRARIES_DIR
-    string
-    option env="LIBRARIES_DIR"
-    default "../../libraries"
+LIBRARIES_DIR := ../../libraries
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
-source "$LIBRARIES_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
+source "$(LIBRARIES_DIR)/Kconfig"

--- a/bsp/bouffalo_lab/bl808/m0/Kconfig
+++ b/bsp/bouffalo_lab/bl808/m0/Kconfig
@@ -1,26 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config LIBRARIES_DIR
-    string
-    option env="LIBRARIES_DIR"
-    default "../../libraries"
+LIBRARIES_DIR := ../../libraries
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
-source "$LIBRARIES_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
+source "$(LIBRARIES_DIR)/Kconfig"

--- a/bsp/bouffalo_lab/bl808/tools/sdk_dist.py
+++ b/bsp/bouffalo_lab/bl808/tools/sdk_dist.py
@@ -1,8 +1,10 @@
 import os
 import sys
 import shutil
+
 cwd_path = os.getcwd()
 sys.path.append(os.path.join(os.path.dirname(cwd_path), 'rt-thread', 'tools'))
+
 
 # BSP dist function
 def dist_do_building(BSP_ROOT, dist_dir):
@@ -10,9 +12,9 @@ def dist_do_building(BSP_ROOT, dist_dir):
     import rtconfig
 
     library_path = os.path.join(os.path.dirname(BSP_ROOT), '../libraries')
-    print("library_path   ",library_path)
-    library_dir  = os.path.join(dist_dir, 'libraries')
-    print("library_dir   ",library_dir)
+    print("library_path   ", library_path)
+    library_dir = os.path.join(dist_dir, 'libraries')
+    print("library_dir   ", library_dir)
     print("=> copy bsp drivers")
     bsp_copy_files(os.path.join(library_path, 'rt_drivers'), os.path.join(library_dir, 'rt_drivers'))
     print("=> copy bsp CMSIS")
@@ -20,7 +22,7 @@ def dist_do_building(BSP_ROOT, dist_dir):
     print("=> copy bsp library")
 
     shutil.copyfile(os.path.join(library_path, 'Kconfig'), os.path.join(library_dir, 'Kconfig'))
-    
+
     # change RTT_ROOT in Kconfig
     if not os.path.isfile(os.path.join(dist_dir, 'Kconfig')):
         return
@@ -28,12 +30,7 @@ def dist_do_building(BSP_ROOT, dist_dir):
     with open(os.path.join(dist_dir, 'Kconfig'), 'r') as f:
         data = f.readlines()
     with open(os.path.join(dist_dir, 'Kconfig'), 'w') as f:
-        found = 0
         for line in data:
-            if line.find('RTT_ROOT') != -1:
-                found = 1
-            if line.find('../../libraries') != -1 and found:
-                position = line.find('../../libraries')
-                line = line[0:position] + 'libraries"\n'
-                found = 0
+            if line.find('source') != -1 and line.find('../libraries') != -1:
+                line = line.replace('../libraries', 'libraries')
             f.write(line)

--- a/bsp/ck802/Kconfig
+++ b/bsp/ck802/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_CK802
     bool

--- a/bsp/core-v-mcu/core-v-cv32e40p/Kconfig
+++ b/bsp/core-v-mcu/core-v-cv32e40p/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/core-v-mcu/tools/sdk_dist.py
+++ b/bsp/core-v-mcu/tools/sdk_dist.py
@@ -1,9 +1,11 @@
 import os
 import sys
 import shutil
+
 cwd_path = os.getcwd()
-#cwd_path = E:\rt-thread\bsp\core-v-mcu\tools
+# cwd_path = E:\rt-thread\bsp\core-v-mcu\tools
 sys.path.append(os.path.join(os.path.dirname(cwd_path), 'rt-thread', 'tools'))
+
 
 # BSP dist function
 def dist_do_building(BSP_ROOT, dist_dir):
@@ -13,25 +15,19 @@ def dist_do_building(BSP_ROOT, dist_dir):
     print("=> copy core-v bsp library")
     library_dir = os.path.join(dist_dir, 'Libraries')
     library_path = os.path.join(os.path.dirname(BSP_ROOT), 'Libraries')
-    bsp_copy_files(os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE),
-                   os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE))
-    #library_dir = E:\rt-thread\bsp\core-v-mcu\Libraries
+    bsp_copy_files(os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE), os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE))
+    # library_dir = E:\rt-thread\bsp\core-v-mcu\Libraries
     print("=> copy bsp drivers")
     bsp_copy_files(os.path.join(library_path, 'core_v_drivers'), os.path.join(library_dir, 'core_v_drivers'))
     shutil.copyfile(os.path.join(library_path, 'Kconfig'), os.path.join(library_dir, 'Kconfig'))
-# change RTT_ROOT in Kconfig
+    # change RTT_ROOT in Kconfig
     if not os.path.isfile(os.path.join(dist_dir, 'Kconfig')):
         return
 
     with open(os.path.join(dist_dir, 'Kconfig'), 'r') as f:
         data = f.readlines()
     with open(os.path.join(dist_dir, 'Kconfig'), 'w') as f:
-        found = 0
         for line in data:
-            if line.find('RTT_ROOT') != -1:
-                found = 1
-            if line.find('../Libraries') != -1 and found:
-                position = line.find('../Libraries')
-                line = line[0:position] + 'Libraries/Kconfig"\n'
-                found = 0
+            if line.find('source') != -1 and line.find('../libraries') != -1:
+                line = line.replace('../libraries', 'libraries')
             f.write(line)

--- a/bsp/cvitek/c906_little/Kconfig
+++ b/bsp/cvitek/c906_little/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config BSP_USING_C906_LITTLE
     bool

--- a/bsp/cvitek/cv18xx_aarch64/Kconfig
+++ b/bsp/cvitek/cv18xx_aarch64/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_CV18XX_AARCH64
     bool
@@ -43,4 +34,4 @@ choice
         
 endchoice
 
-source "$BSP_DIR/board/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/cvitek/cv18xx_risc-v/Kconfig
+++ b/bsp/cvitek/cv18xx_risc-v/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config BSP_USING_CV18XX
     bool

--- a/bsp/dm365/Kconfig
+++ b/bsp/dm365/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_DM365
     bool

--- a/bsp/essemi/es32f0654/Kconfig
+++ b/bsp/essemi/es32f0654/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_ES32F0654LT
     bool
@@ -25,4 +16,4 @@ config SOC_ES32F0654LT
     select ARCH_ARM_CORTEX_M0
     default y
 
-source "drivers/Kconfig"
+rsource "drivers/Kconfig"

--- a/bsp/essemi/es32f0654/drivers/Kconfig
+++ b/bsp/essemi/es32f0654/drivers/Kconfig
@@ -6,7 +6,7 @@ menu "Hardware Drivers Config"
             select RT_USING_PIN
             default y
 
-    source "drivers/ES/Kconfig"
+    rsource "ES/Kconfig"
 
     endmenu
 

--- a/bsp/essemi/es32f365x/Kconfig
+++ b/bsp/essemi/es32f365x/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_ES32F3696LT
     bool
@@ -25,4 +16,4 @@ config SOC_ES32F3696LT
     select ARCH_ARM_CORTEX_M3
     default y
 
-source "drivers/Kconfig"
+rsource "drivers/Kconfig"

--- a/bsp/essemi/es32f365x/drivers/Kconfig
+++ b/bsp/essemi/es32f365x/drivers/Kconfig
@@ -8,7 +8,7 @@ menu "Hardware Drivers Config"
             select RT_USING_PIN
             default y
 
-    source "drivers/ES/Kconfig"
+    rsource "ES/Kconfig"
 
     endmenu
 

--- a/bsp/essemi/es32f369x/Kconfig
+++ b/bsp/essemi/es32f369x/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_ES32F3696LT
     bool
@@ -25,4 +16,4 @@ config SOC_ES32F3696LT
     select ARCH_ARM_CORTEX_M3
     default y
 
-source "drivers/Kconfig"
+rsource "drivers/Kconfig"

--- a/bsp/essemi/es32f369x/drivers/Kconfig
+++ b/bsp/essemi/es32f369x/drivers/Kconfig
@@ -7,7 +7,7 @@ menu "Hardware Drivers Config"
             bool "Enable GPIO"
             select RT_USING_PIN
             default y
-    source "drivers/ES/Kconfig"
+    rsource "ES/Kconfig"
 
     endmenu
 

--- a/bsp/essemi/es32vf2264/Kconfig
+++ b/bsp/essemi/es32vf2264/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_ES32VF2264
     bool
@@ -25,4 +16,4 @@ config SOC_ES32VF2264
     select ARCH_RISCV32
     default y
 
-source "drivers/Kconfig"
+rsource "drivers/Kconfig"

--- a/bsp/essemi/es32vf2264/drivers/Kconfig
+++ b/bsp/essemi/es32vf2264/drivers/Kconfig
@@ -6,7 +6,7 @@ menu "Hardware Drivers Config"
             select RT_USING_PIN
             default y
 
-    source "drivers/ES/Kconfig"    
+    rsource "ES/Kconfig"    
 
         config BSP_USING_ARDUINO
             bool "Compatible with Arduino Ecosystem (RTduino)"

--- a/bsp/fm33lc026/Kconfig
+++ b/bsp/fm33lc026/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/frdm-k64f/Kconfig
+++ b/bsp/frdm-k64f/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_FRDM_K64F
     bool

--- a/bsp/ft2004/Kconfig
+++ b/bsp/ft2004/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 
 config FT2004
@@ -29,4 +20,4 @@ config FT2004
     default y
 
 
-source "./libraries/Kconfig"
+rsource "./libraries/Kconfig"

--- a/bsp/ft32/ft32f072xb-starter/Kconfig
+++ b/bsp/ft32/ft32f072xb-starter/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/ft32/ft32f072xb-starter/board/Kconfig
+++ b/bsp/ft32/ft32f072xb-starter/board/Kconfig
@@ -41,7 +41,7 @@ menu "On-chip Peripheral Drivers"
                 depends on BSP_USING_UART2 && RT_SERIAL_USING_DMA
                 default n
         endif
-    source "../libraries/Drivers/Kconfig"
+    rsource "../../libraries/Drivers/Kconfig"
 
 endmenu
 

--- a/bsp/fujitsu/mb9x/mb9bf500r/Kconfig
+++ b/bsp/fujitsu/mb9x/mb9bf500r/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../"
+RTT_DIR := ../../../../
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"

--- a/bsp/fujitsu/mb9x/mb9bf506r/Kconfig
+++ b/bsp/fujitsu/mb9x/mb9bf506r/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../"
+RTT_DIR := ../../../../
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"

--- a/bsp/fujitsu/mb9x/mb9bf568r/Kconfig
+++ b/bsp/fujitsu/mb9x/mb9bf568r/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../"
+RTT_DIR := ../../../../
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"

--- a/bsp/fujitsu/mb9x/mb9bf618s/Kconfig
+++ b/bsp/fujitsu/mb9x/mb9bf618s/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../"
+RTT_DIR := ../../../../
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"

--- a/bsp/gd32/arm/gd32103c-eval/Kconfig
+++ b/bsp/gd32/arm/gd32103c-eval/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32103c-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32103c-eval/board/Kconfig
@@ -200,7 +200,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32105c-eval/Kconfig
+++ b/bsp/gd32/arm/gd32105c-eval/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32105c-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32105c-eval/board/Kconfig
@@ -196,7 +196,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32105r-start/Kconfig
+++ b/bsp/gd32/arm/gd32105r-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32105r-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32105r-start/board/Kconfig
@@ -204,7 +204,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32107c-eval/Kconfig
+++ b/bsp/gd32/arm/gd32107c-eval/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32107c-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32107c-eval/board/Kconfig
@@ -196,7 +196,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32205r-start/Kconfig
+++ b/bsp/gd32/arm/gd32205r-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32205r-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32205r-start/board/Kconfig
@@ -199,7 +199,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32207i-eval/Kconfig
+++ b/bsp/gd32/arm/gd32207i-eval/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32207i-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32207i-eval/board/Kconfig
@@ -230,7 +230,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32303c-start/Kconfig
+++ b/bsp/gd32/arm/gd32303c-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32303c-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32303c-start/board/Kconfig
@@ -40,7 +40,7 @@ menu "On-chip Peripheral Drivers"
 
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32303e-eval/Kconfig
+++ b/bsp/gd32/arm/gd32303e-eval/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32303e-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32303e-eval/board/Kconfig
@@ -200,7 +200,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32305r-start/Kconfig
+++ b/bsp/gd32/arm/gd32305r-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32305r-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32305r-start/board/Kconfig
@@ -196,7 +196,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32307e-start/Kconfig
+++ b/bsp/gd32/arm/gd32307e-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32307e-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32307e-start/board/Kconfig
@@ -197,7 +197,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32407v-lckfb/Kconfig
+++ b/bsp/gd32/arm/gd32407v-lckfb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32407v-lckfb/board/Kconfig
+++ b/bsp/gd32/arm/gd32407v-lckfb/board/Kconfig
@@ -338,7 +338,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32407v-start/Kconfig
+++ b/bsp/gd32/arm/gd32407v-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32407v-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32407v-start/board/Kconfig
@@ -318,7 +318,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32450z-eval/Kconfig
+++ b/bsp/gd32/arm/gd32450z-eval/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32450z-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32450z-eval/board/Kconfig
@@ -374,7 +374,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/arm/gd32470z-lckfb/Kconfig
+++ b/bsp/gd32/arm/gd32470z-lckfb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/arm/gd32470z-lckfb/board/Kconfig
+++ b/bsp/gd32/arm/gd32470z-lckfb/board/Kconfig
@@ -379,7 +379,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_SDRAM
         default n
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/risc-v/gd32vf103r-start/Kconfig
+++ b/bsp/gd32/risc-v/gd32vf103r-start/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/risc-v/gd32vf103r-start/board/Kconfig
+++ b/bsp/gd32/risc-v/gd32vf103r-start/board/Kconfig
@@ -171,7 +171,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_WDT
         default n
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/gd32/risc-v/gd32vf103v-eval/Kconfig
+++ b/bsp/gd32/risc-v/gd32vf103v-eval/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/gd32/risc-v/gd32vf103v-eval/board/Kconfig
+++ b/bsp/gd32/risc-v/gd32vf103v-eval/board/Kconfig
@@ -174,7 +174,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_WDT
         default n
 
-    source "../libraries/gd32_drivers/Kconfig"
+    rsource "../../libraries/gd32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/hc32/ev_hc32f448_lqfp80/Kconfig
+++ b/bsp/hc32/ev_hc32f448_lqfp80/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hc32/ev_hc32f460_lqfp100_v2/Kconfig
+++ b/bsp/hc32/ev_hc32f460_lqfp100_v2/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hc32/ev_hc32f472_lqfp100/Kconfig
+++ b/bsp/hc32/ev_hc32f472_lqfp100/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hc32/ev_hc32f4a0_lqfp176/Kconfig
+++ b/bsp/hc32/ev_hc32f4a0_lqfp176/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hc32l136/Kconfig
+++ b/bsp/hc32l136/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 
 

--- a/bsp/hc32l196/Kconfig
+++ b/bsp/hc32l196/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 
 

--- a/bsp/hifive1/Kconfig
+++ b/bsp/hifive1/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_FE310
     bool

--- a/bsp/hk32/hk32f030c8-mini/Kconfig
+++ b/bsp/hk32/hk32f030c8-mini/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hpmicro/hpm5300evk/Kconfig
+++ b/bsp/hpmicro/hpm5300evk/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hpmicro/hpm5301evklite/Kconfig
+++ b/bsp/hpmicro/hpm5301evklite/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hpmicro/hpm6200evk/Kconfig
+++ b/bsp/hpmicro/hpm6200evk/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hpmicro/hpm6300evk/Kconfig
+++ b/bsp/hpmicro/hpm6300evk/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hpmicro/hpm6750evk/Kconfig
+++ b/bsp/hpmicro/hpm6750evk/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hpmicro/hpm6750evk2/Kconfig
+++ b/bsp/hpmicro/hpm6750evk2/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hpmicro/hpm6750evkmini/Kconfig
+++ b/bsp/hpmicro/hpm6750evkmini/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/hpmicro/hpm6800evk/Kconfig
+++ b/bsp/hpmicro/hpm6800evk/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/ht32/ht32f12366/Kconfig
+++ b/bsp/ht32/ht32f12366/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/ht32/ht32f52352/Kconfig
+++ b/bsp/ht32/ht32f52352/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/ht32/tools/sdk_dist.py
+++ b/bsp/ht32/tools/sdk_dist.py
@@ -2,8 +2,10 @@ import os
 import re
 import sys
 import shutil
+
 cwd_path = os.getcwd()
 sys.path.append(os.path.join(os.path.dirname(cwd_path), 'rt-thread', 'tools'))
+
 
 def bsp_update_kconfig_library(dist_dir):
     # change RTT_ROOT in Kconfig
@@ -13,15 +15,11 @@ def bsp_update_kconfig_library(dist_dir):
     with open(os.path.join(dist_dir, 'Kconfig'), 'r') as f:
         data = f.readlines()
     with open(os.path.join(dist_dir, 'Kconfig'), 'w') as f:
-        found = 0
         for line in data:
-            if line.find('RTT_ROOT') != -1:
-                found = 1
-            if line.find('../libraries') != -1 and found:
-                position = line.find('../libraries')
-                line = line[0:position] + 'libraries/Kconfig"\n'
-                found = 0
+            if line.find('source') != -1 and line.find('../libraries') != -1:
+                line = line.replace('../libraries', 'libraries')
             f.write(line)
+
 
 # BSP dist function
 def dist_do_building(BSP_ROOT, dist_dir):
@@ -31,14 +29,14 @@ def dist_do_building(BSP_ROOT, dist_dir):
     print("=> copy ht32 bsp library")
     library_dir = os.path.join(dist_dir, 'libraries')
     library_path = os.path.join(os.path.dirname(BSP_ROOT), 'libraries')
-    bsp_copy_files(os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE),
-                   os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE))
+    bsp_copy_files(os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE), os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE))
 
     print("=> copy bsp drivers")
     bsp_copy_files(os.path.join(library_path, 'ht32_drivers'), os.path.join(library_dir, 'ht32_drivers'))
     shutil.copyfile(os.path.join(library_path, 'Kconfig'), os.path.join(library_dir, 'Kconfig'))
     bsp_update_kconfig_library(dist_dir)
-  
+
+
 def get_source(ic_model, file_path, system_path, base_path):
     source_path = []
     files_list = []
@@ -47,7 +45,7 @@ def get_source(ic_model, file_path, system_path, base_path):
         return
 
     with open(file_path, 'r') as file:
-        #content = file.read()
+        # content = file.read()
         for line in file:
             if readafter == 2 and line.find('>') != -1:
                 break
@@ -56,10 +54,10 @@ def get_source(ic_model, file_path, system_path, base_path):
             if line.find(ic_model) != -1:
                 readafter = 1
             if readafter == 1 and line.find('<') != -1:
-                readafter = 2  
+                readafter = 2
     for line in files_list:
         if line.find('system') != -1:
             source_path.append(os.path.join(system_path, line.strip()))
         else:
             source_path.append(os.path.join(base_path, line.strip()))
-    return source_path  
+    return source_path

--- a/bsp/juicevm/Kconfig
+++ b/bsp/juicevm/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_JUICEVM_RV64
     bool
@@ -29,7 +20,7 @@ config BOARD_RV64_FRDM_JUICEVM
     select RT_USING_USER_MAIN
     default y
 
-source "driver/Kconfig"
+rsource "driver/Kconfig"
 
 config __STACKSIZE__
     int

--- a/bsp/k210/Kconfig
+++ b/bsp/k210/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "drivers/Kconfig"
 
 config __STACKSIZE__
     int "stack size for interrupt"

--- a/bsp/lm3s8962/Kconfig
+++ b/bsp/lm3s8962/Kconfig
@@ -1,27 +1,15 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LM3S8962
     bool

--- a/bsp/lm3s9b9x/Kconfig
+++ b/bsp/lm3s9b9x/Kconfig
@@ -1,27 +1,15 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LM3S9B9X
     bool

--- a/bsp/lm4f232/Kconfig
+++ b/bsp/lm4f232/Kconfig
@@ -1,27 +1,15 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LM4F232
     bool

--- a/bsp/loongson/ls1bdev/Kconfig
+++ b/bsp/loongson/ls1bdev/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LS1B
     bool

--- a/bsp/loongson/ls1cdev/Kconfig
+++ b/bsp/loongson/ls1cdev/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$RTT_DIR/libcpu/mips/common/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+source "$(RTT_DIR)/libcpu/mips/common/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LS1C300
     bool

--- a/bsp/loongson/ls2kdev/Kconfig
+++ b/bsp/loongson/ls2kdev/Kconfig
@@ -1,26 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$RTT_DIR/libcpu/mips/common/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+source "$(RTT_DIR)/libcpu/mips/common/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LS2K1000
     bool

--- a/bsp/maxim/max32660-evsys/Kconfig
+++ b/bsp/maxim/max32660-evsys/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/microchip/samc21/Kconfig
+++ b/bsp/microchip/samc21/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default: "rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config SOC_SAMC21
     bool

--- a/bsp/microchip/samd51-adafruit-metro-m4/Kconfig
+++ b/bsp/microchip/samd51-adafruit-metro-m4/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default: "rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config SOC_SAMD51
     bool

--- a/bsp/microchip/samd51-seeed-wio-terminal/Kconfig
+++ b/bsp/microchip/samd51-seeed-wio-terminal/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default: "rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config SOC_SAMD51
     bool

--- a/bsp/microchip/same54/Kconfig
+++ b/bsp/microchip/same54/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default: "rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config SOC_SAME54
     bool

--- a/bsp/microchip/same70/Kconfig
+++ b/bsp/microchip/same70/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default: "rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config SOC_SAME70
     bool

--- a/bsp/microchip/saml10/Kconfig
+++ b/bsp/microchip/saml10/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default: "rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config SOC_SAML10
     bool

--- a/bsp/mini2440/Kconfig
+++ b/bsp/mini2440/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config BOARD_MINI2440
     bool
@@ -44,7 +35,7 @@ choice
         bool "X35"
 endchoice
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 

--- a/bsp/mipssim/Kconfig
+++ b/bsp/mipssim/Kconfig
@@ -1,26 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$RTT_DIR/libcpu/mips/common/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+source "$(RTT_DIR)/libcpu/mips/common/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config MIPSSIM
     bool

--- a/bsp/mm32/mm32f3270-100ask-pitaya/Kconfig
+++ b/bsp/mm32/mm32f3270-100ask-pitaya/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/mm32/mm32f3270-100ask-pitaya/board/Kconfig
+++ b/bsp/mm32/mm32f3270-100ask-pitaya/board/Kconfig
@@ -49,7 +49,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "../libraries/HAL_Drivers/Kconfig"
+    rsource "../../libraries/HAL_Drivers/Kconfig"
 
 endmenu
 

--- a/bsp/mm32f103x/Kconfig
+++ b/bsp/mm32f103x/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "drivers/Kconfig"
 
 config SOC_MM32L373
     bool

--- a/bsp/mm32f327x/Kconfig
+++ b/bsp/mm32f327x/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "drivers/Kconfig"
 
 config SOC_MM32F373
     bool

--- a/bsp/mm32l07x/Kconfig
+++ b/bsp/mm32l07x/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "drivers/Kconfig"
 
 config SOC_MM32L073
     bool

--- a/bsp/mm32l3xx/Kconfig
+++ b/bsp/mm32l3xx/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "drivers/Kconfig"
 
 config SOC_MM32L373
     bool

--- a/bsp/msp432e401y-LaunchPad/Kconfig
+++ b/bsp/msp432e401y-LaunchPad/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/n32/n32g43xcl-stb/Kconfig
+++ b/bsp/n32/n32g43xcl-stb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32g43xcl-stb/board/Kconfig
+++ b/bsp/n32/n32g43xcl-stb/board/Kconfig
@@ -164,7 +164,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_CAN
         default n
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32/n32g457qel-stb/Kconfig
+++ b/bsp/n32/n32g457qel-stb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32g457qel-stb/board/Kconfig
+++ b/bsp/n32/n32g457qel-stb/board/Kconfig
@@ -190,7 +190,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32/n32g45xcl-stb/Kconfig
+++ b/bsp/n32/n32g45xcl-stb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32g45xcl-stb/board/Kconfig
+++ b/bsp/n32/n32g45xcl-stb/board/Kconfig
@@ -190,7 +190,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32/n32g45xml-stb/Kconfig
+++ b/bsp/n32/n32g45xml-stb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32g45xml-stb/board/Kconfig
+++ b/bsp/n32/n32g45xml-stb/board/Kconfig
@@ -190,7 +190,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32/n32g45xrl-stb/Kconfig
+++ b/bsp/n32/n32g45xrl-stb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32g45xrl-stb/board/Kconfig
+++ b/bsp/n32/n32g45xrl-stb/board/Kconfig
@@ -190,7 +190,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32/n32g45xvl-stb/Kconfig
+++ b/bsp/n32/n32g45xvl-stb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32g45xvl-stb/board/Kconfig
+++ b/bsp/n32/n32g45xvl-stb/board/Kconfig
@@ -193,7 +193,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32/n32g4frml-stb/Kconfig
+++ b/bsp/n32/n32g4frml-stb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32g4frml-stb/board/Kconfig
+++ b/bsp/n32/n32g4frml-stb/board/Kconfig
@@ -190,7 +190,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32/n32l40xcl-stb/Kconfig
+++ b/bsp/n32/n32l40xcl-stb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32l40xcl-stb/board/Kconfig
+++ b/bsp/n32/n32l40xcl-stb/board/Kconfig
@@ -164,7 +164,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_CAN
         default n
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32/n32l436-evb/Kconfig
+++ b/bsp/n32/n32l436-evb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32l436-evb/board/Kconfig
+++ b/bsp/n32/n32l436-evb/board/Kconfig
@@ -164,7 +164,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_CAN
         default n
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32/n32l43xml-stb/Kconfig
+++ b/bsp/n32/n32l43xml-stb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32l43xml-stb/board/Kconfig
+++ b/bsp/n32/n32l43xml-stb/board/Kconfig
@@ -164,7 +164,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_CAN
         default n
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32/n32l43xrl-stb/Kconfig
+++ b/bsp/n32/n32l43xrl-stb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32l43xrl-stb/board/Kconfig
+++ b/bsp/n32/n32l43xrl-stb/board/Kconfig
@@ -164,7 +164,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_CAN
         default n
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32/n32wb45xl-evb/Kconfig
+++ b/bsp/n32/n32wb45xl-evb/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/n32/n32wb45xl-evb/board/Kconfig
+++ b/bsp/n32/n32wb45xl-evb/board/Kconfig
@@ -184,7 +184,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "../libraries/n32_drivers/Kconfig"
+    rsource "../../libraries/n32_drivers/Kconfig"
 
 endmenu
 

--- a/bsp/n32g452xx/n32g452xx-mini-system/Kconfig
+++ b/bsp/n32g452xx/n32g452xx-mini-system/Kconfig
@@ -1,20 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nrf5x/libraries/templates/nrfx/Kconfig
+++ b/bsp/nrf5x/libraries/templates/nrfx/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/nrf5x/nrf51822/Kconfig
+++ b/bsp/nrf5x/nrf51822/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/nrf5x/nrf52832/Kconfig
+++ b/bsp/nrf5x/nrf52832/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/nrf5x/nrf52833/Kconfig
+++ b/bsp/nrf5x/nrf52833/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/nrf5x/nrf52840/Kconfig
+++ b/bsp/nrf5x/nrf52840/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/nrf5x/nrf5340/Kconfig
+++ b/bsp/nrf5x/nrf5340/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "board/Kconfig"
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 

--- a/bsp/nuclei/gd32vf103_rvstar/Kconfig
+++ b/bsp/nuclei/gd32vf103_rvstar/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config SOC_GD32VF103
     bool

--- a/bsp/nuclei/nuclei_fpga_eval/Kconfig
+++ b/bsp/nuclei/nuclei_fpga_eval/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 
 config SOC_DEMOSOC
     bool

--- a/bsp/nuvoton/ma35-rtp/Kconfig
+++ b/bsp/nuvoton/ma35-rtp/Kconfig
@@ -1,27 +1,18 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config USE_MA35D1_SUBM
     bool
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/ma35-rtp/board/Kconfig
+++ b/bsp/nuvoton/ma35-rtp/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/ma35/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/ma35/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -18,6 +18,6 @@ menu "Hardware Drivers Config"
 
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 
 endmenu

--- a/bsp/nuvoton/nk-980iot/Kconfig
+++ b/bsp/nuvoton/nk-980iot/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/nk-980iot/board/Kconfig
+++ b/bsp/nuvoton/nk-980iot/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/nuc980/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/nuc980/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -113,6 +113,6 @@ menu "Hardware Drivers Config"
 
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 
 endmenu

--- a/bsp/nuvoton/nk-n9h30/Kconfig
+++ b/bsp/nuvoton/nk-n9h30/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/nk-n9h30/board/Kconfig
+++ b/bsp/nuvoton/nk-n9h30/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/n9h30/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/n9h30/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -130,6 +130,6 @@ menu "Hardware Drivers Config"
 
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 
 endmenu

--- a/bsp/nuvoton/nk-rtu980/Kconfig
+++ b/bsp/nuvoton/nk-rtu980/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/nk-rtu980/board/Kconfig
+++ b/bsp/nuvoton/nk-rtu980/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/nuc980/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/nuc980/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -44,6 +44,6 @@ menu "Hardware Drivers Config"
 
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 
 endmenu

--- a/bsp/nuvoton/numaker-hmi-ma35d1/Kconfig
+++ b/bsp/nuvoton/numaker-hmi-ma35d1/Kconfig
@@ -1,27 +1,18 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config USE_MA35D1_AARCH32
     bool
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/numaker-hmi-ma35d1/board/Kconfig
+++ b/bsp/nuvoton/numaker-hmi-ma35d1/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/ma35/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/ma35/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -166,6 +166,6 @@ menu "Hardware Drivers Config"
 
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 
 endmenu

--- a/bsp/nuvoton/numaker-iot-m467/Kconfig
+++ b/bsp/nuvoton/numaker-iot-m467/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/numaker-iot-m467/board/Kconfig
+++ b/bsp/nuvoton/numaker-iot-m467/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/m460/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/m460/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -143,6 +143,6 @@ menu "Hardware Drivers Config"
 
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 
 endmenu

--- a/bsp/nuvoton/numaker-iot-m487/Kconfig
+++ b/bsp/nuvoton/numaker-iot-m487/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/numaker-iot-m487/board/Kconfig
+++ b/bsp/nuvoton/numaker-iot-m487/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/m480/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/m480/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -142,6 +142,6 @@ menu "Hardware Drivers Config"
 
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 
 endmenu

--- a/bsp/nuvoton/numaker-iot-ma35d1/Kconfig
+++ b/bsp/nuvoton/numaker-iot-ma35d1/Kconfig
@@ -1,27 +1,18 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config USE_MA35D1_AARCH32
     bool
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/numaker-iot-ma35d1/board/Kconfig
+++ b/bsp/nuvoton/numaker-iot-ma35d1/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/ma35/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/ma35/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -85,6 +85,6 @@ menu "Hardware Drivers Config"
     endif
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 
 endmenu

--- a/bsp/nuvoton/numaker-m032ki/Kconfig
+++ b/bsp/nuvoton/numaker-m032ki/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/numaker-m032ki/board/Kconfig
+++ b/bsp/nuvoton/numaker-m032ki/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/m031/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/m031/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -58,5 +58,5 @@ menu "Hardware Drivers Config"
 
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 endmenu

--- a/bsp/nuvoton/numaker-m2354/Kconfig
+++ b/bsp/nuvoton/numaker-m2354/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/numaker-m2354/board/Kconfig
+++ b/bsp/nuvoton/numaker-m2354/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/m2354/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/m2354/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -101,6 +101,6 @@ menu "Hardware Drivers Config"
 
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 
 endmenu

--- a/bsp/nuvoton/numaker-m467hj/Kconfig
+++ b/bsp/nuvoton/numaker-m467hj/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/numaker-m467hj/board/Kconfig
+++ b/bsp/nuvoton/numaker-m467hj/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/m460/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/m460/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -213,6 +213,6 @@ menu "Hardware Drivers Config"
 
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 
 endmenu

--- a/bsp/nuvoton/numaker-pfm-m487/Kconfig
+++ b/bsp/nuvoton/numaker-pfm-m487/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/nuvoton/numaker-pfm-m487/board/Kconfig
+++ b/bsp/nuvoton/numaker-pfm-m487/board/Kconfig
@@ -1,7 +1,7 @@
 menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
-        source "$BSP_DIR/../libraries/m480/rtt_port/Kconfig"
+        source "$(BSP_DIR)/../libraries/m480/rtt_port/Kconfig"
     endmenu
 
     menu "On-board Peripheral Drivers"
@@ -174,6 +174,6 @@ menu "Hardware Drivers Config"
 
     endmenu
 
-    source "$BSP_DIR/../libraries/nu_packages/Kconfig"
+    source "$(BSP_DIR)/../libraries/nu_packages/Kconfig"
 
 endmenu

--- a/bsp/nxp/imx/imx6sx/cortex-a9/Kconfig
+++ b/bsp/nxp/imx/imx6sx/cortex-a9/Kconfig
@@ -1,27 +1,15 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_MCIMX6X4
     bool

--- a/bsp/nxp/imx/imx6ul/Kconfig
+++ b/bsp/nxp/imx/imx6ul/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config BOARD_IMX6UL
     bool
@@ -21,10 +12,10 @@ config BOARD_IMX6UL
     select RT_USING_GIC_V2
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"
 
 config SOC_MCIMX6X4
     bool

--- a/bsp/nxp/imx/imx6ull-smart/Kconfig
+++ b/bsp/nxp/imx/imx6ull-smart/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_IMX6ULL
     bool
@@ -42,4 +33,4 @@ config SOC_IMX6ULL
             default 1
     endif
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"

--- a/bsp/nxp/imx/imxrt/imxrt1021-nxp-evk/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1021-nxp-evk/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/imx/imxrt/imxrt1052-atk-commander/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1052-atk-commander/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/imx/imxrt/imxrt1052-fire-pro/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1052-fire-pro/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/imx/imxrt/imxrt1052-nxp-evk/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1052-nxp-evk/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/imx/imxrt/imxrt1052-seeed-ArchMix/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1052-seeed-ArchMix/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/imx/imxrt/imxrt1060-nxp-evk/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1060-nxp-evk/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/imx/imxrt/imxrt1061-forlinx-OK1061-S/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1061-forlinx-OK1061-S/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/imx/imxrt/imxrt1064-nxp-evk/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1064-nxp-evk/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/imx/imxrt/imxrt1170-nxp-evk/m7/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1170-nxp-evk/m7/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../../.."
+RTT_DIR := ../../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/imx/imxrt/libraries/templates/imxrt1050xxx/Kconfig
+++ b/bsp/nxp/imx/imxrt/libraries/templates/imxrt1050xxx/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/imx/imxrt/libraries/templates/imxrt1064xxx/Kconfig
+++ b/bsp/nxp/imx/imxrt/libraries/templates/imxrt1064xxx/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/lpc/lpc1114/Kconfig
+++ b/bsp/nxp/lpc/lpc1114/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LPC1114
     bool
@@ -25,4 +16,4 @@ config SOC_LPC1114
     select RT_USING_USER_MAIN
     default y
 
-#source "$BSP_DIR/drivers/Kconfig"
+#source "$(BSP_DIR)/drivers/Kconfig"

--- a/bsp/nxp/lpc/lpc176x/Kconfig
+++ b/bsp/nxp/lpc/lpc176x/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 	
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LPC176
     bool

--- a/bsp/nxp/lpc/lpc178x/Kconfig
+++ b/bsp/nxp/lpc/lpc178x/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LPC178
     bool

--- a/bsp/nxp/lpc/lpc2148/Kconfig
+++ b/bsp/nxp/lpc/lpc2148/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LPC2148
     bool

--- a/bsp/nxp/lpc/lpc2478/Kconfig
+++ b/bsp/nxp/lpc/lpc2478/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LPC2478
     bool

--- a/bsp/nxp/lpc/lpc408x/Kconfig
+++ b/bsp/nxp/lpc/lpc408x/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LPC4088
     bool
@@ -25,4 +16,4 @@ config SOC_LPC4088
     select RT_USING_USER_MAIN
     default y
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"

--- a/bsp/nxp/lpc/lpc5410x/Kconfig
+++ b/bsp/nxp/lpc/lpc5410x/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LPC5410
     bool

--- a/bsp/nxp/lpc/lpc54114-lite/Kconfig
+++ b/bsp/nxp/lpc/lpc54114-lite/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LPC54114
     bool
@@ -26,4 +17,4 @@ config SOC_LPC54114
     default y
 
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"

--- a/bsp/nxp/lpc/lpc54608-LPCXpresso/Kconfig
+++ b/bsp/nxp/lpc/lpc54608-LPCXpresso/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_LPC54608
     bool
@@ -25,5 +16,5 @@ config SOC_LPC54608
     select RT_USING_USER_MAIN
     default y
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"
 

--- a/bsp/nxp/lpc/lpc55sxx/Libraries/template/lpc55s6xxxx/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/Libraries/template/lpc55s6xxxx/Kconfig
@@ -1,26 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_LPC55S6x
     bool
     select ARCH_ARM_CORTEX_M33
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s06_nxp_evk/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s06_nxp_evk/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_LPC55S06
     bool
@@ -21,7 +12,7 @@ config SOC_LPC55S06
     select ARCH_ARM_CORTEX_SECURE
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s16_nxp_evk/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s16_nxp_evk/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_LPC55S16
     bool
@@ -21,7 +12,7 @@ config SOC_LPC55S16
     select ARCH_ARM_CORTEX_SECURE
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s28_nxp_evk/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s28_nxp_evk/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_LPC55S28
     bool
@@ -21,7 +12,7 @@ config SOC_LPC55S28
     select ARCH_ARM_CORTEX_SECURE
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s36_nxp_evk/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s36_nxp_evk/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_LPC55S36
     bool
@@ -21,7 +12,7 @@ config SOC_LPC55S36
     select ARCH_ARM_CORTEX_SECURE
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s69_nxp_evk/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s69_nxp_evk/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_LPC55S69
     bool
@@ -21,7 +12,7 @@ config SOC_LPC55S69
     select ARCH_ARM_CORTEX_SECURE
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/lpc/lpc55sxx/tools/sdk_dist.py
+++ b/bsp/nxp/lpc/lpc55sxx/tools/sdk_dist.py
@@ -1,8 +1,10 @@
 import os
 import sys
 import shutil
+
 cwd_path = os.getcwd()
 sys.path.append(os.path.join(os.path.dirname(cwd_path), 'rt-thread', 'tools'))
+
 
 # BSP dist function
 def dist_do_building(BSP_ROOT, dist_dir):
@@ -10,7 +12,7 @@ def dist_do_building(BSP_ROOT, dist_dir):
     import rtconfig
 
     library_path = os.path.join(os.path.dirname(BSP_ROOT), 'Libraries')
-    library_dir  = os.path.join(dist_dir, 'Libraries')
+    library_dir = os.path.join(dist_dir, 'Libraries')
     print("=> copy bsp drivers")
     bsp_copy_files(os.path.join(library_path, 'drivers'), os.path.join(library_dir, 'drivers'))
     print("=> copy bsp CMSIS")
@@ -18,7 +20,7 @@ def dist_do_building(BSP_ROOT, dist_dir):
     print("=> copy bsp library")
     bsp_copy_files(os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE), os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE))
     shutil.copyfile(os.path.join(library_path, 'Kconfig'), os.path.join(library_dir, 'Kconfig'))
-    
+
     # change RTT_ROOT in Kconfig
     if not os.path.isfile(os.path.join(dist_dir, 'Kconfig')):
         return
@@ -26,12 +28,7 @@ def dist_do_building(BSP_ROOT, dist_dir):
     with open(os.path.join(dist_dir, 'Kconfig'), 'r') as f:
         data = f.readlines()
     with open(os.path.join(dist_dir, 'Kconfig'), 'w') as f:
-        found = 0
         for line in data:
-            if line.find('RTT_ROOT') != -1:
-                found = 1
-            if line.find('../Libraries') != -1 and found:
-                position = line.find('../Libraries')
-                line = line[0:position] + 'Libraries/Kconfig"\n'
-                found = 0
+            if line.find('source') != -1 and line.find('../libraries') != -1:
+                line = line.replace('../Libraries', 'Libraries')
             f.write(line)

--- a/bsp/nxp/mcx/mcxa/frdm-mcxa153/Kconfig
+++ b/bsp/nxp/mcx/mcxa/frdm-mcxa153/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_MCX
     bool
@@ -21,7 +12,7 @@ config SOC_MCX
     select ARCH_ARM_CORTEX_SECURE
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/nxp/mcx/mcxn/frdm-mcxn947/Kconfig
+++ b/bsp/nxp/mcx/mcxn/frdm-mcxn947/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../../.."
+RTT_DIR := ../../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_MCX
     bool
@@ -21,7 +12,7 @@ config SOC_MCX
     select ARCH_ARM_CORTEX_SECURE
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/phytium/aarch32/Kconfig
+++ b/bsp/phytium/aarch32/Kconfig
@@ -1,28 +1,16 @@
 mainmenu "RT-Thread Project Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "../."
+BSP_DIR := ../.
 
-config SDK_DIR
-    string
-    option env="SDK_DIR"
-    default ".././libraries/phytium_standalone_sdk"
+SDK_DIR := .././libraries/phytium_standalone_sdk
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$RTT_DIR/bsp/phytium/libraries/drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/../libraries/drivers/Kconfig"
 
 config PHYTIUM_ARCH_AARCH32
     bool
@@ -47,9 +35,9 @@ menu "Standalone Setting"
         help
             Use the Aarch64 to Aarch32 mode function
 
-    source "$SDK_DIR/soc/soc.kconfig"
-    source "$RTT_DIR/bsp/phytium/board/board.kconfig"
-    source "$SDK_DIR/common/common.kconfig"
+    source "$(SDK_DIR)/soc/soc.kconfig"
+    source "$(BSP_DIR)/../board/board.kconfig"
+    source "$(SDK_DIR)/common/common.kconfig"
 endmenu
 
 

--- a/bsp/phytium/aarch64/Kconfig
+++ b/bsp/phytium/aarch64/Kconfig
@@ -1,28 +1,16 @@
 mainmenu "RT-Thread Project Configuration"
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "../."
+BSP_DIR := ../.
 
-config SDK_DIR
-    string
-    option env="SDK_DIR"
-    default ".././libraries/phytium_standalone_sdk"
+SDK_DIR:= .././libraries/phytium_standalone_sdk
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$RTT_DIR/bsp/phytium/libraries/drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/../libraries/drivers/Kconfig"
 
 config BSP_USING_GIC
     bool
@@ -71,9 +59,9 @@ menu "Standalone Setting"
         bool "Armv8 Aarch64"
         default y
 
-    source "$SDK_DIR/soc/soc.kconfig"
-    source "$RTT_DIR/bsp/phytium/board/board.kconfig"
-    source "$SDK_DIR/common/common.kconfig"
+    source "$(SDK_DIR)/soc/soc.kconfig"
+    source "$(BSP_DIR)/../board/board.kconfig"
+    source "$(SDK_DIR)/common/common.kconfig"
 
 endmenu
 

--- a/bsp/qemu-vexpress-a9/Kconfig
+++ b/bsp/qemu-vexpress-a9/Kconfig
@@ -1,20 +1,11 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$BSP_DIR/drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"

--- a/bsp/qemu-virt64-aarch64/Kconfig
+++ b/bsp/qemu-virt64-aarch64/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../"
+RTT_DIR := ../../
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_VIRT64_AARCH64
     bool
@@ -31,4 +22,4 @@ config SOC_VIRT64_AARCH64
     select ARCH_MM_MMU
     default y
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"

--- a/bsp/qemu-virt64-riscv/Kconfig
+++ b/bsp/qemu-virt64-riscv/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../"
+RTT_DIR := ../../
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "driver/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "driver/Kconfig"
 
 config BOARD_QEMU_VIRT_RV64
     bool

--- a/bsp/raspberry-pi/raspi2/Kconfig
+++ b/bsp/raspberry-pi/raspi2/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config BCM2836_SOC
     bool
@@ -25,4 +16,4 @@ config BCM2836_SOC
     select RT_USING_USER_MAIN
     default y
 
-source "driver/Kconfig"
+rsource "driver/Kconfig"

--- a/bsp/raspberry-pi/raspi3-32/Kconfig
+++ b/bsp/raspberry-pi/raspi3-32/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config BCM2836_SOC
     bool
@@ -24,4 +15,4 @@ config BCM2836_SOC
     select RT_USING_USER_MAIN
     default y
 
-source "driver/Kconfig"
+rsource "driver/Kconfig"

--- a/bsp/raspberry-pi/raspi3-64/Kconfig
+++ b/bsp/raspberry-pi/raspi3-64/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config BCM2836_SOC
     bool
@@ -32,4 +23,4 @@ config SOC_BCM283x
     bool
     default y
 
-source "driver/Kconfig"
+rsource "driver/Kconfig"

--- a/bsp/raspberry-pi/raspi4-32/Kconfig
+++ b/bsp/raspberry-pi/raspi4-32/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config BCM2711_SOC
     bool
@@ -27,4 +18,4 @@ config BCM2711_SOC
     select RT_USING_GIC_V2
     default y
 
-source "driver/Kconfig"
+rsource "driver/Kconfig"

--- a/bsp/raspberry-pi/raspi4-64/Kconfig
+++ b/bsp/raspberry-pi/raspi4-64/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config BCM2711_SOC
     bool
@@ -28,4 +19,4 @@ config BCM2711_SOC
     select ARCH_CPU_64BIT
     default y
 
-source "drivers/Kconfig"
+rsource "drivers/Kconfig"

--- a/bsp/raspberry-pico/Kconfig
+++ b/bsp/raspberry-pico/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_RP2040
     bool
@@ -24,6 +15,6 @@ config SOC_RP2040
     select PKG_USING_RASPBERRYPI_PICO_SDK
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/renesas/ebf_qi_min_6m5/Kconfig
+++ b/bsp/renesas/ebf_qi_min_6m5/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/ebf_qi_min_6m5/board/Kconfig
+++ b/bsp/renesas/ebf_qi_min_6m5/board/Kconfig
@@ -13,7 +13,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_UART
             bool "Enable UART"

--- a/bsp/renesas/libraries/bsp-template/Kconfig
+++ b/bsp/renesas/libraries/bsp-template/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/libraries/bsp-template/board/Kconfig
+++ b/bsp/renesas/libraries/bsp-template/board/Kconfig
@@ -13,7 +13,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_UART
             bool "Enable UART"

--- a/bsp/renesas/ra2l1-cpk/Kconfig
+++ b/bsp/renesas/ra2l1-cpk/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/ra2l1-cpk/board/Kconfig
+++ b/bsp/renesas/ra2l1-cpk/board/Kconfig
@@ -16,7 +16,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_UART
             bool "Enable UART"

--- a/bsp/renesas/ra4m2-eco/Kconfig
+++ b/bsp/renesas/ra4m2-eco/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/ra4m2-eco/board/Kconfig
+++ b/bsp/renesas/ra4m2-eco/board/Kconfig
@@ -27,7 +27,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_UART
             bool "Enable UART"

--- a/bsp/renesas/ra6m3-ek/Kconfig
+++ b/bsp/renesas/ra6m3-ek/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/ra6m3-ek/board/Kconfig
+++ b/bsp/renesas/ra6m3-ek/board/Kconfig
@@ -57,7 +57,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_UART
             bool "Enable UART"

--- a/bsp/renesas/ra6m3-hmi-board/Kconfig
+++ b/bsp/renesas/ra6m3-hmi-board/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/ra6m3-hmi-board/board/Kconfig
+++ b/bsp/renesas/ra6m3-hmi-board/board/Kconfig
@@ -121,7 +121,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_UART
             bool "Enable UART"

--- a/bsp/renesas/ra6m4-cpk/Kconfig
+++ b/bsp/renesas/ra6m4-cpk/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/ra6m4-cpk/board/Kconfig
+++ b/bsp/renesas/ra6m4-cpk/board/Kconfig
@@ -42,7 +42,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_UART
             bool "Enable UART"

--- a/bsp/renesas/ra6m4-iot/Kconfig
+++ b/bsp/renesas/ra6m4-iot/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/ra6m4-iot/board/Kconfig
+++ b/bsp/renesas/ra6m4-iot/board/Kconfig
@@ -13,7 +13,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_UART
             bool "Enable UART"

--- a/bsp/renesas/ra8d1-ek/Kconfig
+++ b/bsp/renesas/ra8d1-ek/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/ra8d1-ek/board/Kconfig
+++ b/bsp/renesas/ra8d1-ek/board/Kconfig
@@ -23,7 +23,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_UART
             bool "Enable UART"

--- a/bsp/renesas/ra8d1-vision-board/Kconfig
+++ b/bsp/renesas/ra8d1-vision-board/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/ra8d1-vision-board/board/Kconfig
+++ b/bsp/renesas/ra8d1-vision-board/board/Kconfig
@@ -68,7 +68,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_ADC
             bool "Enable ADC"

--- a/bsp/renesas/ra8m1-ek/Kconfig
+++ b/bsp/renesas/ra8m1-ek/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/ra8m1-ek/board/Kconfig
+++ b/bsp/renesas/ra8m1-ek/board/Kconfig
@@ -27,7 +27,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_UART
             bool "Enable UART"

--- a/bsp/renesas/rzt2m_rsk/Kconfig
+++ b/bsp/renesas/rzt2m_rsk/Kconfig
@@ -1,29 +1,17 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
 # you can change the RTT_ROOT default "rt-thread"
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
-source "$BSP_DIR/board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"

--- a/bsp/renesas/rzt2m_rsk/board/Kconfig
+++ b/bsp/renesas/rzt2m_rsk/board/Kconfig
@@ -13,7 +13,7 @@ menu "Hardware Drivers Config"
 
     menu "On-chip Peripheral Drivers"
 
-        source "../libraries/HAL_Drivers/Kconfig"
+        rsource "../../libraries/HAL_Drivers/Kconfig"
 
         menuconfig BSP_USING_ADC
             bool "Enable ADC"

--- a/bsp/rm48x50/Kconfig
+++ b/bsp/rm48x50/Kconfig
@@ -1,16 +1,7 @@
 mainmenu "RT-Thread Project Configuration"
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+BSP_DIR := .
+RTT_DIR := ../..
+PKGS_DIR := packages
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 

--- a/bsp/rockchip/rk2108/Kconfig
+++ b/bsp/rockchip/rk2108/Kconfig
@@ -1,16 +1,10 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-source "$RTT_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
 
 config BSP_RK2108
     bool
@@ -21,5 +15,5 @@ config BSP_RK2108
     select RT_USING_USER_MAIN
     default y
 
-source "$BSP_DIR/board/Kconfig"
-source "$BSP_DIR/driver/Kconfig"
+source "$(BSP_DIR)/board/Kconfig"
+source "$(BSP_DIR)/driver/Kconfig"

--- a/bsp/rockchip/rk2108/board/Kconfig
+++ b/bsp/rockchip/rk2108/board/Kconfig
@@ -16,6 +16,6 @@ config RT_RUN_MEM_SIZE
     help
         Set RK2108 SRAM MEM SIZE
 
-source "$BSP_DIR/board/$RT_BOARD_NAME/Kconfig"
+source "$(BSP_DIR)/board/$RT_BOARD_NAME/Kconfig"
 
 endmenu

--- a/bsp/rockchip/rk2108/driver/Kconfig
+++ b/bsp/rockchip/rk2108/driver/Kconfig
@@ -1,4 +1,4 @@
-source "$BSP_DIR/../common/drivers/Kconfig"
+source "$(BSP_DIR)/../common/drivers/Kconfig"
 
 menu "RT-Thread rockchip RK2108 drivers"
 

--- a/bsp/rockchip/rk3568/Kconfig
+++ b/bsp/rockchip/rk3568/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_RK3568
     bool
@@ -28,4 +19,4 @@ config SOC_RK3568
     select ARCH_ARM_BOOTWITH_FLUSH_CACHE
     default y
 
-source "$BSP_DIR/driver/Kconfig"
+source "$(BSP_DIR)/driver/Kconfig"

--- a/bsp/rv32m1_vega/ri5cy/Kconfig
+++ b/bsp/rv32m1_vega/ri5cy/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_VEGA_RI5CY
     bool
@@ -29,4 +20,4 @@ config BOARD_X_FRDM_VEGA
     select RT_USING_USER_MAIN
     default y
 
-source "driver/Kconfig"
+rsource "driver/Kconfig"

--- a/bsp/sam7x/Kconfig
+++ b/bsp/sam7x/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"

--- a/bsp/simulator/Kconfig
+++ b/bsp/simulator/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_SIMULATOR
     bool

--- a/bsp/smartfusion2/Kconfig
+++ b/bsp/smartfusion2/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "drivers/Kconfig"
 
 config SOC_SF2_M2S010
     bool

--- a/bsp/sparkfun-redv/Kconfig
+++ b/bsp/sparkfun-redv/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_FE310
     bool

--- a/bsp/stm32/libraries/templates/stm32f0xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f0xx/Kconfig
@@ -1,24 +1,15 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/libraries/templates/stm32f0xx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f0xx/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/libraries/templates/stm32f10x/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f10x/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/libraries/templates/stm32f10x/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f10x/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/libraries/templates/stm32f2xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f2xx/Kconfig
@@ -1,24 +1,15 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/libraries/templates/stm32f2xx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f2xx/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/libraries/templates/stm32f3xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f3xx/Kconfig
@@ -1,24 +1,15 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/libraries/templates/stm32f4xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f4xx/Kconfig
@@ -1,24 +1,15 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/libraries/templates/stm32f4xx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f4xx/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/libraries/templates/stm32f7xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f7xx/Kconfig
@@ -1,24 +1,15 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/libraries/templates/stm32f7xx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32f7xx/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/libraries/templates/stm32h7xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32h7xx/Kconfig
@@ -1,24 +1,15 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/libraries/templates/stm32h7xx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32h7xx/board/Kconfig
@@ -29,7 +29,7 @@ menu "On-chip Peripheral Drivers"
 
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/libraries/templates/stm32l1xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32l1xx/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/libraries/templates/stm32l1xx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32l1xx/board/Kconfig
@@ -206,7 +206,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_WDT
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/libraries/templates/stm32l4xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32l4xx/Kconfig
@@ -1,24 +1,15 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/libraries/templates/stm32l4xx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32l4xx/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/libraries/templates/stm32l5xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32l5xx/Kconfig
@@ -1,24 +1,15 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/libraries/templates/stm32l5xx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32l5xx/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/libraries/templates/stm32mp1xx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32mp1xx/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/libraries/templates/stm32mp1xx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32mp1xx/board/Kconfig
@@ -39,7 +39,7 @@ menu "On-chip Peripheral Drivers"
 
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/libraries/templates/stm32wbxx/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32wbxx/Kconfig
@@ -1,24 +1,15 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/libraries/templates/stm32wbxx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32wbxx/board/Kconfig
@@ -157,7 +157,7 @@ menu "On-chip Peripheral Drivers"
             endchoice
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f072-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f072-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F072RB
     bool
@@ -27,11 +18,11 @@ config BOARD_STM32F072_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f072-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f072-st-nucleo/board/Kconfig
@@ -164,7 +164,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f091-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f091-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F091RC
     bool
@@ -27,11 +18,11 @@ config BOARD_STM32F091_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f091-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f091-st-nucleo/board/Kconfig
@@ -150,7 +150,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_WDT
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-100ask-mini/Kconfig
+++ b/bsp/stm32/stm32f103-100ask-mini/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103C8
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103C8
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-100ask-mini/board/Kconfig
+++ b/bsp/stm32/stm32f103-100ask-mini/board/Kconfig
@@ -72,7 +72,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-100ask-pro/Kconfig
+++ b/bsp/stm32/stm32f103-100ask-pro/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103ZE
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103ZE
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-100ask-pro/board/Kconfig
+++ b/bsp/stm32/stm32f103-100ask-pro/board/Kconfig
@@ -207,7 +207,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_CAN
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-atk-nano/Kconfig
+++ b/bsp/stm32/stm32f103-atk-nano/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103RB
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103RB
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-atk-nano/board/Kconfig
+++ b/bsp/stm32/stm32f103-atk-nano/board/Kconfig
@@ -195,7 +195,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_WDT
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-atk-warshipv3/Kconfig
+++ b/bsp/stm32/stm32f103-atk-warshipv3/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103ZE
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103ZE
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-atk-warshipv3/board/Kconfig
+++ b/bsp/stm32/stm32f103-atk-warshipv3/board/Kconfig
@@ -235,7 +235,7 @@ menu "On-chip Peripheral Drivers"
 
         endif
 
- source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+ source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-blue-pill/Kconfig
+++ b/bsp/stm32/stm32f103-blue-pill/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103C8
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F103C8
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f103-blue-pill/board/Kconfig
+++ b/bsp/stm32/stm32f103-blue-pill/board/Kconfig
@@ -190,7 +190,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_USB_DEVICE
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-dofly-M3S/Kconfig
+++ b/bsp/stm32/stm32f103-dofly-M3S/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103ZE
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103ZE
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-dofly-M3S/board/Kconfig
+++ b/bsp/stm32/stm32f103-dofly-M3S/board/Kconfig
@@ -129,7 +129,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_SDIO
         select RT_USING_DFS
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-dofly-lyc8/Kconfig
+++ b/bsp/stm32/stm32f103-dofly-lyc8/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103C8
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103C8
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-dofly-lyc8/board/Kconfig
+++ b/bsp/stm32/stm32f103-dofly-lyc8/board/Kconfig
@@ -25,7 +25,7 @@ menu "On-chip Peripheral Drivers"
                 depends on BSP_USING_UART1 && RT_SERIAL_USING_DMA
                 default n
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-fire-arbitrary/Kconfig
+++ b/bsp/stm32/stm32f103-fire-arbitrary/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103ZE
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103ZE
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-fire-arbitrary/board/Kconfig
+++ b/bsp/stm32/stm32f103-fire-arbitrary/board/Kconfig
@@ -303,7 +303,7 @@ menu "On-chip Peripheral Drivers"
                 int "USB PULL UP STATUS"
                 default 0
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-gizwits-gokitv21/Kconfig
+++ b/bsp/stm32/stm32f103-gizwits-gokitv21/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103C8
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103C8
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-gizwits-gokitv21/board/Kconfig
+++ b/bsp/stm32/stm32f103-gizwits-gokitv21/board/Kconfig
@@ -71,7 +71,7 @@ menu "On-chip Peripheral Drivers"
                 range 1 216
                 default 16
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-hw100k-ibox/Kconfig
+++ b/bsp/stm32/stm32f103-hw100k-ibox/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103ZE
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103ZE
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-hw100k-ibox/board/Kconfig
+++ b/bsp/stm32/stm32f103-hw100k-ibox/board/Kconfig
@@ -209,7 +209,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable Watchdog Timer"
         select RT_USING_WDT
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-onenet-nbiot/Kconfig
+++ b/bsp/stm32/stm32f103-onenet-nbiot/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103RB
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103RB
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-onenet-nbiot/board/Kconfig
+++ b/bsp/stm32/stm32f103-onenet-nbiot/board/Kconfig
@@ -61,7 +61,7 @@ menu "On-chip Peripheral Drivers"
         endif
 
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-yf-ufun/Kconfig
+++ b/bsp/stm32/stm32f103-yf-ufun/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103RC
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103RC
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-yf-ufun/board/Kconfig
+++ b/bsp/stm32/stm32f103-yf-ufun/board/Kconfig
@@ -94,7 +94,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_DFS_ELMFAT
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f103-ys-f1pro/Kconfig
+++ b/bsp/stm32/stm32f103-ys-f1pro/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F103ZE
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F103ZE
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f103-ys-f1pro/board/Kconfig
+++ b/bsp/stm32/stm32f103-ys-f1pro/board/Kconfig
@@ -27,7 +27,7 @@ menu "On-chip Peripheral Drivers"
 
         endif
 
- source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+ source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f107-uc-eval/Kconfig
+++ b/bsp/stm32/stm32f107-uc-eval/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F107VC
     bool
@@ -22,11 +13,11 @@ config SOC_STM32F107VC
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f107-uc-eval/board/Kconfig
+++ b/bsp/stm32/stm32f107-uc-eval/board/Kconfig
@@ -34,7 +34,7 @@ menu "On-chip Peripheral Drivers"
 
       endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f207-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f207-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F207ZG
     bool
@@ -27,11 +18,11 @@ config BOARD_STM32F207_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32f207-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f207-st-nucleo/board/Kconfig
@@ -21,7 +21,7 @@ menu "On-chip Peripheral Drivers"
                 default y
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f302-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f302-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F302R8
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32F302_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f334-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f334-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F334R8
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32F334_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f401-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f401-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F401RE
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32F401_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f401-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f401-st-nucleo/board/Kconfig
@@ -201,7 +201,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f401-weact-blackpill/Kconfig
+++ b/bsp/stm32/stm32f401-weact-blackpill/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F401CC
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F401CC
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f401-weact-blackpill/board/Kconfig
+++ b/bsp/stm32/stm32f401-weact-blackpill/board/Kconfig
@@ -124,7 +124,7 @@ menu "On-chip Peripheral Drivers"
                 default 46
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f405-smdz-breadfruit/Kconfig
+++ b/bsp/stm32/stm32f405-smdz-breadfruit/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F405RG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F405RG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f405-smdz-breadfruit/board/Kconfig
+++ b/bsp/stm32/stm32f405-smdz-breadfruit/board/Kconfig
@@ -25,7 +25,7 @@ menu "On-chip Peripheral Drivers"
                 depends on BSP_USING_UART2 && RT_SERIAL_USING_DMA
                 default n
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f405zg-mini-template/Kconfig
+++ b/bsp/stm32/stm32f405zg-mini-template/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F405ZG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F405ZG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f405zg-mini-template/board/Kconfig
+++ b/bsp/stm32/stm32f405zg-mini-template/board/Kconfig
@@ -113,7 +113,7 @@ menu "On-chip Peripheral Drivers"
             endif
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f407-armfly-v5/Kconfig
+++ b/bsp/stm32/stm32f407-armfly-v5/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F407IG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F407IG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f407-armfly-v5/board/Kconfig
+++ b/bsp/stm32/stm32f407-armfly-v5/board/Kconfig
@@ -179,7 +179,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_DFS
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f407-atk-explorer/Kconfig
+++ b/bsp/stm32/stm32f407-atk-explorer/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F407ZG
     bool
@@ -26,10 +17,10 @@ config BOARD_STM32F407_ATK_EXPLORER
     bool
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f407-atk-explorer/board/Kconfig
+++ b/bsp/stm32/stm32f407-atk-explorer/board/Kconfig
@@ -490,7 +490,7 @@ menu "On-chip Peripheral Drivers"
     config BSP_USING_FMC
         bool
         default n
- source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+ source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f407-lckfb-skystar/Kconfig
+++ b/bsp/stm32/stm32f407-lckfb-skystar/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F407ZG
     bool
@@ -26,10 +17,10 @@ config BOARD_STM32F407_SPARK
     bool
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f407-lckfb-skystar/board/Kconfig
+++ b/bsp/stm32/stm32f407-lckfb-skystar/board/Kconfig
@@ -415,7 +415,7 @@ menu "On-chip Peripheral Drivers"
     config BSP_USING_FMC
         bool
         default n
- source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+ source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f407-robomaster-c/Kconfig
+++ b/bsp/stm32/stm32f407-robomaster-c/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F407IG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F407IG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f407-robomaster-c/board/Kconfig
+++ b/bsp/stm32/stm32f407-robomaster-c/board/Kconfig
@@ -195,7 +195,7 @@ menu "On-chip Peripheral Drivers"
         endif
 
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f407-rt-spark/Kconfig
+++ b/bsp/stm32/stm32f407-rt-spark/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F407ZG
     bool
@@ -26,10 +17,10 @@ config BOARD_STM32F407_SPARK
     bool
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f407-rt-spark/board/Kconfig
+++ b/bsp/stm32/stm32f407-rt-spark/board/Kconfig
@@ -721,7 +721,7 @@ menu "On-chip Peripheral Drivers"
     config BSP_USING_FMC
         bool
         default n
- source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+ source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f407-st-discovery/Kconfig
+++ b/bsp/stm32/stm32f407-st-discovery/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F407VG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F407VG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f407-st-discovery/board/Kconfig
+++ b/bsp/stm32/stm32f407-st-discovery/board/Kconfig
@@ -63,7 +63,7 @@ menu "On-chip Peripheral Drivers"
                 range 1 216
                 default 25
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f410-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f410-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F410RB
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32F410_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f410-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f410-st-nucleo/board/Kconfig
@@ -107,7 +107,7 @@ menu "On-chip Peripheral Drivers"
                 default 25
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f411-atk-nano/Kconfig
+++ b/bsp/stm32/stm32f411-atk-nano/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F411RC
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F411RC
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f411-atk-nano/board/Kconfig
+++ b/bsp/stm32/stm32f411-atk-nano/board/Kconfig
@@ -152,7 +152,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_WDT
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f411-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f411-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F411RE
     bool
@@ -32,10 +23,10 @@ config BOARD_STM32F411_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f411-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f411-st-nucleo/board/Kconfig
@@ -226,7 +226,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f411-weact-blackpill/Kconfig
+++ b/bsp/stm32/stm32f411-weact-blackpill/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F411RE
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F411RE
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f411-weact-blackpill/board/Kconfig
+++ b/bsp/stm32/stm32f411-weact-blackpill/board/Kconfig
@@ -178,7 +178,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_USB_DEVICE
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f412-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f412-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F412ZG
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32F412_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f413-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f413-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 
 config SOC_STM32F413ZH
@@ -28,10 +19,10 @@ config BOARD_STM32F413_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f413-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f413-st-nucleo/board/Kconfig
@@ -153,7 +153,7 @@ menu "On-chip Peripheral Drivers"
         select BSP_USBD_TYPE_FS
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f427-robomaster-a/Kconfig
+++ b/bsp/stm32/stm32f427-robomaster-a/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F427II
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F427II
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f427-robomaster-a/board/Kconfig
+++ b/bsp/stm32/stm32f427-robomaster-a/board/Kconfig
@@ -239,7 +239,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f429-armfly-v6/Kconfig
+++ b/bsp/stm32/stm32f429-armfly-v6/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F429BI
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F429BI
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f429-armfly-v6/board/Kconfig
+++ b/bsp/stm32/stm32f429-armfly-v6/board/Kconfig
@@ -212,7 +212,7 @@ menu "On-chip Peripheral Drivers"
     config BSP_USING_LTDC
         bool
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f429-atk-apollo/Kconfig
+++ b/bsp/stm32/stm32f429-atk-apollo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F429IG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F429IG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f429-atk-apollo/board/Kconfig
+++ b/bsp/stm32/stm32f429-atk-apollo/board/Kconfig
@@ -288,7 +288,7 @@ menu "On-chip Peripheral Drivers"
     config BSP_USING_FMC
         bool
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f429-fire-challenger/Kconfig
+++ b/bsp/stm32/stm32f429-fire-challenger/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F429IG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F429IG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f429-fire-challenger/board/Kconfig
+++ b/bsp/stm32/stm32f429-fire-challenger/board/Kconfig
@@ -234,7 +234,7 @@ menu "On-chip Peripheral Drivers"
     config BSP_USING_LTDC
         bool
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f429-st-disco/Kconfig
+++ b/bsp/stm32/stm32f429-st-disco/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F429ZI
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F429ZI
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f429-st-disco/board/Kconfig
+++ b/bsp/stm32/stm32f429-st-disco/board/Kconfig
@@ -104,7 +104,7 @@ menu "On-chip Peripheral Drivers"
         select BSP_USING_LCD
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f446-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f446-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F446ZE
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32F446_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f446-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f446-st-nucleo/board/Kconfig
@@ -25,7 +25,7 @@ menu "On-chip Peripheral Drivers"
                 depends on BSP_USING_UART1 && RT_SERIAL_USING_DMA
                 default n
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f469-st-disco/Kconfig
+++ b/bsp/stm32/stm32f469-st-disco/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F469NI
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F469NI
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f469-st-disco/board/Kconfig
+++ b/bsp/stm32/stm32f469-st-disco/board/Kconfig
@@ -287,7 +287,7 @@ menu "On-chip Peripheral Drivers"
     config BSP_USING_LTDC
         bool "Enable LTDC"
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f723-st-disco/Kconfig
+++ b/bsp/stm32/stm32f723-st-disco/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F723E
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F723E
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f723-st-disco/board/Kconfig
+++ b/bsp/stm32/stm32f723-st-disco/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
                 default y
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f746-st-disco/Kconfig
+++ b/bsp/stm32/stm32f746-st-disco/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F746NG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F746NG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f746-st-disco/board/Kconfig
+++ b/bsp/stm32/stm32f746-st-disco/board/Kconfig
@@ -102,7 +102,7 @@ menu "On-chip Peripheral Drivers"
     config BSP_USING_LTDC
         bool
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f746-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f746-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F746ZG
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32F746_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f746-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f746-st-nucleo/board/Kconfig
@@ -234,7 +234,7 @@ menu "On-chip Peripheral Drivers"
                 int "USB PULL UP STATUS"
                 default 0
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f767-atk-apollo/Kconfig
+++ b/bsp/stm32/stm32f767-atk-apollo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F767IG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F767IG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f767-atk-apollo/board/Kconfig
+++ b/bsp/stm32/stm32f767-atk-apollo/board/Kconfig
@@ -248,7 +248,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable LTDC"
         default n
 
- source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+ source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f767-fire-challenger-v1/Kconfig
+++ b/bsp/stm32/stm32f767-fire-challenger-v1/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F767IG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F767IG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f767-fire-challenger-v1/board/Kconfig
+++ b/bsp/stm32/stm32f767-fire-challenger-v1/board/Kconfig
@@ -168,7 +168,7 @@ menu "On-chip Peripheral Drivers"
         bool
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f767-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32f767-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F767ZI
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32F767_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f767-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f767-st-nucleo/board/Kconfig
@@ -49,7 +49,7 @@ menu "On-chip Peripheral Drivers"
                 depends on BSP_USING_UART3 && RT_SERIAL_USING_DMA
                 default n
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32f769-st-disco/Kconfig
+++ b/bsp/stm32/stm32f769-st-disco/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32F769NI
     bool
@@ -22,10 +13,10 @@ config SOC_STM32F769NI
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32f769-st-disco/board/Kconfig
+++ b/bsp/stm32/stm32f769-st-disco/board/Kconfig
@@ -67,7 +67,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32g070-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32g070-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32G070RB
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32G070_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32g070-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32g070-st-nucleo/board/Kconfig
@@ -179,7 +179,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable Watchdog Timer"
         select RT_USING_WDT
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32g071-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32g071-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32G071RB
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32G071_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32g071-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32g071-st-nucleo/board/Kconfig
@@ -208,7 +208,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable Watchdog Timer"
         select RT_USING_WDT
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32g431-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32g431-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32G431RB
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32G431_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32g431-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32g431-st-nucleo/board/Kconfig
@@ -52,7 +52,7 @@ menu "On-chip Peripheral Drivers"
                 depends on BSP_USING_UART4 && RT_SERIAL_USING_DMA
                 default n
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32g474-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32g474-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32G474RE
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32G474_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32g474-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32g474-st-nucleo/board/Kconfig
@@ -187,7 +187,7 @@ menu "On-chip Peripheral Drivers"
                 default 25
         endif
     
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32g491-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32g491-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32G491RE
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32G491_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32g491-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32g491-st-nucleo/board/Kconfig
@@ -269,7 +269,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable Watchdog Timer"
         select RT_USING_WDT
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32h503-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32h503-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H503RB
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32H503_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h503-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32h503-st-nucleo/board/Kconfig
@@ -141,7 +141,7 @@ menu "On-chip Peripheral Drivers"
                 default 23
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32h563-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32h563-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H563ZI
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32H563_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h563-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32h563-st-nucleo/board/Kconfig
@@ -149,7 +149,7 @@ menu "On-chip Peripheral Drivers"
                 default 25
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32h743-armfly-v7/Kconfig
+++ b/bsp/stm32/stm32h743-armfly-v7/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H743XI
     bool
@@ -22,10 +13,10 @@ config SOC_STM32H743XI
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h743-armfly-v7/board/Kconfig
+++ b/bsp/stm32/stm32h743-armfly-v7/board/Kconfig
@@ -22,7 +22,7 @@ menu "On-chip Peripheral Drivers"
 
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32h743-atk-apollo/Kconfig
+++ b/bsp/stm32/stm32h743-atk-apollo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H743II
     bool
@@ -22,10 +13,10 @@ config SOC_STM32H743II
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h743-atk-apollo/board/Kconfig
+++ b/bsp/stm32/stm32h743-atk-apollo/board/Kconfig
@@ -190,7 +190,7 @@ menu "On-chip Peripheral Drivers"
         default n
 
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32h743-openmv-h7plus/Kconfig
+++ b/bsp/stm32/stm32h743-openmv-h7plus/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H743II
     bool
@@ -22,10 +13,10 @@ config SOC_STM32H743II
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h743-openmv-h7plus/board/Kconfig
+++ b/bsp/stm32/stm32h743-openmv-h7plus/board/Kconfig
@@ -52,7 +52,7 @@ menu "Hardware Drivers Config"
                 select RT_USING_RTC
                 default n
 
-        source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+        source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
     endmenu
 

--- a/bsp/stm32/stm32h743-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32h743-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H743ZI
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32H743_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h743-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32h743-st-nucleo/board/Kconfig
@@ -22,7 +22,7 @@ menu "On-chip Peripheral Drivers"
 
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32h747-st-discovery/Kconfig
+++ b/bsp/stm32/stm32h747-st-discovery/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H747XI
     bool
@@ -22,10 +13,10 @@ config SOC_STM32H747XI
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h747-st-discovery/board/Kconfig
+++ b/bsp/stm32/stm32h747-st-discovery/board/Kconfig
@@ -22,7 +22,7 @@ menu "On-chip Peripheral Drivers"
 
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32h750-armfly-h7-tool/Kconfig
+++ b/bsp/stm32/stm32h750-armfly-h7-tool/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H750IB
     bool
@@ -22,10 +13,10 @@ config SOC_STM32H750IB
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h750-armfly-h7-tool/board/Kconfig
+++ b/bsp/stm32/stm32h750-armfly-h7-tool/board/Kconfig
@@ -129,7 +129,7 @@ menu "On-chip Peripheral Drivers"
         select BSP_USBD_PHY_ULPI
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32h750-artpi/Kconfig
+++ b/bsp/stm32/stm32h750-artpi/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H750XB
     bool
@@ -28,10 +19,10 @@ config BOARD_STM32H750_ARTPI
     select SOC_STM32H750XB
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h750-artpi/board/Kconfig
+++ b/bsp/stm32/stm32h750-artpi/board/Kconfig
@@ -374,7 +374,7 @@ menu "On-chip Peripheral Drivers"
     config BSP_USING_LTDC
         bool
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32h750-fk750m1-vbt6/Kconfig
+++ b/bsp/stm32/stm32h750-fk750m1-vbt6/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H750VBT6
     bool
@@ -22,10 +13,10 @@ config SOC_STM32H750VBT6
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h750-fk750m1-vbt6/board/Kconfig
+++ b/bsp/stm32/stm32h750-fk750m1-vbt6/board/Kconfig
@@ -113,7 +113,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable on-chip FLASH"
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32h750-weact-ministm32h7xx/Kconfig
+++ b/bsp/stm32/stm32h750-weact-ministm32h7xx/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H750VBT6
     bool
@@ -22,10 +13,10 @@ config SOC_STM32H750VBT6
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h750-weact-ministm32h7xx/board/Kconfig
+++ b/bsp/stm32/stm32h750-weact-ministm32h7xx/board/Kconfig
@@ -169,7 +169,7 @@ menu "On-chip Peripheral Drivers"
         select BSP_USBD_PHY_ULPI
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32h7s7-st-disco/Kconfig
+++ b/bsp/stm32/stm32h7s7-st-disco/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32H7RS
     bool
@@ -29,10 +20,10 @@ config SOC_SERIES_STM32H7RS
     select SOC_FAMILY_STM32
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32h7s7-st-disco/board/Kconfig
+++ b/bsp/stm32/stm32h7s7-st-disco/board/Kconfig
@@ -242,7 +242,7 @@ menu "On-chip Peripheral Drivers"
     config BSP_USING_LTDC
         bool
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l010-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32l010-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L010RB
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32L010_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l010-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l010-st-nucleo/board/Kconfig
@@ -30,7 +30,7 @@ menu "On-chip Peripheral Drivers"
                 depends on BSP_USING_UART2 && RT_SERIAL_USING_DMA
                 default n
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l053-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32l053-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L053R8
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32L053_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l053-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l053-st-nucleo/board/Kconfig
@@ -31,7 +31,7 @@ menu "On-chip Peripheral Drivers"
                 depends on BSP_USING_UART2 && RT_SERIAL_USING_DMA
                 default n
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l412-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32l412-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L412RB
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32L412_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l412-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l412-st-nucleo/board/Kconfig
@@ -55,7 +55,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable Watchdog Timer"
         select RT_USING_WDT
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l431-BearPi/Kconfig
+++ b/bsp/stm32/stm32l431-BearPi/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L431RC
     bool
@@ -22,10 +13,10 @@ config SOC_STM32L431RC
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l431-BearPi/board/Kconfig
+++ b/bsp/stm32/stm32l431-BearPi/board/Kconfig
@@ -141,7 +141,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l431-tencentos-tiny-EVB_MX+/Kconfig
+++ b/bsp/stm32/stm32l431-tencentos-tiny-EVB_MX+/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L431RC
     bool
@@ -22,10 +13,10 @@ config SOC_STM32L431RC
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l431-tencentos-tiny-EVB_MX+/board/Kconfig
+++ b/bsp/stm32/stm32l431-tencentos-tiny-EVB_MX+/board/Kconfig
@@ -117,7 +117,7 @@ menu "On-chip Peripheral Drivers"
                 default 25
         endif
 
-    source "../libraries/HAL_Drivers/drivers/Kconfig"
+    rsource "../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l432-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32l432-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L432KC
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32L432_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_32
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l432-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l432-st-nucleo/board/Kconfig
@@ -55,7 +55,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable Watchdog Timer"
         select RT_USING_WDT
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l433-ali-startkit/Kconfig
+++ b/bsp/stm32/stm32l433-ali-startkit/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L433CC
     bool
@@ -22,10 +13,10 @@ config SOC_STM32L433CC
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l433-ali-startkit/board/Kconfig
+++ b/bsp/stm32/stm32l433-ali-startkit/board/Kconfig
@@ -213,7 +213,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_WDT
         default n
 
- source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+ source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l433-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32l433-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L433RC
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32L433_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l433-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l433-st-nucleo/board/Kconfig
@@ -77,7 +77,7 @@ menu "On-chip Peripheral Drivers"
             endchoice
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l452-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32l452-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L452RE
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32L452_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l452-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l452-st-nucleo/board/Kconfig
@@ -74,7 +74,7 @@ menu "On-chip Peripheral Drivers"
                 range 1 176
                 default 16
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l475-atk-pandora/Kconfig
+++ b/bsp/stm32/stm32l475-atk-pandora/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L475VE
     bool
@@ -26,10 +17,10 @@ config BOARD_STM32L475_ATK_PANDORA
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l475-atk-pandora/board/Kconfig
+++ b/bsp/stm32/stm32l475-atk-pandora/board/Kconfig
@@ -572,7 +572,7 @@ menu "On-chip Peripheral Drivers"
             BSP_USING_STM32_SDIO use drv_sdio_adapter.c,and
             BSP_USING_SDIO use drv_sdio.c
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l475-st-discovery/Kconfig
+++ b/bsp/stm32/stm32l475-st-discovery/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L475VG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32L475VG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l475-st-discovery/board/Kconfig
+++ b/bsp/stm32/stm32l475-st-discovery/board/Kconfig
@@ -25,7 +25,7 @@ menu "On-chip Peripheral Drivers"
                 depends on BSP_USING_UART1 && RT_SERIAL_USING_DMA
                 default n
         endif
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l476-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32l476-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L476RG
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32L476_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l476-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l476-st-nucleo/board/Kconfig
@@ -262,7 +262,7 @@ menu "On-chip Peripheral Drivers"
             endchoice
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l496-ali-developer/Kconfig
+++ b/bsp/stm32/stm32l496-ali-developer/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L496VG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32L496VG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l496-ali-developer/board/Kconfig
+++ b/bsp/stm32/stm32l496-ali-developer/board/Kconfig
@@ -221,7 +221,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_WDT
         default n
 
- source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+ source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l496-st-discovery/Kconfig
+++ b/bsp/stm32/stm32l496-st-discovery/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L496AG
     bool
@@ -22,10 +13,10 @@ config SOC_STM32L496AG
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l496-st-discovery/board/Kconfig
+++ b/bsp/stm32/stm32l496-st-discovery/board/Kconfig
@@ -30,7 +30,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l496-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32l496-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L496ZG
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32L496_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l496-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l496-st-nucleo/board/Kconfig
@@ -278,7 +278,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_DFS_ELMFAT
         default n
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l4r5-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32l4r5-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L4R5ZI
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32L4R5_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l4r9-st-eval/Kconfig
+++ b/bsp/stm32/stm32l4r9-st-eval/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L4R9AI
     bool
@@ -22,10 +13,10 @@ config SOC_STM32L4R9AI
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l4r9-st-eval/board/Kconfig
+++ b/bsp/stm32/stm32l4r9-st-eval/board/Kconfig
@@ -83,7 +83,7 @@ menu "On-chip Peripheral Drivers"
     config BSP_USING_FMC
         bool
         default n
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l4r9-st-sensortile-box/Kconfig
+++ b/bsp/stm32/stm32l4r9-st-sensortile-box/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L4R9ZI
     bool
@@ -22,10 +13,10 @@ config SOC_STM32L4R9ZI
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l4r9-st-sensortile-box/board/Kconfig
+++ b/bsp/stm32/stm32l4r9-st-sensortile-box/board/Kconfig
@@ -23,7 +23,7 @@ menu "On-chip Peripheral Drivers"
         default y
 
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32l552-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32l552-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32L552ZE
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32L552_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32l552-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l552-st-nucleo/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32mp157a-st-discovery/Kconfig
+++ b/bsp/stm32/stm32mp157a-st-discovery/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32MP157A
     bool
@@ -22,11 +13,11 @@ config SOC_STM32MP157A
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32mp157a-st-discovery/board/Kconfig
+++ b/bsp/stm32/stm32mp157a-st-discovery/board/Kconfig
@@ -284,7 +284,7 @@ menu "On-chip Peripheral Drivers"
                 default n
         endif
 
- source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+ source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32mp157a-st-ev1/Kconfig
+++ b/bsp/stm32/stm32mp157a-st-ev1/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32MP157A
     bool
@@ -22,11 +13,11 @@ config SOC_STM32MP157A
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif
 

--- a/bsp/stm32/stm32mp157a-st-ev1/board/Kconfig
+++ b/bsp/stm32/stm32mp157a-st-ev1/board/Kconfig
@@ -321,7 +321,7 @@ menu "On-chip Peripheral Drivers"
             default n
     endif
 
- source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+ source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32u575-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32u575-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32U575ZI
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32U575_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_144
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32u575-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32u575-st-nucleo/board/Kconfig
@@ -192,7 +192,7 @@ menu "On-chip Peripheral Drivers"
                 endif
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32u585-iot02a/Kconfig
+++ b/bsp/stm32/stm32u585-iot02a/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32U585AIIxQ
     bool
@@ -22,10 +13,10 @@ config SOC_STM32U585AIIxQ
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32u585-iot02a/board/Kconfig
+++ b/bsp/stm32/stm32u585-iot02a/board/Kconfig
@@ -17,7 +17,7 @@ menu "On-chip Peripheral Drivers"
                 default y
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32wb55-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32wb55-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32WB55RG
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32WB55_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32wb55-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32wb55-st-nucleo/board/Kconfig
@@ -150,7 +150,7 @@ menu "On-chip Peripheral Drivers"
             endchoice
         endif
 
-    source "$BSP_DIR/../libraries/HAL_Drivers/drivers/Kconfig"
+    source "$(BSP_DIR)/../libraries/HAL_Drivers/drivers/Kconfig"
 
 endmenu
 

--- a/bsp/stm32/stm32wl55-st-nucleo/Kconfig
+++ b/bsp/stm32/stm32wl55-st-nucleo/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32WL55JC
     bool
@@ -27,10 +18,10 @@ config BOARD_STM32WL55_NUCLEO
     select BOARD_SERIES_STM32_NUCLEO_64
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32wle5-yizhilian-lm401/Kconfig
+++ b/bsp/stm32/stm32wle5-yizhilian-lm401/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32WLE5CB
     bool
@@ -22,10 +13,10 @@ config SOC_STM32WLE5CB
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/stm32/stm32wle5-yizhilian-lm402/Kconfig
+++ b/bsp/stm32/stm32wle5-yizhilian-lm402/Kconfig
@@ -1,19 +1,10 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_STM32WLE5JC
     bool
@@ -22,10 +13,10 @@ config SOC_STM32WLE5JC
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../libraries/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
 
 if !RT_USING_NANO
-source "board/Kconfig"
+rsource "board/Kconfig"
 endif

--- a/bsp/synopsys/boards/Kconfig
+++ b/bsp/synopsys/boards/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_EMSK
     bool
@@ -26,4 +17,4 @@ config SOC_EMSK
     select RT_USING_CPU_FFS
     default y
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"

--- a/bsp/synwit/swm320-mini/Kconfig
+++ b/bsp/synwit/swm320-mini/Kconfig
@@ -1,20 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/synwit/swm341-mini/Kconfig
+++ b/bsp/synwit/swm341-mini/Kconfig
@@ -1,20 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/tae32f5300/Kconfig
+++ b/bsp/tae32f5300/Kconfig
@@ -1,23 +1,14 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "drivers/Kconfig"
 
 
 

--- a/bsp/thead-smart/Kconfig
+++ b/bsp/thead-smart/Kconfig
@@ -1,25 +1,16 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_THEAD_SMART
     bool

--- a/bsp/ti/c28x/tms320f28379d/Kconfig
+++ b/bsp/ti/c28x/tms320f28379d/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
 config SOC_TMS320F28X
     bool
@@ -25,6 +16,6 @@ config SOC_TMS320F28X
     select RT_USING_USER_MAIN
     default y
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/tkm32F499/Kconfig
+++ b/bsp/tkm32F499/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "rt-thread"
+RTT_DIR := rt-thread
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "drivers/Kconfig"
 

--- a/bsp/tm4c123bsp/Kconfig
+++ b/bsp/tm4c123bsp/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"
 

--- a/bsp/tm4c129x/Kconfig
+++ b/bsp/tm4c129x/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_TM4C129
     bool

--- a/bsp/w60x/Kconfig
+++ b/bsp/w60x/Kconfig
@@ -1,32 +1,20 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
 # you can change the RTT_ROOT default "../.." to your rtthread_root,
 # example : default "F:/git_repositories/rt-thread"
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-config ENV_DIR
-    string
-    option env="ENV_ROOT"
-    default "/"
+ENV_DIR := /
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "$ENV_DIR/tools/scripts/cmds/Kconfig"
-source "$BSP_DIR/drivers/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+osource "$ENV_DIR/tools/scripts/cmds/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"
 
 config SOC_W60X
     bool

--- a/bsp/wch/arm/ch32f103c8-core/Kconfig
+++ b/bsp/wch/arm/ch32f103c8-core/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/wch/arm/ch32f203r-evt/Kconfig
+++ b/bsp/wch/arm/ch32f203r-evt/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/wch/arm/ch579m/Kconfig
+++ b/bsp/wch/arm/ch579m/Kconfig
@@ -1,20 +1,11 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/wch/arm/tools/sdk_dist.py
+++ b/bsp/wch/arm/tools/sdk_dist.py
@@ -1,8 +1,10 @@
 import os
 import sys
 import shutil
+
 cwd_path = os.getcwd()
 sys.path.append(os.path.join(os.path.dirname(cwd_path), 'rt-thread', 'tools'))
+
 
 # BSP dist function
 def dist_do_building(BSP_ROOT, dist_dir):
@@ -12,25 +14,22 @@ def dist_do_building(BSP_ROOT, dist_dir):
     print("=> copy ch32 bsp library")
     library_dir = os.path.join(dist_dir, 'Libraries')
     library_path = os.path.join(os.path.dirname(BSP_ROOT), 'Libraries')
-    bsp_copy_files(os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE),
-                   os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE))
+    bsp_copy_files(
+        os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE),
+        os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE),
+    )
 
     print("=> copy bsp drivers")
     bsp_copy_files(os.path.join(library_path, 'ch32_drivers'), os.path.join(library_dir, 'ch32_drivers'))
     shutil.copyfile(os.path.join(library_path, 'Kconfig'), os.path.join(library_dir, 'Kconfig'))
-# change RTT_ROOT in Kconfig
+    # change RTT_ROOT in Kconfig
     if not os.path.isfile(os.path.join(dist_dir, 'Kconfig')):
         return
 
     with open(os.path.join(dist_dir, 'Kconfig'), 'r') as f:
         data = f.readlines()
     with open(os.path.join(dist_dir, 'Kconfig'), 'w') as f:
-        found = 0
         for line in data:
-            if line.find('RTT_ROOT') != -1:
-                found = 1
-            if line.find('../Libraries') != -1 and found:
-                position = line.find('../Libraries')
-                line = line[0:position] + 'Libraries/Kconfig"\n'
-                found = 0
+            if line.find('source') != -1 and line.find('../libraries') != -1:
+                line = line.replace('../Libraries', 'Libraries')
             f.write(line)

--- a/bsp/wch/risc-v/ch32v103r-evt/Kconfig
+++ b/bsp/wch/risc-v/ch32v103r-evt/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/wch/risc-v/ch32v208w-r0/Kconfig
+++ b/bsp/wch/risc-v/ch32v208w-r0/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/wch/risc-v/ch32v307v-r1/Kconfig
+++ b/bsp/wch/risc-v/ch32v307v-r1/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/wch/risc-v/ch569w-evt/Kconfig
+++ b/bsp/wch/risc-v/ch569w-evt/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/wch/risc-v/tools/sdk_dist.py
+++ b/bsp/wch/risc-v/tools/sdk_dist.py
@@ -1,8 +1,10 @@
 import os
 import sys
 import shutil
+
 cwd_path = os.getcwd()
 sys.path.append(os.path.join(os.path.dirname(cwd_path), 'rt-thread', 'tools'))
+
 
 # BSP dist function
 def dist_do_building(BSP_ROOT, dist_dir):
@@ -12,25 +14,19 @@ def dist_do_building(BSP_ROOT, dist_dir):
     print("=> copy ch32 bsp library")
     library_dir = os.path.join(dist_dir, 'Libraries')
     library_path = os.path.join(os.path.dirname(BSP_ROOT), 'Libraries')
-    bsp_copy_files(os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE),
-                   os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE))
+    bsp_copy_files(os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE), os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE))
 
     print("=> copy bsp drivers")
     bsp_copy_files(os.path.join(library_path, 'ch32_drivers'), os.path.join(library_dir, 'ch32_drivers'))
     shutil.copyfile(os.path.join(library_path, 'Kconfig'), os.path.join(library_dir, 'Kconfig'))
-# change RTT_ROOT in Kconfig
+    # change RTT_ROOT in Kconfig
     if not os.path.isfile(os.path.join(dist_dir, 'Kconfig')):
         return
 
     with open(os.path.join(dist_dir, 'Kconfig'), 'r') as f:
         data = f.readlines()
     with open(os.path.join(dist_dir, 'Kconfig'), 'w') as f:
-        found = 0
         for line in data:
-            if line.find('RTT_ROOT') != -1:
-                found = 1
-            if line.find('../Libraries') != -1 and found:
-                position = line.find('../Libraries')
-                line = line[0:position] + 'Libraries/Kconfig"\n'
-                found = 0
+            if line.find('source') != -1 and line.find('../libraries') != -1:
+                line = line.replace('../Libraries', 'Libraries')
             f.write(line)

--- a/bsp/wch/risc-v/yd-ch32v307vct6/Kconfig
+++ b/bsp/wch/risc-v/yd-ch32v307vct6/Kconfig
@@ -1,21 +1,12 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../../.."
+RTT_DIR := ../../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
-source "../Libraries/Kconfig"
-source "board/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
+rsource "../libraries/Kconfig"
+rsource "board/Kconfig"

--- a/bsp/x86/Kconfig
+++ b/bsp/x86/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config IA32
     bool

--- a/bsp/xplorer4330/M4/Kconfig
+++ b/bsp/xplorer4330/M4/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_XPLORER4330_M4
     bool

--- a/bsp/yichip/yc3121-pos/Kconfig
+++ b/bsp/yichip/yc3121-pos/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_SWM320VET7
     bool
@@ -24,4 +15,4 @@ config SOC_SWM320VET7
     select RT_USING_USER_MAIN
     default y
 
-source "drivers/Kconfig"
+rsource "drivers/Kconfig"

--- a/bsp/yichip/yc3122-pos/Kconfig
+++ b/bsp/yichip/yc3122-pos/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../.."
+RTT_DIR := ../../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_YC3122
     bool
@@ -24,4 +15,4 @@ config SOC_YC3122
     select RT_USING_USER_MAIN
     default y
 
-source "drivers/Kconfig"
+rsource "drivers/Kconfig"

--- a/bsp/zynqmp-a53-dfzu2eg/Kconfig
+++ b/bsp/zynqmp-a53-dfzu2eg/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../../"
+RTT_DIR := ../../
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_ZYNQMP_AARCH64
     bool
@@ -31,4 +22,4 @@ config SOC_ZYNQMP_AARCH64
     select ARCH_MM_MMU
     default y
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"

--- a/bsp/zynqmp-r5-axu4ev/Kconfig
+++ b/bsp/zynqmp-r5-axu4ev/Kconfig
@@ -1,22 +1,13 @@
 mainmenu "RT-Thread Project Configuration"
 
-config BSP_DIR
-    string
-    option env="BSP_ROOT"
-    default "."
+BSP_DIR := .
 
-config RTT_DIR
-    string
-    option env="RTT_ROOT"
-    default "../.."
+RTT_DIR := ../..
 
-config PKGS_DIR
-    string
-    option env="PKGS_ROOT"
-    default "packages"
+PKGS_DIR := packages
 
-source "$RTT_DIR/Kconfig"
-source "$PKGS_DIR/Kconfig"
+source "$(RTT_DIR)/Kconfig"
+osource "$PKGS_DIR/Kconfig"
 
 config SOC_ZYNQMP_R5
     bool
@@ -25,4 +16,4 @@ config SOC_ZYNQMP_R5
     select RT_USING_USER_MAIN
     default y
 
-source "$BSP_DIR/drivers/Kconfig"
+source "$(BSP_DIR)/drivers/Kconfig"

--- a/components/Kconfig
+++ b/components/Kconfig
@@ -26,25 +26,25 @@ config RT_USING_LEGACY
     default n
 
 if RT_USING_CONSOLE
-source "$RTT_DIR/components/finsh/Kconfig"
+rsource "finsh/Kconfig"
 endif
 
 if !RT_USING_NANO
-source "$RTT_DIR/components/dfs/Kconfig"
-source "$RTT_DIR/components/fal/Kconfig"
-source "$RTT_DIR/components/drivers/Kconfig"
-source "$RTT_DIR/components/libc/Kconfig"
-source "$RTT_DIR/components/net/Kconfig"
-source "$RTT_DIR/components/mprotect/Kconfig"
-source "$RTT_DIR/components/utilities/Kconfig"
-source "$RTT_DIR/components/vbus/Kconfig"
+rsource "dfs/Kconfig"
+rsource "fal/Kconfig"
+rsource "drivers/Kconfig"
+rsource "libc/Kconfig"
+rsource "net/Kconfig"
+rsource "mprotect/Kconfig"
+rsource "utilities/Kconfig"
+rsource "vbus/Kconfig"
 endif
 
 if RT_USING_SMART
-source "$RTT_DIR/components/lwp/Kconfig"
-source "$RTT_DIR/components/mm/Kconfig"
+rsource "lwp/Kconfig"
+rsource "mm/Kconfig"
 endif
 
-source "$RTT_DIR/components/legacy/Kconfig"
+rsource "legacy/Kconfig"
 
 endmenu

--- a/components/libc/Kconfig
+++ b/components/libc/Kconfig
@@ -9,8 +9,8 @@ config RT_USING_EXTERNAL_LIBC
         RT_USING_EXTERNAL_LIBC in software package's Kconfig
         This option is not available for users to select.
 
-source "$RTT_DIR/components/libc/compilers/common/Kconfig"
-source "$RTT_DIR/components/libc/posix/Kconfig"
-source "$RTT_DIR/components/libc/cplusplus/Kconfig"
+rsource "compilers/common/Kconfig"
+rsource "posix/Kconfig"
+rsource "cplusplus/Kconfig"
 
 endmenu

--- a/components/libc/posix/Kconfig
+++ b/components/libc/posix/Kconfig
@@ -115,6 +115,6 @@ if RT_USING_MODULE
         default n
 endif
 
-source "$RTT_DIR/components/libc/posix/ipc/Kconfig"
+rsource "ipc/Kconfig"
 
 endmenu

--- a/components/lwp/Kconfig
+++ b/components/lwp/Kconfig
@@ -74,6 +74,6 @@ if RT_USING_LWP
             default n
     endif
 
-source "$RTT_DIR/components/lwp/terminal/Kconfig"
+rsource "terminal/Kconfig"
 endif
 

--- a/components/net/Kconfig
+++ b/components/net/Kconfig
@@ -1,8 +1,8 @@
 menu "Network"
 
-source "$RTT_DIR/components/net/sal/Kconfig"
-source "$RTT_DIR/components/net/netdev/Kconfig"
-source "$RTT_DIR/components/net/lwip/Kconfig"
-source "$RTT_DIR/components/net/at/Kconfig"
+rsource "sal/Kconfig"
+rsource "netdev/Kconfig"
+rsource "lwip/Kconfig"
+rsource "at/Kconfig"
 
 endmenu

--- a/components/utilities/Kconfig
+++ b/components/utilities/Kconfig
@@ -220,7 +220,7 @@ config RT_USING_RESOURCE_ID
     bool "Enable resource id"
     default n
 
-source "$RTT_DIR/components/utilities/libadt/Kconfig"
-source "$RTT_DIR/components/utilities/rt-link/Kconfig"
+rsource "libadt/Kconfig"
+rsource "rt-link/Kconfig"
 
 endmenu

--- a/examples/utest/testcases/Kconfig
+++ b/examples/utest/testcases/Kconfig
@@ -7,14 +7,14 @@ config RT_USING_UTESTCASES
 
 if RT_USING_UTESTCASES
 
-source "$RTT_DIR/examples/utest/testcases/utest/Kconfig"
-source "$RTT_DIR/examples/utest/testcases/kernel/Kconfig"
-source "$RTT_DIR/examples/utest/testcases/cpp11/Kconfig"
-source "$RTT_DIR/examples/utest/testcases/drivers/serial_v2/Kconfig"
-source "$RTT_DIR/examples/utest/testcases/drivers/ipc/Kconfig"
-source "$RTT_DIR/examples/utest/testcases/posix/Kconfig"
-source "$RTT_DIR/examples/utest/testcases/mm/Kconfig"
-source "$RTT_DIR/examples/utest/testcases/tmpfs/Kconfig"
+rsource "utest/Kconfig"
+rsource "kernel/Kconfig"
+rsource "cpp11/Kconfig"
+rsource "drivers/serial_v2/Kconfig"
+rsource "drivers/ipc/Kconfig"
+rsource "posix/Kconfig"
+rsource "mm/Kconfig"
+rsource "tmpfs/Kconfig"
 endif
 
 endmenu

--- a/examples/utest/testcases/posix/Kconfig
+++ b/examples/utest/testcases/posix/Kconfig
@@ -6,32 +6,32 @@ menu "RTT Posix Testcase"
         default n
 
     if RTT_POSIX_TESTCASE
-        # source "$RTT_DIR/examples/utest/testcases/posix/aio_h/Kconfig"        # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/arpa/Kconfig"         # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/ctype_h/Kconfig"      # reserve
-        source "$RTT_DIR/examples/utest/testcases/posix/dirent_h/Kconfig"
-        # source "$RTT_DIR/examples/utest/testcases/posix/errno_h/Kconfig"      # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/fcntl_h/Kconfig"      # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/fenv_h/Kconfig"       # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/inttypes_h/Kconfig"   # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/libgen_h/Kconfig"     # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/locale_h/Kconfig"     # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/mqueue_h/Kconfig"     # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/net/Kconfig"          # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/netdb_h/Kconfig"      # reserve
-        source "$RTT_DIR/examples/utest/testcases/posix/pthread_h/Kconfig"
-        # source "$RTT_DIR/examples/utest/testcases/posix/sched_h/Kconfig"      # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/semaphore_h/Kconfig"  # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/setjmp_h/Kconfig"     # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/signal_h/Kconfig"     # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/stdarg_h/Kconfig"     # reserve
-        source "$RTT_DIR/examples/utest/testcases/posix/stdio_h/Kconfig"
-        source "$RTT_DIR/examples/utest/testcases/posix/stdlib_h/Kconfig"
-        # source "$RTT_DIR/examples/utest/testcases/posix/string_h/Kconfig"     # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/stropts_h/Kconfig"    # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/sys/Kconfig"          # reserve
-        # source "$RTT_DIR/examples/utest/testcases/posix/time_h/Kconfig"       # reserve
-        source "$RTT_DIR/examples/utest/testcases/posix/unistd_h/Kconfig"
+        # rsource "aio_h/Kconfig"        # reserve
+        # rsource "arpa/Kconfig"         # reserve
+        # rsource "ctype_h/Kconfig"      # reserve
+        rsource "dirent_h/Kconfig"
+        # rsource "errno_h/Kconfig"      # reserve
+        # rsource "fcntl_h/Kconfig"      # reserve
+        # rsource "fenv_h/Kconfig"       # reserve
+        # rsource "inttypes_h/Kconfig"   # reserve
+        # rsource "libgen_h/Kconfig"     # reserve
+        # rsource "locale_h/Kconfig"     # reserve
+        # rsource "mqueue_h/Kconfig"     # reserve
+        # rsource "net/Kconfig"          # reserve
+        # rsource "netdb_h/Kconfig"      # reserve
+        rsource "pthread_h/Kconfig"
+        # rsource "sched_h/Kconfig"      # reserve
+        # rsource "semaphore_h/Kconfig"  # reserve
+        # rsource "setjmp_h/Kconfig"     # reserve
+        # rsource "signal_h/Kconfig"     # reserve
+        # rsource "stdarg_h/Kconfig"     # reserve
+        rsource "stdio_h/Kconfig"
+        rsource "stdlib_h/Kconfig"
+        # rsource "string_h/Kconfig"     # reserve
+        # rsource "stropts_h/Kconfig"    # reserve
+        # rsource "sys/Kconfig"          # reserve
+        # rsource "time_h/Kconfig"       # reserve
+        rsource "unistd_h/Kconfig"
     endif
 
 endmenu

--- a/examples/utest/testcases/posix/arpa/Kconfig
+++ b/examples/utest/testcases/posix/arpa/Kconfig
@@ -1,1 +1,1 @@
-source "$RTT_DIR/examples/utest/testcases/posix/arpa/inet_h/Kconfig"
+rsource "inet_h/Kconfig"

--- a/examples/utest/testcases/posix/net/Kconfig
+++ b/examples/utest/testcases/posix/net/Kconfig
@@ -1,1 +1,1 @@
-source "$RTT_DIR/examples/utest/testcases/posix/net/if_h/Kconfig"
+rsource "if_h/Kconfig"

--- a/examples/utest/testcases/posix/sys/Kconfig
+++ b/examples/utest/testcases/posix/sys/Kconfig
@@ -1,3 +1,3 @@
-source "$RTT_DIR/examples/utest/testcases/posix/sys/mman_h/Kconfig"
-source "$RTT_DIR/examples/utest/testcases/posix/sys/shm_h/Kconfig"
-source "$RTT_DIR/examples/utest/testcases/posix/sys/utsname_h/Kconfig"
+rsource "mman_h/Kconfig"
+rsource "shm_h/Kconfig"
+rsource "utsname_h/Kconfig"

--- a/tools/mkdist.py
+++ b/tools/mkdist.py
@@ -126,14 +126,9 @@ def bsp_update_kconfig(dist_dir):
     with open(os.path.join(dist_dir, 'Kconfig'), 'r') as f:
         data = f.readlines()
     with open(os.path.join(dist_dir, 'Kconfig'), 'w') as f:
-        found = 0
         for line in data:
-            if line.find('RTT_ROOT') != -1:
-                found = 1
-            if line.find('default') != -1 and found:
-                position = line.find('default')
-                line = line[0:position] + 'default "rt-thread"\n'
-                found = 0
+            if line.find('RTT_DIR') != -1 and line.find(':=') != -1:
+                line = 'RTT_DIR := rt-thread\n'
             f.write(line)
 
 def bsp_update_kconfig_library(dist_dir):
@@ -144,14 +139,9 @@ def bsp_update_kconfig_library(dist_dir):
     with open(os.path.join(dist_dir, 'Kconfig'), 'r') as f:
         data = f.readlines()
     with open(os.path.join(dist_dir, 'Kconfig'), 'w') as f:
-        found = 0
         for line in data:
-            if line.find('RTT_ROOT') != -1:
-                found = 1
-            if line.find('../libraries') != -1 and found:
-                position = line.find('../libraries')
-                line = line[0:position] + 'libraries/Kconfig"\n'
-                found = 0
+            if line.find('source') != -1 and line.find('../libraries') != -1:
+                line = line.replace('../libraries', 'libraries')
             f.write(line)
 
     # change board/kconfig path
@@ -162,9 +152,8 @@ def bsp_update_kconfig_library(dist_dir):
         data = f.readlines()
     with open(os.path.join(dist_dir, 'board/Kconfig'), 'w') as f:
         for line in data:
-            if line.find('../libraries/HAL_Drivers/drivers/Kconfig') != -1:
-                position = line.find('../libraries/HAL_Drivers/drivers/Kconfig')
-                line = line[0:position] + 'libraries/HAL_Drivers/drivers/Kconfig"\n'
+            if line.find('source') != -1 and line.find('../libraries') != -1:
+                line = line.replace('../libraries', 'libraries')
             f.write(line)
 
 def zip_dist(dist_dir, dist_name):


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

通过这段时间的测试和分析，可以判断rtt studio、rtt studio for vscode、以及env-windows等均支持kconfiglib。当前仓库Kconfig中仍然保留了option env语句，其实scons --menuconfig和rtt env已经彻底转为kconfiglib（windows和Ubuntu都是），并没有使用kconfig-frontends工具，option env仍然保留只是因为担心rtt studio不支持，以及还需要同步修改mkdist部分工和文档。

目前已经确定rtt studio本质还是调用的kconfiglib，因此准备将option env语法移除，全面切换到kconfiglib的相对路径语句。

前两次关于kconfiglib的pr是：
- [将scons --menuconfig/--pyconfig/--pyconfig-silent统一调用kconfiglib](https://github.com/RT-Thread/rt-thread/pull/8664)
- [[Kconfig] 是不是放弃“option env=”了？](https://github.com/RT-Thread/rt-thread/issues/8863)


#### 你的解决方案是什么 (what is your solution)

第一步，RTT目录（除了bsp文件夹）下的Kconfig文件中将$RTT_DIR语句替换为相对路径

第二步，BSP文件夹下所有Kconfig文件中option env语句替换为kconfig新语法
```
BSP_DIR := ../../..
source "$(RTT_DIR)/Kconfig"
```

- source "$RTT_DIR，替换为source "$(RTT_DIR)，RTT_DIR和BSP_DIR采用变量定义，使用的时候需要增加括号
- source "$BSP_DIR，替换为source "$(BSP_DIR)
- source "$PKGS_DIR，替换为osource $PKGS_DIR，pkgs_dir还是继续使用环境变量，因此不需要括号，另外以防pkgs_dir环境变量没有定义而报错，使用osource（option source）
- source "$ENV_DIR，替换为osource $ENV_DIR
- source "直接路径的，替换为rsource "相对路径

第三步，将mkdist中对RTT_ROOT修改进行对应调整

第四步，测试配套工具链是否正常工作

第五步，修改README.md等文档

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
