### PR TITLE
【修复】修复ART-PI samrt上读取不到emmc/sd分区问题

### DIFF
--- a/components/drivers/sdio/sd.c
+++ b/components/drivers/sdio/sd.c
@@ -755,6 +755,25 @@ static rt_int32_t mmcsd_sd_init_card(struct rt_mmcsd_host *host,
             goto err1;
     }
 
+    /*
+     * change SD card to the highest supported speed
+     */
+    err = mmcsd_switch(card);
+    if (err)
+        goto err1;
+
+    /* set bus speed */
+    max_data_rate = (unsigned int)-1;
+    if (max_data_rate < card->hs_max_data_rate)
+    {
+        max_data_rate = card->hs_max_data_rate;
+    }
+    if (max_data_rate < card->max_data_rate)
+    {
+        max_data_rate = card->max_data_rate;
+    }
+
+    mmcsd_set_clock(host, max_data_rate);
     /*switch bus width*/
     if ((host->flags & MMCSD_BUSWIDTH_4) && (card->scr.sd_bus_widths & SD_SCR_BUS_WIDTH_4))
     {
@@ -779,26 +798,6 @@ static rt_int32_t mmcsd_sd_init_card(struct rt_mmcsd_host *host,
          */
         card->flags |= CARD_FLAG_SDR50 | CARD_FLAG_SDR104 | CARD_FLAG_DDR50;
     }
-
-    /*
-     * change SD card to the highest supported speed
-     */
-    err = mmcsd_switch(card);
-    if (err)
-        goto err1;
-
-    /* set bus speed */
-    max_data_rate = (unsigned int)-1;
-    if (max_data_rate < card->hs_max_data_rate)
-    {
-        max_data_rate = card->hs_max_data_rate;
-    }
-    if (max_data_rate < card->max_data_rate)
-    {
-        max_data_rate = card->max_data_rate;
-    }
-
-    mmcsd_set_clock(host, max_data_rate);
 
     host->card = card;
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
在ART-PI上移植rtthread的时候，发现最新主线上的内核读取不到emmc和sd的分区，经过回退代码确认，发现是这一次的提交导致了该问题：
#8987 
经过调试发现之前版本中是先初始化总线时钟频率再初始化总线宽度，这次得修改中将顺序反过来了，导致读取不到emmc/sd分区（但是为什么在其他板子上可以读取？），在网上查阅资料发现带宽得初始化一般都是放在最后面（可以保证配置的一致性和稳定性？）。

#### 你的解决方案是什么 (what is your solution)

将初始化时钟频率放在初始化带宽前面

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
