### PR TITLE
[bsp/cvitek]: add calibration for adc

### DIFF
--- a/bsp/cvitek/drivers/drv_adc.c
+++ b/bsp/cvitek/drivers/drv_adc.c
@@ -103,7 +103,13 @@ static const struct rt_adc_ops _adc_ops =
 int rt_hw_adc_init(void)
 {
     rt_uint8_t i;
-    for (i = 0; i < sizeof(adc_dev_config) / sizeof(adc_dev_config[0]); i ++)
+
+    for (i = 0; i < sizeof(adc_dev_config) / sizeof(adc_dev_config[0]); i++)
+    {
+        cvi_do_calibration(adc_dev_config[i].base);
+    }
+
+    for (i = 0; i < sizeof(adc_dev_config) / sizeof(adc_dev_config[0]); i++)
     {
         if (rt_hw_adc_register(&adc_dev_config[i].device, adc_dev_config[i].name, &_adc_ops, &adc_dev_config[i]) != RT_EOK)
         {

--- a/bsp/cvitek/drivers/drv_adc.h
+++ b/bsp/cvitek/drivers/drv_adc.h
@@ -48,6 +48,11 @@
 #define SARADC_RESULT_MASK                  0x0FFF
 #define SARADC_RESULT_VALID                 (1 << 15)
 
+#define SARADC_TEST_OFFSET                  0x030
+#define SARADC_TEST_VREFSEL_BIT             2
+
+#define SARADC_TRIM_OFFSET                  0x034
+
 rt_inline void cvi_set_saradc_ctrl(unsigned long reg_base, rt_uint32_t value)
 {
     value |= mmio_read_32(reg_base + SARADC_CTRL_OFFSET);
@@ -76,6 +81,19 @@ rt_inline void cvi_set_cyc(unsigned long reg_base)
 
     value |= SARADC_CYC_CLKDIV_DIV_16;                                                               //set saradc clock cycle=840ns
     mmio_write_32(reg_base + SARADC_CYC_SET_OFFSET, value);
+}
+
+rt_inline void cvi_do_calibration(unsigned long reg_base)
+{
+    rt_uint32_t val;
+
+    val = mmio_read_32(reg_base + SARADC_TEST_OFFSET);
+    val |= 1 << SARADC_TEST_VREFSEL_BIT;
+    mmio_write_32(reg_base + SARADC_TEST_OFFSET, val);
+
+    val = mmio_read_32(reg_base + SARADC_TRIM_OFFSET);
+    val |= 0x4;
+    mmio_write_32(reg_base + SARADC_TRIM_OFFSET, val);
 }
 
 int rt_hw_adc_init(void);


### PR DESCRIPTION
The ADC controller needs to be calibrated during the initialization phase, otherwise the measured voltage value will be inaccurate.

Fixed #8945

## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

请看 commit text

#### 你的解决方案是什么 (what is your solution)

adc 初始化中增加 adc 的 calibration 校正操作

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: bsp/cvitek

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config: N/A

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
