### PR TITLE
[libcpu] quality: call PV_OFFSET on entry for once

### DIFF
--- a/libcpu/aarch64/common/setup.c
+++ b/libcpu/aarch64/common/setup.c
@@ -208,11 +208,12 @@ void rt_hw_common_setup(void)
     rt_region_t init_page_region = { 0 };
     rt_region_t platform_mem_region = { 0 };
     static struct mem_desc platform_mem_desc;
+    const rt_ubase_t pv_off = PV_OFFSET;
 
     system_vectors_init();
 
 #ifdef RT_USING_SMART
-    rt_hw_mmu_map_init(&rt_kernel_space, (void*)0xfffffffff0000000, 0x10000000, MMUTable, PV_OFFSET);
+    rt_hw_mmu_map_init(&rt_kernel_space, (void*)0xfffffffff0000000, 0x10000000, MMUTable, pv_off);
 #else
     rt_hw_mmu_map_init(&rt_kernel_space, (void*)0xffffd0000000, 0x10000000, MMUTable, 0);
 #endif
@@ -234,13 +235,13 @@ void rt_hw_common_setup(void)
     rt_memblock_reserve_memory("init-page", init_page_start, init_page_end, MEMBLOCK_NONE);
     rt_memblock_reserve_memory("fdt", fdt_start, fdt_end, MEMBLOCK_NONE);
 
-    rt_memmove((void *)(fdt_start - PV_OFFSET), (void *)(fdt_ptr - PV_OFFSET), fdt_size);
-    fdt_ptr = (void *)fdt_start - PV_OFFSET;
+    rt_memmove((void *)(fdt_start - pv_off), (void *)(fdt_ptr - pv_off), fdt_size);
+    fdt_ptr = (void *)fdt_start - pv_off;
 
-    rt_system_heap_init((void *)(heap_start - PV_OFFSET), (void *)(heap_end - PV_OFFSET));
+    rt_system_heap_init((void *)(heap_start - pv_off), (void *)(heap_end - pv_off));
 
-    init_page_region.start = init_page_start - PV_OFFSET;
-    init_page_region.end = init_page_end - PV_OFFSET;
+    init_page_region.start = init_page_start - pv_off;
+    init_page_region.end = init_page_end - pv_off;
     rt_page_init(init_page_region);
 
     /* create MMU mapping of kernel memory */
@@ -248,8 +249,8 @@ void rt_hw_common_setup(void)
     platform_mem_region.end   = RT_ALIGN(platform_mem_region.end, ARCH_PAGE_SIZE);
 
     platform_mem_desc.paddr_start = platform_mem_region.start;
-    platform_mem_desc.vaddr_start = platform_mem_region.start - PV_OFFSET;
-    platform_mem_desc.vaddr_end = platform_mem_region.end - PV_OFFSET - 1;
+    platform_mem_desc.vaddr_start = platform_mem_region.start - pv_off;
+    platform_mem_desc.vaddr_end = platform_mem_region.end - pv_off - 1;
     platform_mem_desc.attr = NORMAL_MEM;
 
     rt_hw_mmu_setup(&rt_kernel_space, &platform_mem_desc, 1);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

This patch improves the efficiency and readability of the AArch64 common setup
code by calculating the `PV_OFFSET` once at the start and reusing the value.
This change reduces redundant calculations.

#### 你的解决方案是什么 (what is your solution)

Changes:
- Declared `pv_off` constant at the beginning of `rt_hw_common_setup`.
- Replaced multiple occurrences of `PV_OFFSET` with the single `pv_off` variable

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
