### PR TITLE
bsp: cvitek: fix cv18xx_aarch64 mnt init blocking

### DIFF
--- a/bsp/cvitek/cv18xx_aarch64/board/board.c
+++ b/bsp/cvitek/cv18xx_aarch64/board/board.c
@@ -81,6 +81,46 @@ void rt_hw_board_init(void)
 {
     rt_hw_common_setup();
 }
+
+/*
+ * FIXME: This is a temporary workaround.
+ * When aarch bsp enables the device tree, the current u-boot will
+ * pass in bootargs, which contains "root=/dev/mmcblk0p2 rootwait rw",
+ * which means that the kernel is required to wait until the rootfs
+ * in /dev/mmcblk0p2 loaded successfully. However, the current aarch64 bsp
+ * default does not implement sdmmc device mounting, causing the kernel file
+ * system mounting module (rootfs_mnt_init() of components/drivers/core/mnt.c)
+ * to enter an infinite loop waiting.
+ * Solution: At present, we do not plan to modify the startup parameters
+ * of u-boot. The temporary solution adopted is to create a pseudo
+ * /dev/mmcblk0p2 device during the board initialization process, and
+ * then cancel the pseudo device after mnt is completed. This allows the
+ * kernel boot to be completed successfully.
+ */
+static struct rt_device *pseudo_mmcblk;
+
+static int pseudo_mmcblk_setup(void)
+{
+    pseudo_mmcblk = rt_calloc(1, sizeof(*pseudo_mmcblk));
+
+    RT_ASSERT(pseudo_mmcblk != RT_NULL);
+
+    pseudo_mmcblk->type = RT_Device_Class_Graphic;
+
+    return (int)rt_device_register(pseudo_mmcblk, "/dev/mmcblk0p2", RT_DEVICE_FLAG_DEACTIVATE);
+}
+INIT_BOARD_EXPORT(pseudo_mmcblk_setup);
+
+static int pseudo_mmcblk_remove(void)
+{
+    if (pseudo_mmcblk)
+    {
+        return (int)rt_device_unregister(pseudo_mmcblk);
+    }
+
+    return 0;
+}
+INIT_FS_EXPORT(pseudo_mmcblk_remove);
 #endif /* RT_USING_OFW */
 
 static rt_ubase_t pinmux_base = RT_NULL;


### PR DESCRIPTION
The aarch64 core of duo on the master cannot enter the
console interface. It can only print the RT flag and hold it.

Analysis: The latest commit that can work is https://github.com/RT-Thread/rt-thread/commit/ae6a3287e6ab4121c07b1e0624b44d0e4477e14f ("Add
psoc62, 61 config"). This phenomenon will occur after adding
https://github.com/RT-Thread/rt-thread/commit/754c59a41185fadd543ae2eaee518ebcbe68af5b ("[Feature] DFS mount auto by kernel parameters").
The specific reason is that when aarch bsp enables the device
tree, the current u-boot will pass in bootargs, which contains
"root=/dev/mmcblk0p2 rootwait rw", which means that the
kernel is required to wait until the rootfs in /dev/mmcblk0p2
loaded successfully. However, the current aarch64 bsp default
does not implement sdmmc device mounting, causing the
 kernel file system mounting module (rootfs_mnt_init() of
components/drivers/core/mnt.c) to enter an infinite loop waiting.

Solution: At present, we do not plan to modify the startup
parameters of u-boot. The temporary solution adopted is to
create a pseudo /dev/mmcblk0p2 device during the board
initialization process, and then cancel the pseudo device
after mnt is completed. This allows the kernel boot to be
completed successfully.

Reviewed-by: Chen Wang <unicorn_wang@outlook.com>

## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
Fixed https://github.com/RT-Thread/rt-thread/issues/9243

#### 你的解决方案是什么 (what is your solution)
伪造一个 /dev/mmcblk0p2 设备, 初始化结束之后反注册这个设备.


#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: bsp/cvitek

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
