### PR TITLE
[armlibc] 修复AC6更新至6.19后_sys_tmpnam()函数编译报错， 直接从主分支的 commit #cef57d0 rebase过来。

### DIFF
--- a/components/libc/compilers/armlibc/syscalls.c
+++ b/components/libc/compilers/armlibc/syscalls.c
@@ -282,11 +282,18 @@ int _sys_seek(FILEHANDLE fh, long pos)
 /**
  * used by tmpnam() or tmpfile()
  */
+#if __ARMCC_VERSION >= 6190000
+void _sys_tmpnam(char *name, int fileno, unsigned maxlength)
+{
+    rt_snprintf(name, maxlength, "tem%03d", fileno);
+}
+#else
 int _sys_tmpnam(char *name, int fileno, unsigned maxlength)
 {
     rt_snprintf(name, maxlength, "tem%03d", fileno);
     return 1;
 }
+#endif /* __ARMCC_VERSION >= 6190000 */
 
 char *_sys_command_string(char *cmd, int len)
 {


### PR DESCRIPTION
* [armlibc] 修复AC6更新至6.19后_sys_tmpnam()函数编译报错

## 拉取/合并请求描述：(PR description)
直接从主分支的 commit #cef57d006d6a1f46245c7829752498f8f7137ae8 rebase过来的。

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范]
