### PR TITLE
[BSP][airm2m/air32f103] fix build errors when using arm gnu toolchain

### DIFF
--- a/bsp/airm2m/air32f103/libraries/AIR32F10xLib/src/air32f10x_flash.c
+++ b/bsp/airm2m/air32f103/libraries/AIR32F10xLib/src/air32f10x_flash.c
@@ -648,27 +648,27 @@ __STATIC_INLINE void SetStrt(void)
     __ASM("BX       lr");
 }
 #elif defined(__GNUC__)
-void SetStrt(void)
+__STATIC_INLINE void SetStrt(void)
 {
-    asm("MOV        R0, PC");
-    asm("LDR        R1, [R0,#16]");
-    asm("LDR        R1, [R0,#32]");
-    asm("LDR        R0, =0x40022010");
-    asm("LDR        R1, =0x60");
-    asm("STR        R1,[R0]");
-    asm("NOP");
-    asm("NOP");
-    asm("NOP");
-    asm("NOP");
-    asm("NOP");
-    asm("NOP");
-    asm("FLAGLABLE");
-    asm("LDR        R1, =0x4002200C");
-    asm("LDR        R2, [R1]");
-    asm("AND        R2, #0x01");
-    asm("CMP        R2, #0x00");
-    asm("BNE        FLAGLABLE");
-    asm("BX         lr");
+    __asm("MOV        R0, PC");
+    __asm("LDR        R1, [R0,#16]");
+    __asm("LDR        R1, [R0,#32]");
+    __asm("LDR        R0, =0x40022010");
+    __asm("LDR        R1, =0x60");
+    __asm("STR        R1,[R0]");
+    __asm("NOP");
+    __asm("NOP");
+    __asm("NOP");
+    __asm("NOP");
+    __asm("NOP");
+    __asm("NOP");
+    __asm("FLAGLABLE:");
+    __asm("LDR        R1, =0x4002200C");
+    __asm("LDR        R2, [R1]");
+    __asm("AND        R2, #0x01");
+    __asm("CMP        R2, #0x00");
+    __asm("BNE        FLAGLABLE");
+    __asm("BX         lr");
 }
 
 #endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

This PR is to fix the build error when using the GCC toolchain. The errors are primarily caused by the `SetStrt` function in `air32f10x_flash.c`

##### Error 1：Compatibility issues with the `asm` keyword

###### How to reproduce：

The function is missing a declaration, so we call `FLASH_EraseOptionBytes`, as it calls the `SetStrt`. Add this statement in `main.c`:
```c
FLASH_Status st = FLASH_EraseOptionBytes();
```
Then we try to build the project: 
```shell
scons --target=cmake
scons
```
###### Error msg：

```
/path/to/ld.exe: build/libraries/AIR32F10xLib/src/air32f10x_flash.o: in function `SetStrt':
/path/to/air32f10x_flash.c:653: undefined reference to `asm`
```
###### Solution：

`asm` keyword is a GNU extension. It works only under specific conditions, such as `-std=gnu99`. Problems will occur during compilation if `-std=c99` is used.  `__asm` or `__ASM` should be used by convention (from `cmsis_gcc.h`).

##### Error 2: Syntax error in assembly statements

###### Solution

Clearly, a colon is missing here:

```c
// before:
__asm("FLAGLABLE"); //a colon is missing

// after:
__asm("FLAGLABLE:");
```
##### Error 3: Build error in release settings

###### How to reproduce：

Just build the release version of the project:

```shell
cmake -DCMAKE_BUILD_TYPE=Release .. && make
```

It reports the buid errors:

```
Error: symbol `FLAGLABLE' is already defined
```
###### Solution:

This function should be `static`. Use `__STATIC_INLINE` like the clang branch :
```c
__STATIC_INLINE void SetStrt(void)
```


#### 你的解决方案是什么 (what is your solution)

##### Final solution:

Modify the func `SetStrt` of the `__GNUC__` branch to below:
```c
#elif defined(__GNUC__)
__STATIC_INLINE void SetStrt(void)  
{  
    __asm("MOV      R0, PC");  
    __asm("LDR     R1, [R0,#16]");  
    __asm("LDR     R1, [R0,#32]");  
    __asm("LDR     R0, =0x40022010");  
    __asm("LDR     R1, =0x60");  
    __asm("STR      R1,[R0]");  
    __asm("NOP");  
    __asm("NOP");  
    __asm("NOP");  
    __asm("NOP");  
    __asm("NOP");  
    __asm("NOP");  
    __asm("FLAGLABLE:");  
    __asm("LDR     R1, =0x4002200C");  
    __asm("LDR     R2, [R1]");  
    __asm("AND     R2,    #0x01");  
    __asm("CMP     R2,    #0x00");  
    __asm("BNE     FLAGLABLE");  
    __asm("BX      lr");  
}
#endif
```



#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
