### PR TITLE
[stm32][sdmmc]Optimize execution efficiency and find the right clock division

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_sdmmc.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_sdmmc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -8,6 +8,7 @@
  * 2020-05-23     liuduanfei   first version
  * 2020-08-25     wanghaijing  add sdmmmc2
  * 2023-03-26     wdfk-prog    Distinguish between SDMMC and SDIO drivers
+ * 2024-08-05     wdfk-prog    Optimize execution efficiency and find the right clock division
  */
 
 #ifndef __DRV_SDMMC_H__
@@ -20,9 +21,6 @@
 #include <string.h>
 #include <drivers/mmcsd_core.h>
 #include <drivers/sdio.h>
-
-#define SDIO_BUFF_SIZE       4096
-#define SDIO_ALIGN_LEN       32
 
 #define SDIO1_BASE_ADDRESS  (SDMMC1_BASE)
 #define SDIO2_BASE_ADDRESS  (SDMMC2_BASE)
@@ -39,14 +37,14 @@
 #define SDIO_ALIGN_LEN       (32)
 #endif
 
-#ifndef SDIO_MAX_FREQ
-#define SDIO_MAX_FREQ        (25 * 1000 * 1000)
-#endif
-
 /* Frequencies used in the driver for clock divider calculation */
 #define SD_INIT_FREQ                   400000U   /* Initalization phase : 400 kHz max */
 #define SD_NORMAL_SPEED_FREQ           25000000U /* Normal speed phase : 25 MHz max */
 #define SD_HIGH_SPEED_FREQ             50000000U /* High speed phase : 50 MHz max */
+
+#ifndef SDIO_MAX_FREQ
+#define SDIO_MAX_FREQ        (SD_HIGH_SPEED_FREQ)
+#endif
 
 #define SDIO_ERRORS \
     (SDMMC_STA_IDMATE | SDMMC_STA_ACKTIMEOUT | \

--- a/components/drivers/include/drivers/mmcsd_card.h
+++ b/components/drivers/include/drivers/mmcsd_card.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2024, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -8,6 +8,7 @@
  * 2011-07-25     weety         first version
  * 2024-05-24     HPMicro       add HS400 support
  * 2024-05-26     HPMicro       add UHS-I support for SD card
+ * 2024-08-05     wdfk-prog     add SD Specifications Physical Layer Specification Version 9.10
  */
 
 #ifndef __MMCSD_CARD_H__
@@ -25,7 +26,7 @@ extern "C" {
 struct rt_mmcsd_cid {
     rt_uint8_t  mid;       /* ManufacturerID */
     rt_uint8_t  prv;       /* Product Revision */
-    rt_uint16_t oid;       /* OEM/Application ID */
+    rt_uint8_t  oid[2];       /* OEM/Application ID */
     rt_uint32_t psn;       /* Product Serial Number */
     rt_uint8_t  pnm[5];    /* Product Name */
     rt_uint8_t  reserved1;/* reserved */
@@ -91,8 +92,22 @@ struct rt_sdio_cccr {
 union rt_sd_status {
     rt_uint32_t status_words[16];
     struct {
-        rt_uint32_t reserved[12];
-        rt_uint64_t : 8;
+        rt_uint8_t  reserved[39];
+
+        rt_uint64_t fule_support: 1;
+        rt_uint64_t discard_support: 1;
+        rt_uint64_t boot_partition_support: 1;
+        rt_uint64_t wp_upc_support: 1;
+        rt_uint64_t : 12;
+        rt_uint64_t performance_enhance : 8;
+        rt_uint64_t app_perf_class : 4;
+        rt_uint64_t : 6;
+        rt_uint64_t sus_addr : 20;
+
+        rt_uint16_t vsc_au_size : 10;
+        rt_uint16_t : 6;
+
+        rt_uint64_t vsc_speed_class : 8;
         rt_uint64_t uhs_au_size: 4;
         rt_uint64_t uhs_speed_grade: 4;
         rt_uint64_t erase_offset: 2;
@@ -106,7 +121,8 @@ union rt_sd_status {
         rt_uint32_t size_of_protected_area;
 
         rt_uint32_t sd_card_type: 16;
-        rt_uint32_t : 6;
+        rt_uint32_t secure_cmd_status : 3;
+        rt_uint32_t : 3;
         rt_uint32_t : 7;
         rt_uint32_t secured_mode: 1;
         rt_uint32_t data_bus_width: 2;
@@ -204,6 +220,7 @@ struct rt_mmcsd_card {
 #define CARD_FLAG_HIGHSPEED  (1 << 0)   /* SDIO bus speed 50MHz */
 #define CARD_FLAG_SDHC       (1 << 1)   /* SDHC card */
 #define CARD_FLAG_SDXC       (1 << 2)   /* SDXC card */
+#define CARD_FLAG_SDUC       (1 << 9)   /* SD Ultra Capacity */
 #define CARD_FLAG_HIGHSPEED_DDR  (1 << 3)   /* HIGH SPEED DDR */
 #define CARD_FLAG_HS200      (1 << 4)   /* BUS SPEED 200MHz */
 #define CARD_FLAG_HS400      (1 << 5)   /* BUS SPEED 400MHz */
@@ -212,6 +229,7 @@ struct rt_mmcsd_card {
 #define CARD_FLAG_DDR50      (1 << 8)   /* DDR50, works on 1.8V only */
     struct rt_sd_scr    scr;
     struct rt_mmcsd_csd csd;
+    union rt_sd_status sd_status;
     rt_uint32_t     hs_max_data_rate;  /* max data transfer rate in high speed mode */
 
     rt_uint8_t      sdio_function_num;  /* total number of SDIO functions */

--- a/components/drivers/include/drivers/mmcsd_cmd.h
+++ b/components/drivers/include/drivers/mmcsd_cmd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -16,6 +16,7 @@
 extern "C" {
 #endif
 
+/* MMC commands                     type  argument      response */
    /* class 1 */
 #define GO_IDLE_STATE         0   /* bc                          */
 #define SEND_OP_COND          1   /* bcr  [31:0] OCR         R3  */
@@ -83,6 +84,7 @@ extern "C" {
 
   /* Application commands */
 #define SD_APP_SET_BUS_WIDTH      6   /* ac   [1:0] bus width    R1  */
+#define SD_APP_SD_STATUS          13  /* adtc                    R1  */
 #define SD_APP_SEND_NUM_WR_BLKS  22   /* adtc                    R1  */
 #define SD_APP_OP_COND           41   /* bcr  [31:0] OCR         R3  */
 #define SD_APP_SEND_SCR          51   /* adtc                    R1  */

--- a/components/drivers/include/drivers/mmcsd_core.h
+++ b/components/drivers/include/drivers/mmcsd_core.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -172,50 +172,6 @@ struct rt_mmcsd_req
 #define R5_OUT_OF_RANGE     (1 << 8)
 #define R5_STATUS(x)        (x & 0xCB00)
 #define R5_IO_CURRENT_STATE(x)  ((x & 0x3000) >> 12)
-
-
-
-/**
- * fls - find last (most-significant) bit set
- * @x: the word to search
- *
- * This is defined the same way as ffs.
- * Note fls(0) = 0, fls(1) = 1, fls(0x80000000) = 32.
- */
-
-rt_inline rt_uint32_t __rt_fls(rt_uint32_t val)
-{
-    rt_uint32_t  bit = 32;
-
-    if (!val)
-        return 0;
-    if (!(val & 0xffff0000u))
-    {
-        val <<= 16;
-        bit -= 16;
-    }
-    if (!(val & 0xff000000u))
-    {
-        val <<= 8;
-        bit -= 8;
-    }
-    if (!(val & 0xf0000000u))
-    {
-        val <<= 4;
-        bit -= 4;
-    }
-    if (!(val & 0xc0000000u))
-    {
-        val <<= 2;
-        bit -= 2;
-    }
-    if (!(val & 0x80000000u))
-    {
-        bit -= 1;
-    }
-
-    return bit;
-}
 
 #define MMCSD_HOST_PLUGED       0
 #define MMCSD_HOST_UNPLUGED     1

--- a/components/drivers/include/drivers/mmcsd_host.h
+++ b/components/drivers/include/drivers/mmcsd_host.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2024, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/components/drivers/sdio/Kconfig
+++ b/components/drivers/sdio/Kconfig
@@ -13,7 +13,7 @@ config RT_USING_SDIO
 
         config RT_MMCSD_STACK_SIZE
             int "The stack size for mmcsd thread"
-            default 1024
+            default 2048
 
         config RT_MMCSD_THREAD_PREORITY
             int "The priority level value of mmcsd thread"

--- a/components/drivers/sdio/block_dev.c
+++ b/components/drivers/sdio/block_dev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/components/drivers/sdio/gpt.c
+++ b/components/drivers/sdio/gpt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -251,7 +251,8 @@ static int is_gpt_valid(struct rt_mmcsd_card *card, size_t lba, gpt_header **gpt
         goto fail;
     }
     /* Check that sizeof_partition_entry has the correct value */
-    if ((uint32_t)((*gpt)->sizeof_partition_entry) != sizeof(gpt_entry)) {
+    if ((uint32_t)((*gpt)->sizeof_partition_entry) != sizeof(gpt_entry))
+    {
         LOG_E("GUID Partition Entry Size check failed.");
         goto fail;
     }

--- a/components/drivers/sdio/mmc.c
+++ b/components/drivers/sdio/mmc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2024, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -461,7 +461,7 @@ rt_err_t mmc_send_op_cond(struct rt_mmcsd_host *host,
 
         err = -RT_ETIMEOUT;
 
-        rt_thread_mdelay(10); //delay 10ms
+        rt_thread_mdelay(10); /*delay 10ms*/
     }
 
     if (rocr && !controller_is_spi(host))
@@ -586,23 +586,23 @@ static int mmc_select_timing(struct rt_mmcsd_card *card)
 
     if (card->flags & CARD_FLAG_HS400)
     {
-        LOG_I("emmc: switch to HS400 mode\n");
+        LOG_I("emmc: switch to HS400 mode");
         ret = mmc_select_hs400(card);
     }
     else if (card->flags & CARD_FLAG_HS200)
     {
-        LOG_I("emmc: switch to HS200 mode\n");
+        LOG_I("emmc: switch to HS200 mode");
         ret = mmc_select_hs200(card);
     }
     else if (card->flags & CARD_FLAG_HIGHSPEED_DDR)
     {
-        LOG_I("emmc: switch to HIGH Speed DDR mode\n");
+        LOG_I("emmc: switch to HIGH Speed DDR mode");
         mmcsd_set_timing(card->host, MMCSD_TIMING_MMC_DDR52);
         mmcsd_set_clock(card->host, card->hs_max_data_rate);
     }
     else
     {
-        LOG_I("emmc: switch to HIGH Speed mode\n");
+        LOG_I("emmc: switch to HIGH Speed mode");
         mmcsd_set_timing(card->host, MMCSD_TIMING_MMC_HS);
         mmcsd_set_clock(card->host, card->hs_max_data_rate);
     }

--- a/components/drivers/sdio/mmcsd_core.c
+++ b/components/drivers/sdio/mmcsd_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -34,7 +34,6 @@
 #endif
 #endif
 
-//static struct rt_semaphore mmcsd_sem;
 static struct rt_thread mmcsd_detect_thread;
 static rt_uint8_t mmcsd_stack[RT_MMCSD_STACK_SIZE];
 static struct rt_mailbox  mmcsd_detect_mb;
@@ -109,7 +108,7 @@ rt_int32_t mmcsd_go_idle(struct rt_mmcsd_host *host)
     rt_int32_t err;
     struct rt_mmcsd_cmd cmd;
 
-    if (!controller_is_spi(host))
+    if (controller_is_spi(host))
     {
         mmcsd_set_chip_select(host, MMCSD_CS_HIGH);
         rt_thread_mdelay(1);
@@ -125,7 +124,7 @@ rt_int32_t mmcsd_go_idle(struct rt_mmcsd_host *host)
 
     rt_thread_mdelay(1);
 
-    if (!controller_is_spi(host))
+    if (controller_is_spi(host))
     {
         mmcsd_set_chip_select(host, MMCSD_CS_IGNORE);
         rt_thread_mdelay(1);
@@ -755,7 +754,6 @@ int rt_mmcsd_core_init(void)
 {
     rt_err_t ret;
 
-    /* initialize detect SD cart thread */
     /* initialize mailbox and create detect SD card thread */
     ret = rt_mb_init(&mmcsd_detect_mb, "mmcsdmb",
                      &mmcsd_detect_mb_pool[0], sizeof(mmcsd_detect_mb_pool) / sizeof(mmcsd_detect_mb_pool[0]),
@@ -772,8 +770,6 @@ int rt_mmcsd_core_init(void)
     {
         rt_thread_startup(&mmcsd_detect_thread);
     }
-
-    rt_sdio_init();
 
     return 0;
 }

--- a/components/drivers/sdio/mmcsd_core.c
+++ b/components/drivers/sdio/mmcsd_core.c
@@ -24,7 +24,7 @@
 #include <rtdbg.h>
 
 #ifndef RT_MMCSD_STACK_SIZE
-#define RT_MMCSD_STACK_SIZE 1024
+#define RT_MMCSD_STACK_SIZE 2048
 #endif
 #ifndef RT_MMCSD_THREAD_PREORITY
 #if (RT_THREAD_PRIORITY_MAX == 32)

--- a/components/drivers/sdio/sdio.c
+++ b/components/drivers/sdio/sdio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -1403,9 +1403,3 @@ rt_int32_t sdio_unregister_driver(struct rt_sdio_driver *driver)
 
     return 0;
 }
-
-void rt_sdio_init(void)
-{
-
-}
-

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -786,6 +786,7 @@ rt_device_t rt_console_get_device(void);
 #endif /* RT_USING_THREADSAFE_PRINTF */
 #endif /* defined(RT_USING_DEVICE) && defined(RT_USING_CONSOLE) */
 
+int __rt_fls(int val);
 int __rt_ffs(int value);
 
 void rt_show_version(void);

--- a/libcpu/arm/cortex-m7/cpu_cache.c
+++ b/libcpu/arm/cortex-m7/cpu_cache.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -36,7 +36,7 @@ rt_base_t rt_hw_cpu_icache_status(void)
 
 void rt_hw_cpu_icache_ops(int ops, void* addr, int size)
 {
-    rt_uint32_t address = (rt_uint32_t)addr & (rt_uint32_t) ~(L1CACHE_LINESIZE_BYTE - 1);
+    rt_uint32_t address = RT_ALIGN_DOWN((rt_uint32_t)addr, L1CACHE_LINESIZE_BYTE);
     rt_int32_t size_byte = size + address - (rt_uint32_t)addr;
     rt_uint32_t linesize = 32U;
     if (ops & RT_HW_CACHE_INVALIDATE)
@@ -70,7 +70,7 @@ rt_base_t rt_hw_cpu_dcache_status(void)
 
 void rt_hw_cpu_dcache_ops(int ops, void* addr, int size)
 {
-    rt_uint32_t startAddr = (rt_uint32_t)addr & (rt_uint32_t)~(L1CACHE_LINESIZE_BYTE - 1);
+    rt_uint32_t startAddr = RT_ALIGN_DOWN((rt_uint32_t)addr, L1CACHE_LINESIZE_BYTE);
     rt_uint32_t size_byte = size + (rt_uint32_t)addr - startAddr;
     rt_uint32_t clean_invalid = RT_HW_CACHE_FLUSH | RT_HW_CACHE_INVALIDATE;
 

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -1025,6 +1025,50 @@ rt_weak void rt_free_align(void *ptr)
 RTM_EXPORT(rt_free_align);
 #endif /* RT_USING_HEAP */
 
+/**
+ * fls - find last (most-significant) bit set
+ * @x: the word to search
+ *
+ * This is defined the same way as ffs.
+ * Note fls(0) = 0, fls(1) = 1, fls(0x80000000) = 32.
+ */
+
+int __rt_fls(int val)
+{
+    int bit = 32;
+
+    if (!val)
+    {
+        return 0;
+    }
+    if (!(val & 0xffff0000u))
+    {
+        val <<= 16;
+        bit -= 16;
+    }
+    if (!(val & 0xff000000u))
+    {
+        val <<= 8;
+        bit -= 8;
+    }
+    if (!(val & 0xf0000000u))
+    {
+        val <<= 4;
+        bit -= 4;
+    }
+    if (!(val & 0xc0000000u))
+    {
+        val <<= 2;
+        bit -= 2;
+    }
+    if (!(val & 0x80000000u))
+    {
+        bit -= 1;
+    }
+
+    return bit;
+}
+
 #ifndef RT_USING_CPU_FFS
 #ifdef RT_USING_TINY_FFS
 const rt_uint8_t __lowest_bit_bitmap[] =


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
1.  [stm32][sdmmc]Optimize execution efficiency and find the right clock division
2. [drivers][sdio]Resolves cid,csd,scr, add CSD Version 3.0 support
3. add SD Specifications Physical Layer Specification Version 9.10

#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: STM32H750
- SD卡: https://www.westerndigital.com/zh-cn/products/memory-cards/sandisk-ultra-uhs-i-microsd?sku=SDSQUNC-032G-ZN3MN

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config: 

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action: https://github.com/wdfk-prog/ART-PI/commit/aebd2076265eda274949c25d9132d0c7401c45b6

#### card_brands
- 参考如下编写
> https://www.usb2sd.com/article/https-wwwcameramemoryspeedcom-sd-memory-card-faq-reading-sd-card-cid-serial-psn-internal-numbers--i00004i1.html

#### mmcsd_core 栈大小修改原因

- 使用1024爆栈,执行`check_gpt`失败

#### 测试结果如下

- 测试程序
```c
/**
  * @brief  SDCARD速度测试
  * @param  None.
  * @retval None.
  * @note   None.
*/
static void cmd_sdcard_speed_test(uint8_t argc, char **argv)
{
    #define PATH_LEN 128
    const char *dir_path = "/sdcard/test";
    char file_path[PATH_LEN];

    /* check log file directory  */
    if (access(dir_path, F_OK) < 0)
    {
        mkdir(dir_path, 0);
    }
    /* open file */
    rt_snprintf(file_path, PATH_LEN, "%s/%s.txt", dir_path, "test");
    int file_fd = open(file_path, O_CREAT | O_RDWR | O_APPEND);
    if (file_path < 0)
    {
        rt_kprintf("test file(%s) open failed.\n", file_path);
        return;
    }
    char test[1024];
    int last_time = rt_tick_get_millisecond();
    for(rt_uint16_t i = 0; i <1024; i++)
    {
      /* write to the file */
      if (write(file_fd, test, 1024) != 1024)
      {
          rt_kprintf("test file(%s) write failed.\n", file_path);
          return;
      }
      /* flush file cache */
      fsync(file_fd);
    }
    int now_time = rt_tick_get_millisecond();
    rt_kprintf("test file write 1MB time =  %dms.\n", now_time - last_time);

    last_time = rt_tick_get_millisecond();
    rt_size_t file_size = lseek(file_fd, 0, SEEK_SET);
    for(rt_uint16_t i = 0; i <1024; i++)
    {
      /* read to the file */
      read(file_fd, test, 1024);
    }
    now_time = rt_tick_get_millisecond();
    rt_kprintf("test file read 1MB time = %dms.\n", now_time - last_time);

    close(file_fd);
}
MSH_CMD_EXPORT_ALIAS(cmd_sdcard_speed_test,test_sdcard,test sdcard speed);
```

```log
[2024/8/5 23:40:45 478]    ___  ______  _____         ______  _   ______  _____  _____  _____ 
[2024/8/5 23:40:45 485]   / _ \ | ___ \|_   _|        | ___ \(_)  | ___ \/  _  \/  _  \|_   _|
[2024/8/5 23:40:45 488]  / /_\ \| |_/ /  | |   ______ | |_/ / _   | |_/ /| | | || | | |  | |  
[2024/8/5 23:40:45 502]  |  _  ||    /   | |  |______||  __/ | |  | ___ \| | | || | | |  | |  
[2024/8/5 23:40:45 502]  | | | || |\ \   | |          | |    | |  | |_/ /\ \_/ /\ \_/ /  | |  
[2024/8/5 23:40:45 506]  \_| |_/\_| \_|  \_/          \_|    |_|  \____/  \___/  \___/   \_/  
[2024/8/5 23:40:45 506] 
[2024/8/5 23:40:45 510]  Powered by RT-Thread.
[2024/8/5 23:40:45 510] 
[2024/8/5 23:40:45 768] msh >rcc_rsr = 0x05fe0000(Independent watchdog reset flag)
[2024/8/5 23:40:45 772] 
[2024/8/5 23:40:45 773]  \ | /
[2024/8/5 23:40:45 784] - RT -     Thread Operating System
[2024/8/5 23:40:45 784]  / | \     5.2.0 build Aug  5 2024 23:40:28
[2024/8/5 23:40:45 784]  2006 - 2024 Copyright by RT-Thread team
[2024/8/5 23:40:45 971] 08-05 23:40:21.050 found part[0], begin: 4194304, size: 29.748GB

[2024/8/5 23:40:45 999] 08-05 23:40:21.144 I/main:  \ | /
[2024/8/5 23:40:46 006] 08-05 23:40:21.144 W/main: - HLY -    Version FULL V0.0.1
[2024/8/5 23:40:46 253] 08-05 23:40:21.144 E/main:  / | \     build Aug  5 2024 23:40:21
[2024/8/5 23:40:46 260] 08-05 23:40:21.144 I/main: System Clock information
[2024/8/5 23:40:46 271] 08-05 23:40:21.144 W/main: SYSCLK_Frequency = 480000000 HCLK_Frequency   = 240000000
[2024/8/5 23:40:46 275] 08-05 23:40:21.144 W/main: PCLK1_Frequency  = 120000000 PCLK2_Frequency  = 120000000
[2024/8/5 23:40:46 282] 08-05 23:40:21.144 W/main: SPI1_Frequency   = 480000000
[2024/8/5 23:40:46 287] 08-05 23:40:21.144 W/main: SDMMC_Frequency  = 480000000
[2024/8/5 23:40:46 294] 08-05 23:40:21.144 W/main: HAL version      = V1.11.3
[2024/8/5 23:40:46 309] 08-05 23:40:21.144 W/main: ARMcompiler version = 6220000
[2024/8/5 23:40:46 381] 08-05 23:40:21.160 I/SDIO: SD card MID: SanDisk, OID: SD<𻒄32G, PNM: SD32G, PRV: 8.5, PSN: 0xfcf33c9e, MDT: 3mont
[2024/8/5 23:40:46 390] 08-05 23:40:21.160 I/SDIO: SD card version SDHC or SDXC,class 10, capacity 31178752 KB.
[2024/8/5 23:40:46 395] 08-05 23:40:21.164 I/SDIO: SD spec version 6
[2024/8/5 23:40:46 402] 08-05 23:40:21.164 I/SDIO: sd: switch to High Speed / SDR25 mode
[2024/8/5 23:40:46 414] 08-05 23:40:21.351 I/app.filesystem: sd card mount to '/sdcard'
```

#### drv_sdmmc.c修改前后性能对比如下

- 修改前
```log
[2024/8/5 22:40:00 423] test file write 1MB time =  12919ms.
[2024/8/5 22:40:06 791] test file read 1MB time = 6364ms.
```

- 修改后

```c
[2024/8/5 23:36:16 597] test file write 1MB time =  2280ms.
[2024/8/5 23:36:16 969] test file read 1MB time = 368ms.
```

#### 修改原因

`rthw_sdio_iocfg`对于`div`的处理有问题,导致都是使用400khz频率再跑;导致性能低下

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
