### PR TITLE
[bsp/cvitek]修正sdhci发送命令超时后触发两次信号量的问题

### DIFF
--- a/bsp/cvitek/drivers/drv_sdhci.c
+++ b/bsp/cvitek/drivers/drv_sdhci.c
@@ -403,7 +403,6 @@ static void sdhci_cmd_irq(struct rthw_sdhci *sdhci, uint32_t intmask)
 
     if (intmask & SDIF_INT_RESPONSE)
     {
-        sdhci->cmd_error = RT_EOK;
         if (sdhci->response_type == RESP_R2)
         {
             /* CRC is stripped so we need to do some shifting. */
@@ -419,6 +418,8 @@ static void sdhci_cmd_irq(struct rthw_sdhci *sdhci, uint32_t intmask)
             sdhci->response[0] = mmio_read_32(BASE + SDIF_RESPONSE_01);
             LOG_D("sdhci->response: [%08x]", sdhci->response[0]);
         }
+
+        rt_sem_release(sdhci->sem_cmd);
     }
 }
 
@@ -486,7 +487,6 @@ static void sdhci_transfer_handle_irq(int irqno, void *param)
         if (intmask & SDIF_INT_CMD_MASK)
         {
             sdhci_cmd_irq(sdhci, intmask & SDIF_INT_CMD_MASK);
-            rt_sem_release(sdhci->sem_cmd);
         }
 
         if (intmask & SDIF_INT_DMA_END)


### PR DESCRIPTION
详解:
中断状态寄存器的BIT0仅表示sdhci处理命令完成，完成结果由其它位指示，当出错时
BIT0也会值1产生中断

## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
这个问题导致emmc无法正常初始化

#### 你的解决方案是什么 (what is your solution)
在命令完成中断到达时才触发等待信号量(错误原因中断比完成中断先到达)


#### 请提供验证的bsp和config (provide the config and bsp) 
修改后SD卡识别正常：
```
- RT -     Thread Operating System
 / | \     5.2.0 build Aug 14 2024 11:21:42
 2006 - 2024 Copyright by RT-Thread team
lwIP-2.1.2 initialized!
[I/sal.skt] Socket Abstraction Layer initialize success.
Hello RISC-V!
msh />[I/SDIO] SD card capacity 31166976 KB.
[I/SDIO] sd: switch to High Speed / SDR25 mode 

found part[0], begin: 512, size: 128.0MB
found part[1], begin: 134218240, size: 768.0MB
[I/app.filesystem] sd card mount to '/sdcard'
```
duos-emmc上emmc识别正常:
```
[I/SDIO] emmc card capacity 7634944 KB, card sec count:15269888.
[I/SDIO] emmc: switch to HIGH Speed mode

```

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
