### PR TITLE
允许重写中断控制API以支持独立的中断管理

### DIFF
--- a/libcpu/arm/cortex-m4/README.md
+++ b/libcpu/arm/cortex-m4/README.md
@@ -1,0 +1,53 @@
+## Independent Interrupts Management
+
+### Introduction
+Calling `rt_hw_interrupt_disable` in multiple places on `rt-thread` may cause interruption delays when the application requires accurate interrupt responses. This is because the system cannot generate any interrupts except abnormal interrupts after disabling interrupts. This is a common problem in the interrupt management of the operating system. The independent interrupt management module is designed to solve this problem.
+
+The independent interrupt management module is designed to solve the problem of interrupt delays caused by calling `rt_hw_interrupt_disable` in multiple places on `rt-thread`. The module is implemented by rewrite the `rt_hw_interrupt_disable` and `rt_hw_interrupt_enable` functions in the `libcpu` library. 
+
+
+### Usage
+- Add the following code to the project's `board.c` file.
+```
+#ifdef RT_USING_INDEPENDENT_INTERRUPT_MANAGEMENT
+#define RT_NVIC_PRO_BITS    __NVIC_PRIO_BITS
+
+rt_base_t rt_hw_interrupt_disable(void)
+{
+    rt_base_t level = __get_BASEPRI();
+    __set_BASEPRI(RT_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - RT_NVIC_PRO_BITS));
+
+    __ISB();
+    __DSB();
+
+    return level;
+}
+
+void rt_hw_interrupt_enable(rt_base_t level)
+{
+    __set_BASEPRI(level);
+}
+
+#endif /* RT_USING_INDEPENDENT_INTERRUPT_MANAGEMENT */
+```
+- Add the following configuration to the `Kconfig` file in the `board` directory.
+```
+    menuconfig RT_USING_INDEPENDENT_INTERRUPT_MANAGEMENT
+        bool "Enable independent interrupt management"
+        default n
+
+        if RT_USING_INDEPENDENT_INTERRUPT_MANAGEMENT
+            config RT_MAX_SYSCALL_INTERRUPT_PRIORITY
+                int "Set max syscall interrupt priority"
+                range 0 7
+                default 2
+        endif
+```
+- Select `RT_USING_INDEPENDENT_INTERRUPT_MANAGEMENT` to enable this feature.
+- Select `RT_MAX_SYSCALL_INTERRUPT_PRIORITY` to set the maximum priority of the interrupt that can be called by the system call. The default value is 2.
+
+### Description
+- The [basepri](https://developer.arm.com/documentation/107706/0100/Exceptions-and-interrupts-overview/Special-registers-for-exception-masking/BASEPRI) register is used in the functions to complete the interrupt management.
+- For example, if `RT_MAX_SYSCALL_INTERRUPT_PRIORITY` is set to 0x01, the system masking only interrupts with a priority of `0x01-0xFF`.
+- Interrupts with a priority of 0 are not managed by the system and can continue to respond to interrupts after `rt_hw_interrupt_disable` is called.
+- When using the [basepri](https://developer.arm.com/documentation/107706/0100/Exceptions-and-interrupts-overview/Special-registers-for-exception-masking/BASEPRI) register for independent interrupt management, note that interrupts with a priority value lower than `RT_MAX_SYSCALL_INTERRUPT_PRIORITY` cannot call any `system API`.

--- a/libcpu/arm/cortex-m4/context_gcc.S
+++ b/libcpu/arm/cortex-m4/context_gcc.S
@@ -10,6 +10,7 @@
  * 2013-06-18     aozima       add restore MSP feature.
  * 2013-06-23     aozima       support lazy stack optimized.
  * 2018-07-24     aozima       enhancement hard fault exception handler.
+ * 2024-08-13     Evlers       allows rewrite to interrupt enable/disable api to support independent interrupts management
  */
 
 /**
@@ -32,6 +33,7 @@
  * rt_base_t rt_hw_interrupt_disable();
  */
 .global rt_hw_interrupt_disable
+.weak rt_hw_interrupt_disable
 .type rt_hw_interrupt_disable, %function
 rt_hw_interrupt_disable:
     MRS     r0, PRIMASK
@@ -42,6 +44,7 @@ rt_hw_interrupt_disable:
  * void rt_hw_interrupt_enable(rt_base_t level);
  */
 .global rt_hw_interrupt_enable
+.weak rt_hw_interrupt_enable
 .type rt_hw_interrupt_enable, %function
 rt_hw_interrupt_enable:
     MSR     PRIMASK, r0
@@ -207,6 +210,10 @@ rt_hw_context_switch_to:
     /* enable interrupts at processor level */
     CPSIE   F
     CPSIE   I
+
+    /* clear the BASEPRI register to disable masking priority */
+    MOV     r0, #0x00
+    MSR     BASEPRI, r0
 
     /* ensure PendSV exception taken place before subsequent operation */
     DSB

--- a/libcpu/arm/cortex-m4/context_iar.S
+++ b/libcpu/arm/cortex-m4/context_iar.S
@@ -11,6 +11,7 @@
 ; * 2013-06-18     aozima       add restore MSP feature.
 ; * 2013-06-23     aozima       support lazy stack optimized.
 ; * 2018-07-24     aozima       enhancement hard fault exception handler.
+; * 2024-08-13     Evlers       allows rewrite to interrupt enable/disable api to support independent interrupts management
 ; */
 
 ;/**
@@ -36,7 +37,8 @@ NVIC_PENDSVSET  EQU     0x10000000               ; value to trigger PendSV excep
 ;/*
 ; * rt_base_t rt_hw_interrupt_disable();
 ; */
-    EXPORT rt_hw_interrupt_disable
+    PUBWEAK rt_hw_interrupt_disable
+    SECTION .text:CODE:REORDER:NOROOT(2)
 rt_hw_interrupt_disable:
     MRS     r0, PRIMASK
     CPSID   I
@@ -45,7 +47,8 @@ rt_hw_interrupt_disable:
 ;/*
 ; * void rt_hw_interrupt_enable(rt_base_t level);
 ; */
-    EXPORT  rt_hw_interrupt_enable
+    PUBWEAK  rt_hw_interrupt_enable
+    SECTION .text:CODE:REORDER:NOROOT(2)
 rt_hw_interrupt_enable:
     MSR     PRIMASK, r0
     BX      LR
@@ -207,6 +210,10 @@ rt_hw_context_switch_to:
     ; enable interrupts at processor level
     CPSIE   F
     CPSIE   I
+
+    ; clear the BASEPRI register to disable masking priority
+    MOV     r0, #0x00
+    MSR     BASEPRI, r0
 
     ; ensure PendSV exception taken place before subsequent operation
     DSB

--- a/libcpu/arm/cortex-m4/context_rvds.S
+++ b/libcpu/arm/cortex-m4/context_rvds.S
@@ -10,6 +10,7 @@
 ; * 2013-06-18     aozima       add restore MSP feature.
 ; * 2013-06-23     aozima       support lazy stack optimized.
 ; * 2018-07-24     aozima       enhancement hard fault exception handler.
+; * 2024-08-13     Evlers       allows rewrite to interrupt enable/disable api to support independent interrupts management
 ; */
 
 ;/**
@@ -36,7 +37,7 @@ NVIC_PENDSVSET  EQU     0x10000000               ; value to trigger PendSV excep
 ; * rt_base_t rt_hw_interrupt_disable();
 ; */
 rt_hw_interrupt_disable    PROC
-    EXPORT  rt_hw_interrupt_disable
+    EXPORT  rt_hw_interrupt_disable [WEAK]
     MRS     r0, PRIMASK
     CPSID   I
     BX      LR
@@ -46,7 +47,7 @@ rt_hw_interrupt_disable    PROC
 ; * void rt_hw_interrupt_enable(rt_base_t level);
 ; */
 rt_hw_interrupt_enable    PROC
-    EXPORT  rt_hw_interrupt_enable
+    EXPORT  rt_hw_interrupt_enable [WEAK]
     MSR     PRIMASK, r0
     BX      LR
     ENDP
@@ -207,6 +208,10 @@ rt_hw_context_switch_to    PROC
     ; enable interrupts at processor level
     CPSIE   F
     CPSIE   I
+
+    ; clear the BASEPRI register to disable masking priority
+    MOV     r0, #0x00
+    MSR     BASEPRI, r0
 
     ; ensure PendSV exception taken place before subsequent operation
     DSB


### PR DESCRIPTION
…pi to support independent interrupts management

## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
在程序需要精准的中断响应时，由于`rt-thread`多处地方调用`rt_hw_interrupt_disable`导致中断延迟的问题

#### 你的解决方案是什么 (what is your solution)
- 在`libcpu`中的`rt_hw_interrupt_disable`函数添加`weak`修饰以实现临界区的重写
- 在对应bsp的`board.c`文件中添加如下代码
```
#ifdef RT_USING_INDEPENDENT_INTERRUPT_MANAGEMENT
#define RT_NVIC_PRO_BITS    __NVIC_PRIO_BITS

rt_base_t rt_hw_interrupt_disable(void)
{
    rt_base_t level = __get_BASEPRI();
    __set_BASEPRI(RT_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - RT_NVIC_PRO_BITS));

    __ISB();
    __DSB();

    return level;
}

void rt_hw_interrupt_enable(rt_base_t level)
{
    __set_BASEPRI(level);
}

#endif /* RT_USING_INDEPENDENT_INTERRUPT_MANAGEMENT */
```
- 在`board`目录`Kconfig`文件中添加如下配置
```
    menuconfig RT_USING_INDEPENDENT_INTERRUPT_MANAGEMENT
        bool "Enable independent interrupt management"
        default n

        if RT_USING_INDEPENDENT_INTERRUPT_MANAGEMENT
            config RT_MAX_SYSCALL_INTERRUPT_PRIORITY
                int "Set max syscall interrupt priority"
                range 0 7
                default 2
        endif
```

- 在新加的两个函数中使用的是[basepri](https://developer.arm.com/documentation/107706/0100/Exceptions-and-interrupts-overview/Special-registers-for-exception-masking/BASEPRI)寄存器来完成中断管理的，例如`RT_MAX_SYSCALL_INTERRUPT_PRIORITY`配置为0x01，则系统只屏蔽`0x01-0xFF`优先级的中断
- 而需要精准中断则使用优先级0，不受系统管理，但是也不能调用`rt-thread`中的任何`API`
- 通过[basepri](https://developer.arm.com/documentation/107706/0100/Exceptions-and-interrupts-overview/Special-registers-for-exception-masking/BASEPRI)寄存器实现独立的中断管理时，需要注意优先级数值低于`RT_MAX_SYSCALL_INTERRUPT_PRIORITY`的中断不能调用任何系统API

**在不重写`rt_hw_interrupt_disable & rt_hw_interrupt_enable`函数的情况下不影响之前的临界区代码**

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: bsp/gd32/arm/gd32470z-lckfb

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:
#define RT_USING_INDEPENDENT_INTERRUPT_MANAGEMENT
#define RT_MAX_SYSCALL_INTERRUPT_PRIORITY 2

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
