### PR TITLE
feat: add ISR safe completion API

### DIFF
--- a/components/drivers/include/ipc/completion.h
+++ b/components/drivers/include/ipc/completion.h
@@ -14,9 +14,9 @@
 #include <rtconfig.h>
 
 /**
- * Completion - A tiny & rapid IPC primitive for resource-constrained scenarios
+ * RT-Completion - A Tiny(resource-constrained) & Rapid(lockless) IPC Primitive
  *
- * It's an IPC using one CPU word with the encoding:
+ * It's an IPC using one pointer word with the encoding:
  *
  * BIT      | MAX-1 ----------------- 1 |       0        |
  * CONTENT  |   suspended_thread & ~1   | completed flag |
@@ -33,8 +33,12 @@ struct rt_completion
 void rt_completion_init(struct rt_completion *completion);
 rt_err_t rt_completion_wait(struct rt_completion *completion,
                             rt_int32_t            timeout);
+rt_err_t rt_completion_wait_noisr(struct rt_completion *completion,
+                                  rt_int32_t            timeout);
 rt_err_t rt_completion_wait_flags(struct rt_completion *completion,
                                   rt_int32_t timeout, int suspend_flag);
+rt_err_t rt_completion_wait_flags_noisr(struct rt_completion *completion,
+                                        rt_int32_t timeout, int suspend_flag);
 void rt_completion_done(struct rt_completion *completion);
 rt_err_t rt_completion_wakeup(struct rt_completion *completion);
 rt_err_t rt_completion_wakeup_by_errno(struct rt_completion *completion, rt_err_t error);

--- a/components/drivers/ipc/completion_comm.c
+++ b/components/drivers/ipc/completion_comm.c
@@ -36,6 +36,28 @@ rt_err_t rt_completion_wakeup(struct rt_completion *completion)
 }
 
 /**
+ * @brief This is same as rt_completion_wait(), except that this API is NOT
+ *        ISR-safe (you can NOT call completion_done() on isr routine).
+ *
+ * @param completion is a pointer to a completion object.
+ *
+ * @param timeout is a timeout period (unit: OS ticks). If the completion is unavailable, the thread will wait for
+ *                the completion done up to the amount of time specified by the argument.
+ *                NOTE: Generally, we use the macro RT_WAITING_FOREVER to set this parameter, which means that when the
+ *                completion is unavailable, the thread will be waitting forever.
+ *
+ * @return Return the operation status. ONLY when the return value is RT_EOK, the operation is successful.
+ *         If the return value is any other values, it means that the completion wait failed.
+ *
+ * @warning This function can ONLY be called in the thread context. It MUST NOT be called in interrupt context.
+ */
+rt_err_t rt_completion_wait_noisr(struct rt_completion *completion,
+                                  rt_int32_t            timeout)
+{
+    return rt_completion_wait_flags_noisr(completion, timeout, RT_UNINTERRUPTIBLE);
+}
+
+/**
  * @brief This function will wait for a completion, if the completion is unavailable, the thread shall wait for
  *        the completion up to a specified time.
  *

--- a/components/drivers/ipc/completion_up.c
+++ b/components/drivers/ipc/completion_up.c
@@ -149,6 +149,28 @@ __exit:
 }
 
 /**
+ * @brief This is same as rt_completion_wait_flags(), except that this API is NOT
+ *        ISR-safe (you can NOT call completion_done() on isr routine).
+ *
+ * @param completion is a pointer to a completion object.
+ * @param timeout is a timeout period (unit: OS ticks). If the completion is unavailable, the thread will wait for
+ *                the completion done up to the amount of time specified by the argument.
+ *                NOTE: Generally, we use the macro RT_WAITING_FOREVER to set this parameter, which means that when the
+ *                completion is unavailable, the thread will be waitting forever.
+ * @param suspend_flag suspend flags. See rt_thread_suspend_with_flag()
+ *
+ * @return Return the operation status. ONLY when the return value is RT_EOK, the operation is successful.
+ *         If the return value is any other values, it means that the completion wait failed.
+ *
+ * @warning This function can ONLY be called in the thread context. It MUST NOT be called in interrupt context.
+ */
+rt_err_t rt_completion_wait_flags_noisr(struct rt_completion *completion,
+                                        rt_int32_t timeout, int suspend_flag)
+{
+    return rt_completion_wait_flags(completion, timeout, suspend_flag);
+}
+
+/**
  * @brief   This function indicates a completion has done and wakeup the thread
  *          and update its errno. No update is applied if it's a negative value.
  *


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

Since the completion is used to sync with ISR mostly, we should set the default semantic to ISR-safe. So most user will be happy and don't see any weird behavior in their codes.

#### 你的解决方案是什么 (what is your solution)

Changes:
- Added `rt_completion_wait_noisr` and `rt_completion_wait_flags_noisr` functions in `completion.h`, `completion_comm.c`, `completion_mp.c`, and `completion_up.c`.
- The new APIs allow waiting for completions in non-ISR contexts while ensuring thread context safety.
- Existing documentation and comments were updated to clarify usage contexts and emphasize restrictions on ISR usage.

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
