### PR TITLE
【修复】修复lseek系统调用的错误值返回异常问题

### DIFF
--- a/components/dfs/dfs_v2/filesystems/devfs/devfs.c
+++ b/components/dfs/dfs_v2/filesystems/devfs/devfs.c
@@ -265,7 +265,7 @@ static int dfs_devfs_flush(struct dfs_file *file)
 
 static off_t dfs_devfs_lseek(struct dfs_file *file, off_t offset, int wherece)
 {
-    off_t ret = 0;
+    off_t ret = -EPERM;
     rt_device_t device;
 
     RT_ASSERT(file != RT_NULL);

--- a/components/dfs/dfs_v2/src/dfs.c
+++ b/components/dfs/dfs_v2/src/dfs.c
@@ -673,7 +673,7 @@ int sys_dup(int oldfd)
 #ifdef RT_USING_SMART
     return (sysret_t)newfd;
 #else
-    return newfd;
+return newfd;
 #endif
 }
 

--- a/components/dfs/dfs_v2/src/dfs_posix.c
+++ b/components/dfs/dfs_v2/src/dfs_posix.c
@@ -399,7 +399,7 @@ off_t lseek(int fd, off_t offset, int whence)
     result = dfs_file_lseek(file, offset, whence);
     if (result < 0)
     {
-        rt_set_errno(result);
+        rt_set_errno(-EPERM);
 
         return -1;
     }

--- a/components/lwp/lwp_syscall.c
+++ b/components/lwp/lwp_syscall.c
@@ -461,7 +461,7 @@ ssize_t sys_write(int fd, const void *buf, size_t nbyte)
 /* syscall: "lseek" ret: "off_t" args: "int" "off_t" "int" */
 size_t sys_lseek(int fd, size_t offset, int whence)
 {
-    size_t ret = lseek(fd, offset, whence);
+    ssize_t ret = lseek(fd, offset, whence);
     return (ret < 0 ? GET_ERRNO() : ret);
 }
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
lseek系统调用返回异常值到用户层错误，正常来说，用户调用lseek失败时应期望返回-1，但是由于size变量的设置以及devfs中ret的设置会导致返回的错误码有问题

#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
