### PR TITLE
【修复】audio_pipe中函数在开启POSIX IPC时与 POSIX PIPE冲突问题

### DIFF
--- a/components/drivers/audio/dev_audio_pipe.c
+++ b/components/drivers/audio/dev_audio_pipe.c
@@ -12,7 +12,7 @@
 #include <rtdevice.h>
 #include "dev_audio_pipe.h"
 
-static void _rt_pipe_resume_writer(struct rt_audio_pipe *pipe)
+static void _rt_audio_pipe_resume_writer(struct rt_audio_pipe *pipe)
 {
     if (!rt_list_isempty(&pipe->suspended_write_list))
     {
@@ -30,7 +30,7 @@ static void _rt_pipe_resume_writer(struct rt_audio_pipe *pipe)
     }
 }
 
-static rt_ssize_t rt_pipe_read(rt_device_t dev,
+static rt_ssize_t rt_audio_pipe_read(rt_device_t dev,
                               rt_off_t    pos,
                               void       *buffer,
                               rt_size_t   size)
@@ -50,7 +50,7 @@ static rt_ssize_t rt_pipe_read(rt_device_t dev,
 
         /* if the ringbuffer is empty, there won't be any writer waiting */
         if (read_nbytes)
-            _rt_pipe_resume_writer(pipe);
+            _rt_audio_pipe_resume_writer(pipe);
 
         rt_hw_interrupt_enable(level);
 
@@ -78,7 +78,7 @@ static rt_ssize_t rt_pipe_read(rt_device_t dev,
         }
         else
         {
-            _rt_pipe_resume_writer(pipe);
+            _rt_audio_pipe_resume_writer(pipe);
             rt_hw_interrupt_enable(level);
             break;
         }
@@ -88,7 +88,7 @@ static rt_ssize_t rt_pipe_read(rt_device_t dev,
     return read_nbytes;
 }
 
-static void _rt_pipe_resume_reader(struct rt_audio_pipe *pipe)
+static void _rt_audio_pipe_resume_reader(struct rt_audio_pipe *pipe)
 {
     if (pipe->parent.rx_indicate)
         pipe->parent.rx_indicate(&pipe->parent,
@@ -110,7 +110,7 @@ static void _rt_pipe_resume_reader(struct rt_audio_pipe *pipe)
     }
 }
 
-static rt_ssize_t rt_pipe_write(rt_device_t dev,
+static rt_ssize_t rt_audio_pipe_write(rt_device_t dev,
                                rt_off_t    pos,
                                const void *buffer,
                                rt_size_t   size)
@@ -135,7 +135,7 @@ static rt_ssize_t rt_pipe_write(rt_device_t dev,
             write_nbytes = rt_ringbuffer_put(&(pipe->ringbuffer),
                                              (const rt_uint8_t *)buffer, size);
 
-        _rt_pipe_resume_reader(pipe);
+        _rt_audio_pipe_resume_reader(pipe);
 
         rt_hw_interrupt_enable(level);
 
@@ -164,7 +164,7 @@ static rt_ssize_t rt_pipe_write(rt_device_t dev,
         }
         else
         {
-            _rt_pipe_resume_reader(pipe);
+            _rt_audio_pipe_resume_reader(pipe);
             rt_hw_interrupt_enable(level);
             break;
         }
@@ -174,7 +174,7 @@ static rt_ssize_t rt_pipe_write(rt_device_t dev,
     return write_nbytes;
 }
 
-static rt_err_t rt_pipe_control(rt_device_t dev, int cmd, void *args)
+static rt_err_t rt_audio_pipe_control(rt_device_t dev, int cmd, void *args)
 {
     struct rt_audio_pipe *pipe;
 
@@ -191,9 +191,9 @@ const static struct rt_device_ops audio_pipe_ops =
     RT_NULL,
     RT_NULL,
     RT_NULL,
-    rt_pipe_read,
-    rt_pipe_write,
-    rt_pipe_control
+    rt_audio_pipe_read,
+    rt_audio_pipe_write,
+    rt_audio_pipe_control
 };
 #endif
 
@@ -235,9 +235,9 @@ rt_err_t rt_audio_pipe_init(struct rt_audio_pipe *pipe,
     pipe->parent.init    = RT_NULL;
     pipe->parent.open    = RT_NULL;
     pipe->parent.close   = RT_NULL;
-    pipe->parent.read    = rt_pipe_read;
-    pipe->parent.write   = rt_pipe_write;
-    pipe->parent.control = rt_pipe_control;
+    pipe->parent.read    = rt_audio_pipe_read;
+    pipe->parent.write   = rt_audio_pipe_write;
+    pipe->parent.control = rt_audio_pipe_control;
 #endif
 
     return rt_device_register(&(pipe->parent), name, RT_DEVICE_FLAG_RDWR);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

audio_pipe中函数在开启POSIX IPC时与 POSIX PIPE冲突问题。在drivers/audio/audio_pipe.c中申明了：

```
rt_pipe_read
rt_pipe_write
rt_pipe_control
```
这三个函数，如果在不开启POSIX IPC的情况下可以正常编译过去，但是如果开启 POSIX并打开IPC时，会提示以下错误：

![3c2b4c3dd7ccee40d3fef1837f21695](https://github.com/user-attachments/assets/a7ce6850-88cc-4813-b499-fea5034b771f)


#### 你的解决方案是什么 (what is your solution)

将以下三个函数：

```
rt_pipe_read
rt_pipe_write
rt_pipe_control
```

重命名为：

```
rt_audio_pipe_read
rt_audio_pipe_write
rt_audio_pipe_control
```
符合下面 rt_audio_pipe_init函数整体规则。

#### 请提供验证的bsp和config (provide the config and bsp) 


- BSP:

bsp\at32f437_start


- .config:


#define RT_USING_POSIX_FS
#define RT_USING_POSIX_POLL
#define RT_USING_POSIX_SELECT
#define RT_USING_POSIX_SOCKET
#define RT_USING_POSIX_DELAY
#define RT_USING_POSIX_CLOCK
#define RT_USING_POSIX_TIMER
#define RT_USING_PTHREADS
#define PTHREAD_NUM_MAX 8
#define RT_USING_POSIX_MESSAGE_SEMAPHORE

#define RT_USING_AUDIO
#define RT_AUDIO_REPLAY_MP_BLOCK_SIZE 3840
#define RT_AUDIO_REPLAY_MP_BLOCK_COUNT 2
#define RT_AUDIO_RECORD_PIPE_SIZE 7680

- action:

![image](https://github.com/user-attachments/assets/579f423d-a2b6-4b9b-a964-2c0b1415dd35)

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
