### PR TITLE
[components][lwip] add support for independent dns services for multiple network devices

### DIFF
--- a/components/net/lwip/lwip-2.1.2/src/core/ipv4/dhcp.c
+++ b/components/net/lwip/lwip-2.1.2/src/core/ipv4/dhcp.c
@@ -673,7 +673,16 @@ dhcp_handle_ack(struct netif *netif, struct dhcp_msg *msg_in)
   for (n = 0; (n < LWIP_DHCP_PROVIDE_DNS_SERVERS) && dhcp_option_given(dhcp, DHCP_OPTION_IDX_DNS_SERVER + n); n++) {
     ip_addr_t dns_addr;
     ip_addr_set_ip4_u32_val(dns_addr, lwip_htonl(dhcp_get_option_value(dhcp, DHCP_OPTION_IDX_DNS_SERVER + n)));
+#ifdef RT_USING_NETDEV
+    extern struct netdev *netdev_get_by_name(const char *name);
+    extern void netdev_set_dns_server(struct netdev *netdev, uint8_t dns_num, const ip_addr_t *dns_server);
+    /* Here we only need to set the dns server of the corresponding network device,
+     * but do not need to configure all network devices.
+     */
+    netdev_set_dns_server(netdev_get_by_name(netif->name), n, &dns_addr);
+#else
     dns_setserver(n, &dns_addr);
+#endif
   }
 #endif /* LWIP_DHCP_PROVIDE_DNS_SERVERS */
 }

--- a/components/net/lwip/lwip-2.1.2/src/core/ipv6/dhcp6.c
+++ b/components/net/lwip/lwip-2.1.2/src/core/ipv6/dhcp6.c
@@ -538,7 +538,16 @@ dhcp6_handle_config_reply(struct netif *netif, struct pbuf *p_msg_in)
       }
       ip6_addr_assign_zone(dns_addr6, IP6_UNKNOWN, netif);
       /* @todo: do we need a different offset than DHCP(v4)? */
+#ifdef RT_USING_NETDEV
+      extern struct netdev *netdev_get_by_name(const char *name);
+      extern void netdev_set_dns_server(struct netdev *netdev, uint8_t dns_num, const ip_addr_t *dns_server);
+      /* Here we only need to set the dns server of the corresponding network device,
+      * but do not need to configure all network devices.
+      */
+      netdev_set_dns_server(netdev_get_by_name(netif->name), n, &dns_addr);
+#else
       dns_setserver(n, &dns_addr);
+#endif
     }
   }
   /* @ todo: parse and set Domain Search List */

--- a/components/net/lwip/port/ethernetif.c
+++ b/components/net/lwip/port/ethernetif.c
@@ -15,6 +15,7 @@
  * 2018-11-02     MurphyZhao   port to lwIP 2.1.0
  * 2021-09-07     Grissiom     fix eth_tx_msg ack bug
  * 2022-02-22     xiangxistu   integrate v1.4.1 v2.0.3 and v2.1.2 porting layer
+ * 2024-09-12     Evlers       add support for independent dns services for multiple network devices
  */
 
 /*
@@ -169,8 +170,11 @@ static int lwip_netdev_set_addr_info(struct netdev *netif, ip_addr_t *ip_addr, i
 }
 
 #ifdef RT_LWIP_DNS
-static int lwip_netdev_set_dns_server(struct netdev *netif, uint8_t dns_num, ip_addr_t *dns_server)
+static int lwip_netdev_set_dns_server(struct netdev *netdev, uint8_t dns_num, ip_addr_t *dns_server)
 {
+#if RT_USING_LWIP_VER_NUM >= 0x20102
+    netdev_low_level_set_dns_server(netdev, dns_num, dns_server);
+#else
 #if LWIP_VERSION_MAJOR == 1U /* v1.x */
     extern void dns_setserver(u8_t numdns, ip_addr_t *dnsserver);
 #else /* >=2.x */
@@ -178,6 +182,7 @@ static int lwip_netdev_set_dns_server(struct netdev *netif, uint8_t dns_num, ip_
 #endif /* LWIP_VERSION_MAJOR == 1U */
 
     dns_setserver(dns_num, dns_server);
+#endif /* RT_USING_LWIP_VER_NUM >= 0x20102 */
     return ERR_OK;
 }
 #endif /* RT_LWIP_DNS */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
**在使用多个网络设备时，`dns servers`会被`DHCP`应答处理设置到所有网络设备**
- 在使用`WiFi + ETH + PPP`三个网络设备的情况下，`WiFi`和`ETH`往往使用的是网关作为DNS服务器
- 在`WiFi`和`ETH`发起`DHCP`请求时，`PPP设备(GSM模组)`的DNS服务器也会被设置到`WiFi`和`ETH`的`网关IP`
- 如果`默认的网络`是`PPP网络设备`，那么发起的`DNS`请求会到`WiFi/ETH`的`网关IP`去，导致`gethostbyname`超时

**以下是修改前的DNS IP**
```
msh />dns
network interface device: e0 (Default)
dns server #0: 202.96.128.86
dns server #1: 202.96.134.133

network interface device: w0
dns server #0: 202.96.128.86
dns server #1: 202.96.134.133

network interface device: w1
dns server #0: 0.0.0.0
dns server #1: 0.0.0.0

network interface device: pp
dns server #0: 202.96.128.86
dns server #1: 202.96.134.133
```
- 由于`GSM`启动较慢，`WiFi`和`ETH`先获取到了`DNS`，而后面启动的`PPP网络设备`将`WiFi`和`ETH`的`DNS`都给改掉了
- 且等待一段时间后，`WiFi`和`ETH`再次发起`DHCP`请求时，`PPP网络设备`的`DNS`会被换成`WiFi`和`ETH`的`DNS`
```
msh />dns
network interface device: e0 (Default)
dns server #0: 192.168.1.1
dns server #1: 192.168.0.1

network interface device: w0
dns server #0: 192.168.1.1
dns server #1: 192.168.0.1

network interface device: w1
dns server #0: 0.0.0.0
dns server #1: 0.0.0.0

network interface device: pp
dns server #0: 192.168.1.1
dns server #1: 192.168.0.1
```

#### 你的解决方案是什么 (what is your solution)
**添加独立的DNS Servers支持，每个网络设备都有自己的DNS，使用默认网络设备的DNS并在udp中绑定对应网络设备**
- 在`dns.c`文件的`dns_send`函数中，读取`默认网络设备`的`dns servers`并在发起`udp`数据前绑定该`dns servers`对应的`网络设备`
- 在`DHCP`应答中使用`netdev_set_dns_server`来设置对应网卡的`DNS`，而不是使用`dns_setserver`修改所有`网络设备`的`DNS`

**以下是修改后的DNS IP**
```
msh />dns
network interface device: e0 (Default)
dns server #0: 192.168.1.1
dns server #1: 192.168.0.1

network interface device: w0
dns server #0: 192.168.1.1
dns server #1: 192.168.0.1

network interface device: w1
dns server #0: 0.0.0.0
dns server #1: 0.0.0.0

network interface device: pp
dns server #0: 202.96.128.86
dns server #1: 202.96.134.133
```

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:GD32F470

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
