### PR TITLE
fix: suppress unused warnings when DEBUG disabled

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -117,7 +117,7 @@ extern "C" {
 
 /* Common Utilities */
 
-#define RT_UNUSED(x)                   ((void)x)
+#define RT_UNUSED(x)                   ((void)(x))
 
 /* compile time assertion */
 #define RT_STATIC_ASSERT(name, expn) typedef char _static_assert_##name[(expn)?1:-1]

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -804,7 +804,7 @@ if (!(EX))                                                                    \
     rt_assert_handler(#EX, __FUNCTION__, __LINE__);                           \
 }
 #else
-#define RT_ASSERT(EX)
+#define RT_ASSERT(EX) {RT_UNUSED(EX);}
 #endif /* RT_DEBUGING_ASSERT */
 
 #ifdef RT_DEBUGING_CONTEXT


### PR DESCRIPTION
When RT_USING_DEBUG is disabled, variables used only in RT_ASSERT statements become unused, triggering -Wunused-but-set-variable compiler warnings. These variables are essential for runtime assertions in debug builds but appear unused in release builds.

Example:
- Variables used in RT_ASSERT(var != RT_NULL) checks
- Affects multiple drivers and components using RT_ASSERT

This is a general cleanup to improve code compilation without affecting functionality.

## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
避免編譯警告

#### 你的解决方案是什么 (what is your solution)
透過 { (void)(EX); }告知編譯器


#### 请提供验证的bsp和config (provide the config and bsp) 
例如 HMI Board 的 BSP 會出現
譬如下面這段源代碼

```
/* I2C initialization function */
int rt_hw_i2c_init(void)
{
    rt_size_t obj_num = sizeof(i2c_obj) / sizeof(struct ra_i2c);
    rt_err_t result;

    for (int i = 0; i < obj_num; i++)
    {
        i2c_obj[i].ops = ra_bit_ops_default;
        i2c_obj[i].ops.data = (void *)&soft_i2c_config[i];
        i2c_obj[i].i2c2_bus.priv = &i2c_obj[i].ops;
        ra_i2c_gpio_init(&i2c_obj[i]);
        result = rt_i2c_bit_add_bus(&i2c_obj[i].i2c2_bus, soft_i2c_config[i].bus_name);
        RT_ASSERT(result == RT_EOK);
        ra_i2c_bus_unlock(&soft_i2c_config[i]);

        LOG_D("software simulation %s init done, pin scl: %d, pin sda %d",
              soft_i2c_config[i].bus_name,
              soft_i2c_config[i].scl,
              soft_i2c_config[i].sda);
    }

    return RT_EOK;
}
```
未修改前　會發生
libraries/HAL_Drivers/drv_soft_i2c.c:196:14: warning: variable 'result' set but not used [-Wunused-but-set-variable]
  196 |     rt_err_t result = RT_EOK;
      |              ^~~~~~

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [X ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ X] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ X] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ X] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ X] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ X] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ X] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md) 
