### PR TITLE
[DM/FIXUP] Fixup PCI device ofw private node for MSI

### DIFF
--- a/components/drivers/pci/ofw.c
+++ b/components/drivers/pci/ofw.c
@@ -461,7 +461,7 @@ static void ofw_msi_pic_init(struct rt_pci_device *pdev)
 {
 #ifdef RT_PCI_MSI
     rt_uint32_t rid;
-    struct rt_pci_bus *bus;
+    struct rt_pci_host_bridge *bridge;
     struct rt_ofw_node *np, *msi_ic_np = RT_NULL;
 
     /*
@@ -473,26 +473,14 @@ static void ofw_msi_pic_init(struct rt_pci_device *pdev)
      */
     rid = rt_pci_dev_id(pdev);
 
-    for (bus = pdev->bus; bus; bus = bus->parent)
+    bridge = rt_pci_find_host_bridge(pdev->bus);
+    RT_ASSERT(bridge != RT_NULL);
+
+    np = bridge->parent.ofw_node;
+
+    if (!(msi_ic_np = rt_ofw_parse_phandle(np, "msi-parent", 0)))
     {
-        if (rt_pci_is_root_bus(bus))
-        {
-            np = bus->host_bridge->parent.ofw_node;
-        }
-        else
-        {
-            np = bus->self->parent.ofw_node;
-        }
-
-        if ((msi_ic_np = rt_ofw_parse_phandle(np, "msi-parent", 0)))
-        {
-            break;
-        }
-
-        if (!rt_ofw_map_id(np, rid, "msi-map", "msi-map-mask", &msi_ic_np, RT_NULL))
-        {
-            break;
-        }
+        rt_ofw_map_id(np, rid, "msi-map", "msi-map-mask", &msi_ic_np, RT_NULL);
     }
 
     if (!msi_ic_np)

--- a/components/drivers/pci/probe.c
+++ b/components/drivers/pci/probe.c
@@ -486,7 +486,7 @@ static void pcie_fixup_link(struct rt_pci_device *pdev)
 
         if (!!(exp_lnksta & PCIEM_LINK_STA_DL_ACTIVE))
         {
-            return;
+            goto _status_sync;
         }
 
         rt_thread_mdelay(10);
@@ -496,6 +496,10 @@ static void pcie_fixup_link(struct rt_pci_device *pdev)
     rt_pci_write_config_u16(pdev, pos + PCIER_LINK_CTL2, exp_lnkctl2);
     rt_pci_write_config_u16(pdev, pos + PCIER_LINK_CTL,
             exp_lnkctl | PCIEM_LINK_CTL_RETRAIN_LINK);
+
+_status_sync:
+    /* Wait a while for success or failure */
+    rt_thread_mdelay(100);
 }
 
 static rt_uint32_t pci_scan_bridge_extend(struct rt_pci_bus *bus, struct rt_pci_device *pdev,


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
Some PCI device devicetree is like:
```dts
pcie@fe270000 {
    device_type = "pci";
    msi-map = <0x1000 0x9c 0x1000 0x1000>;

    pcie@10 {
        reg = <0x100000 0x00 0x00 0x00 0x00>;
        #address-cells = <0x03>;
        #size-cells = <0x02>;

        pcie@10,0 {
            reg = <0x00 0x00 0x00 0x00 0x00>;
        };
    };
};
```

that the pcie@10,0 have a private ofw node, it will find property name `msi-map` or `msi-parent` fail.
We should only find the property in host bridge's ofw node.

- BSP:

qemu-virt64-aarch64
rockchip/rk3568 (rock3a,r5s,r5c)

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
