### PR TITLE
[libcpu]riscv使用call指令解决长跳转问题

### DIFF
--- a/libcpu/risc-v/common64/context_gcc.S
+++ b/libcpu/risc-v/common64/context_gcc.S
@@ -77,11 +77,11 @@
 rt_hw_context_switch_to:
     LOAD sp, (a0)
 
-    jal rt_thread_self
+    call rt_thread_self
     mv s1, a0
 
     #ifdef RT_USING_SMART
-        jal lwp_aspace_switch
+        call lwp_aspace_switch
     #endif
 
     RESTORE_CONTEXT
@@ -104,11 +104,11 @@ rt_hw_context_switch:
     LOAD sp, (a1)
 
     // restore Address Space
-    jal rt_thread_self
+    call rt_thread_self
     mv s1, a0
 
     #ifdef RT_USING_SMART
-        jal lwp_aspace_switch
+        call lwp_aspace_switch
     #endif
 
     RESTORE_CONTEXT

--- a/libcpu/risc-v/common64/interrupt_gcc.S
+++ b/libcpu/risc-v/common64/interrupt_gcc.S
@@ -46,7 +46,8 @@ _distinguish_syscall:
 #ifdef RT_USING_SMART
     // TODO swap 8 with config macro name
     li      t1, 8
-    beq     t0, t1, syscall_entry
+    bne     t0, t1, _handle_interrupt_and_exception
+    call syscall_entry
     // syscall never return here
 #endif
 
@@ -78,7 +79,8 @@ _resume_execution:
 #ifdef RT_USING_SMART
     LOAD    t0, FRAME_OFF_SSTATUS(sp)
     andi    t0, t0, SSTATUS_SPP
-    beqz    t0, arch_ret_to_user
+    bnez    t0, _resume_kernel
+    call arch_ret_to_user
 #endif
 
 _resume_kernel:


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
内核链接太多静态库后会导致jal指令跳转范围不够用

#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 


- BSP:

k230
- .config:


- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
