### PR TITLE
Revert "[tools] use project's dir basename as default project name"

### DIFF
--- a/.github/workflows/action_tools.yml
+++ b/.github/workflows/action_tools.yml
@@ -77,7 +77,7 @@ jobs:
       if: ${{ success() }}
       run: |
         echo "Test to dist project"
-        scons --dist --project-name=project -C $TEST_BSP_ROOT
+        scons --dist -C $TEST_BSP_ROOT
         scons --dist-ide -C $TEST_BSP_ROOT
         ls $TEST_BSP_ROOT
         ls $TEST_BSP_ROOT/dist

--- a/tools/options.py
+++ b/tools/options.py
@@ -22,9 +22,8 @@
 # 2022-04-20     WuGensheng  Add Options to SCons
 #
 
-from SCons.Script import AddOption, Dir
+from SCons.Script import AddOption
 import platform
-import os
 
 def AddOptions():
     ''' ===== Add generic options to SCons ===== '''
@@ -46,7 +45,7 @@ def AddOptions():
     AddOption('--project-name',
                 dest = 'project-name',
                 type = 'string',
-                default = os.path.basename(Dir('#').abspath),
+                default = "project",
                 help = 'set project name')
     AddOption('--cscope',
                 dest = 'cscope',


### PR DESCRIPTION
这个暂时不能改，bsp中的工程名默认为project
改了之后`scons --target=mdk5`之后的工程名都变了
之前为`project.uvprojx`
Reverts RT-Thread/rt-thread#9625
