### PR TITLE
add comments for pthread barrier APIs and fix some errors.

### DIFF
--- a/components/libc/posix/pthreads/pthread_barrier.c
+++ b/components/libc/posix/pthreads/pthread_barrier.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -51,6 +51,31 @@ int pthread_barrierattr_setpshared(pthread_barrierattr_t *attr, int pshared)
 }
 RTM_EXPORT(pthread_barrierattr_setpshared);
 
+/**
+ * @brief Destroys a barrier object.
+ *
+ * The `pthread_barrier_destroy` function releases any resources associated
+ * with the specified barrier object. After a barrier has been destroyed,
+ * it cannot be used again unless it is reinitialized using `pthread_barrier_init`.
+ *
+ * @param[in] barrier
+ * A pointer to an initialized `pthread_barrier_t` object to be destroyed.
+ *
+ * @return
+ * - `0` on success.
+ * - `EINVAL` if the `barrier` is invalid or uninitialized.
+ * - `EBUSY` if there are threads currently blocked on the barrier.
+ *
+ * @note
+ * - Ensure that no threads are blocked on the barrier before calling this function.
+ * - Attempting to destroy a barrier that is still in use results in undefined behavior.
+ *
+ * @warning
+ * Destroying a barrier without ensuring it is no longer in use can lead to
+ * resource leaks or undefined program behavior.
+ *
+ * @see pthread_barrier_init, pthread_barrier_wait
+ */
 int pthread_barrier_destroy(pthread_barrier_t *barrier)
 {
     rt_err_t result;
@@ -64,6 +89,38 @@ int pthread_barrier_destroy(pthread_barrier_t *barrier)
 }
 RTM_EXPORT(pthread_barrier_destroy);
 
+/**
+ * @brief Initializes a barrier for synchronizing threads.
+ *
+ * The `pthread_barrier_init` function initializes a barrier object
+ * that allows a specified number of threads to synchronize at a barrier point.
+ * Each thread waits at the barrier until the required number of threads have called
+ * `pthread_barrier_wait`.
+ *
+ * @param[out] barrier
+ * A pointer to the `pthread_barrier_t` object to be initialized.
+ * This object must not already be initialized.
+ *
+ * @param[in] attr
+ * A pointer to a `pthread_barrierattr_t` object that specifies
+ * attributes for the barrier (e.g., process-shared or process-private).
+ * If NULL, the default attributes are used.
+ *
+ * @param[in] count
+ * The number of threads that must call `pthread_barrier_wait`
+ * before any of them successfully return from the barrier.
+ *
+ * @return
+ * - `0` on success.
+ * - `EINVAL` if the `count` is zero or `barrier` is invalid.
+ *
+ * @note The barrier must be destroyed using `pthread_barrier_destroy`
+ * when it is no longer needed.
+ *
+ * @warning If `count` is set to zero, the behavior is undefined.
+ *
+ * @see pthread_barrier_wait, pthread_barrier_destroy
+ */
 int pthread_barrier_init(pthread_barrier_t           *barrier,
                          const pthread_barrierattr_t *attr,
                          unsigned                     count)
@@ -83,6 +140,33 @@ int pthread_barrier_init(pthread_barrier_t           *barrier,
 }
 RTM_EXPORT(pthread_barrier_init);
 
+/**
+ * @brief Synchronizes threads at a barrier.
+ *
+ * The `pthread_barrier_wait` function blocks the calling thread at the specified
+ * barrier until the required number of threads have reached the barrier. Once
+ * the required number of threads have called this function, all threads are
+ * unblocked and can proceed.
+ *
+ * @param[in] barrier
+ * A pointer to an initialized `pthread_barrier_t` object representing the barrier
+ * at which threads will synchronize.
+ *
+ * @return
+ * - `0` for all threads except one.
+ * - `EINVAL` - The `barrier` is invalid or uninitialized.
+ *
+ * @note
+ * - All threads participating in the barrier must call `pthread_barrier_wait`
+ *   before any of them are released.
+ *
+ * @warning
+ * Ensure that the number of threads specified during the barrier's initialization
+ * matches the number of threads calling this function, otherwise the program
+ * may hang indefinitely.
+ *
+ * @see pthread_barrier_init, pthread_barrier_destroy
+ */
 int pthread_barrier_wait(pthread_barrier_t *barrier)
 {
     rt_err_t result;

--- a/components/libc/posix/pthreads/pthread_barrier.c
+++ b/components/libc/posix/pthreads/pthread_barrier.c
@@ -45,7 +45,10 @@ int pthread_barrierattr_setpshared(pthread_barrierattr_t *attr, int pshared)
     if (!attr)
         return EINVAL;
     if (pshared == PTHREAD_PROCESS_PRIVATE)
-        attr = PTHREAD_PROCESS_PRIVATE;
+    {
+        *attr = PTHREAD_PROCESS_PRIVATE;
+        return 0;
+    }
 
     return EINVAL;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
1. 为pthread barrier API增加注释；
2. 修正一些问题：
   1）pthread_barrierattr_setpshared中，将PTHREAD_PROCESS_PRIVATE直接赋值给指针attr，应该赋给*attr。此外，该函数的返回值在任何时候都是EINVAL；
   2）pthread_barrier_destroy函数，在执行destroy前，未检查barrier->count是否为0，即barrier是否仍在使用中。此外，此函数只销毁了barrier中的条件变量cond，而没有销毁mutex。

#### 你的解决方案是什么 (what is your solution)
增加代码以及修正以上问题。


#### 请提供验证的bsp和config (provide the config and bsp) 


- BSP:

- .config:

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
