### PR TITLE
[componets] fix when printf 0 addr by %p will return nil

### DIFF
--- a/components/drivers/ofw/fdt.c
+++ b/components/drivers/ofw/fdt.c
@@ -37,6 +37,12 @@ static rt_phandle _phandle_max;
 static rt_size_t _root_size_cells;
 static rt_size_t _root_addr_cells;
 
+#ifdef ARCH_CPU_64BIT
+#define MIN_BIT   16
+#else
+#define MIN_BIT   8
+#endif
+
 const char *rt_fdt_node_name(const char *full_name)
 {
     const char *node_name = strrchr(full_name, '/');
@@ -358,11 +364,11 @@ static rt_err_t fdt_scan_memory(void)
 
             if (!err)
             {
-                LOG_I("Memory node(%d) ranges: %p - %p%s", no, base, base + size, "");
+                LOG_I("Memory node(%d) ranges: 0x%.*lx - 0x%.*lx%s", no, MIN_BIT, base, MIN_BIT, base + size, "");
             }
             else
             {
-                LOG_W("Memory node(%d) ranges: %p - %p%s", no, base, base + size, " unable to record");
+                LOG_W("Memory node(%d) ranges: 0x%.*lx - 0x%.*lx%s", no, MIN_BIT, base, MIN_BIT, base + size, " unable to record");
             }
         }
     }

--- a/components/mm/mm_memblock.c
+++ b/components/mm/mm_memblock.c
@@ -22,6 +22,12 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
+#ifdef ARCH_CPU_64BIT
+#define MIN_BIT   16
+#else
+#define MIN_BIT   8
+#endif
+
 #ifndef RT_INIT_MEMORY_REGIONS
 #define RT_INIT_MEMORY_REGIONS 128
 #endif
@@ -155,16 +161,16 @@ static rt_err_t _memblock_add_range(struct rt_memblock *memblock,
 
 rt_err_t rt_memblock_add_memory(const char *name, rt_size_t start, rt_size_t end, mmblk_flag_t flags)
 {
-    LOG_D("add physical address range [%p-%p) with flag 0x%x" \
-            " to overall memory regions\n", base, base + size, flag);
+    LOG_D("add physical address range [0x%.*lx-0x%.*lx) with flag 0x%x" \
+            " to overall memory regions\n", MIN_BIT, base, MIN_BIT, base + size, flag);
 
     return _memblock_add_range(&mmblk_memory, name, start, end, flags);
 }
 
 rt_err_t rt_memblock_reserve_memory(const char *name, rt_size_t start, rt_size_t end, mmblk_flag_t flags)
 {
-    LOG_D("add physical address range [%p-%p) to reserved memory regions\n",\
-                                        base, base + size);
+    LOG_D("add physical address range %s [0x%.*lx-0x%.*lx) to reserved memory regions\n",
+                                     name, MIN_BIT, start, MIN_BIT, end);
 
     return _memblock_add_range(&mmblk_reserved, name, start, end, flags);
 }
@@ -347,14 +353,14 @@ void rt_memblock_setup_memory_environment(void)
 
     rt_slist_for_each_entry(iter, &(mmblk_memory.reg_list), node)
     {
-        LOG_I("  %-*.s [%p, %p]", RT_NAME_MAX, iter->memreg.name, iter->memreg.start, iter->memreg.end);
+        LOG_I("  %-*.s [0x%.*lx, 0x%.*lx]", RT_NAME_MAX, iter->memreg.name, MIN_BIT, iter->memreg.start, MIN_BIT, iter->memreg.end);
     }
 
     LOG_I("Reserved memory:");
 
     rt_slist_for_each_entry(iter, &(mmblk_reserved.reg_list), node)
     {
-        LOG_I("  %-*.s [%p, %p]", RT_NAME_MAX, iter->memreg.name, iter->memreg.start, iter->memreg.end);
+        LOG_I("  %-*.s [0x%.*lx, 0x%.*lx]", RT_NAME_MAX, iter->memreg.name, MIN_BIT, iter->memreg.start, MIN_BIT, iter->memreg.end);
 
         if (iter->flags != MEMBLOCK_NONE)
         {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)


#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
