### PR TITLE
Xinliu0260 patch 1

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.c
@@ -390,6 +390,10 @@ static rt_ssize_t stm32_transmit(struct rt_serial_device     *serial,
 
     if (uart->uart_dma_flag & RT_DEVICE_FLAG_DMA_TX)
     {
+#if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+        struct rt_serial_tx_fifo *tx_fifo = (struct rt_serial_tx_fifo *) serial->serial_tx;
+        SCB_CleanDCache_by_Addr((uint32_t *)tx_fifo->rb.buffer_ptr, tx_fifo->rb.buffer_size);
+#endif    
         HAL_UART_Transmit_DMA(&uart->handle, buf, size);
         return size;
     }

--- a/components/drivers/include/drivers/dev_serial_v2.h
+++ b/components/drivers/include/drivers/dev_serial_v2.h
@@ -253,7 +253,7 @@ struct rt_serial_rx_fifo
     rt_uint16_t rx_cpt_index;
 
     /* software fifo */
-    rt_uint8_t buffer[];
+    rt_align(32) rt_uint8_t buffer[];
 };
 
 /**
@@ -271,7 +271,7 @@ struct rt_serial_tx_fifo
     struct rt_completion tx_cpt;
 
     /* software fifo */
-    rt_uint8_t buffer[];
+    rt_align(32) rt_uint8_t buffer[];
 };
 
 /**


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
stm32h7系列开启DCache后，使用串口设备框架V2进行串口DMA接收发送
+ 接收数据时，现有版本对接收FIFO的buffer进行了Cache无效化，但会连带无效化接收FIFO结构体中的其他成员数据，导致接收FIFO结构体其他成员数据出错，比如对buffer地址、大小、读写索引的初始化没被写入到内存，对Buffer的操作仍需依赖这些成员信息，最终造成总线错误类型的硬件错误中断等
+ 发送数据与内存数据不一致，需要在DMA发送前，对发送FIFO的buffer进行清空Cache

#### 你的解决方案是什么 (what is your solution)
+ 串口设备驱动框架层中的.h文件定义struct rt_serial_rx_fifo和struct rt_serial_tx_fifo时，对buffer成员进行32字节地址对齐约束
```c
struct rt_serial_rx_fifo
{
    ......
    rt_align(32) rt_uint8_t buffer[];
};

struct rt_serial_tx_fifo
{
    .....
    rt_align(32) rt_uint8_t buffer[];
};
```
+ stm32h7串口设备驱动层在发送前，Clean DCache
```c
static rt_ssize_t stm32_transmit(struct rt_serial_device     *serial,
                                       rt_uint8_t           *buf,
                                       rt_size_t             size,
                                       rt_uint32_t           tx_flag)
{
.......
    if (uart->uart_dma_flag & RT_DEVICE_FLAG_DMA_TX)
    {
#if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
        struct rt_serial_tx_fifo *tx_fifo = (struct rt_serial_tx_fifo *) serial->serial_tx;
        SCB_CleanDCache_by_Addr((uint32_t *)tx_fifo->rb.buffer_ptr, tx_fifo->rb.buffer_size);
#endif        
        HAL_UART_Transmit_DMA(&uart->handle, buf, size);
        return size;
    }
......
}
```

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: bsp\stm32\stm32h743-atk-apollo

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config: 
CONFIG_BSP_SCB_ENABLE_I_CACHE=y
CONFIG_BSP_SCB_ENABLE_D_CACHE=y
CONFIG_RT_USING_SERIAL_V2=y
CONFIG_RT_SERIAL_USING_DMA=y
CONFIG_BSP_USING_UART2=y
CONFIG_BSP_UART2_RX_BUFSIZE=256
CONFIG_BSP_UART2_TX_BUFSIZE=256
CONFIG_BSP_UART2_RX_USING_DMA=y
CONFIG_BSP_UART2_TX_USING_DMA=y


<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:
- no links 

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
