### PR TITLE
[DM/PIC] Support AMP mode

### DIFF
--- a/components/drivers/pic/pic-gicv2.c
+++ b/components/drivers/pic/pic-gicv2.c
@@ -83,6 +83,11 @@ static void gicv2_dist_init(struct gicv2 *gic)
 
     LOG_D("Max irq = %d", gic->max_irq);
 
+    if (gic->skip_init)
+    {
+        return;
+    }
+
     HWREG32(base + GIC_DIST_CTRL) = GICD_DISABLE;
 
     /* Set all global (unused) interrupts to this CPU only. */
@@ -619,6 +624,8 @@ static rt_err_t gicv2_ofw_init(struct rt_ofw_node *np, const struct rt_ofw_node_
             err = -RT_EINVAL;
             break;
         }
+
+        gic->skip_init = rt_ofw_prop_read_bool(np, "skip-init");
 
         gic_common_init_quirk_ofw(np, _gicv2_quirks, gic);
         gicv2_init(gic);

--- a/components/drivers/pic/pic-gicv2.h
+++ b/components/drivers/pic/pic-gicv2.h
@@ -78,6 +78,8 @@ struct gicv2
     rt_size_t hyp_size;
     void *vcpu_base;
     rt_size_t vcpu_size;
+
+    rt_bool_t skip_init;
 };
 
 #endif /* __IRQ_GICV2_H__ */

--- a/components/drivers/pic/pic-gicv3.c
+++ b/components/drivers/pic/pic-gicv3.c
@@ -216,6 +216,11 @@ static void gicv3_dist_init(void)
     LOG_D("%d SPIs implemented", _gic.line_nr - 32);
     LOG_D("%d Extended SPIs implemented", _gic.espi_nr);
 
+    if (_gic.skip_init)
+    {
+        goto _get_max_irq;
+    }
+
     /* Disable the distributor */
     HWREG32(base + GICD_CTLR) = 0;
     gicv3_dist_wait_for_rwp();
@@ -266,6 +271,7 @@ static void gicv3_dist_init(void)
         HWREG64(base + GICD_IROUTERnE + i * 8) = affinity;
     }
 
+_get_max_irq:
     if (GICD_TYPER_NUM_LPIS(_gic.gicd_typer) > 1)
     {
         /* Max LPI = 8192 + Math.pow(2, num_LPIs + 1) - 1 */
@@ -1063,6 +1069,7 @@ static rt_err_t gicv3_ofw_init(struct rt_ofw_node *np, const struct rt_ofw_node_
             redist_stride = 0;
         }
         _gic.redist_stride = redist_stride;
+        _gic.skip_init = rt_ofw_prop_read_bool(np, "skip-init");
 
         gic_common_init_quirk_ofw(np, _gicv3_quirks, &_gic.parent);
         gicv3_init();

--- a/components/drivers/pic/pic-gicv3.h
+++ b/components/drivers/pic/pic-gicv3.h
@@ -385,6 +385,8 @@ struct gicv3
     rt_uint64_t redist_flags;
     rt_size_t redist_stride;
     rt_size_t redist_regions_nr;
+
+    rt_bool_t skip_init;
 };
 
 #endif /* __PIC_GICV3_H__ */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1. PIC GICv2 and GICv3 support on AMP slave mode.
2. PIC-Mailbox support on AMP master/slave mode.

- BSP:
qemu-virt64-aarch64

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
