### PR TITLE
[bsp][stm32] hardware i2c driver add support for STM32F1 series

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/dma_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/dma_config.h
@@ -19,6 +19,13 @@ extern "C" {
 #endif
 
 /* DMA1 channel1 */
+#if defined(BSP_ADC1_USING_DMA) && !defined(ADC1_DMA_INSTANCE)
+#define ADC1_DMA_IRQHandler             DMA1_Channel1_IRQHandler
+#define ADC1_DMA_RCC                    RCC_AHBENR_DMA1EN
+#define ADC1_DMA_INSTANCE               DMA1_Channel1
+#define ADC1_DMA_IRQ                    DMA1_Channel1_IRQn
+#endif
+
 /* DMA1 channel2 */
 #if defined(BSP_SPI1_RX_USING_DMA) && !defined(SPI1_RX_DMA_INSTANCE)
 #define SPI1_DMA_RX_IRQHandler          DMA1_Channel2_IRQHandler
@@ -56,6 +63,11 @@ extern "C" {
 #define UART1_TX_DMA_RCC                RCC_AHBENR_DMA1EN
 #define UART1_TX_DMA_INSTANCE           DMA1_Channel4
 #define UART1_TX_DMA_IRQ                DMA1_Channel4_IRQn
+#elif defined(BSP_I2C2_TX_USING_DMA) && !defined(I2C2_TX_DMA_INSTANCE)
+#define I2C2_DMA_TX_IRQHandler          DMA1_Channel4_IRQHandler
+#define I2C2_TX_DMA_RCC                 RCC_AHBENR_DMA1EN
+#define I2C2_TX_DMA_INSTANCE            DMA1_Channel4
+#define I2C2_TX_DMA_IRQ                 DMA1_Channel4_IRQn
 #endif
 
 /* DMA1 channel5 */
@@ -64,12 +76,16 @@ extern "C" {
 #define SPI2_TX_DMA_RCC                 RCC_AHBENR_DMA1EN
 #define SPI2_TX_DMA_INSTANCE            DMA1_Channel5
 #define SPI2_TX_DMA_IRQ                 DMA1_Channel5_IRQn
-
 #elif defined(BSP_UART1_RX_USING_DMA) && !defined(UART1_RX_DMA_INSTANCE)
 #define UART1_DMA_RX_IRQHandler         DMA1_Channel5_IRQHandler
 #define UART1_RX_DMA_RCC                RCC_AHBENR_DMA1EN
 #define UART1_RX_DMA_INSTANCE           DMA1_Channel5
 #define UART1_RX_DMA_IRQ                DMA1_Channel5_IRQn
+#elif defined(BSP_I2C2_RX_USING_DMA) && !defined(I2C2_RX_DMA_INSTANCE)
+#define I2C2_DMA_RX_IRQHandler          DMA1_Channel5_IRQHandler
+#define I2C2_RX_DMA_RCC                 RCC_AHBENR_DMA1EN
+#define I2C2_RX_DMA_INSTANCE            DMA1_Channel5
+#define I2C2_RX_DMA_IRQ                 DMA1_Channel5_IRQn
 #endif
 
 /* DMA1 channel6 */
@@ -78,6 +94,11 @@ extern "C" {
 #define UART2_RX_DMA_RCC                RCC_AHBENR_DMA1EN
 #define UART2_RX_DMA_INSTANCE           DMA1_Channel6
 #define UART2_RX_DMA_IRQ                DMA1_Channel6_IRQn
+#elif defined(BSP_I2C1_TX_USING_DMA) && !defined(I2C1_TX_DMA_INSTANCE)
+#define I2C1_DMA_TX_IRQHandler          DMA1_Channel6_IRQHandler
+#define I2C1_TX_DMA_RCC                 RCC_AHBENR_DMA1EN
+#define I2C1_TX_DMA_INSTANCE            DMA1_Channel6
+#define I2C1_TX_DMA_IRQ                 DMA1_Channel6_IRQn
 #endif
 
 /* DMA1 channel7 */
@@ -86,6 +107,11 @@ extern "C" {
 #define UART2_TX_DMA_RCC                RCC_AHBENR_DMA1EN
 #define UART2_TX_DMA_INSTANCE           DMA1_Channel7
 #define UART2_TX_DMA_IRQ                DMA1_Channel7_IRQn
+#elif defined(BSP_I2C1_RX_USING_DMA) && !defined(I2C1_RX_DMA_INSTANCE)
+#define I2C1_DMA_RX_IRQHandler          DMA1_Channel7_IRQHandler
+#define I2C1_RX_DMA_RCC                 RCC_AHBENR_DMA1EN
+#define I2C1_RX_DMA_INSTANCE            DMA1_Channel7
+#define I2C1_RX_DMA_IRQ                 DMA1_Channel7_IRQn
 #endif
 
 /* DMA2 channel1 */
@@ -111,9 +137,27 @@ extern "C" {
 #define UART4_RX_DMA_INSTANCE           DMA2_Channel3
 #define UART4_RX_DMA_IRQ                DMA2_Channel3_IRQn
 #endif
+
 /* DMA2 channel4 */
+#if defined(BSP_SDIO_TX_USING_DMA) && !defined(SDIO_TX_DMA_INSTANCE)
+#define SDIO_DMA_TX_IRQHandler          DMA2_Channel4_5_IRQHandler
+#define SDIO_TX_DMA_RCC                 RCC_AHBENR_DMA2EN
+#define SDIO_TX_DMA_INSTANCE            DMA2_Channel4
+#define SDIO_TX_DMA_IRQ                 DMA2_Channel4_5_IRQn
+#elif defined(BSP_SDIO_RX_USING_DMA) && !defined(SDIO_RX_DMA_INSTANCE)
+#define SDIO_DMA_RX_IRQHandler          DMA2_Channel4_5_IRQHandler
+#define SDIO_RX_DMA_RCC                 RCC_AHBENR_DMA2EN
+#define SDIO_RX_DMA_INSTANCE            DMA2_Channel4
+#define SDIO_RX_DMA_IRQ                 DMA2_Channel4_5_IRQn
+#endif
+
 /* DMA2 channel5 */
-#if defined(BSP_UART4_TX_USING_DMA) && !defined(UART4_TX_DMA_INSTANCE)
+#if defined(BSP_ADC3_USING_DMA) && !defined(ADC3_DMA_INSTANCE)
+#define ADC3_DMA_IRQHandler             DMA2_Channel4_5_IRQHandler
+#define ADC3_DMA_RCC                    RCC_AHBENR_DMA2EN
+#define ADC3_DMA_INSTANCE               DMA2_Channel5
+#define ADC3_DMA_IRQ                    DMA2_Channel4_5_IRQn
+#elif defined(BSP_UART4_TX_USING_DMA) && !defined(UART4_TX_DMA_INSTANCE)
 #define UART4_DMA_TX_IRQHandler         DMA2_Channel4_5_IRQHandler
 #define UART4_TX_DMA_RCC                RCC_AHBENR_DMA2EN
 #define UART4_TX_DMA_INSTANCE           DMA2_Channel5

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/i2c_hard_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/i2c_hard_config.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2006-2023, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2024-02-06     Dyyt587   first version
+ * 2024-04-23     Zeidan    Add I2Cx_xx_DMA_CONFIG
+ */
+#ifndef __I2C_HARD_CONFIG_H__
+#define __I2C_HARD_CONFIG_H__
+
+#include <rtthread.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef BSP_USING_HARD_I2C1
+#ifndef I2C1_BUS_CONFIG
+#define I2C1_BUS_CONFIG                             \
+    {                                               \
+        .Instance = I2C1,                           \
+        .timeout=0x1000,                            \
+        .name = "hwi2c1",                           \
+        .evirq_type = I2C1_EV_IRQn,                 \
+        .erirq_type = I2C1_ER_IRQn,                 \
+    }
+#endif /* I2C1_BUS_CONFIG */
+#endif /* BSP_USING_HARD_I2C1 */
+
+#ifdef BSP_I2C1_TX_USING_DMA
+#ifndef I2C1_TX_DMA_CONFIG
+#define I2C1_TX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C1_TX_DMA_RCC,                 \
+        .Instance = I2C1_TX_DMA_INSTANCE,           \
+        .dma_irq = I2C1_TX_DMA_IRQ,                 \
+    }
+#endif /* I2C1_TX_DMA_CONFIG */
+#endif /* BSP_I2C1_TX_USING_DMA */
+
+#ifdef BSP_I2C1_RX_USING_DMA
+#ifndef I2C1_RX_DMA_CONFIG
+#define I2C1_RX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C1_RX_DMA_RCC,                 \
+        .Instance = I2C1_RX_DMA_INSTANCE,           \
+        .dma_irq = I2C1_RX_DMA_IRQ,                 \
+    }
+#endif /* I2C1_RX_DMA_CONFIG */
+#endif /* BSP_I2C1_RX_USING_DMA */
+
+#ifdef BSP_USING_HARD_I2C2
+#ifndef I2C2_BUS_CONFIG
+#define I2C2_BUS_CONFIG                             \
+    {                                               \
+        .Instance = I2C2,                           \
+        .timeout=0x1000,                            \
+        .name = "hwi2c2",                           \
+        .evirq_type = I2C2_EV_IRQn,                 \
+        .erirq_type = I2C2_ER_IRQn,                 \
+    }
+#endif /* I2C2_BUS_CONFIG */
+#endif /* BSP_USING_HARD_I2C2 */
+
+#ifdef BSP_I2C2_TX_USING_DMA
+#ifndef I2C2_TX_DMA_CONFIG
+#define I2C2_TX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C2_TX_DMA_RCC,                 \
+        .Instance = I2C2_TX_DMA_INSTANCE,           \
+        .dma_irq = I2C2_TX_DMA_IRQ,                 \
+    }
+#endif /* I2C2_TX_DMA_CONFIG */
+#endif /* BSP_I2C2_TX_USING_DMA */
+
+#ifdef BSP_I2C2_RX_USING_DMA
+#ifndef I2C2_RX_DMA_CONFIG
+#define I2C2_RX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C2_RX_DMA_RCC,                 \
+        .Instance = I2C2_RX_DMA_INSTANCE,           \
+        .dma_irq = I2C2_RX_DMA_IRQ,                 \
+    }
+#endif /* I2C2_RX_DMA_CONFIG */
+#endif /* BSP_I2C2_RX_USING_DMA */
+
+#ifdef BSP_USING_HARD_I2C3
+#ifndef I2C3_BUS_CONFIG
+#define I2C3_BUS_CONFIG                             \
+    {                                               \
+        .Instance = I2C3,                           \
+        .timeout=0x1000,                            \
+        .name = "hwi2c3",                           \
+        .evirq_type = I2C3_EV_IRQn,                 \
+        .erirq_type = I2C3_ER_IRQn,                 \
+    }
+#endif /* I2C3_BUS_CONFIG */
+#endif /* BSP_USING_HARD_I2C3 */
+
+#ifdef BSP_I2C3_TX_USING_DMA
+#ifndef I2C3_TX_DMA_CONFIG
+#define I2C3_TX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C3_TX_DMA_RCC,                 \
+        .Instance = I2C3_TX_DMA_INSTANCE,           \
+        .dma_irq = I2C3_TX_DMA_IRQ,                 \
+    }
+#endif /* I2C3_TX_DMA_CONFIG */
+#endif /* BSP_I2C3_TX_USING_DMA */
+
+#ifdef BSP_I2C3_RX_USING_DMA
+#ifndef I2C3_RX_DMA_CONFIG
+#define I2C3_RX_DMA_CONFIG                          \
+    {                                               \
+        .dma_rcc = I2C3_RX_DMA_RCC,                 \
+        .Instance = I2C3_RX_DMA_INSTANCE,           \
+        .dma_irq = I2C3_RX_DMA_IRQ,                 \
+    }
+#endif /* I2C3_RX_DMA_CONFIG */
+#endif /* BSP_I2C3_RX_USING_DMA */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__I2C_HARD_CONFIG_H__ */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_config.h
@@ -35,6 +35,7 @@ extern "C" {
 #include "f1/sdio_config.h"
 #include "f1/pwm_config.h"
 #include "f1/usbd_config.h"
+#include "f1/i2c_hard_config.h"
 #include "f1/pulse_encoder_config.h"
 #elif  defined(SOC_SERIES_STM32F2)
 #include "f2/dma_config.h"

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
@@ -23,51 +23,51 @@ enum
 {
 #ifdef BSP_USING_HARD_I2C1
     I2C1_INDEX,
-#endif
+#endif /* BSP_USING_HARD_I2C1 */
 #ifdef BSP_USING_HARD_I2C2
     I2C2_INDEX,
-#endif
+#endif /* BSP_USING_HARD_I2C2 */
 #ifdef BSP_USING_HARD_I2C3
     I2C3_INDEX,
-#endif
+#endif /* BSP_USING_HARD_I2C3 */
 };
 
 static struct stm32_i2c_config i2c_config[] =
 {
 #ifdef BSP_USING_HARD_I2C1
         I2C1_BUS_CONFIG,
-#endif
+#endif /* BSP_USING_HARD_I2C1 */
 #ifdef BSP_USING_HARD_I2C2
         I2C2_BUS_CONFIG,
-#endif
+#endif /* BSP_USING_HARD_I2C2 */
 #ifdef BSP_USING_HARD_I2C3
         I2C3_BUS_CONFIG,
-#endif
+#endif /* BSP_USING_HARD_I2C3 */
 };
 
 static struct stm32_i2c i2c_objs[sizeof(i2c_config) / sizeof(i2c_config[0])] = {0};
 
 static rt_err_t stm32_i2c_init(struct stm32_i2c *i2c_drv)
 {
-	RT_ASSERT(i2c_drv != RT_NULL);
-	
+    RT_ASSERT(i2c_drv != RT_NULL);
+
     I2C_HandleTypeDef *i2c_handle = &i2c_drv->handle;
-	struct stm32_i2c_config *cfg = i2c_drv->config;
-	
+    struct stm32_i2c_config *cfg = i2c_drv->config;
+
     rt_memset(i2c_handle, 0, sizeof(I2C_HandleTypeDef));
-    
+
     i2c_handle->Instance = cfg->Instance;
 #if defined(SOC_SERIES_STM32H7)
     i2c_handle->Init.Timing = cfg->timing;
-#endif
+#endif /* defined(SOC_SERIES_STM32H7) */
 #if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F4)
     i2c_handle->Init.ClockSpeed = 100000;
     i2c_handle->Init.DutyCycle = I2C_DUTYCYCLE_2;
-#endif
+#endif /* defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F4) */
     i2c_handle->Init.OwnAddress1 = 0;
     i2c_handle->Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
     i2c_handle->Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
-	i2c_handle->Init.OwnAddress2 = 0;
+    i2c_handle->Init.OwnAddress2 = 0;
     i2c_handle->Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
     i2c_handle->Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
     if (HAL_I2C_DeInit(i2c_handle) != HAL_OK)
@@ -117,7 +117,7 @@ static rt_err_t stm32_i2c_init(struct stm32_i2c *i2c_drv)
 
     /* In the data transfer function stm32_i2c_master_xfer(), the IT transfer function
        HAL_I2C_Master_Seq_Transmit_IT() is used when DMA is not used, so the IT interrupt
-       must be enable anyway, regardless of the DMA configuration, otherwise 
+       must be enable anyway, regardless of the DMA configuration, otherwise
        the rt_completion_wait() will always timeout. */
     HAL_NVIC_SetPriority(i2c_drv->config->evirq_type, 2, 0);
     HAL_NVIC_EnableIRQ(i2c_drv->config->evirq_type);
@@ -156,14 +156,14 @@ static rt_ssize_t stm32_i2c_master_xfer(struct rt_i2c_bus_device *bus,
     uint8_t next_flag = 0;
     struct rt_completion *completion;
     rt_uint32_t timeout;
-	
+
     if (num == 0)
     {
         return 0;
     }
-	
+
     RT_ASSERT((msgs != RT_NULL) && (bus != RT_NULL));
-	
+
     i2c_obj = rt_container_of(bus, struct stm32_i2c, i2c_bus);
     completion = &i2c_obj->completion;
     I2C_HandleTypeDef *handle = &i2c_obj->handle;
@@ -351,7 +351,7 @@ int RT_hw_i2c_bus_init(void)
             i2c_objs[i].dma.handle_rx.Init.Channel = i2c_config[i].dma_rx->channel;
 #elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
             i2c_objs[i].dma.handle_rx.Init.Request = i2c_config[i].dma_rx->request;
-#endif
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
 #ifndef SOC_SERIES_STM32U5
             i2c_objs[i].dma.handle_rx.Init.Direction           = DMA_PERIPH_TO_MEMORY;
             i2c_objs[i].dma.handle_rx.Init.PeriphInc           = DMA_PINC_DISABLE;
@@ -366,7 +366,7 @@ int RT_hw_i2c_bus_init(void)
             i2c_objs[i].dma.handle_tx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
             i2c_objs[i].dma.handle_tx.Init.MemBurst            = DMA_MBURST_INC4;
             i2c_objs[i].dma.handle_tx.Init.PeriphBurst         = DMA_PBURST_INC4;
-#endif
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7) */
 
             {
                 rt_uint32_t tmpreg = 0x00U;
@@ -382,11 +382,11 @@ int RT_hw_i2c_bus_init(void)
                 __HAL_RCC_DMAMUX_CLK_ENABLE();
                 SET_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_rx->dma_rcc);
                 tmpreg = READ_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_rx->dma_rcc);
-#endif
+#endif /* defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0) */
                 UNUSED(tmpreg); /* To avoid compiler warnings */
             }
         }
-		
+
         if (i2c_objs[i].i2c_dma_flag & I2C_USING_TX_DMA_FLAG)
         {
             i2c_objs[i].dma.handle_tx.Instance = i2c_config[i].dma_tx->Instance;
@@ -394,7 +394,7 @@ int RT_hw_i2c_bus_init(void)
             i2c_objs[i].dma.handle_tx.Init.Channel = i2c_config[i].dma_tx->channel;
 #elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
             i2c_objs[i].dma.handle_tx.Init.Request = i2c_config[i].dma_tx->request;
-#endif
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
 #ifndef SOC_SERIES_STM32U5
             i2c_objs[i].dma.handle_tx.Init.Direction           = DMA_MEMORY_TO_PERIPH;
             i2c_objs[i].dma.handle_tx.Init.PeriphInc           = DMA_PINC_DISABLE;
@@ -410,7 +410,7 @@ int RT_hw_i2c_bus_init(void)
             i2c_objs[i].dma.handle_tx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
             i2c_objs[i].dma.handle_tx.Init.MemBurst            = DMA_MBURST_INC4;
             i2c_objs[i].dma.handle_tx.Init.PeriphBurst         = DMA_PBURST_INC4;
-#endif
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7) */
 
             {
                 rt_uint32_t tmpreg = 0x00U;
@@ -426,7 +426,7 @@ int RT_hw_i2c_bus_init(void)
                 __HAL_RCC_DMAMUX_CLK_ENABLE();
                 SET_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_tx->dma_rcc);
                 tmpreg = READ_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_tx->dma_rcc);
-#endif
+#endif /* defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0) */
                 UNUSED(tmpreg); /* To avoid compiler warnings */
             }
         }

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
@@ -7,14 +7,10 @@
  * Date           Author       Notes
  * 2024-02-17     Dyyt587   first version
  * 2024-04-23     Zeidan    fix bugs, test on STM32F429IGTx
+ * 2024-12-10     zzk597    add support for STM32F1 series
  */
 
-#include <rtthread.h>
-#include <rthw.h>
-#include <board.h>
 #include "drv_hard_i2c.h"
-#include "drv_config.h"
-#include <string.h>
 
 /* not fully support for I2C4 */
 #if defined(BSP_USING_HARD_I2C1) || defined(BSP_USING_HARD_I2C2) || defined(BSP_USING_HARD_I2C3)
@@ -27,52 +23,51 @@ enum
 {
 #ifdef BSP_USING_HARD_I2C1
     I2C1_INDEX,
-#endif /* BSP_USING_HARD_I2C1 */
+#endif
 #ifdef BSP_USING_HARD_I2C2
     I2C2_INDEX,
-#endif /* BSP_USING_HARD_I2C2 */
+#endif
 #ifdef BSP_USING_HARD_I2C3
     I2C3_INDEX,
-#endif /* BSP_USING_HARD_I2C3 */
+#endif
 };
 
 static struct stm32_i2c_config i2c_config[] =
 {
 #ifdef BSP_USING_HARD_I2C1
         I2C1_BUS_CONFIG,
-#endif /* BSP_USING_HARD_I2C1 */
+#endif
 #ifdef BSP_USING_HARD_I2C2
         I2C2_BUS_CONFIG,
-#endif /* BSP_USING_HARD_I2C2 */
+#endif
 #ifdef BSP_USING_HARD_I2C3
         I2C3_BUS_CONFIG,
-#endif /* BSP_USING_HARD_I2C3 */
+#endif
 };
 
 static struct stm32_i2c i2c_objs[sizeof(i2c_config) / sizeof(i2c_config[0])] = {0};
 
-
 static rt_err_t stm32_i2c_init(struct stm32_i2c *i2c_drv)
 {
-    RT_ASSERT(i2c_drv != RT_NULL);
-
+	RT_ASSERT(i2c_drv != RT_NULL);
+	
     I2C_HandleTypeDef *i2c_handle = &i2c_drv->handle;
+	struct stm32_i2c_config *cfg = i2c_drv->config;
+	
     rt_memset(i2c_handle, 0, sizeof(I2C_HandleTypeDef));
-    struct stm32_i2c_config *cfg = i2c_drv->config;
+    
     i2c_handle->Instance = cfg->Instance;
 #if defined(SOC_SERIES_STM32H7)
     i2c_handle->Init.Timing = cfg->timing;
-#endif /* defined(SOC_SERIES_STM32H7) */
-#if defined(SOC_SERIES_STM32F4)
+#endif
+#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F4)
     i2c_handle->Init.ClockSpeed = 100000;
     i2c_handle->Init.DutyCycle = I2C_DUTYCYCLE_2;
-#endif /* defined(SOC_SERIES_STM32F4) */
+#endif
     i2c_handle->Init.OwnAddress1 = 0;
     i2c_handle->Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
-#if defined(SOC_SERIES_STM32H7)
     i2c_handle->Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
-#endif /* defined(SOC_SERIES_STM32H7) */
-    i2c_handle->Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+	i2c_handle->Init.OwnAddress2 = 0;
     i2c_handle->Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
     i2c_handle->Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
     if (HAL_I2C_DeInit(i2c_handle) != HAL_OK)
@@ -120,11 +115,12 @@ static rt_err_t stm32_i2c_init(struct stm32_i2c *i2c_drv)
         HAL_NVIC_EnableIRQ(i2c_drv->config->dma_tx->dma_irq);
     }
 
-    if (i2c_drv->i2c_dma_flag & I2C_USING_TX_DMA_FLAG || i2c_drv->i2c_dma_flag & I2C_USING_RX_DMA_FLAG)
-    {
-        HAL_NVIC_SetPriority(i2c_drv->config->evirq_type, 2, 0);
-        HAL_NVIC_EnableIRQ(i2c_drv->config->evirq_type);
-    }
+    /* In the data transfer function stm32_i2c_master_xfer(), the IT transfer function
+       HAL_I2C_Master_Seq_Transmit_IT() is used when DMA is not used, so the IT interrupt
+       must be enable anyway, regardless of the DMA configuration, otherwise 
+       the rt_completion_wait() will always timeout. */
+    HAL_NVIC_SetPriority(i2c_drv->config->evirq_type, 2, 0);
+    HAL_NVIC_EnableIRQ(i2c_drv->config->evirq_type);
 
     return RT_EOK;
 }
@@ -160,11 +156,14 @@ static rt_ssize_t stm32_i2c_master_xfer(struct rt_i2c_bus_device *bus,
     uint8_t next_flag = 0;
     struct rt_completion *completion;
     rt_uint32_t timeout;
+	
     if (num == 0)
     {
         return 0;
     }
+	
     RT_ASSERT((msgs != RT_NULL) && (bus != RT_NULL));
+	
     i2c_obj = rt_container_of(bus, struct stm32_i2c, i2c_bus);
     completion = &i2c_obj->completion;
     I2C_HandleTypeDef *handle = &i2c_obj->handle;
@@ -345,31 +344,6 @@ int RT_hw_i2c_bus_init(void)
         i2c_objs[i].config = &i2c_config[i];
         i2c_objs[i].i2c_bus.timeout = i2c_config[i].timeout;
 
-        if (i2c_objs[i].i2c_dma_flag & I2C_USING_TX_DMA_FLAG)
-        {
-            i2c_objs[i].dma.handle_tx.Instance = i2c_config[i].dma_tx->Instance;
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-            i2c_objs[i].dma.handle_tx.Init.Channel = i2c_config[i].dma_tx->channel;
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-            i2c_objs[i].dma.handle_tx.Init.Request = i2c_config[i].dma_tx->request;
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
-#ifndef SOC_SERIES_STM32U5
-            i2c_objs[i].dma.handle_tx.Init.Direction = DMA_MEMORY_TO_PERIPH;
-            i2c_objs[i].dma.handle_tx.Init.PeriphInc = DMA_PINC_DISABLE;
-            i2c_objs[i].dma.handle_tx.Init.MemInc = DMA_MINC_ENABLE;
-            i2c_objs[i].dma.handle_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-            i2c_objs[i].dma.handle_tx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-            i2c_objs[i].dma.handle_tx.Init.Mode = DMA_NORMAL;
-            i2c_objs[i].dma.handle_tx.Init.Priority = DMA_PRIORITY_LOW;
-#endif
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7)
-
-            i2c_objs[i].dma.handle_tx.Init.FIFOMode = DMA_FIFOMODE_DISABLE;
-            i2c_objs[i].dma.handle_tx.Init.FIFOThreshold = DMA_FIFO_THRESHOLD_FULL;
-            i2c_objs[i].dma.handle_tx.Init.MemBurst = DMA_MBURST_INC4;
-            i2c_objs[i].dma.handle_tx.Init.PeriphBurst = DMA_PBURST_INC4;
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7) */
-        }
         if ((i2c_objs[i].i2c_dma_flag & I2C_USING_RX_DMA_FLAG))
         {
             i2c_objs[i].dma.handle_rx.Instance = i2c_config[i].dma_rx->Instance;
@@ -377,30 +351,73 @@ int RT_hw_i2c_bus_init(void)
             i2c_objs[i].dma.handle_rx.Init.Channel = i2c_config[i].dma_rx->channel;
 #elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
             i2c_objs[i].dma.handle_rx.Init.Request = i2c_config[i].dma_rx->request;
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#endif
 #ifndef SOC_SERIES_STM32U5
-            i2c_objs[i].dma.handle_rx.Init.Direction = DMA_PERIPH_TO_MEMORY;
-            i2c_objs[i].dma.handle_rx.Init.PeriphInc = DMA_PINC_DISABLE;
-            i2c_objs[i].dma.handle_rx.Init.MemInc = DMA_MINC_ENABLE;
+            i2c_objs[i].dma.handle_rx.Init.Direction           = DMA_PERIPH_TO_MEMORY;
+            i2c_objs[i].dma.handle_rx.Init.PeriphInc           = DMA_PINC_DISABLE;
+            i2c_objs[i].dma.handle_rx.Init.MemInc              = DMA_MINC_ENABLE;
             i2c_objs[i].dma.handle_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-            i2c_objs[i].dma.handle_rx.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
-            i2c_objs[i].dma.handle_rx.Init.Mode = DMA_NORMAL;
-            i2c_objs[i].dma.handle_rx.Init.Priority = DMA_PRIORITY_LOW;
-#endif /* SOC_SERIES_STM32U5 */
+            i2c_objs[i].dma.handle_rx.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
+            i2c_objs[i].dma.handle_rx.Init.Mode                = DMA_NORMAL;
+            i2c_objs[i].dma.handle_rx.Init.Priority            = DMA_PRIORITY_LOW;
+#endif
+#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7)
+            i2c_objs[i].dma.handle_rx.Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
+            i2c_objs[i].dma.handle_tx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
+            i2c_objs[i].dma.handle_tx.Init.MemBurst            = DMA_MBURST_INC4;
+            i2c_objs[i].dma.handle_tx.Init.PeriphBurst         = DMA_PBURST_INC4;
+#endif
+
+            {
+                rt_uint32_t tmpreg = 0x00U;
+#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0)
+                /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
+                SET_BIT(RCC->AHBENR, i2c_config[i].dma_rx->dma_rcc);
+                tmpreg = READ_BIT(RCC->AHBENR, i2c_config[i].dma_rx->dma_rcc);
+#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
+                SET_BIT(RCC->AHB1ENR, i2c_config[i].dma_rx->dma_rcc);
+                /* Delay after an RCC peripheral clock enabling */
+                tmpreg = READ_BIT(RCC->AHB1ENR, i2c_config[i].dma_rx->dma_rcc);
+#elif defined(SOC_SERIES_STM32MP1)
+                __HAL_RCC_DMAMUX_CLK_ENABLE();
+                SET_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_rx->dma_rcc);
+                tmpreg = READ_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_rx->dma_rcc);
+#endif
+                UNUSED(tmpreg); /* To avoid compiler warnings */
+            }
+        }
+		
+        if (i2c_objs[i].i2c_dma_flag & I2C_USING_TX_DMA_FLAG)
+        {
+            i2c_objs[i].dma.handle_tx.Instance = i2c_config[i].dma_tx->Instance;
+#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
+            i2c_objs[i].dma.handle_tx.Init.Channel = i2c_config[i].dma_tx->channel;
+#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
+            i2c_objs[i].dma.handle_tx.Init.Request = i2c_config[i].dma_tx->request;
+#endif
+#ifndef SOC_SERIES_STM32U5
+            i2c_objs[i].dma.handle_tx.Init.Direction           = DMA_MEMORY_TO_PERIPH;
+            i2c_objs[i].dma.handle_tx.Init.PeriphInc           = DMA_PINC_DISABLE;
+            i2c_objs[i].dma.handle_tx.Init.MemInc              = DMA_MINC_ENABLE;
+            i2c_objs[i].dma.handle_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+            i2c_objs[i].dma.handle_tx.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
+            i2c_objs[i].dma.handle_tx.Init.Mode                = DMA_NORMAL;
+            i2c_objs[i].dma.handle_tx.Init.Priority            = DMA_PRIORITY_LOW;
+#endif
 #if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7)
 
-            i2c_objs[i].dma.handle_rx.Init.FIFOMode = DMA_FIFOMODE_DISABLE;
-            i2c_objs[i].dma.handle_tx.Init.FIFOThreshold = DMA_FIFO_THRESHOLD_FULL;
-            i2c_objs[i].dma.handle_tx.Init.MemBurst = DMA_MBURST_INC4;
-            i2c_objs[i].dma.handle_tx.Init.PeriphBurst = DMA_PBURST_INC4;
-        }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7) */
-        {
-            rt_uint32_t tmpreg = 0x00U;
+            i2c_objs[i].dma.handle_tx.Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
+            i2c_objs[i].dma.handle_tx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
+            i2c_objs[i].dma.handle_tx.Init.MemBurst            = DMA_MBURST_INC4;
+            i2c_objs[i].dma.handle_tx.Init.PeriphBurst         = DMA_PBURST_INC4;
+#endif
+
+            {
+                rt_uint32_t tmpreg = 0x00U;
 #if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0)
-            /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-            SET_BIT(RCC->AHBENR, i2c_config[i].dma_tx->dma_rcc);
-            tmpreg = READ_BIT(RCC->AHBENR, i2c_config[i].dma_tx->dma_rcc);
+                /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
+                SET_BIT(RCC->AHBENR, i2c_config[i].dma_tx->dma_rcc);
+                tmpreg = READ_BIT(RCC->AHBENR, i2c_config[i].dma_tx->dma_rcc);
 #elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
                 SET_BIT(RCC->AHB1ENR, i2c_config[i].dma_tx->dma_rcc);
                 /* Delay after an RCC peripheral clock enabling */
@@ -409,9 +426,11 @@ int RT_hw_i2c_bus_init(void)
                 __HAL_RCC_DMAMUX_CLK_ENABLE();
                 SET_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_tx->dma_rcc);
                 tmpreg = READ_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_tx->dma_rcc);
-#endif /* defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0) */
-            UNUSED(tmpreg); /* To avoid compiler warnings */
+#endif
+                UNUSED(tmpreg); /* To avoid compiler warnings */
+            }
         }
+
         rt_completion_init(&i2c_objs[i].completion);
         stm32_i2c_configure(&i2c_objs[i].i2c_bus);
         ret = rt_i2c_bus_device_register(&i2c_objs[i].i2c_bus, i2c_objs[i].config->name);
@@ -694,47 +713,11 @@ void I2C3_DMA_TX_IRQHandler(void)
 }
 #endif /* defined(BSP_USING_HARD_I2C3) && defined(BSP_I2C3_TX_USING_DMA) */
 
-#if defined(BSP_USING_I2C4) && defined(BSP_I2C4_RX_USING_DMA)
-/**
- * @brief  This function handles DMA Rx interrupt request.
- * @param  None
- * @retval None
- */
-void I2C4_DMA_RX_IRQHandler(void)
-{
-    /* enter interrupt */
-    rt_interrupt_enter();
-
-    HAL_DMA_IRQHandler(&i2c_objs[I2C4_INDEX].dma.handle_rx);
-
-    /* leave interrupt */
-    rt_interrupt_leave();
-}
-#endif /* defined(BSP_USING_I2C4) && defined(BSP_I2C4_RX_USING_DMA) */
-
-#if defined(BSP_USING_I2C4) && defined(BSP_I2C4_TX_USING_DMA)
-/**
- * @brief  This function handles DMA Rx interrupt request.
- * @param  None
- * @retval None
- */
-void I2C4_DMA_TX_IRQHandler(void)
-{
-    /* enter interrupt */
-    rt_interrupt_enter();
-
-    HAL_DMA_IRQHandler(&i2c_objs[I2C4_INDEX].dma.handle_tx);
-
-    /* leave interrupt */
-    rt_interrupt_leave();
-}
-#endif /* defined(BSP_USING_I2C4) && defined(BSP_I2C4_TX_USING_DMA) */
-
 int rt_hw_hw_i2c_init(void)
 {
     stm32_get_dma_info();
     return RT_hw_i2c_bus_init();
 }
-INIT_CORE_EXPORT(rt_hw_hw_i2c_init);
+INIT_BOARD_EXPORT(rt_hw_hw_i2c_init);
 
 #endif /* defined(BSP_USING_HARD_I2C1) || defined(BSP_USING_HARD_I2C2) || defined(BSP_USING_HARD_I2C3) */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
@@ -367,7 +367,6 @@ int RT_hw_i2c_bus_init(void)
             i2c_objs[i].dma.handle_tx.Init.MemBurst            = DMA_MBURST_INC4;
             i2c_objs[i].dma.handle_tx.Init.PeriphBurst         = DMA_PBURST_INC4;
 #endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7) */
-
             {
                 rt_uint32_t tmpreg = 0x00U;
 #if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0)
@@ -411,7 +410,6 @@ int RT_hw_i2c_bus_init(void)
             i2c_objs[i].dma.handle_tx.Init.MemBurst            = DMA_MBURST_INC4;
             i2c_objs[i].dma.handle_tx.Init.PeriphBurst         = DMA_PBURST_INC4;
 #endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7) */
-
             {
                 rt_uint32_t tmpreg = 0x00U;
 #if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0)

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.h
@@ -16,6 +16,12 @@
 #include "drv_config.h"
 #include <ipc/completion.h>
 
+/* C binding of definitions if building with C++ compiler */
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 struct stm32_i2c_config
 {
     const char        *name;
@@ -25,13 +31,13 @@ struct stm32_i2c_config
     IRQn_Type         evirq_type;
     IRQn_Type         erirq_type;
     struct dma_config *dma_rx;
-	struct dma_config *dma_tx;
+    struct dma_config *dma_tx;
 };
 
 struct stm32_i2c
 {
     I2C_HandleTypeDef        handle;
-	struct stm32_i2c_config  *config;
+    struct stm32_i2c_config  *config;
     struct
     {
         DMA_HandleTypeDef    handle_rx;
@@ -44,5 +50,9 @@ struct stm32_i2c
 
 #define I2C_USING_TX_DMA_FLAG       (1U)
 #define I2C_USING_RX_DMA_FLAG       (1U << 1)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __DRV_I2C_H__ */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.h
@@ -11,55 +11,38 @@
 #ifndef __DRV_HARD_I2C_H__
 #define __DRV_HARD_I2C_H__
 
-#include "drv_config.h"
-#include <rtthread.h>
-#include "rtdevice.h"
-#include <rthw.h>
 #include <drv_common.h>
 #include "drv_dma.h"
+#include "drv_config.h"
 #include <ipc/completion.h>
-#if defined(RT_USING_I2C) && defined(BSP_USING_I2C)
-
-/* C binding of definitions if building with C++ compiler */
-#ifdef __cplusplus
-extern "C"
-{
-#endif
 
 struct stm32_i2c_config
 {
-    const char              *name;
-    I2C_TypeDef          *Instance;
-     rt_uint32_t             timing;
-    rt_uint32_t             timeout;
-    IRQn_Type evirq_type;
-    IRQn_Type erirq_type;
-
-    struct dma_config *dma_rx, *dma_tx;
+    const char        *name;
+    I2C_TypeDef       *Instance;
+    rt_uint32_t       timing;
+    rt_uint32_t       timeout;
+    IRQn_Type         evirq_type;
+    IRQn_Type         erirq_type;
+    struct dma_config *dma_rx;
+	struct dma_config *dma_tx;
 };
 
 struct stm32_i2c
 {
-    I2C_HandleTypeDef handle;
+    I2C_HandleTypeDef        handle;
+	struct stm32_i2c_config  *config;
     struct
     {
-        DMA_HandleTypeDef handle_rx;
-        DMA_HandleTypeDef handle_tx;
+        DMA_HandleTypeDef    handle_rx;
+        DMA_HandleTypeDef    handle_tx;
     } dma;
-    struct stm32_i2c_config      *config;
-    struct rt_i2c_bus_device    i2c_bus;
-    rt_uint8_t                  i2c_dma_flag;
-    struct rt_completion completion;
-
+    rt_uint8_t               i2c_dma_flag;
+    struct rt_i2c_bus_device i2c_bus;
+    struct rt_completion     completion;
 };
 
 #define I2C_USING_TX_DMA_FLAG       (1U)
 #define I2C_USING_RX_DMA_FLAG       (1U << 1)
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif /* BSP_USING_I2C */
 
 #endif /* __DRV_I2C_H__ */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

- 我正在尝试使用rt-thread进行项目开发，发现硬件I2C驱动并没有支持我使用的STM32F1系列芯片。

#### 你的解决方案是什么 (what is your solution)

- 基于现有驱动完善对STM32F1系列的支持
- 完善的过程中发现了现有驱动的通用bug，并进行了修复

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: 没有官方BSP列表中的开发板，使用的是基于模板修改而来的BSP。
- 使用scons --dist命令将BSP导出，因文件上传大小限制，已剔除rt-thread文件夹：[project.zip](https://github.com/user-attachments/files/18072648/project.zip)

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config: bsp工程中board文件夹下的Kconfig文件，添加以下定义：

```
menu "On-chip Peripheral Drivers"
...
...
...
    menuconfig BSP_USING_I2C
        bool "Enable I2C1 BUS (hardware)"
        default n
        select RT_USING_I2C
        if BSP_USING_I2C
            config BSP_USING_HARD_I2C1
                bool "Enable I2C1 BUS"
                default n
				
            config BSP_I2C1_TX_USING_DMA
                bool "Enable I2C1 TX DMA"
                depends on BSP_USING_HARD_I2C1
                default n
				
            config BSP_I2C1_RX_USING_DMA
                bool "Enable I2C1 RX DMA"
                depends on BSP_USING_HARD_I2C1
                default n
        endif
...
...
...
```

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action: null

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
