### PR TITLE
Update irq.c 解决K210 系统无法正常启动的问题

### DIFF
--- a/src/irq.c
+++ b/src/irq.c
@@ -150,7 +150,8 @@ RTM_EXPORT(rt_hw_interrupt_enable);
 
 rt_weak rt_bool_t rt_hw_interrupt_is_disabled(void)
 {
-    return RT_FALSE;
+  //  return RT_FALSE;
+      return RT_TURE;
 }
 RTM_EXPORT(rt_hw_interrupt_is_disabled);
 /**@}*/


### PR DESCRIPTION
rt_weak rt_bool_t rt_hw_interrupt_is_disabled(void) 

返回  return RT_FALSE; 


会导致 void rt_sched_post_ctx_switch(struct rt_thread *thread) 无法通过判断造成RISC-V芯片K210产生错误，无法正确启动
