### PR TITLE
[DFS/FIXUP] Fixup ISO9660 build

### DIFF
--- a/components/dfs/dfs_v1/filesystems/iso9660/dfs_iso9660.c
+++ b/components/dfs/dfs_v1/filesystems/iso9660/dfs_iso9660.c
@@ -20,6 +20,7 @@
 #include <dfs.h>
 #include <dfs_fs.h>
 #include <dfs_file.h>
+#include <posix/string.h>
 #include <drivers/misc.h>
 #include <drivers/byteorder.h>
 
@@ -118,7 +119,7 @@ rt_packed(struct iso9660_common_voldesc
     struct iso9660_date created;
     struct iso9660_date modified;
     rt_uint8_t unused5[0 /* 1201 */];
-};
+});
 
 struct iso9660
 {
@@ -250,7 +251,7 @@ static struct iso9660_fd *iso9660_lookup(struct iso9660 *iso, const char *path,
 
         /* Skip the first '/' */
         ++path;
-        len = rt_strchrnul(path, '/') - path;
+        len = strchrnul(path, '/') - path;
     }
 
     lba = rt_le32_to_cpu(dirent->first_sector);
@@ -359,7 +360,7 @@ static struct iso9660_fd *iso9660_lookup(struct iso9660 *iso, const char *path,
             sz = 0;
 
             path += len + 1;
-            len = rt_strchrnul(path, '/') - path;
+            len = strchrnul(path, '/') - path;
         }
     } while (len);
 
@@ -474,7 +475,7 @@ _end:
     return rcount;
 }
 
-static int dfs_iso9660_lseek(struct dfs_file *fd, off_t offset)
+static off_t dfs_iso9660_lseek(struct dfs_file *fd, off_t offset)
 {
     int ret = -EIO;
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
1. Fix strchrnul.
2. Fix type of lseek return.
3. Fix packed

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
