### PR TITLE
workqueue 去掉timer，使用list排序处理方式

### DIFF
--- a/components/drivers/include/ipc/workqueue.h
+++ b/components/drivers/include/ipc/workqueue.h
@@ -13,6 +13,7 @@
 
 #include <rtdef.h>
 #include <rtconfig.h>
+#include "completion.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,6 +43,7 @@ struct rt_workqueue
     struct rt_semaphore sem;
     rt_thread_t    work_thread;
     struct rt_spinlock spinlock;
+    struct rt_completion wakeup_completion;
 };
 
 struct rt_work
@@ -52,7 +54,7 @@ struct rt_work
     void *work_data;
     rt_uint16_t flags;
     rt_uint16_t type;
-    struct rt_timer timer;
+    rt_tick_t timeout_tick;
     struct rt_workqueue *workqueue;
 };
 

--- a/components/drivers/ipc/workqueue.c
+++ b/components/drivers/ipc/workqueue.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2022, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -10,14 +10,13 @@
  * 2021-08-14     Jackistang   add comments for function interface
  * 2022-01-16     Meco Man     add rt_work_urgent()
  * 2023-09-15     xqyjlj       perf rt_hw_interrupt_disable/enable
+ * 2024-12-21     yuqingli     delete timer, using list
  */
 
 #include <rthw.h>
 #include <rtdevice.h>
 
 #ifdef RT_USING_HEAP
-
-static void _delayed_work_timeout_handler(void *parameter);
 
 rt_inline rt_err_t _workqueue_work_completion(struct rt_workqueue *queue)
 {
@@ -50,38 +49,61 @@ rt_inline rt_err_t _workqueue_work_completion(struct rt_workqueue *queue)
 
 static void _workqueue_thread_entry(void *parameter)
 {
-    rt_base_t level;
-    struct rt_work *work;
+    rt_base_t            level;
+    struct rt_work      *work;
     struct rt_workqueue *queue;
+    rt_tick_t            current_tick;
+    rt_int32_t           delay_tick;
+    void (*work_func)(struct rt_work *work, void *work_data);
+    void *work_data;
 
-    queue = (struct rt_workqueue *) parameter;
+    queue = (struct rt_workqueue *)parameter;
     RT_ASSERT(queue != RT_NULL);
 
     while (1)
     {
         level = rt_spin_lock_irqsave(&(queue->spinlock));
+
+        /* timer check */
+        current_tick = rt_tick_get();
+        delay_tick   = RT_WAITING_FOREVER;
+        while (!rt_list_isempty(&(queue->delayed_list)))
+        {
+            work = rt_list_entry(queue->delayed_list.next, struct rt_work, list);
+            if ((current_tick - work->timeout_tick) < RT_TICK_MAX / 2)
+            {
+                rt_list_remove(&(work->list));
+                rt_list_insert_after(queue->work_list.prev, &(work->list));
+                work->flags &= ~RT_WORK_STATE_SUBMITTING;
+                work->flags |= RT_WORK_STATE_PENDING;
+            }
+            else
+            {
+                delay_tick = work->timeout_tick - current_tick;
+                break;
+            }
+        }
+
         if (rt_list_isempty(&(queue->work_list)))
         {
-            /* no software timer exist, suspend self. */
-            rt_thread_suspend_with_flag(rt_thread_self(), RT_UNINTERRUPTIBLE);
-
-            /* release lock after suspend so we will not lost any wakeups */
             rt_spin_unlock_irqrestore(&(queue->spinlock), level);
-
-            rt_schedule();
+            /* wait for work completion */
+            rt_completion_wait(&(queue->wakeup_completion), delay_tick);
             continue;
         }
 
         /* we have work to do with. */
         work = rt_list_entry(queue->work_list.next, struct rt_work, list);
         rt_list_remove(&(work->list));
-        queue->work_current = work;
-        work->flags &= ~RT_WORK_STATE_PENDING;
-        work->workqueue = RT_NULL;
+        queue->work_current  = work;
+        work->flags         &= ~RT_WORK_STATE_PENDING;
+        work->workqueue      = RT_NULL;
+        work_func            = work->work_func;
+        work_data            = work->work_data;
         rt_spin_unlock_irqrestore(&(queue->spinlock), level);
 
         /* do work */
-        work->work_func(work, work->work_data);
+        work_func(work, work_data);
         /* clean current work */
         queue->work_current = RT_NULL;
 
@@ -93,52 +115,54 @@ static void _workqueue_thread_entry(void *parameter)
 static rt_err_t _workqueue_submit_work(struct rt_workqueue *queue,
                                        struct rt_work *work, rt_tick_t ticks)
 {
-    rt_base_t level;
-    rt_err_t err = RT_EOK;
+    rt_base_t       level;
+    rt_err_t        err = RT_EOK;
+    struct rt_work *work_tmp;
+    rt_list_t      *list_tmp;
 
     level = rt_spin_lock_irqsave(&(queue->spinlock));
-
     /* remove list */
     rt_list_remove(&(work->list));
-    work->flags &= ~RT_WORK_STATE_PENDING;
+    work->flags = 0;
 
     if (ticks == 0)
     {
         rt_list_insert_after(queue->work_list.prev, &(work->list));
-        work->flags |= RT_WORK_STATE_PENDING;
-        work->workqueue = queue;
+        work->flags     |= RT_WORK_STATE_PENDING;
+        work->workqueue  = queue;
 
-        /* whether the workqueue is doing work */
-        if (queue->work_current == RT_NULL)
-        {
-            /* resume work thread, and do a re-schedule if succeed */
-            rt_thread_resume(queue->work_thread);
-        }
+        rt_completion_done(&(queue->wakeup_completion));
+        err = RT_EOK;
     }
     else if (ticks < RT_TICK_MAX / 2)
     {
-        /* Timer started */
-        if (work->flags & RT_WORK_STATE_SUBMITTING)
-        {
-            rt_timer_control(&work->timer, RT_TIMER_CTRL_SET_TIME, &ticks);
-        }
-        else
-        {
-            rt_timer_init(&(work->timer), "work", _delayed_work_timeout_handler,
-                          work, ticks, RT_TIMER_FLAG_ONE_SHOT | RT_TIMER_FLAG_SOFT_TIMER);
-            work->flags |= RT_WORK_STATE_SUBMITTING;
-        }
-        work->workqueue = queue;
         /* insert delay work list */
-        rt_list_insert_after(queue->delayed_list.prev, &(work->list));
+        work->flags        |= RT_WORK_STATE_SUBMITTING;
+        work->workqueue     = queue;
+        work->timeout_tick  = rt_tick_get() + ticks;
 
-        err = rt_timer_start(&(work->timer));
+        list_tmp = &(queue->delayed_list);
+        rt_list_for_each_entry(work_tmp, &(queue->delayed_list), list)
+        {
+            if ((work_tmp->timeout_tick - work->timeout_tick) == 0)
+            {
+                continue;
+            }
+            else if ((work_tmp->timeout_tick - work->timeout_tick) < RT_TICK_MAX / 2)
+            {
+                list_tmp = &(work_tmp->list);
+                break;
+            }
+        }
+        rt_list_insert_before(list_tmp, &(work->list));
+
+        rt_completion_done(&(queue->wakeup_completion));
+        err = RT_EOK;
     }
     else
     {
-        err = - RT_ERROR;
+        err = -RT_ERROR;
     }
-
     rt_spin_unlock_irqrestore(&(queue->spinlock), level);
     return err;
 }
@@ -146,59 +170,15 @@ static rt_err_t _workqueue_submit_work(struct rt_workqueue *queue,
 static rt_err_t _workqueue_cancel_work(struct rt_workqueue *queue, struct rt_work *work)
 {
     rt_base_t level;
-    rt_err_t err;
+    rt_err_t  err;
 
     level = rt_spin_lock_irqsave(&(queue->spinlock));
     rt_list_remove(&(work->list));
-    work->flags &= ~RT_WORK_STATE_PENDING;
-    /* Timer started */
-    if (work->flags & RT_WORK_STATE_SUBMITTING)
-    {
-        if ((err = rt_timer_stop(&(work->timer))) != RT_EOK)
-        {
-            goto exit;
-        }
-        rt_timer_detach(&(work->timer));
-        work->flags &= ~RT_WORK_STATE_SUBMITTING;
-    }
-    err = queue->work_current != work ? RT_EOK : -RT_EBUSY;
+    work->flags     = 0;
+    err             = queue->work_current != work ? RT_EOK : -RT_EBUSY;
     work->workqueue = RT_NULL;
-exit:
     rt_spin_unlock_irqrestore(&(queue->spinlock), level);
     return err;
-}
-
-static void _delayed_work_timeout_handler(void *parameter)
-{
-    struct rt_work *work;
-    struct rt_workqueue *queue;
-    rt_base_t level;
-
-    work = (struct rt_work *)parameter;
-    queue = work->workqueue;
-
-    RT_ASSERT(work->flags & RT_WORK_STATE_SUBMITTING);
-    RT_ASSERT(queue != RT_NULL);
-
-    level = rt_spin_lock_irqsave(&(queue->spinlock));
-    rt_timer_detach(&(work->timer));
-    work->flags &= ~RT_WORK_STATE_SUBMITTING;
-    /* remove delay list */
-    rt_list_remove(&(work->list));
-    /* insert work queue */
-    if (queue->work_current != work)
-    {
-        rt_list_insert_after(queue->work_list.prev, &(work->list));
-        work->flags |= RT_WORK_STATE_PENDING;
-    }
-    /* whether the workqueue is doing work */
-    if (queue->work_current == RT_NULL)
-    {
-        /* resume work thread, and do a re-schedule if succeed */
-        rt_thread_resume(queue->work_thread);
-    }
-
-    rt_spin_unlock_irqrestore(&(queue->spinlock), level);
 }
 
 /**
@@ -221,8 +201,8 @@ void rt_work_init(struct rt_work *work,
     work->work_func = work_func;
     work->work_data = work_data;
     work->workqueue = RT_NULL;
-    work->flags = 0;
-    work->type = 0;
+    work->flags     = 0;
+    work->type      = 0;
 }
 
 /**
@@ -248,6 +228,7 @@ struct rt_workqueue *rt_workqueue_create(const char *name, rt_uint16_t stack_siz
         rt_list_init(&(queue->delayed_list));
         queue->work_current = RT_NULL;
         rt_sem_init(&(queue->sem), "wqueue", 0, RT_IPC_FLAG_FIFO);
+        rt_completion_init(&(queue->wakeup_completion));
 
         /* create the work thread */
         queue->work_thread = rt_thread_create(name, _workqueue_thread_entry, queue, stack_size, priority, 10);
@@ -346,14 +327,10 @@ rt_err_t rt_workqueue_urgent_work(struct rt_workqueue *queue, struct rt_work *wo
     /* NOTE: the work MUST be initialized firstly */
     rt_list_remove(&(work->list));
     rt_list_insert_after(&queue->work_list, &(work->list));
-    /* whether the workqueue is doing work */
-    if (queue->work_current == RT_NULL)
-    {
-        /* resume work thread, and do a re-schedule if succeed */
-        rt_thread_resume(queue->work_thread);
-    }
 
+    rt_completion_done(&(queue->wakeup_completion));
     rt_spin_unlock_irqrestore(&(queue->spinlock), level);
+
     return RT_EOK;
 }
 

--- a/components/drivers/ipc/workqueue.c
+++ b/components/drivers/ipc/workqueue.c
@@ -144,11 +144,7 @@ static rt_err_t _workqueue_submit_work(struct rt_workqueue *queue,
         list_tmp = &(queue->delayed_list);
         rt_list_for_each_entry(work_tmp, &(queue->delayed_list), list)
         {
-            if ((work_tmp->timeout_tick - work->timeout_tick) == 0)
-            {
-                continue;
-            }
-            else if ((work_tmp->timeout_tick - work->timeout_tick) < RT_TICK_MAX / 2)
+            if ((work_tmp->timeout_tick - work->timeout_tick) < RT_TICK_MAX / 2)
             {
                 list_tmp = &(work_tmp->list);
                 break;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->
bsp\qemu-vexpress-a9

#### 为什么提交这份PR (why to submit this PR)
1、#9814 bug修复
2、去掉每个work的定时器，能大量减少 work的内存占用，和性能优化

#### 你的解决方案是什么 (what is your solution)
去掉work的 timer，只需要在 work线程里面 延迟和同步即可


#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: bsp\qemu-vexpress-a9

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:  没用改动，直接 menuconfig 生成新的即可

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action: 

测试main函数如下
~~~c

#include <stdint.h>
#include <stdio.h>
#include <rtthread.h>
#include <rtdevice.h>

struct rt_work work_test0;
struct rt_work work_test1;
struct rt_work work_test2;
struct rt_work work_test3;
struct rt_work work_test4;

void work_func(struct rt_work *work, void *work_data)
{
    rt_kprintf("name=%s tick=%d\n", (char *)work_data, rt_tick_get());
}

int main(void)
{
    rt_kprintf("Hello RT-Thread!\n");
    rt_thread_delay(100);

    rt_work_init(&work_test0, work_func, "work_test0");
    rt_work_init(&work_test1, work_func, "work_test1");
    rt_work_init(&work_test2, work_func, "work_test2");
    rt_work_init(&work_test3, work_func, "work_test3");
    rt_work_init(&work_test4, work_func, "work_test4");
   
    rt_kprintf("test rt_work_urgent tick=%d\n", rt_tick_get());
    rt_work_submit(&work_test0, 100);
    rt_thread_delay(10);
    rt_work_urgent(&work_test0);
    rt_thread_delay(100);
    
    rt_kprintf("test rt_work_submit tick=%d\n", rt_tick_get());
    rt_work_submit(&work_test3, 300);
    rt_work_submit(&work_test1, 100);
    rt_work_submit(&work_test4, 300);
    rt_work_submit(&work_test2, 100);
    rt_thread_delay(250);
    rt_work_submit(&work_test1, 50);
    rt_work_submit(&work_test2, 200);
    rt_thread_delay(300);

    rt_kprintf("test rt_work_cancel tick=%d\n", rt_tick_get());
    rt_work_submit(&work_test1, 50);
    rt_work_submit(&work_test2, 100);
    rt_work_submit(&work_test3, 150);
    rt_thread_delay(50);
    rt_work_cancel(&work_test2);

    return 0;
}

~~~

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
