### PR TITLE
修复编译过程中的 DFS_V2报错、FAL警告

### DIFF
--- a/components/dfs/dfs_v2/src/dfs_pcache.c
+++ b/components/dfs/dfs_v2/src/dfs_pcache.c
@@ -16,14 +16,15 @@
 #include <dfs_pcache.h>
 #include <dfs_dentry.h>
 #include <dfs_mnt.h>
-#include <mm_page.h>
-#include <mm_private.h>
-#include <mmu.h>
-#include <tlb.h>
 
 #include <rthw.h>
 
 #ifdef RT_USING_PAGECACHE
+
+#include <mm_page.h>
+#include <mm_private.h>
+#include <mmu.h>
+#include <tlb.h>
 
 #ifndef RT_PAGECACHE_COUNT
 #define RT_PAGECACHE_COUNT          4096

--- a/components/drivers/core/device.c
+++ b/components/drivers/core/device.c
@@ -31,9 +31,9 @@
 #include <rtdevice.h> /* for wqueue_init */
 #endif /* RT_USING_POSIX_DEVIO */
 
-#ifdef RT_USING_DFS_V2
+#if((defined RT_USING_DFS_V2) && (defined RT_USING_DFS_DEVFS))
 #include <devfs.h>
-#endif /* RT_USING_DFS_V2 */
+#endif /* RT_USING_DFS_V2  RT_USING_DFS_DEVFS */
 
 #ifdef RT_USING_DEVICE
 
@@ -84,7 +84,7 @@ rt_err_t rt_device_register(rt_device_t dev,
     rt_wqueue_init(&(dev->wait_queue));
 #endif /* RT_USING_POSIX_DEVIO */
 
-#ifdef RT_USING_DFS_V2
+#if((defined RT_USING_DFS_V2) && (defined RT_USING_DFS_DEVFS))
     dfs_devfs_device_add(dev);
 #endif /* RT_USING_DFS_V2 */
 

--- a/components/drivers/core/device.c
+++ b/components/drivers/core/device.c
@@ -84,7 +84,7 @@ rt_err_t rt_device_register(rt_device_t dev,
     rt_wqueue_init(&(dev->wait_queue));
 #endif /* RT_USING_POSIX_DEVIO */
 
-#if((defined RT_USING_DFS_V2) && (defined RT_USING_DFS_DEVFS))
+#if defined (RT_USING_DFS_V2) && defined (RT_USING_DFS_DEVFS)
     dfs_devfs_device_add(dev);
 #endif /* RT_USING_DFS_V2 */
 

--- a/components/drivers/core/device.c
+++ b/components/drivers/core/device.c
@@ -31,7 +31,7 @@
 #include <rtdevice.h> /* for wqueue_init */
 #endif /* RT_USING_POSIX_DEVIO */
 
-#if((defined RT_USING_DFS_V2) && (defined RT_USING_DFS_DEVFS))
+#if defined (RT_USING_DFS_V2) && defined (RT_USING_DFS_DEVFS)
 #include <devfs.h>
 #endif /* RT_USING_DFS_V2  RT_USING_DFS_DEVFS */
 

--- a/components/fal/src/fal_rtt.c
+++ b/components/fal/src/fal_rtt.c
@@ -52,7 +52,7 @@ static rt_err_t blk_dev_control(rt_device_t dev, rt_uint8_t cmd, void *args)
             return -RT_ERROR;
         }
 
-        memcpy(geometry, &part->geometry, sizeof(struct rt_device_blk_geometry));
+        rt_memcpy(geometry, &part->geometry, sizeof(struct rt_device_blk_geometry));
     }
     else if (cmd == RT_DEVICE_CTRL_BLK_ERASE)
     {

--- a/components/fal/src/fal_rtt.c
+++ b/components/fal/src/fal_rtt.c
@@ -10,6 +10,8 @@
  */
 
 #include <fal.h>
+#include <string.h>
+#include <stdlib.h>
 #include <rtdevice.h>
 
 #define DBG_TAG "FAL"


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->
自己板子

#### 为什么提交这份PR (why to submit this PR)
当定义了RT_USING_DFS_V2但未定义RT_RT_USING_DFS_DEVFS时，编译报错
当定义了RT_USING_DFS_V2但未定义RT-USING_SMART时，会发生错误
fal_rtt.c 缺少头，提醒函数未定义

#### 你的解决方案是什么 (what is your solution)
修改源码

#### 请提供验证的bsp和config (provide the config and bsp) 
 [ 
[config.txt](https://github.com/user-attachments/files/18203351/config.txt)
]

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo
Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: bsp\stm32\stm32f103-atk-nano

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like 
- .config:
#
# DFS: device virtual file system
#
CONFIG_RT_USING_DFS=y
CONFIG_DFS_USING_POSIX=y
CONFIG_DFS_USING_WORKDIR=y
CONFIG_DFS_FD_MAX=16
# CONFIG_RT_USING_DFS_V1 is not set
CONFIG_RT_USING_DFS_V2=y
# CONFIG_RT_USING_DFS_ELMFAT is not set
# CONFIG_RT_USING_DFS_DEVFS is not set
# CONFIG_RT_USING_DFS_ROMFS is not set
# CONFIG_RT_USING_DFS_CROMFS is not set
# CONFIG_RT_USING_DFS_TMPFS is not set
# CONFIG_RT_USING_DFS_MQUEUE is not set
# end of DFS: device virtual file system

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
