### PR TITLE
[bsp][cvitek] fix c906_little build warning in cache.c

### DIFF
--- a/bsp/cvitek/c906_little/board/cache.c
+++ b/bsp/cvitek/c906_little/board/cache.c
@@ -5,6 +5,7 @@
  *
  * Change Logs:
  * Date           Author       Notes
+ * 2025/01/16     zdtyuiop4444 fix type cast warning
  * 2024/11/26     zdtyuiop4444 The first version
  */
 
@@ -33,10 +34,10 @@ inline void rt_hw_cpu_dcache_ops(int ops, void* addr, int size)
     switch (ops)
     {
     case RT_HW_CACHE_FLUSH:
-        flush_dcache_range(addr, size);
+        flush_dcache_range((uintptr_t)addr, size);
         break;
     case RT_HW_CACHE_INVALIDATE:
-        inv_dcache_range(addr, size);
+        inv_dcache_range((uintptr_t)addr, size);
         break;
     default:
         break;
@@ -62,7 +63,7 @@ inline void rt_hw_cpu_icache_ops(int ops, void* addr, int size)
     switch (ops)
     {
     case RT_HW_CACHE_INVALIDATE:
-        inv_icache_range(addr, size);
+        inv_icache_range((uintptr_t)addr, size);
         break;
     default:
         break;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
Fixed #9920 

参数类型是void* 与预设的uintptr_t不匹配

#### 你的解决方案是什么 (what is your solution)

将void* 显示转换为uintptr_t类型

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP: cvitek/c906_little

- .config:

- action:

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
