### PR TITLE
[tools] ci.attachconfig.yml is used in combination with scons

### DIFF
--- a/tools/attachconfig.py
+++ b/tools/attachconfig.py
@@ -1,0 +1,87 @@
+import os
+import sys
+import shutil
+import yaml
+
+from SCons.Script import *
+
+# SCons AttachConfig Command Function
+def GenAttachConfigProject(program = None):
+    Rtt_Root = os.getcwd()
+    config_file = os.path.join(os.getcwd(), 'rtt_root', Rtt_Root, '.config')
+    config_bacakup = config_file+'.origin'
+    rtconfig_file = os.path.join(os.getcwd(), 'rtt_root', Rtt_Root, 'rtconfig.h')
+    rtconfig__bacakup = rtconfig_file+'.origin'
+    if GetOption('attach') == '?':
+        attachconfig=[]
+        GetAttachConfig("get",attachconfig,0)
+        print("\033[32m✅ AttachConfig has: \033[0m")
+        prefix=attachconfig[0]
+        for line in attachconfig:
+            temp_prefix=line.split(".", 1)
+            if prefix!=temp_prefix[0]:
+                print("\033[42m \033[30m------"+temp_prefix[0]+"------\033[0m")
+                prefix=temp_prefix[0]
+            print(line)
+            
+            
+    elif GetOption('attach') == 'default':
+        if os.path.exists(config_bacakup):
+            shutil.copyfile(config_bacakup, config_file)
+            os.remove(config_bacakup)
+        if os.path.exists(rtconfig__bacakup):
+            shutil.copyfile(rtconfig__bacakup, rtconfig_file)
+            os.remove(rtconfig__bacakup)
+        print("\033[32m✅ Default .config and rtconfig.h recovery success!\033[0m")
+    else:
+        attachconfig=GetOption('attach')
+        attachconfig_result=[]
+        GetAttachConfig("search",attachconfig,attachconfig_result)
+        if attachconfig_result==[]:
+            print("❌\033[31m Without this AttachConfig:"+attachconfig+"\033[0m")
+            return
+        if os.path.exists(config_bacakup)==False:
+            shutil.copyfile(config_file, config_bacakup)
+        if os.path.exists(rtconfig__bacakup)==False:
+            shutil.copyfile(rtconfig_file, rtconfig__bacakup)
+        with open(config_file, 'a') as destination:
+            for line in attachconfig_result:
+                destination.write(line + '\n')
+        from env_utility import defconfig
+        defconfig(Rtt_Root)
+        print("\033[32m✅ AttachConfig add success!\033[0m")
+
+def GetAttachConfig(action,attachconfig,attachconfig_result):
+    rtt_root = os.getcwd()
+    yml_files_content = []
+    directory = os.path.join(rtt_root, 'rtt_root', rtt_root, '.ci/attachconfig')
+    if os.path.exists(directory):
+            for root, dirs, files in os.walk(directory):
+                for filename in files:
+                    if filename.endswith('attachconfig.yml'):
+                        file_path = os.path.join(root, filename)
+                        if os.path.exists(file_path):
+                            try:
+                                with open(file_path, 'r') as file:
+                                    content = yaml.safe_load(file)
+                                    if content is None:
+                                        continue
+                                    yml_files_content.append(content)
+                            except yaml.YAMLError as e:
+                                print(f"::error::Error parsing YAML file: {e}")
+                                continue
+                            except Exception as e:
+                                print(f"::error::Error reading file: {e}")
+                                continue
+    for projects in yml_files_content:
+            for name, details in projects.items():
+                if details.get("kconfig") is None:
+                    continue
+                if(projects.get(name) is not None):
+                    if action == "get":
+                        attachconfig.append(name)
+                    if action == "search" and name == attachconfig:
+                        from ci.bsp_buildings import get_details_and_dependencies
+                        detail_list=get_details_and_dependencies([name],projects)
+                        for line in detail_list:
+                            attachconfig_result.append(line)

--- a/tools/building.py
+++ b/tools/building.py
@@ -33,7 +33,6 @@ import operator
 import rtconfig
 import platform
 import logging
-
 from SCons.Script import *
 from utils import _make_path_relative
 from mkdist import do_copy_file
@@ -335,6 +334,11 @@ def PrepareBuilding(env, root_directory, has_libcpu=False, remove_components = [
                     print('--global-macros arguments are illegal!')
         else:
             print('--global-macros arguments are illegal!')
+
+    if GetOption('attach'):
+        from attachconfig import GenAttachConfigProject
+        GenAttachConfigProject()
+        exit(0)
 
     if GetOption('genconfig'):
         from env_utility import genconfig

--- a/tools/options.py
+++ b/tools/options.py
@@ -141,3 +141,10 @@ def AddOptions():
                 action = 'store_true',
                 default = False,
                 help = 'make compile_commands.json')
+    AddOption('--attach',
+                dest = 'attach',
+                type = 'string',
+                help = 'View attachconfig or add attach to.config.'+\
+                'e.g. scons --attach=? View all attachconfig for the current bsp.'+\
+                ' or scons --attach=component.cherryusb_cdc Set option component.cherryusb_cdc inside attachconfig to.config.'+\
+                ' or scons --attach=default Restore.config and rtconfig to before attch was set.')


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
尝试将ci.attachconfig.yml 和scons结合使用

#### 你的解决方案是什么 (what is your solution)
按照issues #9941 的要求实现功能
目前已实现:
scons --attach=? 打印出yml中的所有配置
![图片](https://github.com/user-attachments/assets/3cb24376-6e4a-4590-8a29-e3ec3dd99a9f)

scons --attach=component.cherryusb_cdc 该命令把yml中的component.cherryusb_cdc配置放到.config的最后中，并且执行一下menuconfig
![图片](https://github.com/user-attachments/assets/156dfc65-2a6b-4580-9c10-6f5fb1a2fff5)

scons --attach=default 恢复备份文件,恢复.config rtconfig为原样。
![图片](https://github.com/user-attachments/assets/92f1f727-a179-44ab-8a82-a8629eb35280)

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
