### PR TITLE
[Kernel|DM] Rename some symbol

### DIFF
--- a/components/dfs/dfs_v1/filesystems/iso9660/dfs_iso9660.c
+++ b/components/dfs/dfs_v1/filesystems/iso9660/dfs_iso9660.c
@@ -391,7 +391,7 @@ static int dfs_iso9660_close(struct dfs_file *fd)
     return 0;
 }
 
-static int dfs_iso9660_read(struct dfs_file *fd, void *buf, size_t count)
+static ssize_t dfs_iso9660_read(struct dfs_file *fd, void *buf, size_t count)
 {
     rt_uint32_t pos;
     void *buf_ptr;

--- a/components/drivers/clk/clk.c
+++ b/components/drivers/clk/clk.c
@@ -16,7 +16,7 @@
 #define DBG_LVL DBG_INFO
 #include <rtdbg.h>
 
-static struct rt_spinlock _clk_lock = { 0 };
+static RT_DEFINE_SPINLOCK(_clk_lock);
 static rt_list_t _clk_nodes = RT_LIST_OBJECT_INIT(_clk_nodes);
 static rt_list_t _clk_notifier_nodes = RT_LIST_OBJECT_INIT(_clk_notifier_nodes);
 

--- a/components/drivers/core/bus.c
+++ b/components/drivers/core/bus.c
@@ -86,7 +86,7 @@ rt_err_t rt_device_bus_destroy(rt_device_t dev)
 #ifdef RT_USING_DM
 #include <drivers/core/bus.h>
 
-static struct rt_spinlock bus_lock = {};
+static RT_DEFINE_SPINLOCK(bus_lock);
 static rt_list_t bus_nodes = RT_LIST_OBJECT_INIT(bus_nodes);
 
 static void _dm_bus_lock(struct rt_spinlock *spinlock)

--- a/components/drivers/core/dm.c
+++ b/components/drivers/core/dm.c
@@ -191,7 +191,7 @@ struct prefix_track
     int uid;
     const char *prefix;
 };
-static struct rt_spinlock _prefix_nodes_lock = { 0 };
+static RT_DEFINE_SPINLOCK(_prefix_nodes_lock);
 static rt_list_t _prefix_nodes = RT_LIST_OBJECT_INIT(_prefix_nodes);
 
 int rt_dm_dev_set_name_auto(rt_device_t dev, const char *prefix)

--- a/components/drivers/dma/dma.c
+++ b/components/drivers/dma/dma.c
@@ -17,7 +17,7 @@
 #include <rtdbg.h>
 
 static rt_list_t dmac_nodes = RT_LIST_OBJECT_INIT(dmac_nodes);
-static struct rt_spinlock dmac_nodes_lock = {};
+static RT_DEFINE_SPINLOCK(dmac_nodes_lock);
 
 rt_err_t rt_dma_controller_register(struct rt_dma_controller *ctrl)
 {

--- a/components/drivers/dma/dma_pool.c
+++ b/components/drivers/dma/dma_pool.c
@@ -19,7 +19,7 @@
 #include <mm_aspace.h>
 #include <dt-bindings/size.h>
 
-static struct rt_spinlock dma_pools_lock = {};
+static RT_DEFINE_SPINLOCK(dma_pools_lock);
 static rt_list_t dma_pool_nodes = RT_LIST_OBJECT_INIT(dma_pool_nodes);
 
 static struct rt_dma_pool *dma_pool_install(rt_region_t *region);

--- a/components/drivers/include/drivers/core/dm.h
+++ b/components/drivers/include/drivers/core/dm.h
@@ -40,6 +40,11 @@ struct rt_dm_ida
 };
 
 #define RT_DM_IDA_INIT(id)  { .master_id = MASTER_ID_##id }
+#define rt_dm_ida_init(ida, id)         \
+do {                                    \
+    (ida)->master_id = MASTER_ID_##id;  \
+    rt_spin_lock_init(&(ida)->lock);    \
+} while (0)
 
 int rt_dm_ida_alloc(struct rt_dm_ida *ida);
 rt_bool_t rt_dm_ida_take(struct rt_dm_ida *ida, int id);

--- a/components/drivers/include/drivers/dev_pin.h
+++ b/components/drivers/include/drivers/dev_pin.h
@@ -111,7 +111,7 @@ struct rt_device_pin
     const struct rt_pin_ops *ops;
 };
 
-#define PIN_NONE                (-1)
+#define PIN_NONE                (-RT_EEMPTY)
 
 #define PIN_LOW                 0x00 /*!< low level */
 #define PIN_HIGH                0x01 /*!< high level */

--- a/components/drivers/include/drivers/led.h
+++ b/components/drivers/include/drivers/led.h
@@ -46,8 +46,8 @@ struct rt_led_ops
     rt_err_t (*set_brightness)(struct rt_led_device *led, rt_uint32_t brightness);
 };
 
-rt_err_t rt_hw_led_register(struct rt_led_device *led);
-rt_err_t rt_hw_led_unregister(struct rt_led_device *led);
+rt_err_t rt_led_register(struct rt_led_device *led);
+rt_err_t rt_led_unregister(struct rt_led_device *led);
 
 rt_err_t rt_led_set_state(struct rt_led_device *led, enum rt_led_state state);
 rt_err_t rt_led_get_state(struct rt_led_device *led, enum rt_led_state *out_state);

--- a/components/drivers/led/led-gpio.c
+++ b/components/drivers/led/led-gpio.c
@@ -23,7 +23,7 @@ struct gpio_led
     rt_uint8_t active_val;
 };
 
-#define raw_to_gpio_led(raw) rt_container_of(raw, struct gpio_led, parent);
+#define raw_to_gpio_led(raw) rt_container_of(raw, struct gpio_led, parent)
 
 static rt_err_t gpio_led_set_state(struct rt_led_device *led, enum rt_led_state state)
 {
@@ -108,7 +108,7 @@ static rt_err_t ofw_append_gpio_led(struct rt_ofw_node *np)
 
     gled->parent.ops = &gpio_led_ops;
 
-    if ((err = rt_hw_led_register(&gled->parent)))
+    if ((err = rt_led_register(&gled->parent)))
     {
         goto _fail;
     }
@@ -203,7 +203,7 @@ static rt_err_t gpio_led_remove(struct rt_platform_device *pdev)
 
         rt_ofw_data(led_np) = RT_NULL;
 
-        rt_hw_led_unregister(&gled->parent);
+        rt_led_unregister(&gled->parent);
 
         rt_free(gled);
     }

--- a/components/drivers/led/led.c
+++ b/components/drivers/led/led.c
@@ -119,7 +119,7 @@ static void _led_blink_timerout(void *param)
     btimer->toggle = !btimer->toggle;
 }
 
-rt_err_t rt_hw_led_register(struct rt_led_device *led)
+rt_err_t rt_led_register(struct rt_led_device *led)
 {
     rt_err_t err;
     int device_id;
@@ -193,7 +193,7 @@ _fail:
     return err;
 }
 
-rt_err_t rt_hw_led_unregister(struct rt_led_device *led)
+rt_err_t rt_led_unregister(struct rt_led_device *led)
 {
     if (!led)
     {

--- a/components/drivers/mailbox/mailbox.c
+++ b/components/drivers/mailbox/mailbox.c
@@ -20,7 +20,7 @@
 #include <drivers/platform.h>
 #include <drivers/core/dm.h>
 
-static struct rt_spinlock mbox_ops_lock = {};
+static RT_DEFINE_SPINLOCK(mbox_ops_lock);
 static rt_list_t mbox_nodes = RT_LIST_OBJECT_INIT(mbox_nodes);
 
 static void mbox_chan_timeout(void *param);

--- a/components/drivers/mfd/mfd-syscon.c
+++ b/components/drivers/mfd/mfd-syscon.c
@@ -17,7 +17,7 @@
 #include <drivers/core/dm.h>
 #include <drivers/platform.h>
 
-static struct rt_spinlock _syscon_nodes_lock = { 0 };
+static RT_DEFINE_SPINLOCK(_syscon_nodes_lock);
 static rt_list_t _syscon_nodes = RT_LIST_OBJECT_INIT(_syscon_nodes);
 
 rt_err_t rt_syscon_read(struct rt_syscon *syscon, rt_off_t offset, rt_uint32_t *out_val)

--- a/components/drivers/nvme/nvme.c
+++ b/components/drivers/nvme/nvme.c
@@ -19,7 +19,7 @@
 static struct rt_dm_ida nvme_controller_ida = RT_DM_IDA_INIT(CUSTOM);
 static struct rt_dm_ida nvme_ida = RT_DM_IDA_INIT(NVME);
 
-static struct rt_spinlock nvme_lock = {};
+static RT_DEFINE_SPINLOCK(nvme_lock);
 static rt_list_t nvme_nodes = RT_LIST_OBJECT_INIT(nvme_nodes);
 
 rt_inline rt_uint32_t nvme_readl(struct rt_nvme_controller *nvme, int offset)

--- a/components/drivers/ofw/base.c
+++ b/components/drivers/ofw/base.c
@@ -84,7 +84,7 @@ rt_err_t ofw_phandle_hash_reset(rt_phandle min, rt_phandle max)
 static rt_phandle ofw_phandle_next(void)
 {
     rt_phandle next;
-    static struct rt_spinlock op_lock = {};
+    static RT_DEFINE_SPINLOCK(op_lock);
 
     rt_hw_spin_lock(&op_lock.lock);
 

--- a/components/drivers/pci/endpoint/endpoint.c
+++ b/components/drivers/pci/endpoint/endpoint.c
@@ -15,7 +15,7 @@
 #include <rtdbg.h>
 
 static rt_list_t _ep_nodes = RT_LIST_OBJECT_INIT(_ep_nodes);
-static struct rt_spinlock _ep_lock = { 0 };
+static RT_DEFINE_SPINLOCK(_ep_lock);
 
 rt_err_t rt_pci_ep_write_header(struct rt_pci_ep *ep, rt_uint8_t func_no,
         struct rt_pci_ep_header *hdr)

--- a/components/drivers/pci/msi/irq.c
+++ b/components/drivers/pci/msi/irq.c
@@ -14,7 +14,7 @@
 #define DBG_LVL DBG_INFO
 #include <rtdbg.h>
 
-static struct rt_spinlock msi_irq_map_lock = {};
+static RT_DEFINE_SPINLOCK(msi_irq_map_lock);
 static RT_BITMAP_DECLARE(msi_irq_map, MAX_HANDLERS) = {};
 
 rt_err_t rt_pci_msi_setup_irqs(struct rt_pci_device *pdev, int nvec, int type)

--- a/components/drivers/pic/pic-gic-common.c
+++ b/components/drivers/pic/pic-gic-common.c
@@ -87,7 +87,7 @@ rt_err_t gic_common_configure_irq(void *base, int irq, rt_uint32_t mode, void (*
     rt_uint32_t val, oldval;
     rt_uint32_t confoff = (irq / 16) * 4;
     rt_uint32_t confmask = 0x2 << ((irq % 16) * 2);
-    static struct rt_spinlock ic_lock = { 0 };
+    static RT_DEFINE_SPINLOCK(ic_lock);
 
     level = rt_spin_lock_irqsave(&ic_lock);
 

--- a/components/drivers/pic/pic-gicv2.c
+++ b/components/drivers/pic/pic-gicv2.c
@@ -224,7 +224,7 @@ static rt_err_t gicv2_irq_set_affinity(struct rt_pic_irq *pirq, rt_bitmap_t *aff
         rt_uint32_t val;
         rt_ubase_t level;
         rt_ubase_t offset = (rt_ubase_t)io_addr & 3UL, shift = offset * 8;
-        static struct rt_spinlock rmw_lock = {};
+        static RT_DEFINE_SPINLOCK(rmw_lock);
 
         level = rt_spin_lock_irqsave(&rmw_lock);
 

--- a/components/drivers/pic/pic-gicv3-its.c
+++ b/components/drivers/pic/pic-gicv3-its.c
@@ -121,7 +121,8 @@ static rt_uint32_t lpi_id_bits;
 static void *lpi_table;
 static void *lpi_pending_table;
 static rt_bitmap_t *lpis_vectors = RT_NULL;
-static struct rt_spinlock lpis_lock = {}, map_lock = {};
+static RT_DEFINE_SPINLOCK(lpis_lock);
+static RT_DEFINE_SPINLOCK(map_lock);
 static rt_list_t its_nodes = RT_LIST_OBJECT_INIT(its_nodes);
 static rt_list_t map_nodes = RT_LIST_OBJECT_INIT(map_nodes);
 

--- a/components/drivers/pic/pic.c
+++ b/components/drivers/pic/pic.c
@@ -51,7 +51,7 @@ static struct rt_pic_irq _pirq_hash[MAX_HANDLERS] =
     }
 };
 
-static struct rt_spinlock _pic_lock = { };
+static RT_DEFINE_SPINLOCK(_pic_lock);
 static rt_size_t _pic_name_max = sizeof("PIC");
 static rt_list_t _pic_nodes = RT_LIST_OBJECT_INIT(_pic_nodes);
 static rt_list_t _traps_nodes = RT_LIST_OBJECT_INIT(_traps_nodes);

--- a/components/drivers/pin/dev_pin_dm.c
+++ b/components/drivers/pin/dev_pin_dm.c
@@ -11,7 +11,7 @@
 #include "dev_pin_dm.h"
 
 static rt_size_t pin_total_nr = 0;
-static struct rt_spinlock pin_lock = {};
+static RT_DEFINE_SPINLOCK(pin_lock);
 static rt_list_t pin_nodes = RT_LIST_OBJECT_INIT(pin_nodes);
 
 static struct rt_device_pin *pin_device_find(rt_ubase_t pin)

--- a/components/drivers/regulator/regulator-gpio.c
+++ b/components/drivers/regulator/regulator-gpio.c
@@ -193,7 +193,7 @@ static rt_err_t regulator_gpio_probe(struct rt_platform_device *pdev)
     /* GPIO flags are ignored, we check by enable-active-high */
     rg->enable_pin = rt_pin_get_named_pin(dev, "enable", 0, RT_NULL, RT_NULL);
 
-    if (rg->enable_pin < 0 && rg->enable_pin != -RT_EEMPTY)
+    if (rg->enable_pin < 0 && rg->enable_pin != PIN_NONE)
     {
         err = rg->enable_pin;
         goto _fail;

--- a/components/drivers/regulator/regulator.c
+++ b/components/drivers/regulator/regulator.c
@@ -24,7 +24,7 @@ struct rt_regulator
     struct rt_regulator_node *reg_np;
 };
 
-static struct rt_spinlock _regulator_lock = { 0 };
+static RT_DEFINE_SPINLOCK(_regulator_lock);
 
 static rt_err_t regulator_enable(struct rt_regulator_node *reg_np);
 static rt_err_t regulator_disable(struct rt_regulator_node *reg_np);

--- a/components/drivers/thermal/thermal.c
+++ b/components/drivers/thermal/thermal.c
@@ -23,7 +23,7 @@
 #define device_list(dev)            (dev)->parent.parent.list
 #define device_foreach(dev, nodes)  rt_list_for_each_entry(dev, nodes, parent.parent.list)
 
-static struct rt_spinlock nodes_lock = {};
+static RT_DEFINE_SPINLOCK(nodes_lock);
 static rt_list_t thermal_zone_device_nodes = RT_LIST_OBJECT_INIT(thermal_zone_device_nodes);
 static rt_list_t thermal_cooling_device_nodes = RT_LIST_OBJECT_INIT(thermal_cooling_device_nodes);
 static rt_list_t thermal_cooling_governor_nodes = RT_LIST_OBJECT_INIT(thermal_cooling_governor_nodes);

--- a/libcpu/aarch64/cortex-a/entry_point.S
+++ b/libcpu/aarch64/cortex-a/entry_point.S
@@ -57,7 +57,7 @@
 /*
  * Our goal is to boot the rt-thread as possible without modifying the
  * bootloader's config, so we use the kernel's boot header for ARM64:
- *   https://www.kernel.org/doc/html/latest/arm64/booting.html#call-the-kernel-image
+ *   https://www.kernel.org/doc/html/latest/arch/arm64/booting.html#call-the-kernel-image
  */
 _head:
     b       _start          /* Executable code */


### PR DESCRIPTION
[
1. Update kernel's boot link for ARM64.
2. Add IDA init in runtime.
3. Reset the value of PIN_NONE.
4. Remove warning for ISO9660 ops.
5. Replace spinlock static init by RT_DEFINE_SPINLOCK.
6. Rename LED register/unregister.

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
