### PR TITLE
components: libc: fix pointer-to-integer cast warnings and address tr…

### DIFF
--- a/components/libc/posix/libdl/dlelf.c
+++ b/components/libc/posix/libdl/dlelf.c
@@ -383,9 +383,9 @@ rt_err_t dlmodule_load_relocated_object(struct rt_dlmodule* module, void *module
             rt_memcpy(ptr,
                       (rt_uint8_t *)elf_module + shdr[index].sh_offset,
                       shdr[index].sh_size);
-            rodata_addr = (rt_uint32_t)ptr;
+            rodata_addr = (rt_ubase_t)ptr;
             LOG_D("load rodata 0x%x, size %d, rodata 0x%x", ptr,
-                shdr[index].sh_size, *(rt_uint32_t *)data_addr);
+                shdr[index].sh_size, *(rt_ubase_t *)rodata_addr);
             ptr += shdr[index].sh_size;
         }
 
@@ -395,9 +395,9 @@ rt_err_t dlmodule_load_relocated_object(struct rt_dlmodule* module, void *module
             rt_memcpy(ptr,
                       (rt_uint8_t *)elf_module + shdr[index].sh_offset,
                       shdr[index].sh_size);
-            data_addr = (rt_uint32_t)ptr;
+            data_addr = (rt_ubase_t)ptr;
             LOG_D("load data 0x%x, size %d, data 0x%x", ptr,
-                shdr[index].sh_size, *(rt_uint32_t *)data_addr);
+                shdr[index].sh_size, *(rt_ubase_t *)data_addr);
             ptr += shdr[index].sh_size;
         }
 
@@ -405,7 +405,7 @@ rt_err_t dlmodule_load_relocated_object(struct rt_dlmodule* module, void *module
         if (IS_NOPROG(shdr[index]) && IS_AW(shdr[index]))
         {
             rt_memset(ptr, 0, shdr[index].sh_size);
-            bss_addr = (rt_uint32_t)ptr;
+            bss_addr = (rt_ubase_t)ptr;
             LOG_D("load bss 0x%x, size %d", ptr, shdr[index].sh_size);
         }
     }

--- a/components/libc/posix/libdl/dlmodule.c
+++ b/components/libc/posix/libdl/dlmodule.c
@@ -837,10 +837,10 @@ void dlmodule_exit(int ret_code)
  * @brief search for a symbol by its name in the kernel symbol table.
  *
  * @param sym_str the symbol name string.
- * @return rt_uint32_t On success, it returns the address of the symbol.
+ * @return rt_ubase_t On success, it returns the address of the symbol.
  *         Otherwise, it returns 0 (indicating the symbol was not found).
  */
-rt_uint32_t dlmodule_symbol_find(const char *sym_str)
+rt_ubase_t dlmodule_symbol_find(const char *sym_str)
 {
     /* find in kernel symbol table */
     struct rt_module_symtab *index;
@@ -848,7 +848,7 @@ rt_uint32_t dlmodule_symbol_find(const char *sym_str)
     for (index = _rt_module_symtab_begin; index != _rt_module_symtab_end; index ++)
     {
         if (rt_strcmp(index->name, sym_str) == 0)
-            return (rt_uint32_t)index->addr;
+            return (rt_ubase_t)index->addr;
     }
 
     return 0;

--- a/components/libc/posix/libdl/dlmodule.h
+++ b/components/libc/posix/libdl/dlmodule.h
@@ -82,6 +82,6 @@ void dlmodule_exit(int ret_code);
 
 struct rt_dlmodule *dlmodule_find(const char *name);
 
-rt_uint32_t dlmodule_symbol_find(const char *sym_str);
+rt_ubase_t dlmodule_symbol_find(const char *sym_str);
 
 #endif


### PR DESCRIPTION
…uncation

[Problem Description]
1. When enabling RT_USING_MODULE=y, compilation warnings occur: dlelf.c:386:27: warning: cast from pointer to integer of different size dlelf.c:398:25: warning: cast from pointer to integer of different size dlelf.c:408:24: warning: cast from pointer to integer of different size

2. On RV64 architectures (e.g. Sophgo SG2042 with RISC-V Sv39 and 40-bit physical addressing), dlsym may fail when accessing addresses beyond 32-bit range.

[Root Cause]
In dlmodule_load_relocated_object() and dlmodule_symbol_find(), pointer is cast to rt_uint32_t which truncates:
| rt_ubase_t rodata_addr = (rt_uint32_t)ptr;
This causes:
- Warnings on 64-bit systems (pointer width > 32-bit)
- Actual address truncation on RV64 when physical address exceeds 32-bit

[Solution]
Replace rt_uint32_t with architecture-adaptive rt_ubase_t: | rt_ubase_t rodata_addr = (rt_ubase_t)ptr;
The rt_ubase_t is defined in include/rttypes.h as: | #ifdef ARCH_CPU_64BIT
|   typedef rt_uint64_t rt_ubase_t;
| #else
|   typedef rt_uint32_t rt_ubase_t;
| #endif
This ensures correct width casting for both 32/64-bit architectures.

## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)


#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
