### PR TITLE
[bugfix][risc-v]fix the PPN length error in GET_PPN(pte).

### DIFF
--- a/libcpu/risc-v/common64/mmu.h
+++ b/libcpu/risc-v/common64/mmu.h
@@ -41,7 +41,7 @@ struct mem_desc
 #define GET_L2(addr)        __PARTBIT(addr, VPN1_SHIFT, VPN1_BIT)
 #define GET_L3(addr)        __PARTBIT(addr, VPN0_SHIFT, VPN0_BIT)
 #define GET_PPN(pte)                                                           \
-    (__PARTBIT(pte, PTE_PPN_SHIFT, PHYSICAL_ADDRESS_WIDTH_BITS - PTE_PPN_SHIFT))
+    (__PARTBIT(pte, PTE_PPN_SHIFT, PHYSICAL_ADDRESS_WIDTH_BITS - PAGE_OFFSET_BIT))
 #define GET_PADDR(pte)            (GET_PPN(pte) << PAGE_OFFSET_BIT)
 #define VPN_TO_PPN(vaddr, pv_off) (((rt_uintptr_t)(vaddr)) + (pv_off))
 #define PPN_TO_VPN(paddr, pv_off) (((rt_uintptr_t)(paddr)) - (pv_off))


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
libcpu\risc-v\common64\mmu.h中宏参数有误：
```
#define GET_PPN(pte)                                                           \
    (__PARTBIT(pte, PTE_PPN_SHIFT, PHYSICAL_ADDRESS_WIDTH_BITS - PTE_PPN_SHIFT))
```
其中第三个参数为PPN的bit位数，即44位，而PHYSICAL_ADDRESS_WIDTH_BITS为物理地址总位数即56，PTE_PPN_SHIFT为10（对应PTE的属性位数），56-10=46，显然不是44。
物理地址的组成为44bit PPN + 12bit page offset，因此这里正确的计算方式应该是，
PPN位数=物理地址总位数( PHYSICAL_ADDRESS_WIDTH_BITS(=56) ) - page offset位数( PAGE_OFFSET_BIT(=12) )= 44 bit。

#### 你的解决方案是什么 (what is your solution)
将PTE_PPN_SHIFT修改为PAGE_OFFSET_BIT.


#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:

- .config:

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
