### PR TITLE
[components][drivers][spi] dev_spi_flash_sfud: fix: set message.paren…

### DIFF
--- a/components/drivers/spi/dev_spi_flash_sfud.c
+++ b/components/drivers/spi/dev_spi_flash_sfud.c
@@ -214,7 +214,9 @@ static sfud_err qspi_read(const struct __sfud_spi *spi, uint32_t addr, sfud_qspi
     message.parent.cs_release = 1;
     message.parent.cs_take = 1;
     message.qspi_data_lines = qspi_read_cmd_format->data_lines;
-
+    /* set next */
+    /* Ensure correct QSPI message chaining by setting next pointer to NULL, preventing unintended data transmission issues.*/
+    message.parent.next = RT_NULL;
     if (rt_qspi_transfer_message(qspi_dev, &message) != read_size) {
         result = SFUD_ERR_TIMEOUT;
     }


### PR DESCRIPTION
…t.next to NULL for qspi_read API

- Ensure correct QSPI message chaining by setting next pointer to NULL, preventing unintended data transmission issues


#### 为什么提交这份PR (why to submit this PR)
- 在当前代码中，message只传输一次，message.parent.next 未被正确设置为 NULL，这可能导致消息链处理不正确，进而引发意外的数据传输问题。

#### 你的解决方案是什么 (what is your solution)

- 通过将 message.parent.next 设置为 NULL，可以确保 QSPI 消息的正确处理，避免这些问题。


- BSP:
  - HPM5300EVK

- .config:
  - 无

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
