### PR TITLE
[libcpu][risc-v]处理mmu.c中_unmap_area函数的几处潜在风险或问题

### DIFF
--- a/libcpu/risc-v/common64/mmu.c
+++ b/libcpu/risc-v/common64/mmu.c
@@ -36,7 +36,7 @@
 #define USER_VADDR_START 0
 #endif
 
-static size_t _unmap_area(struct rt_aspace *aspace, void *v_addr, size_t size);
+static size_t _unmap_area(struct rt_aspace *aspace, void *v_addr);
 
 static void *current_mmu_table = RT_NULL;
 
@@ -198,7 +198,7 @@ void *rt_hw_mmu_map(struct rt_aspace *aspace, void *v_addr, void *p_addr,
             while (unmap_va != v_addr)
             {
                 MM_PGTBL_LOCK(aspace);
-                _unmap_area(aspace, unmap_va, ARCH_PAGE_SIZE);
+                _unmap_area(aspace, unmap_va);
                 MM_PGTBL_UNLOCK(aspace);
                 unmap_va += ARCH_PAGE_SIZE;
             }
@@ -245,8 +245,8 @@ static void _unmap_pte(rt_ubase_t *pentry, rt_ubase_t *lvl_entry[], int level)
     }
 }
 
-/* Unmaps a virtual address range from the page table. */
-static size_t _unmap_area(struct rt_aspace *aspace, void *v_addr, size_t size)
+/* Unmaps a virtual address range (1GB/2MB/4KB according to actual page level) from the page table. */
+static size_t _unmap_area(struct rt_aspace *aspace, void *v_addr)
 {
     rt_ubase_t loop_va = __UMASKVALUE((rt_ubase_t)v_addr, PAGE_OFFSET_MASK);
     size_t unmapped = 0;
@@ -315,7 +315,7 @@ void rt_hw_mmu_unmap(struct rt_aspace *aspace, void *v_addr, size_t size)
     while (size > 0)
     {
         MM_PGTBL_LOCK(aspace);
-        unmapped = _unmap_area(aspace, v_addr, size);
+        unmapped = _unmap_area(aspace, v_addr);
         MM_PGTBL_UNLOCK(aspace);
 
         /* when unmapped == 0, region not exist in pgtbl */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
_unmap_area函数存在几处潜在风险或问题：
1._unmap_area 函数的size 参数未被使用。
  经过分析代码，该函数每次解除映射的范围实际由页表层级自动决定（如 1GB/2MB/4KB），而非依赖 size 参数。该参数未被使用，容易造成对该函数使用方式的误解，建议删除该参数。

2._unmap_area函数中对无效页表项的情况未做处理，可能导致返回的unmapped值不正确。

#### 你的解决方案是什么 (what is your solution)

1. 删除无用的size参数；
2. 针对无效页表项的情况，返回unmapped值为0，这与rt_hw_mmu_unmap中对_unmap_area返回值的异常检查保持一致（rt_hw_mmu_unmap中判定_unmap_area返回0为异常）。


#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:

- .config:

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
