### PR TITLE
解决bps/simulator无法在vs2019环境下编译

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 *.crf
 build
 Debug
+.vs
 rtthread
 settings
 documentation/html

--- a/bsp/simulator/template_vs2012.vcxproj
+++ b/bsp/simulator/template_vs2012.vcxproj
@@ -45,6 +45,7 @@
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <LanguageStandard_C>stdc11</LanguageStandard_C>
+      <TreatSpecificWarningsAsErrors>4029</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <Link>
       <AdditionalDependencies>winmm.lib;Packet.lib;wpcap.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/bsp/simulator/template_vs2012.vcxproj
+++ b/bsp/simulator/template_vs2012.vcxproj
@@ -44,6 +44,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <LanguageStandard_C>stdc11</LanguageStandard_C>
     </ClCompile>
     <Link>
       <AdditionalDependencies>winmm.lib;Packet.lib;wpcap.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/components/finsh/finsh.h
+++ b/components/finsh/finsh.h
@@ -212,14 +212,22 @@ typedef struct msh_cmd_opt
  *
  * @param[in] command The command associated with these options.
  */
+#ifdef _MSC_VER
+#define CMD_OPTIONS_STATEMENT(command) static struct msh_cmd_opt command##_msh_options[16];
+#else
 #define CMD_OPTIONS_STATEMENT(command) static struct msh_cmd_opt command##_msh_options[];
+#endif
 
 /**
  * @brief Starts the definition of command options for a specific command.
  *
  * @param[in] command The command these options are associated with.
  */
+#ifdef _MSC_VER
+#define CMD_OPTIONS_NODE_START(command) static struct msh_cmd_opt command##_msh_options[16] = {
+#else
 #define CMD_OPTIONS_NODE_START(command) static struct msh_cmd_opt command##_msh_options[] = {
+#endif
 
 /**
  * @brief Defines a single command option.

--- a/include/rttypes.h
+++ b/include/rttypes.h
@@ -32,6 +32,12 @@ extern "C" {
  * RT-Thread basic data types definition
  */
 
+#if defined(_WIN64) || defined(__x86_64__)
+#ifndef ARCH_CPU_64BIT
+#define ARCH_CPU_64BIT
+#endif // ARCH_CPU_64BIT
+#endif // defined(_WIN64) || defined(__x86_64__)
+
 typedef int                             rt_bool_t;      /**< boolean type */
 
 #ifndef RT_USING_ARCH_DATA_TYPE

--- a/libcpu/sim/win32/cpu_port.c
+++ b/libcpu/sim/win32/cpu_port.c
@@ -97,8 +97,9 @@ static MMRESULT     OSTick_TimerID;
 /*
  * flag in interrupt handling
  */
-rt_uint32_t rt_interrupt_from_thread, rt_interrupt_to_thread;
-rt_uint32_t rt_thread_switch_interrupt_flag;
+volatile rt_ubase_t rt_interrupt_from_thread = 0;
+volatile rt_ubase_t rt_interrupt_to_thread   = 0;
+volatile rt_uint32_t rt_thread_switch_interrupt_flag = 0;
 
 /*
 *********************************************************************************************************
@@ -248,18 +249,17 @@ void rt_hw_interrupt_enable(rt_base_t level)
 * Note(s)     : none
 *********************************************************************************************************
 */
-void rt_hw_context_switch_interrupt(rt_uint32_t from,
-                                    rt_uint32_t to)
+void rt_hw_context_switch_interrupt(rt_ubase_t from, rt_ubase_t to, rt_thread_t from_thread, rt_thread_t to_thread)
 {
     if(rt_thread_switch_interrupt_flag != 1)
     {
         rt_thread_switch_interrupt_flag = 1;
 
         // set rt_interrupt_from_thread
-        rt_interrupt_from_thread = *((rt_uint32_t *)(from));
+        rt_interrupt_from_thread = from;
     }
 
-    rt_interrupt_to_thread = *((rt_uint32_t *)(to));
+    rt_interrupt_to_thread = to;
 
     //trigger YIELD exception(cause context switch)
     TriggerSimulateInterrupt(CPU_INTERRUPT_YIELD);

--- a/libcpu/sim/win32/cpu_port.c
+++ b/libcpu/sim/win32/cpu_port.c
@@ -267,20 +267,19 @@ void rt_hw_context_switch_interrupt(rt_ubase_t from, rt_ubase_t to, rt_thread_t 
 
 
 
-void rt_hw_context_switch(rt_uint32_t from,
-                          rt_uint32_t to)
+void rt_hw_context_switch(rt_ubase_t from, rt_ubase_t to)
 {
     if(rt_thread_switch_interrupt_flag != 1)
     {
         rt_thread_switch_interrupt_flag  = 1;
 
         // set rt_interrupt_from_thread
-        rt_interrupt_from_thread = *((rt_uint32_t *)(from));
+        rt_interrupt_from_thread = from;
 
     }
 
     // set rt_interrupt_to_thread
-    rt_interrupt_to_thread = *((rt_uint32_t *)(to));
+    rt_interrupt_to_thread = to;
 
     //trigger YIELD exception(cause contex switch)
     TriggerSimulateInterrupt(CPU_INTERRUPT_YIELD);
@@ -310,10 +309,10 @@ void rt_hw_context_switch(rt_uint32_t from,
 * Note(s)     : this function is used to perform the first thread switch
 *********************************************************************************************************
 */
-void rt_hw_context_switch_to(rt_uint32_t to)
+void rt_hw_context_switch_to(rt_ubase_t to)
 {
     //set to thread
-    rt_interrupt_to_thread = *((rt_uint32_t *)(to));
+    rt_interrupt_to_thread = to;
 
     //clear from thread
     rt_interrupt_from_thread = 0;

--- a/libcpu/sim/win32/cpu_port.c
+++ b/libcpu/sim/win32/cpu_port.c
@@ -256,10 +256,10 @@ void rt_hw_context_switch_interrupt(rt_ubase_t from, rt_ubase_t to, rt_thread_t 
         rt_thread_switch_interrupt_flag = 1;
 
         // set rt_interrupt_from_thread
-        rt_interrupt_from_thread = from;
+        rt_interrupt_from_thread = *((rt_ubase_t *)(from));
     }
 
-    rt_interrupt_to_thread = to;
+    rt_interrupt_to_thread = *((rt_ubase_t *)(to));
 
     //trigger YIELD exception(cause context switch)
     TriggerSimulateInterrupt(CPU_INTERRUPT_YIELD);
@@ -274,12 +274,12 @@ void rt_hw_context_switch(rt_ubase_t from, rt_ubase_t to)
         rt_thread_switch_interrupt_flag  = 1;
 
         // set rt_interrupt_from_thread
-        rt_interrupt_from_thread = from;
+        rt_interrupt_from_thread = *((rt_ubase_t *)(from));
 
     }
 
     // set rt_interrupt_to_thread
-    rt_interrupt_to_thread = to;
+    rt_interrupt_to_thread = *((rt_ubase_t *)(to));
 
     //trigger YIELD exception(cause contex switch)
     TriggerSimulateInterrupt(CPU_INTERRUPT_YIELD);
@@ -312,7 +312,7 @@ void rt_hw_context_switch(rt_ubase_t from, rt_ubase_t to)
 void rt_hw_context_switch_to(rt_ubase_t to)
 {
     //set to thread
-    rt_interrupt_to_thread = to;
+    rt_interrupt_to_thread = *((rt_ubase_t *)(to));
 
     //clear from thread
     rt_interrupt_from_thread = 0;

--- a/libcpu/sim/win32/cpu_port.c
+++ b/libcpu/sim/win32/cpu_port.c
@@ -699,14 +699,3 @@ rt_uint32_t YieldInterruptHandle(void)
 
     return 0;
 } /*** YieldInterruptHandle ***/
-
-/* system entry */
-extern int rtthread_startup(void);
-int wmain(int argc, char* argv[])
-{
-    /* disable interrupt first */
-    rt_hw_interrupt_disable();
-    /* startup RT-Thread RTOS */
-    rtthread_startup();
-}
-#pragma comment(linker, "/subsystem:console /entry:wmainCRTStartup")

--- a/libcpu/sim/win32/startup_msvc.c
+++ b/libcpu/sim/win32/startup_msvc.c
@@ -221,33 +221,16 @@ void rt_application_init(void);
 void rt_hw_board_init(void);
 int rtthread_startup(void);
 
-#if defined(__ARMCC_VERSION)
-extern int $Super$$main(void);
-/* re-define main function */
-int $Sub$$main(void)
+/* system entry */
+extern int rtthread_startup(void);
+int wmain(int argc, char* argv[])
 {
+    /* disable interrupt first */
+    rt_hw_interrupt_disable();
+    /* startup RT-Thread RTOS */
     rtthread_startup();
-    return 0;
 }
-#elif defined(__ICCARM__)
-extern int main(void);
-/* __low_level_init will auto called by IAR cstartup */
-extern void __iar_data_init3(void);
-int __low_level_init(void)
-{
-    // call IAR table copy function.
-    __iar_data_init3();
-    rtthread_startup();
-    return 0;
-}
-#elif defined(__GNUC__)
-/* Add -eentry to arm-none-eabi-gcc argument */
-int entry(void)
-{
-    rtthread_startup();
-    return 0;
-}
-#endif
+#pragma comment(linker, "/subsystem:console /entry:wmainCRTStartup")
 
 #ifndef RT_USING_HEAP
 /* if there is not enable heap, we should use static thread and stack. */
@@ -269,15 +252,9 @@ void main_thread_entry(void *parameter)
 #ifdef RT_USING_SMP
     rt_hw_secondary_cpu_up();
 #endif
+
     /* invoke system main function */
-#if defined(__ARMCC_VERSION)
-    {
-        extern int $Super$$main(void);
-        $Super$$main(); /* for ARMCC. */
-    }
-#elif defined(__ICCARM__) || defined(__GNUC__) || defined(__TASKING__) || defined(_MSC_VER)
     main();
-#endif
 }
 
 void rt_application_init(void)

--- a/src/SConscript
+++ b/src/SConscript
@@ -50,9 +50,14 @@ if GetDepend('RT_USING_HOOKLIST') == True:
     elif rtconfig.PLATFORM in ['armcc']:
         LOCAL_CFLAGS += ' --c99 --gnu'
 
-group = DefineGroup('Kernel', src, depend=[''], CPPPATH=inc,
-                    LINKFLAGS=LINKFLAGS, LOCAL_CFLAGS=LOCAL_CFLAGS,
-                    CPPDEFINES=['__RTTHREAD__'], LOCAL_CPPDEFINES=['__RT_KERNEL_SOURCE__'])
+if rtconfig.CROSS_TOOL == 'msvc':
+    group = DefineGroup('Kernel', src, depend=[''], CPPPATH=inc,
+                        LINKFLAGS=LINKFLAGS, LOCAL_CFLAGS=LOCAL_CFLAGS,
+                        CPPDEFINES=['__RTTHREAD__', '__RT_KERNEL_SOURCE__'])
+else:
+    group = DefineGroup('Kernel', src, depend=[''], CPPPATH=inc,
+                        LINKFLAGS=LINKFLAGS, LOCAL_CFLAGS=LOCAL_CFLAGS,
+                        CPPDEFINES=['__RTTHREAD__'], LOCAL_CPPDEFINES=['__RT_KERNEL_SOURCE__'])
 
 list = os.listdir(cwd)
 for item in list:

--- a/src/scheduler_up.c
+++ b/src/scheduler_up.c
@@ -32,6 +32,7 @@
  * 2023-10-17     ChuShicheng  Modify the timing of clearing RT_THREAD_STAT_YIELD flag bits
  */
 
+#define __RT_IPC_SOURCE__
 #include <rtthread.h>
 #include <rthw.h>
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

随着master的升级（主要是finsh中MSH_CMD_EXPORT宏变化影响较大），但是bsp/simulator没有得到同步维护，bsp/simulator无法使用visual studio 2012/2019/2022等进行正常编译。

本次pr主要是修复该问题，使得bsp/simulator可以在vs中进行编译，并运行。

#### 你的解决方案是什么 (what is your solution)

1、finsh.h随着master做了较大更新，但是vs不支持“变维度数组”，因此对以下宏进行了修复
```
#ifdef _MSC_VER
#define CMD_OPTIONS_STATEMENT(command) static struct msh_cmd_opt command##_msh_options[16];
#else
#define CMD_OPTIONS_STATEMENT(command) static struct msh_cmd_opt command##_msh_options[];
#endif

#ifdef _MSC_VER
#define CMD_OPTIONS_NODE_START(command) static struct msh_cmd_opt command##_msh_options[16] = {
#else
#define CMD_OPTIONS_NODE_START(command) static struct msh_cmd_opt command##_msh_options[] = {
#endif
```

2、finsh中MSH_CMD_EXPORT宏机进行了较大变化，导致vs中老版本的c语言无法正确对MSH_CMD_EXPORT宏进行展开，因此需要将`template_vs2012.vcxproj`中添加默认是使用c11版本

```
      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
      <LanguageStandard_C>stdc11</LanguageStandard_C>
    </ClCompile>
```

3、scheduler_up.c文件中使用了`rt_sched_insert_thread`等函数，需要开启`__RT_IPC_SOURCE__`才能正常工作

```
#define __RT_IPC_SOURCE__
#include <rtthread.h>
#include <rthw.h>
```

4、最终在vs2019和2022运行效果如下
![2025-03-16_01-05-37](https://github.com/user-attachments/assets/816c19e4-a198-4e11-a96b-773ee5af799c)




#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: bsp/simulator

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
