### PR TITLE
[bsp][cvitek] fix spi driver build error

### DIFF
--- a/bsp/cvitek/drivers/drv_spi.c
+++ b/bsp/cvitek/drivers/drv_spi.c
@@ -335,7 +335,7 @@ int rt_hw_spi_init(void)
 
     for (rt_size_t i = 0; i < sizeof(_spi_obj) / sizeof(struct _device_spi); i++)
     {
-        _spi_obj[i].base_addr = (rt_ubase_t)DRV_IOREMAP((void *)_spi_obj[i].base_addr, 0x1000);
+        _spi_obj[i].dws.regs = (rt_ubase_t)DRV_IOREMAP((void *)_spi_obj[i].dws.regs, 0x1000);
 
         _spi_obj[i].spi_bus.parent.user_data = (void *)&_spi_obj[i];
         ret = rt_spi_bus_register(&_spi_obj[i].spi_bus, _spi_obj[i].device_name, &_spi_ops);


### PR DESCRIPTION
Build error: 'struct _device_spi' has no member named 'base_addr'

Analyze: the name should be dws.regs

Solution: change base_addr to dws.regs

## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
Fixed #10132 
开启SPI功能后编译错误: 'struct _device_spi' has no member named 'base_addr'

#### 你的解决方案是什么 (what is your solution)

修改变量名，将base_addr重命名为dws.reg

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP: cvitek

- .config:

- action:

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
