### PR TITLE
bsp/simulator: fix issues for Visual Studio project generator

### DIFF
--- a/bsp/simulator/rtconfig.py
+++ b/bsp/simulator/rtconfig.py
@@ -148,3 +148,5 @@ elif PLATFORM == 'cl':
     LPATH = ''
 
     POST_ACTION = ''
+
+    DEVICE = ''


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

I find some issues like the following output mentioned when I use bsp/simulator's Visual Studio project generator:

```
(RTThreadPython) D:\Projects\MobilityOS\rt-thread\bsp\simulator>scons --target=vs2012 -s
Successfully installed VC 14.3, path:C:\Program Files\Microsoft Visual Studio\2022\Community\VC
Successfully installed VC 14.3, path:C:\Program Files\Microsoft Visual Studio\2022\Community\VC
AttributeError: module 'rtconfig' has no attribute 'DEVICE':
  File "D:\Projects\MobilityOS\rt-thread\bsp\simulator\SConstruct", line 81:
    objs = PrepareBuilding(env, RTT_ROOT, has_libcpu=False)
  File "D:\Projects\MobilityOS\rt-thread\tools\building.py", line 407:
    objs.extend(SConscript(Rtt_Root + '/components/SConscript',
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 687:
    return method(*args, **kw)
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 623:
    return _SConscript(self.fs, *files, **subst_kw)
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 281:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "D:\Projects\MobilityOS\rt-thread\components\SConscript", line 15:
    objs = objs + SConscript(os.path.join(item, 'SConscript'))
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 687:
    return method(*args, **kw)
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 623:
    return _SConscript(self.fs, *files, **subst_kw)
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 281:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "D:\Projects\MobilityOS\rt-thread\components\libc\SConscript", line 14:
    objs = objs + SConscript(os.path.join(d, 'SConscript'))
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 687:
    return method(*args, **kw)
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 623:
    return _SConscript(self.fs, *files, **subst_kw)
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 281:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "D:\Projects\MobilityOS\rt-thread\components\libc\compilers\SConscript", line 13:
    objs = objs + SConscript(os.path.join(d, 'SConscript'))
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 687:
    return method(*args, **kw)
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 623:
    return _SConscript(self.fs, *files, **subst_kw)
  File "D:\Projects\MobilityOS\RTThreadPython\Lib\site-packages\SCons\Script\SConscript.py", line 281:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "D:\Projects\MobilityOS\rt-thread\components\libc\compilers\newlib\SConscript", line 8:
    newlib_version = GetNewLibVersion(rtconfig)
  File "D:\Projects\MobilityOS\rt-thread\tools\gcc.py", line 170:
    fn = GetHeader(rtconfig, 'picolibc.h')
  File "D:\Projects\MobilityOS\rt-thread\tools\gcc.py", line 105:
    include_dirs = GetGccDefaultSearchDirs(rtconfig)
  File "D:\Projects\MobilityOS\rt-thread\tools\gcc.py", line 74:
    device_flags = rtconfig.DEVICE.split()

(RTThreadPython) D:\Projects\MobilityOS\rt-thread\bsp\simulator>
```

I do a simple fix to make the generator happy.

Kenji Mouri

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
