### PR TITLE
components: drivers: rtc: add the alarm using local time for calculation

### DIFF
--- a/components/drivers/rtc/Kconfig
+++ b/components/drivers/rtc/Kconfig
@@ -19,6 +19,11 @@ config RT_USING_RTC
             config RT_ALARM_PRIORITY
                 int "priority for alarm thread"
                 default 10
+
+            config RT_ALARM_USING_LOCAL_TIME
+                bool "Using local time for the alarm calculation"
+                default n
+                depends on RT_USING_ALARM
         endif
 
         config RT_USING_SOFT_RTC


### PR DESCRIPTION
- add the alarm using local time for calculation

#### 为什么提交这份PR (why to submit this PR)

rtc的alarm驱动不支持带时区（local time)的时间比较闹钟事件触发

#### 你的解决方案是什么 (what is your solution)

在kconfig中加入使用本地时间的alarm的配置，RT_ALARM_USING_LOCAL_TIME，默认不使能，也就是默认还是UTC时区闹钟。



另外rt_alarm_dump命令加入支持timezone显示，这样比较直观些。

![4e0eab221709821b29904b1713693013](https://github.com/user-attachments/assets/7a1fab96-f20c-4dda-bb78-90b25b9f6ebc)

![44c4631cb1eaac063f82fd8aaf94f34d](https://github.com/user-attachments/assets/2e96fdab-8fb5-4a5a-b8db-da6986363e55)

