### PR TITLE
[pthreads] Fix pthread_cond_timedwait lacks timeout wakeup

### DIFF
--- a/components/libc/posix/pthreads/pthread_cond.c
+++ b/components/libc/posix/pthreads/pthread_cond.c
@@ -367,30 +367,27 @@ rt_err_t _pthread_cond_timedwait(pthread_cond_t *cond,
     }
 
     {
-        register rt_base_t temp;
         struct rt_thread *thread;
 
         /* parameter check */
         RT_ASSERT(sem != RT_NULL);
         RT_ASSERT(rt_object_get_type(&sem->parent.parent) == RT_Object_Class_Semaphore);
 
-        /* disable interrupt */
-        temp = rt_hw_interrupt_disable();
+        rt_enter_critical();
 
         if (sem->value > 0)
         {
             /* semaphore is available */
             sem->value--;
 
-            /* enable interrupt */
-            rt_hw_interrupt_enable(temp);
+            rt_exit_critical();
         }
         else
         {
             /* no waiting, return with timeout */
             if (time == 0)
             {
-                rt_hw_interrupt_enable(temp);
+                rt_exit_critical();
 
                 return -RT_ETIMEOUT;
             }
@@ -434,11 +431,8 @@ rt_err_t _pthread_cond_timedwait(pthread_cond_t *cond,
                     return -RT_ERROR;
                 }
 
-                /* enable interrupt */
-                rt_hw_interrupt_enable(temp);
-
-                /* do schedule */
-                rt_schedule();
+                /* exit critical and do schedule */
+                rt_exit_critical();
 
                 result = thread->error;
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;



并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

修复#10444

#### 你的解决方案是什么 (what is your solution)

原有实现中只是通过`rt_hw_interrupt_disable/enable`进行保护，然而在`rt_timer_control`中会进行`rt_enter/exit_critical`操作，在`rt_exit_critical`时会进行`rt_schedule`发生调度，而这时`rt_timer_start`还未执行，导致超时唤醒丢失
```c
                /* suspend thread */
                rt_thread_suspend(thread);

                /* Only support FIFO */
                rt_list_insert_before(&(sem->parent.suspend_thread), &RT_THREAD_LIST_NODE(thread));

                /**
                rt_ipc_list_suspend(&(sem->parent.suspend_thread),
                                    thread,
                                    sem->parent.parent.flag);
                */

                /* has waiting time, start thread timer */
                if (time > 0)
                {
                    /* reset the timeout of thread timer and start it */
                    rt_timer_control(&(thread->thread_timer),
                                     RT_TIMER_CTRL_SET_TIME,
                                     &time);
                    rt_timer_start(&(thread->thread_timer));
                }
```

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:
qemu-vexpress-a9
<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:
```diff
--- a/bsp/qemu-vexpress-a9/.config
+++ b/bsp/qemu-vexpress-a9/.config
@@ -390,7 +390,8 @@ CONFIG_RT_USING_POSIX_AIO=y
 CONFIG_RT_USING_POSIX_DELAY=y
 CONFIG_RT_USING_POSIX_CLOCK=y
 CONFIG_RT_USING_POSIX_TIMER=y
-# CONFIG_RT_USING_PTHREADS is not set
+CONFIG_RT_USING_PTHREADS=y
+CONFIG_PTHREAD_NUM_MAX=8
 # CONFIG_RT_USING_MODULE is not set
 ```

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:


]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
