### PR TITLE
fix #4286,fifx memory leak when sal_socket failed

### DIFF
--- a/components/net/sal/socket/net_sockets.c
+++ b/components/net/sal/socket/net_sockets.c
@@ -657,12 +657,12 @@ int socket(int domain, int type, int protocol)
         rt_set_errno(-ENOMEM);
         return -1;
     }
+    dfs_vnode_init(d->vnode, FT_SOCKET, dfs_net_get_fops());
 
     /* create socket  and then put it to the dfs_file */
     socket = sal_socket(domain, type, protocol);
     if (socket >= 0)
     {
-        dfs_vnode_init(d->vnode, FT_SOCKET, dfs_net_get_fops());
         d->flags = O_RDWR; /* set flags as read and write */
 
         /* set socket to the data of dfs_file */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 问题描述
发现个内存泄漏的地方，解决特殊情况下出现的内存泄漏问题，将申请的内存直接进行初始化，而不是在其他条件下执行成功才初始化，执行失败不进行初始化直接释放内存，这段内存只有正确初始化之后才会被释放掉，否则不会被释放掉


#### 修改方案
将申请的内存直接进行初始化，而不是在其他条件下执行成功才初始化，执行失败不进行初始化直接释放内存


#### 测试验证
- BSP:rt-thread\bsp\hc32\ev_hc32f4a0_lqfp176

- .config:rt-thread默认配置UDP数量为4

- action:开启超过4个的udp连接，此时sal_socket会执行失败，失败原因是UDP数量不够，失败的时候不会执行dfs_vnode_init初始化函数对申请的vnode内存进行初始化，直接就释放该内存，但是释放该内存的依据是ref_count--为0，未进行初始化的时候，ret_count是个随机值，进行自减极大概率不会变成0，导致这块内存实际上并没有被释放掉


<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
