### PR TITLE
[tools]:修复iar添加宏不完全 

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -825,7 +825,7 @@ def GenTargetProject(program = None):
     if GetOption('target') == 'iar':
         from targets.iar import IARProject, IARVersion
         print("IAR Version: " + IARVersion())
-        IARProject(GetOption('project-name') + '.ewp', Projects)
+        IARProject(Env, GetOption('project-name') + '.ewp', Projects)
         print("IAR project has generated successfully!")
 
     if GetOption('target') == 'vs':
@@ -934,7 +934,7 @@ def EndBuilding(target, program = None):
             if not isinstance(project_path, str) or len(project_path) == 0:
                 project_path = os.path.join(BSP_ROOT, 'rt-studio-project')
             MkDist(program, BSP_ROOT, Rtt_Root, Env, project_name, project_path)
-            child = subprocess.Popen('scons --target=eclipse --project-name="{}"'.format(project_name), 
+            child = subprocess.Popen('scons --target=eclipse --project-name="{}"'.format(project_name),
                                    cwd=project_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
             stdout, stderr = child.communicate()
             need_exit = True

--- a/tools/targets/iar.py
+++ b/tools/targets/iar.py
@@ -77,7 +77,7 @@ def IARWorkspace(target):
     out.write(xml)
     out.close()
 
-def IARProject(target, script):
+def IARProject(env, target, script):
     project_path = os.path.dirname(os.path.abspath(target))
 
     tree = etree.parse('template.ewp')
@@ -86,7 +86,7 @@ def IARProject(target, script):
     out = open(target, 'w')
 
     CPPPATH = []
-    CPPDEFINES = []
+    CPPDEFINES = env.get('CPPDEFINES', [])
     LOCAL_CPPDEFINES = []
     LINKFLAGS = ''
     CFLAGS = ''
@@ -112,9 +112,6 @@ def IARProject(target, script):
         if 'CPPPATH' in group and group['CPPPATH']:
             CPPPATH += group['CPPPATH']
 
-        # get each group's definitions
-        if 'CPPDEFINES' in group and group['CPPDEFINES']:
-            CPPDEFINES += group['CPPDEFINES']
 
         if 'LOCAL_CPPDEFINES' in group and group['LOCAL_CPPDEFINES']:
             LOCAL_CPPDEFINES += group['LOCAL_CPPDEFINES']


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
https://github.com/RT-Thread/rt-thread/pull/10169 把env.Append(CPPDEFINES=['STM32F091xC'])放到了bsp顶层的Sconscript中，但是keil和iar的宏定义是从组里面读取的，所以没有添加到对应型号的宏定义

#10503 
#### 你的解决方案是什么 (what is your solution)

参考#10456

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [X] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [X]  已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [X]  代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [X]  没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [X]  所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [X]  对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [X] 代码是高质量的 Code in this PR is of high quality
- [X] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
