### PR TITLE
[bsp][wch]:适配WCH RISC-V系列uart_v2驱动

### DIFF
--- a/bsp/wch/risc-v/Libraries/ch32_drivers/SConscript
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/SConscript
@@ -10,7 +10,10 @@ if  GetDepend('SOC_RISCV_FAMILY_CH32'):
         src += ['drv_gpio.c']
 
     if GetDepend('BSP_USING_UART'):
-        src += ['drv_usart.c']
+        if GetDepend('RT_USING_SERIAL_V2'):
+            src += ['drv_usart_v2.c']
+        else:
+            src += ['drv_usart.c']
 
     if GetDepend('BSP_USING_ADC'):
         src += ['drv_adc.c']

--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_usart_v2.c
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_usart_v2.c
@@ -1,0 +1,1449 @@
+/*
+ * Copyright (c) 2006-2025, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2025-07-16     CYFS         first version
+ */
+
+#include <rtthread.h>
+#include <rtdevice.h>
+#include "board.h"
+#include "drv_usart_v2.h"
+#ifdef RT_USING_SERIAL_V2
+#if !defined(BSP_USING_UART1) && !defined(BSP_USING_UART2) && !defined(BSP_USING_UART3) && !defined(BSP_USING_UART4) && !defined(BSP_USING_UART5) && !defined(BSP_USING_UART6) && !defined(BSP_USING_UART7) && !defined(BSP_USING_UART8) && !defined(BSP_USING_LPUART1)
+#error "Please define at least one BSP_USING_UARTx"
+/* this driver can be disabled at menuconfig -> RT-Thread Components -> Device Drivers */
+#endif
+
+/******************************* declare ****************************************************************************************** */
+enum
+{
+#ifdef BSP_USING_UART1
+    UART1_INDEX,
+#endif
+#ifdef BSP_USING_UART2
+    UART2_INDEX,
+#endif
+#ifdef BSP_USING_UART3
+    UART3_INDEX,
+#endif
+#ifdef BSP_USING_UART4
+    UART4_INDEX,
+#endif
+#ifdef BSP_USING_UART5
+    UART5_INDEX,
+#endif
+#ifdef BSP_USING_UART6
+    UART6_INDEX,
+#endif
+#ifdef BSP_USING_UART7
+    UART7_INDEX,
+#endif
+#ifdef BSP_USING_UART8
+    UART8_INDEX,
+#endif
+};
+
+
+
+struct DMA_HandleTypeDef
+{
+    DMA_Channel_TypeDef           *Instance; /* DMA registers base address */
+    struct UART_HandleTypeDef *Parent;
+    DMA_InitTypeDef               Init;     /* DMA initialization parameters */
+    rt_uint32_t                dma_rcc;
+    IRQn_Type                  dma_irq;
+    void (*DMA_ITC_Callback)(struct UART_HandleTypeDef *huart) ;/* DMA transfer complete callback */
+    void (*DMA_IE_Callback)(void);  /* DMA error complete callback */
+};
+
+struct UART_HandleTypeDef
+{
+    USART_TypeDef             *Instance; /*!< UART registers base address        */
+    USART_InitTypeDef            Init;     /*!< UART communication parameters      */
+    struct DMA_HandleTypeDef *HDMA_Tx;  /*!< UART Tx DMA handle parameters */
+    struct DMA_HandleTypeDef *HDMA_Rx;  /*!< UART Rx DMA handle parameters */
+};
+
+struct ch32_uart_config
+{
+    const char   *name;
+    USART_TypeDef *Instance;
+    rt_uint32_t   rcc;
+    IRQn_Type     irq_type;
+    GPIO_TypeDef  *tx_port;
+    uint16_t      tx_pin;
+    GPIO_TypeDef  *rx_port;
+    uint16_t      rx_pin;
+};
+
+struct ch32_uart
+{
+    struct UART_HandleTypeDef handle;
+    struct ch32_uart_config   *config;
+#ifdef RT_SERIAL_USING_DMA
+    struct
+    {
+        struct DMA_HandleTypeDef handle;
+        rt_size_t                remaining_cnt;
+    } dma_rx;
+    struct
+    {
+        struct DMA_HandleTypeDef handle;
+    } dma_tx;
+#endif
+    rt_uint16_t             uart_dma_flag;
+    struct rt_serial_device serial;
+};
+/********************************************************************************************************************************** */
+/******************************* funtion ****************************************************************************************** */
+static void     ch32_uart_get_config(void);
+static rt_err_t ch32_configure(struct rt_serial_device *serial, struct serial_configure *cfg);
+static void     NVIC_Set(IRQn_Type irq, FunctionalState state);
+#ifdef RT_SERIAL_USING_DMA
+static void dma_recv_isr(struct rt_serial_device *serial, rt_uint8_t isr_flag);
+static void ch32_uart_dma_config(struct rt_serial_device *serial, rt_ubase_t flag);
+void HAL_UART_TxCpltCallback(struct UART_HandleTypeDef *huart);
+void HAL_UART_RxCpltCallback(struct UART_HandleTypeDef *huart);
+static void HAL_DMA_IRQHandler(struct DMA_HandleTypeDef *hdma);
+#endif
+static void GPIOInit(GPIO_TypeDef* GPIOx, GPIOMode_TypeDef mode, GPIOSpeed_TypeDef speed, uint16_t Pin);
+/********************************************************************************************************************************** */
+/******************************** value ******************************************************************************************* */
+static struct ch32_uart_config uart_config[] =
+{
+#ifdef BSP_USING_UART1
+    {
+        .name = "uart1",
+        .Instance = USART1,
+        .rcc = RCC_APB2Periph_USART1,
+        .irq_type = USART1_IRQn,
+        .tx_port  = GPIOA,
+        .tx_pin   = GPIO_Pin_9,
+        .rx_port  = GPIOA,
+        .rx_pin   = GPIO_Pin_10
+    },
+#endif
+#ifdef BSP_USING_UART2
+    {
+        .name = "uart2",
+        .Instance = USART2,
+        .rcc = RCC_APB1Periph_USART2,
+        .irq_type = USART2_IRQn,
+        .tx_port  = GPIOA,
+        .tx_pin   = GPIO_Pin_2,
+        .rx_port  = GPIOA,
+        .rx_pin   = GPIO_Pin_3
+    },
+#endif
+#ifdef BSP_USING_UART3
+    {
+        .name = "uart3",
+        .Instance = USART3,
+        .rcc = RCC_APB1Periph_USART3,
+        .irq_type = USART3_IRQn,
+        .tx_port  = GPIOB,
+        .tx_pin   = GPIO_Pin_10,
+        .rx_port  = GPIOB,
+        .rx_pin   = GPIO_Pin_11,
+    },
+#endif
+#ifdef BSP_USING_UART4
+    {
+        .name = "uart4",
+        .Instance = UART4,
+        .rcc = RCC_APB1Periph_UART4,
+        .irq_type = UART4_IRQn,
+        .tx_port  = GPIOC,
+        .tx_pin   = GPIO_Pin_10,
+        .rx_port  = GPIOC,
+        .rx_pin   = GPIO_Pin_11,
+    },
+#endif
+#ifdef BSP_USING_UART5
+    {
+        .name = "uart5",
+        .Instance = UART5,
+        .rcc = RCC_APB1Periph_UART5,
+        .irq_type = UART5_IRQn,
+        .tx_port  = GPIOC,
+        .tx_pin   = GPIO_Pin_12,
+        .rx_port  = GPIOD,
+        .rx_pin   = GPIO_Pin_2,
+    },
+#endif
+#ifdef BSP_USING_UART6
+    {
+        .name = "uart6",
+        .Instance = UART6,
+        .rcc = RCC_APB1Periph_UART6,
+        .irq_type = UART6_IRQn,
+        .tx_port  = GPIOC,
+        .tx_pin   = GPIO_Pin_0,
+        .rx_port  = GPIOC,
+        .rx_pin   = GPIO_Pin_1,
+
+    },
+#endif
+#ifdef BSP_USING_UART7
+    {
+        .name = "uart7",
+        .Instance = UART7,
+        .rcc = RCC_APB1Periph_UART7,
+        .irq_type = UART7_IRQn,
+        .tx_port  = GPIOC,
+        .tx_pin   = GPIO_Pin_2,
+        .rx_port  = GPIOC,
+        .rx_pin   = GPIO_Pin_3,
+    },
+#endif
+#ifdef BSP_USING_UART8
+    {
+        .name = "uart8",
+        .Instance = UART8,
+        .rcc = RCC_APB1Periph_UART8,
+        .irq_type = UART8_IRQn,
+        .tx_port  = GPIOC,
+        .tx_pin   = GPIO_Pin_4,
+        .rx_port  = GPIOC,
+        .rx_pin   = GPIO_Pin_5,
+    },
+#endif
+};
+static struct ch32_uart uart_obj[sizeof(uart_config) / sizeof(struct ch32_uart_config)];
+/********************************************************************************************************************************** */
+
+static void GPIOInit(GPIO_TypeDef* GPIOx, GPIOMode_TypeDef mode, GPIOSpeed_TypeDef speed, uint16_t Pin)
+{
+    GPIO_InitTypeDef GPIO_InitStructure;
+    /* Enable the GPIO Clock */
+    if (GPIOx == GPIOA)
+    {
+        RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOA, ENABLE);
+    }
+    else if (GPIOx == GPIOB)
+    {
+        RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOB, ENABLE);
+    }
+    else if (GPIOx == GPIOC)
+    {
+        RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOC, ENABLE);
+    }
+    else if (GPIOx == GPIOD)
+    {
+        RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOD, ENABLE);
+    }
+    else if (GPIOx == GPIOE)
+    {
+        RCC_APB2PeriphClockCmd(RCC_APB2Periph_GPIOE, ENABLE);
+    }
+    /* Configure the GPIO pin */
+    GPIO_InitStructure.GPIO_Pin   = Pin;
+    GPIO_InitStructure.GPIO_Mode  = mode;
+    GPIO_InitStructure.GPIO_Speed = speed;
+    GPIO_Init(GPIOx, &GPIO_InitStructure);
+}
+
+static void ch32_uart_init(struct ch32_uart_config *uart)
+{
+    if (uart->Instance==USART1)
+    {
+        RCC_APB2PeriphClockCmd(uart->rcc, ENABLE);
+    }
+    else
+    {
+        RCC_APB1PeriphClockCmd(uart->rcc, ENABLE);
+    }
+    NVIC_SetPriority(uart->irq_type, 0);
+    GPIOInit(uart->rx_port, GPIO_Mode_IPU, GPIO_Speed_50MHz, uart->rx_pin);
+    GPIOInit(uart->tx_port, GPIO_Mode_AF_PP, GPIO_Speed_50MHz, uart->tx_pin);
+}
+
+static rt_err_t ch32_configure(struct rt_serial_device *serial, struct serial_configure *cfg)
+{
+    struct ch32_uart *uart;
+
+    RT_ASSERT(serial != RT_NULL);
+    RT_ASSERT(cfg != RT_NULL);
+    uart = rt_container_of(serial, struct ch32_uart, serial);
+    ch32_uart_init(uart->config);
+    uart->handle.Init.USART_BaudRate = cfg->baud_rate;
+
+    switch (cfg->data_bits)
+    {
+    case DATA_BITS_8:
+        uart->handle.Init.USART_WordLength = USART_WordLength_8b;
+        break;
+    case DATA_BITS_9:
+        uart->handle.Init.USART_WordLength = USART_WordLength_9b;
+        break;
+
+    default:
+        uart->handle.Init.USART_WordLength = USART_WordLength_8b;
+        ;
+        break;
+    }
+
+    switch (cfg->stop_bits)
+    {
+    case STOP_BITS_1:
+        uart->handle.Init.USART_StopBits = USART_StopBits_1;
+        break;
+    case STOP_BITS_2:
+        uart->handle.Init.USART_StopBits = USART_StopBits_0_5;
+        break;
+    case STOP_BITS_3:
+        uart->handle.Init.USART_StopBits = USART_StopBits_2;
+        break;
+    case STOP_BITS_4:
+        uart->handle.Init.USART_StopBits = USART_StopBits_1_5;
+        break;
+    default:
+        break;
+    }
+
+    switch (cfg->parity)
+    {
+    case PARITY_ODD:
+        uart->handle.Init.USART_Parity = USART_Parity_Odd;
+        break;
+    case PARITY_EVEN:
+        uart->handle.Init.USART_Parity = USART_Parity_Even;
+        break;
+    case PARITY_NONE:
+        uart->handle.Init.USART_Parity = USART_Parity_No;
+        break;
+    default:
+        break;
+    }
+
+    switch (cfg->flowcontrol)
+    {
+    case RT_SERIAL_FLOWCONTROL_NONE:
+        uart->handle.Init.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+        break;
+    case RT_SERIAL_FLOWCONTROL_CTSRTS:
+        uart->handle.Init.USART_HardwareFlowControl = USART_HardwareFlowControl_CTS;
+        break;
+    default:
+        uart->handle.Init.USART_HardwareFlowControl = USART_HardwareFlowControl_None;
+        break;
+    }
+    uart->handle.Init.USART_Mode = USART_Mode_Rx | USART_Mode_Tx;
+    USART_DeInit(uart->handle.Instance);
+    USART_Init(uart->handle.Instance, &uart->handle.Init);
+    USART_Cmd(uart->handle.Instance, ENABLE);
+#ifdef RT_SERIAL_USING_DMA
+    uart->dma_rx.remaining_cnt = serial->config.dma_ping_bufsz;
+#endif
+    return RT_EOK;
+}
+
+/**
+ * @brief  Configures the nested vectored interrupt controller.
+ */
+static void NVIC_Set(IRQn_Type irq, FunctionalState state)
+{
+    if (state == ENABLE)
+    {
+        NVIC_SetPriority(irq, 0);
+        NVIC_EnableIRQ(irq);
+    }
+    else if (state == DISABLE)
+    {
+        NVIC_DisableIRQ(irq);
+    }
+}
+
+static rt_err_t ch32_control(struct rt_serial_device *serial, int cmd, void *arg)
+{
+    struct ch32_uart *uart;
+    rt_ubase_t       ctrl_arg = (rt_ubase_t)arg;
+
+    RT_ASSERT(serial != RT_NULL);
+    uart = rt_container_of(serial, struct ch32_uart, serial);
+    if (ctrl_arg & (RT_DEVICE_FLAG_RX_BLOCKING | RT_DEVICE_FLAG_RX_NON_BLOCKING))
+    {
+        if (uart->uart_dma_flag & RT_DEVICE_FLAG_DMA_RX)
+            ctrl_arg = RT_DEVICE_FLAG_DMA_RX;
+        else
+            ctrl_arg = RT_DEVICE_FLAG_INT_RX;
+    }
+    else if (ctrl_arg & (RT_DEVICE_FLAG_TX_BLOCKING | RT_DEVICE_FLAG_TX_NON_BLOCKING))
+    {
+        if (uart->uart_dma_flag & RT_DEVICE_FLAG_DMA_TX)
+            ctrl_arg = RT_DEVICE_FLAG_DMA_TX;
+        else
+            ctrl_arg = RT_DEVICE_FLAG_INT_TX;
+    }
+
+    switch (cmd)
+    {
+    /* disable interrupt */
+    case RT_DEVICE_CTRL_CLR_INT:
+        NVIC_Set(uart->config->irq_type, DISABLE);
+        if (ctrl_arg & RT_DEVICE_FLAG_INT_RX)
+        {
+            USART_ITConfig(uart->handle.Instance, USART_IT_RXNE, DISABLE);
+        }
+
+        if (ctrl_arg & RT_DEVICE_FLAG_INT_TX)
+        {
+            USART_ITConfig(uart->handle.Instance, USART_IT_TC, DISABLE);
+
+        }
+#ifdef RT_SERIAL_USING_DMA
+        if (ctrl_arg & RT_DEVICE_FLAG_DMA_RX)
+        {
+            NVIC_Set(uart->dma_rx.handle.dma_irq, DISABLE);
+            USART_ITConfig(uart->handle.Instance, USART_IT_IDLE, DISABLE);
+            DMA_DeInit(uart->dma_rx.handle.Instance);
+
+        }
+        else if (ctrl_arg & RT_DEVICE_FLAG_DMA_TX)
+        {
+            NVIC_Set(uart->dma_tx.handle.dma_irq, DISABLE);
+            USART_ITConfig(uart->handle.Instance, USART_IT_TC, DISABLE);
+            USART_ClearFlag(uart->handle.Instance, USART_FLAG_TC);
+            DMA_DeInit(uart->dma_tx.handle.Instance);
+        }
+#endif
+        break;
+
+    case RT_DEVICE_CTRL_CONFIG:
+#ifdef RT_SERIAL_USING_DMA
+        if (ctrl_arg & (RT_DEVICE_FLAG_DMA_RX | RT_DEVICE_FLAG_DMA_TX))
+        {
+            ch32_uart_dma_config(serial, ctrl_arg);
+
+        }
+        else
+            ch32_control(serial, RT_DEVICE_CTRL_SET_INT, (void *)ctrl_arg);
+        break;
+#endif
+    case RT_DEVICE_CTRL_SET_INT:
+        NVIC_Set(uart->config->irq_type, ENABLE);
+        if (ctrl_arg & RT_DEVICE_FLAG_INT_RX)
+        {
+
+            USART_ITConfig(uart->handle.Instance, USART_IT_RXNE, ENABLE);
+            USART_ClearITPendingBit(uart->config->Instance, USART_IT_RXNE);
+            USART_ClearFlag(uart->handle.Instance, USART_FLAG_RXNE);
+        }
+        else if (ctrl_arg & RT_DEVICE_FLAG_INT_TX)
+        {
+            USART_ITConfig(uart->handle.Instance, USART_IT_TC, ENABLE);
+            USART_ClearFlag(uart->handle.Instance, USART_FLAG_TC);
+        }
+        NVIC_Set(uart->config->irq_type, ENABLE);
+        break;
+
+    case RT_DEVICE_CHECK_OPTMODE:
+        if (ctrl_arg & RT_DEVICE_FLAG_DMA_TX)
+            return RT_SERIAL_TX_BLOCKING_NO_BUFFER;
+        else
+            return RT_SERIAL_TX_BLOCKING_BUFFER;
+    case RT_DEVICE_CTRL_CLOSE:
+#ifdef RT_SERIAL_USING_DMA
+        DMA_Cmd(uart->dma_tx.handle.Instance, DISABLE);
+        DMA_Cmd(uart->dma_rx.handle.Instance, DISABLE);
+        NVIC_Set(uart->dma_rx.handle.dma_irq, DISABLE);
+#endif
+        USART_DeInit(uart->handle.Instance);
+        NVIC_Set(uart->config->irq_type, DISABLE);
+        USART_ITConfig(uart->handle.Instance, USART_IT_TC, DISABLE);
+        USART_ITConfig(uart->handle.Instance, USART_IT_RXNE, DISABLE);
+        USART_ITConfig(uart->handle.Instance, USART_IT_IDLE, DISABLE);
+        USART_ITConfig(uart->handle.Instance, USART_IT_RXNE, DISABLE);
+        break;
+    }
+
+    return RT_EOK;
+}
+
+static int ch32_putc(struct rt_serial_device *serial, char c)
+{
+    struct ch32_uart *uart;
+
+    RT_ASSERT(serial != RT_NULL);
+    uart = rt_container_of(serial, struct ch32_uart, serial);
+     while (USART_GetFlagStatus(uart->config->Instance, USART_FLAG_TC) == RESET);
+    uart->config->Instance->DATAR = c;
+/* Transmit Data */
+
+    return 1;
+}
+
+static int ch32_getc(struct rt_serial_device *serial)
+{
+    struct ch32_uart *uart;
+
+    RT_ASSERT(serial != RT_NULL);
+    uart = rt_container_of(serial, struct ch32_uart, serial);
+
+    return (int)(uart->handle.Instance->DATAR & (uint16_t)0xFF);
+}
+
+static rt_ssize_t ch32_transmit(struct rt_serial_device *serial,
+                              rt_uint8_t              *buf,
+                              rt_size_t                size,
+                              rt_uint32_t              tx_flag)
+{
+    struct ch32_uart *uart;
+
+    RT_ASSERT(serial != RT_NULL);
+    RT_ASSERT(buf != RT_NULL);
+    uart = rt_container_of(serial, struct ch32_uart, serial);
+
+#ifdef RT_SERIAL_USING_DMA
+    if (uart->uart_dma_flag & RT_DEVICE_FLAG_DMA_TX)
+    {
+        DMA_Cmd(uart->dma_tx.handle.Instance, DISABLE);
+        uart->dma_tx.handle.Instance->MADDR = (unsigned int)buf;
+        uart->dma_tx.handle.Instance->CNTR = size & 0xFFFF;
+        DMA_Cmd(uart->dma_tx.handle.Instance, ENABLE);
+
+        return size & 0xFFFF;
+    }
+#endif
+
+    return size;
+}
+
+
+/**
+ * Uart common interrupt process. This need add to uart ISR.
+ *
+ * @param serial serial device
+ */
+static void uart_isr(struct rt_serial_device *serial)
+{
+    struct ch32_uart *uart;
+
+    RT_ASSERT(serial != RT_NULL);
+    uart = rt_container_of(serial, struct ch32_uart, serial);
+    /* If the Read data register is not empty and the RXNE interrupt is enabled  （RDR） */
+    if (USART_GetITStatus(uart->handle.Instance, USART_IT_RXNE) != RESET && USART_GetFlagStatus(uart->handle.Instance, USART_FLAG_RXNE) != RESET)
+    {
+        char chr = uart->handle.Instance->DATAR;
+        rt_hw_serial_control_isr(serial, RT_HW_SERIAL_CTRL_PUTC, &chr);
+        rt_hw_serial_isr(serial, RT_SERIAL_EVENT_RX_IND);
+        USART_ClearITPendingBit(uart->config->Instance, USART_IT_RXNE);
+    }
+    /* If the Transmit data register is empty and the TXE interrupt enable is enabled  （TDR）*/
+    else if (USART_GetITStatus(uart->handle.Instance, USART_IT_TXE) != RESET && USART_GetFlagStatus(uart->handle.Instance, USART_FLAG_TXE) != RESET)
+    {
+        rt_uint8_t put_char = 0;
+        if (rt_hw_serial_control_isr(serial, RT_HW_SERIAL_CTRL_GETC, &put_char) == RT_EOK)
+        {
+            USART_SendData(uart->handle.Instance, put_char);
+        }
+         USART_ClearITPendingBit(uart->config->Instance, USART_IT_TXE);
+    }
+    else if (USART_GetITStatus(uart->handle.Instance, USART_IT_TC) != RESET && USART_GetFlagStatus(uart->handle.Instance, USART_FLAG_TC))
+    {
+        /* Clear Transmission complete interrupt flag ( ISR Register ) */
+        USART_ClearITPendingBit(uart->handle.Instance, USART_IT_TC);
+        rt_hw_serial_isr(serial, RT_SERIAL_EVENT_TX_DONE);
+    }
+
+#ifdef RT_SERIAL_USING_DMA
+    else if ((uart->uart_dma_flag) && (USART_GetFlagStatus(uart->handle.Instance, USART_FLAG_IDLE) != RESET)
+             && (USART_GetITStatus(uart->handle.Instance, USART_IT_IDLE) != RESET))
+    {
+        /* clean IDLEF flag */
+        dma_recv_isr(serial, UART_RX_DMA_IT_IDLE_FLAG);
+        USART_ReceiveData(uart->handle.Instance);
+    }
+#endif
+
+}
+
+
+
+#if defined(BSP_USING_UART1)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void USART1_IRQHandler(void) __attribute__((interrupt()));
+#else
+void USART1_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void USART1_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    uart_isr(&(uart_obj[UART1_INDEX].serial));
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART1_RX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA1_Channel5_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA1_Channel5_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA1_Channel5_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART1_INDEX].dma_rx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART1_RX_USING_DMA) */
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART1_TX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA1_Channel4_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA1_Channel4_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA1_Channel4_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART1_INDEX].dma_tx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART1_TX_USING_DMA) */
+#endif /* BSP_USING_UART1 */
+
+#if defined(BSP_USING_UART2)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void USART2_IRQHandler(void) __attribute__((interrupt()));
+#else
+void USART2_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void USART2_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    uart_isr(&(uart_obj[UART2_INDEX].serial));
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART2_RX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA1_Channel6_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA1_Channel6_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA1_Channel6_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART2_INDEX].dma_rx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART2_RX_USING_DMA) */
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART2_TX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA1_Channel7_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA1_Channel7_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA1_Channel7_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART2_INDEX].dma_tx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART2_TX_USING_DMA) */
+#endif /* BSP_USING_UART2 */
+
+#if defined(BSP_USING_UART3)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void USART3_IRQHandler(void) __attribute__((interrupt()));
+#else
+void USART3_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void USART3_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    uart_isr(&(uart_obj[UART3_INDEX].serial));
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART3_RX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA1_Channel3_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA1_Channel3_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA1_Channel3_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART3_INDEX].dma_rx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(BSP_UART_USING_DMA_RX) && defined(BSP_UART3_RX_USING_DMA) */
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART3_TX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA1_Channel2_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA1_Channel2_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA1_Channel2_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART3_INDEX].dma_tx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(BSP_UART_USING_DMA_TX) && defined(BSP_UART3_TX_USING_DMA) */
+#endif /* BSP_USING_UART3*/
+
+#if defined(BSP_USING_UART4)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void UART4_IRQHandler(void) __attribute__((interrupt()));
+#else
+void UART4_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void UART4_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    uart_isr(&(uart_obj[UART4_INDEX].serial));
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART4_RX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA2_Channel3_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA2_Channel3_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA2_Channel3_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART4_INDEX].dma_rx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(BSP_UART_USING_DMA_RX) && defined(BSP_UART4_RX_USING_DMA) */
+
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART4_TX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA2_Channel5_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA2_Channel5_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA2_Channel5_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART4_INDEX].dma_tx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(BSP_UART_USING_DMA_TX) && defined(BSP_UART4_TX_USING_DMA) */
+#endif /* BSP_USING_UART4*/
+
+#if defined(BSP_USING_UART5)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void UART5_IRQHandler(void) __attribute__((interrupt()));
+#else
+void UART5_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void UART5_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    uart_isr(&(uart_obj[UART5_INDEX].serial));
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART5_RX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA2_Channel2_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA2_Channel2_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA2_Channel2_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART5_INDEX].dma_rx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART5_RX_USING_DMA) */
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART5_TX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA2_Channel4_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA2_Channel4_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA2_Channel4_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART5_INDEX].dma_tx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART5_TX_USING_DMA) */
+#endif /* BSP_USING_UART5*/
+
+#if defined(BSP_USING_UART6)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void UART6_IRQHandler(void) __attribute__((interrupt()));
+#else
+void UART6_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void UART6_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    uart_isr(&(uart_obj[UART6_INDEX].serial));
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART6_RX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA2_Channel7_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA2_Channel7_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA2_Channel7_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART6_INDEX].dma_rx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART6_RX_USING_DMA) */
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART6_TX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA2_Channel6_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA2_Channel6_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA2_Channel6_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART6_INDEX].dma_tx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART6_TX_USING_DMA) */
+#endif /* BSP_USING_UART6*/
+
+#if defined(BSP_USING_UART7)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void UART7_IRQHandler(void) __attribute__((interrupt()));
+#else
+void UART7_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void UART7_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    uart_isr(&(uart_obj[UART7_INDEX].serial));
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART7_RX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA2_Channel9_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA2_Channel9_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA2_Channel9_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART7_INDEX].dma_rx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART7_RX_USING_DMA) */
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART7_TX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA2_Channel8_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA2_Channel8_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA2_Channel8_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART7_INDEX].dma_tx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART7_TX_USING_DMA) */
+#endif /* BSP_USING_UART7*/
+
+#if defined(BSP_USING_UART8)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void UART8_IRQHandler(void) __attribute__((interrupt()));
+#else
+void UART8_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void UART8_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    uart_isr(&(uart_obj[UART8_INDEX].serial));
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART8_RX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA2_Channel11_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA2_Channel11_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA2_Channel11_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART8_INDEX].dma_rx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART8_RX_USING_DMA) */
+#if defined(RT_SERIAL_USING_DMA) && defined(BSP_UART8_TX_USING_DMA)
+#if defined (SOC_RISCV_SERIES_CH32V2)
+void DMA2_Channel10_IRQHandler(void) __attribute__((interrupt()));
+#else
+void DMA2_Channel10_IRQHandler(void) __attribute__((interrupt("WCH-Interrupt-fast")));
+#endif
+void DMA2_Channel10_IRQHandler(void)
+{
+    GET_INT_SP();
+    /* enter interrupt */
+    rt_interrupt_enter();
+
+    HAL_DMA_IRQHandler(&uart_obj[UART8_INDEX].dma_tx.handle);
+
+    /* leave interrupt */
+    rt_interrupt_leave();
+    FREE_INT_SP();
+}
+#endif /* defined(RT_SERIAL_USING_DMA) && defined(BSP_UART8_TX_USING_DMA) */
+#endif /* BSP_USING_UART8*/
+static void ch32_uart_get_config(void)
+{
+    struct serial_configure config = RT_SERIAL_CONFIG_DEFAULT;
+
+#ifdef BSP_USING_UART1
+    uart_obj[UART1_INDEX].serial.config          = config;
+    uart_obj[UART1_INDEX].serial.config.rx_bufsz = BSP_UART1_RX_BUFSIZE;
+    uart_obj[UART1_INDEX].serial.config.tx_bufsz = BSP_UART1_TX_BUFSIZE;
+    uart_obj[UART1_INDEX].handle.Instance        = USART1;
+    uart_obj[UART1_INDEX].uart_dma_flag          = 0;
+#ifdef BSP_UART1_RX_USING_DMA
+    uart_obj[UART1_INDEX].handle.HDMA_Rx          = &uart_obj[UART1_INDEX].dma_rx.handle;
+    uart_obj[UART1_INDEX].serial.config.dma_ping_bufsz = BSP_UART1_DMA_PING_BUFSIZE;
+    uart_obj[UART1_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_RX;
+    uart_obj[UART1_INDEX].dma_rx.handle.Parent    = &uart_obj[UART1_INDEX].handle;
+    uart_obj[UART1_INDEX].dma_rx.handle.Instance  = DMA1_Channel5;
+    uart_obj[UART1_INDEX].dma_rx.handle.dma_rcc   = RCC_AHBPeriph_DMA1;
+    uart_obj[UART1_INDEX].dma_rx.handle.dma_irq   = DMA1_Channel5_IRQn;
+#endif
+#ifdef BSP_UART1_TX_USING_DMA
+    uart_obj[UART1_INDEX].handle.HDMA_Tx          = &uart_obj[UART1_INDEX].dma_tx.handle;
+    uart_obj[UART1_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_TX;
+    uart_obj[UART1_INDEX].dma_tx.handle.Parent    = &uart_obj[UART1_INDEX].handle;
+    uart_obj[UART1_INDEX].dma_tx.handle.Instance  = DMA1_Channel4;
+    uart_obj[UART1_INDEX].dma_tx.handle.dma_rcc   = RCC_AHBPeriph_DMA1;
+    uart_obj[UART1_INDEX].dma_tx.handle.dma_irq   = DMA1_Channel4_IRQn;
+#endif
+#endif
+
+#ifdef BSP_USING_UART2
+    uart_obj[UART2_INDEX].serial.config          = config;
+    uart_obj[UART2_INDEX].serial.config.rx_bufsz = BSP_UART2_RX_BUFSIZE;
+    uart_obj[UART2_INDEX].serial.config.tx_bufsz = BSP_UART2_TX_BUFSIZE;
+    uart_obj[UART2_INDEX].handle.Instance        = USART2;
+    uart_obj[UART2_INDEX].uart_dma_flag          = 0;
+#ifdef BSP_UART2_RX_USING_DMA
+    uart_obj[UART2_INDEX].handle.HDMA_Rx          = &uart_obj[UART2_INDEX].dma_rx.handle;
+    uart_obj[UART2_INDEX].serial.config.dma_ping_bufsz = BSP_UART2_DMA_PING_BUFSIZE;
+    uart_obj[UART2_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_RX;
+    uart_obj[UART2_INDEX].dma_rx.handle.Parent    = &uart_obj[UART2_INDEX].handle;
+    uart_obj[UART2_INDEX].dma_rx.handle.DMA_ITC_Callback = HAL_UART_RxCpltCallback;
+    uart_obj[UART2_INDEX].dma_rx.handle.Instance  = DMA1_Channel6;
+    uart_obj[UART2_INDEX].dma_rx.handle.dma_rcc   = RCC_AHBPeriph_DMA1;
+    uart_obj[UART2_INDEX].dma_rx.handle.dma_irq   = DMA1_Channel6_IRQn;
+#endif
+#ifdef BSP_UART2_TX_USING_DMA
+    uart_obj[UART2_INDEX].handle.HDMA_Tx          = &uart_obj[UART2_INDEX].dma_tx.handle;
+    uart_obj[UART2_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_TX;
+    uart_obj[UART2_INDEX].dma_tx.handle.Parent    = &uart_obj[UART2_INDEX].handle;
+    uart_obj[UART2_INDEX].dma_tx.handle.DMA_ITC_Callback = HAL_UART_TxCpltCallback;
+    uart_obj[UART2_INDEX].dma_tx.handle.Instance  = DMA1_Channel7;
+    uart_obj[UART2_INDEX].dma_tx.handle.dma_rcc   = RCC_AHBPeriph_DMA1;
+    uart_obj[UART2_INDEX].dma_tx.handle.dma_irq   = DMA1_Channel7_IRQn;
+#endif
+#endif
+
+#ifdef BSP_USING_UART3
+    uart_obj[UART3_INDEX].serial.config          = config;
+    uart_obj[UART3_INDEX].serial.config.rx_bufsz = BSP_UART3_RX_BUFSIZE;
+    uart_obj[UART3_INDEX].serial.config.tx_bufsz = BSP_UART3_TX_BUFSIZE;
+    uart_obj[UART3_INDEX].handle.Instance        = USART3;
+    uart_obj[UART3_INDEX].uart_dma_flag          = 0;
+#ifdef BSP_UART3_RX_USING_DMA
+    uart_obj[UART3_INDEX].handle.HDMA_Rx          = &uart_obj[UART3_INDEX].dma_rx.handle;
+    uart_obj[UART3_INDEX].serial.config.dma_ping_bufsz = BSP_UART3_DMA_PING_BUFSIZE;
+    uart_obj[UART3_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_RX;
+    uart_obj[UART3_INDEX].dma_rx.handle.Parent    = &uart_obj[UART3_INDEX].handle;
+    uart_obj[UART3_INDEX].dma_rx.handle.DMA_ITC_Callback = HAL_UART_RxCpltCallback;
+    uart_obj[UART3_INDEX].dma_rx.handle.Instance  = DMA1_Channel3;
+    uart_obj[UART3_INDEX].dma_rx.handle.dma_rcc   = RCC_AHBPeriph_DMA1;
+    uart_obj[UART3_INDEX].dma_rx.handle.dma_irq   = DMA1_Channel3_IRQn;
+#endif
+#ifdef BSP_UART3_TX_USING_DMA
+    uart_obj[UART3_INDEX].handle.HDMA_Tx          = &uart_obj[UART3_INDEX].dma_tx.handle;
+    uart_obj[UART3_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_TX;
+    uart_obj[UART3_INDEX].dma_tx.handle.Parent    = &uart_obj[UART3_INDEX].handle;
+    uart_obj[UART3_INDEX].dma_tx.handle.Instance  = DMA1_Channel2;
+    uart_obj[UART3_INDEX].dma_tx.handle.DMA_ITC_Callback = HAL_UART_TxCpltCallback;
+    uart_obj[UART3_INDEX].dma_tx.handle.dma_rcc   = RCC_AHBPeriph_DMA1;
+    uart_obj[UART3_INDEX].dma_tx.handle.dma_irq   = DMA1_Channel2_IRQn;
+#endif
+#endif
+
+#ifdef BSP_USING_UART4
+    uart_obj[UART4_INDEX].serial.config          = config;
+    uart_obj[UART4_INDEX].serial.config.rx_bufsz = BSP_UART4_RX_BUFSIZE;
+    uart_obj[UART4_INDEX].serial.config.tx_bufsz = BSP_UART4_TX_BUFSIZE;
+    uart_obj[UART4_INDEX].handle.Instance        = UART4;
+    uart_obj[UART4_INDEX].uart_dma_flag          = 0;
+#ifdef BSP_UART4_RX_USING_DMA
+    uart_obj[UART4_INDEX].handle.HDMA_Rx          = &uart_obj[UART4_INDEX].dma_rx.handle;
+    uart_obj[UART4_INDEX].serial.config.dma_ping_bufsz = BSP_UART4_DMA_PING_BUFSIZE;
+    uart_obj[UART4_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_RX;
+    uart_obj[UART4_INDEX].dma_rx.handle.Parent    = &uart_obj[UART4_INDEX].handle;
+    uart_obj[UART4_INDEX].dma_rx.handle.DMA_ITC_Callback = HAL_UART_RxCpltCallback;
+    uart_obj[UART4_INDEX].dma_rx.handle.Instance  = DMA2_Channel3;
+    uart_obj[UART4_INDEX].dma_rx.handle.dma_rcc   = RCC_AHBPeriph_DMA2;
+    uart_obj[UART4_INDEX].dma_rx.handle.dma_irq   = DMA2_Channel3_IRQn;
+#endif
+#ifdef BSP_UART4_TX_USING_DMA
+    uart_obj[UART4_INDEX].handle.HDMA_Tx          = &uart_obj[UART4_INDEX].dma_tx.handle;
+    uart_obj[UART4_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_TX;
+    uart_obj[UART4_INDEX].dma_tx.handle.Parent    = &uart_obj[UART4_INDEX].handle;
+    uart_obj[UART4_INDEX].dma_tx.handle.DMA_ITC_Callback = HAL_UART_TxCpltCallback;
+    uart_obj[UART4_INDEX].dma_tx.handle.Instance  = DMA2_Channel5;
+    uart_obj[UART4_INDEX].dma_tx.handle.dma_rcc   = RCC_AHBPeriph_DMA2;
+    uart_obj[UART4_INDEX].dma_tx.handle.dma_irq   = DMA2_Channel5_IRQn;
+#endif
+#endif
+
+#ifdef BSP_USING_UART5
+    uart_obj[UART5_INDEX].serial.config          = config;
+    uart_obj[UART5_INDEX].serial.config.rx_bufsz = BSP_UART5_RX_BUFSIZE;
+    uart_obj[UART5_INDEX].serial.config.tx_bufsz = BSP_UART5_TX_BUFSIZE;
+    uart_obj[UART5_INDEX].handle.Instance        = UART5;
+    uart_obj[UART5_INDEX].uart_dma_flag          = 0;
+#ifdef BSP_UART5_RX_USING_DMA
+    uart_obj[UART5_INDEX].handle.HDMA_Rx          = &uart_obj[UART5_INDEX].dma_rx.handle;
+    uart_obj[UART5_INDEX].serial.config.dma_ping_bufsz = BSP_UART5_DMA_PING_BUFSIZE;
+    uart_obj[UART5_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_RX;
+    uart_obj[UART5_INDEX].dma_rx.handle.Parent    = &uart_obj[UART5_INDEX].handle;
+    uart_obj[UART5_INDEX].dma_rx.handle.DMA_ITC_Callback = HAL_UART_RxCpltCallback;
+    uart_obj[UART5_INDEX].dma_rx.handle.Instance  = DMA2_Channel2;
+    uart_obj[UART5_INDEX].dma_rx.handle.dma_rcc   = RCC_AHBPeriph_DMA2;
+    uart_obj[UART5_INDEX].dma_rx.handle.dma_irq   = DMA2_Channel2_IRQn;
+#endif
+#ifdef BSP_UART5_TX_USING_DMA
+    uart_obj[UART5_INDEX].handle.HDMA_Tx          = &uart_obj[UART5_INDEX].dma_tx.handle;
+    uart_obj[UART5_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_TX;
+    uart_obj[UART5_INDEX].dma_tx.handle.Parent    = &uart_obj[UART5_INDEX].handle;
+    uart_obj[UART5_INDEX].dma_tx.handle.DMA_ITC_Callback = HAL_UART_TxCpltCallback;
+    uart_obj[UART5_INDEX].dma_tx.handle.Instance  = DMA2_Channel4;
+    uart_obj[UART5_INDEX].dma_tx.handle.dma_rcc   = RCC_AHBPeriph_DMA2;
+    uart_obj[UART5_INDEX].dma_tx.handle.dma_irq   = DMA2_Channel4_IRQn;
+#endif
+#endif
+
+#ifdef BSP_USING_UART6
+    uart_obj[UART6_INDEX].serial.config          = config;
+    uart_obj[UART6_INDEX].serial.config.rx_bufsz = BSP_UART6_RX_BUFSIZE;
+    uart_obj[UART6_INDEX].serial.config.tx_bufsz = BSP_UART6_TX_BUFSIZE;
+    uart_obj[UART6_INDEX].handle.Instance        = UART6;
+    uart_obj[UART6_INDEX].uart_dma_flag          = 0;
+#ifdef BSP_UART6_RX_USING_DMA
+    uart_obj[UART6_INDEX].handle.HDMA_Rx          = &uart_obj[UART6_INDEX].dma_rx.handle;
+    uart_obj[UART6_INDEX].serial.config.dma_ping_bufsz = BSP_UART6_DMA_PING_BUFSIZE;
+    uart_obj[UART6_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_RX;
+    uart_obj[UART6_INDEX].dma_rx.handle.Parent    = &uart_obj[UART6_INDEX].handle;
+    uart_obj[UART6_INDEX].dma_rx.handle.DMA_ITC_Callback = HAL_UART_RxCpltCallback;
+    uart_obj[UART6_INDEX].dma_rx.handle.Instance  = DMA2_Channel7;
+    uart_obj[UART6_INDEX].dma_rx.handle.dma_rcc   = RCC_AHBPeriph_DMA2;
+    uart_obj[UART6_INDEX].dma_rx.handle.dma_irq   = DMA2_Channel7_IRQn;
+#endif
+#ifdef BSP_UART6_TX_USING_DMA
+    uart_obj[UART6_INDEX].handle.HDMA_Tx          = &uart_obj[UART6_INDEX].dma_tx.handle;
+    uart_obj[UART6_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_TX;
+    uart_obj[UART6_INDEX].dma_tx.handle.Parent    = &uart_obj[UART6_INDEX].handle;
+    uart_obj[UART6_INDEX].dma_tx.handle.DMA_ITC_Callback = HAL_UART_TxCpltCallback;
+    uart_obj[UART6_INDEX].dma_tx.handle.Instance  = DMA2_Channel6;
+    uart_obj[UART6_INDEX].dma_tx.handle.dma_rcc   = RCC_AHBPeriph_DMA2;
+    uart_obj[UART6_INDEX].dma_tx.handle.dma_irq   = DMA2_Channel6_IRQn;
+#endif
+#endif
+
+#ifdef BSP_USING_UART7
+    uart_obj[UART7_INDEX].serial.config          = config;
+    uart_obj[UART7_INDEX].serial.config.rx_bufsz = BSP_UART7_RX_BUFSIZE;
+    uart_obj[UART7_INDEX].serial.config.tx_bufsz = BSP_UART7_TX_BUFSIZE;
+    uart_obj[UART7_INDEX].handle.Instance        = UART7;
+    uart_obj[UART7_INDEX].uart_dma_flag          = 0;
+#ifdef BSP_UART7_RX_USING_DMA
+    uart_obj[UART7_INDEX].handle.HDMA_Rx          = &uart_obj[UART7_INDEX].dma_rx.handle;
+    uart_obj[UART7_INDEX].serial.config.dma_ping_bufsz = BSP_UART7_DMA_PING_BUFSIZE;
+    uart_obj[UART7_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_RX;
+    uart_obj[UART7_INDEX].dma_rx.handle.Parent    = &uart_obj[UART7_INDEX].handle;
+    uart_obj[UART7_INDEX].dma_rx.handle.DMA_ITC_Callback = HAL_UART_RxCpltCallback;
+    uart_obj[UART7_INDEX].dma_rx.handle.Instance  = DMA2_Channel9;
+    uart_obj[UART7_INDEX].dma_rx.handle.dma_rcc   = RCC_AHBPeriph_DMA2;
+    uart_obj[UART7_INDEX].dma_rx.handle.dma_irq   = DMA2_Channel9_IRQn;
+#endif
+#ifdef BSP_UART7_TX_USING_DMA
+    uart_obj[UART7_INDEX].handle.HDMA_Tx          = &uart_obj[UART7_INDEX].dma_tx.handle;
+    uart_obj[UART7_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_TX;
+    uart_obj[UART7_INDEX].dma_tx.handle.Parent    = &uart_obj[UART7_INDEX].handle;
+    uart_obj[UART7_INDEX].dma_tx.handle.DMA_ITC_Callback = HAL_UART_TxCpltCallback;
+    uart_obj[UART7_INDEX].dma_tx.handle.Instance  = DMA2_Channel8;
+    uart_obj[UART7_INDEX].dma_tx.handle.dma_rcc   = RCC_AHBPeriph_DMA2;
+    uart_obj[UART7_INDEX].dma_tx.handle.dma_irq   = DMA2_Channel8_IRQn;
+#endif
+#endif
+
+#ifdef BSP_USING_UART8
+    uart_obj[UART8_INDEX].serial.config            = config;
+    uart_obj[UART8_INDEX].serial.config.rx_bufsz   = BSP_UART8_RX_BUFSIZE;
+    uart_obj[UART8_INDEX].serial.config.tx_bufsz   = BSP_UART8_TX_BUFSIZE;
+    uart_obj[UART8_INDEX].handle.Instance          = UART8;
+    uart_obj[UART8_INDEX].uart_dma_flag            = 0;
+#ifdef BSP_UART8_RX_USING_DMA
+    uart_obj[UART8_INDEX].handle.HDMA_Rx          = &uart_obj[UART8_INDEX].dma_rx.handle;
+    uart_obj[UART8_INDEX].serial.config.dma_ping_bufsz = BSP_UART8_DMA_PING_BUFSIZE;
+    uart_obj[UART8_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_RX;
+    uart_obj[UART8_INDEX].dma_rx.handle.Parent    = &uart_obj[UART8_INDEX].handle;
+    uart_obj[UART8_INDEX].dma_rx.handle.DMA_ITC_Callback = HAL_UART_RxCpltCallback;
+    uart_obj[UART8_INDEX].dma_rx.handle.Instance  = DMA2_Channel10;
+    uart_obj[UART8_INDEX].dma_rx.handle.dma_rcc   = RCC_AHBPeriph_DMA2;
+    uart_obj[UART8_INDEX].dma_rx.handle.dma_irq   = DMA2_Channel10_IRQn;
+#endif
+#ifdef BSP_UART8_TX_USING_DMA
+    uart_obj[UART8_INDEX].handle.HDMA_Tx          = &uart_obj[UART8_INDEX].dma_tx.handle;
+    uart_obj[UART8_INDEX].uart_dma_flag          |= RT_DEVICE_FLAG_DMA_TX;
+    uart_obj[UART8_INDEX].dma_tx.handle.Parent    = &uart_obj[UART8_INDEX].handle;
+    uart_obj[UART8_INDEX].dma_tx.handle.DMA_ITC_Callback = HAL_UART_TxCpltCallback;
+    uart_obj[UART8_INDEX].dma_tx.handle.Instance  = DMA2_Channel11;
+    uart_obj[UART8_INDEX].dma_tx.handle.dma_rcc   = RCC_AHBPeriph_DMA2;
+    uart_obj[UART8_INDEX].dma_tx.handle.dma_irq   = DMA2_Channel11_IRQn;
+#endif
+#endif
+}
+
+#ifdef RT_SERIAL_USING_DMA
+static void ch32_uart_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
+{
+    struct DMA_HandleTypeDef *DMA_Handle;
+    struct ch32_uart          *uart;
+
+    RT_ASSERT(serial != RT_NULL);
+    RT_ASSERT(flag == RT_DEVICE_FLAG_DMA_TX || flag == RT_DEVICE_FLAG_DMA_RX);
+    uart = rt_container_of(serial, struct ch32_uart, serial);
+    if (RT_DEVICE_FLAG_DMA_RX == flag)
+    {
+        DMA_Handle = &uart->dma_rx.handle;
+    }
+    else /* RT_DEVICE_FLAG_DMA_TX == flag */
+    {
+        DMA_Handle = &uart->dma_tx.handle;
+    }
+
+    RCC_AHBPeriphClockCmd(DMA_Handle->dma_rcc, ENABLE);
+    DMA_DeInit(DMA_Handle->Instance);
+    DMA_Handle->Init.DMA_PeripheralBaseAddr     = (unsigned int)uart->config->Instance + 0x4;
+    DMA_Handle->Init.DMA_PeripheralInc      = DMA_PeripheralInc_Disable;
+    DMA_Handle->Init.DMA_MemoryInc  = DMA_MemoryInc_Enable;
+    DMA_Handle->Init.DMA_PeripheralDataSize = DMA_PeripheralDataSize_Byte;
+    DMA_Handle->Init.DMA_MemoryDataSize    = DMA_MemoryDataSize_Byte;
+    DMA_Handle->Init.DMA_M2M        = DMA_M2M_Disable;
+    if (RT_DEVICE_FLAG_DMA_RX == flag)
+    {
+        rt_uint8_t *ptr = NULL;
+        rt_hw_serial_control_isr(serial, RT_HW_SERIAL_CTRL_GET_DMA_PING_BUF, &ptr);
+        DMA_Handle->Init.DMA_DIR    = DMA_DIR_PeripheralSRC;
+        DMA_Handle->Init.DMA_MemoryBaseAddr      = (unsigned int)ptr;
+        DMA_Handle->Init.DMA_BufferSize      = serial->config.dma_ping_bufsz;
+        DMA_Handle->Init.DMA_Mode = DMA_Mode_Circular;
+        DMA_Handle->Init.DMA_Priority     = DMA_Priority_VeryHigh;
+    }
+    else if (RT_DEVICE_FLAG_DMA_TX == flag)
+    {
+        DMA_Handle->Init.DMA_DIR    = DMA_DIR_PeripheralDST;
+        DMA_Handle->Init.DMA_MemoryBaseAddr      = (unsigned int)1;
+        DMA_Handle->Init.DMA_BufferSize      = 1;
+        DMA_Handle->Init.DMA_Mode = DMA_Mode_Normal;
+        DMA_Handle->Init.DMA_Priority     = DMA_Priority_High;
+    }
+    DMA_Init(DMA_Handle->Instance, &DMA_Handle->Init);
+    NVIC_Set(DMA_Handle->dma_irq, ENABLE);
+    /* Enable USART DMA Rx or TX request */
+    if (RT_DEVICE_FLAG_DMA_RX == flag)
+    {
+        DMA_Cmd(DMA_Handle->Instance, DISABLE);
+        USART_DMACmd(uart->handle.Instance, USART_DMAReq_Rx, ENABLE);
+        USART_ITConfig(uart->handle.Instance, USART_IT_IDLE, ENABLE);
+        USART_ReceiveData(uart->handle.Instance);
+        DMA_ITConfig(DMA_Handle->Instance, DMA_IT_TC, ENABLE);
+        NVIC_Set(uart->config->irq_type, ENABLE);
+        DMA_Cmd(DMA_Handle->Instance, ENABLE);
+    }
+    else if (RT_DEVICE_FLAG_DMA_TX == flag)
+    {
+        USART_DMACmd(uart->handle.Instance, USART_DMAReq_Tx, ENABLE);
+        DMA_ITConfig(uart->dma_tx.handle.Instance, DMA_IT_TC, ENABLE);
+    }
+    USART_Cmd(uart->handle.Instance, ENABLE);
+}
+/**
+  * @brief  Handle DMA interrupt request.
+  * @param  hdma pointer to a DMA_HandleTypeDef structure that contains
+  *               the configuration information for the specified DMA Channel.
+  * @retval None
+  */
+static void HAL_DMA_IRQHandler(struct DMA_HandleTypeDef *hdma)
+{
+    DMA_TypeDef *dmax = RT_NULL;
+    if ((unsigned int)hdma->Instance < DMA2_BASE)
+    {
+        dmax = DMA1;
+    }
+    else
+    {
+        dmax = DMA2;
+    }
+    unsigned int flag_it        = dmax->INTFR;
+    unsigned int channel_offset = ((unsigned int)hdma->Instance - (unsigned int)dmax - 8) / 20;
+    /* Transfer Complete Interrupt management ***********************************/
+    if ((flag_it & 2u << (4 * channel_offset)))
+    {
+        /* Clear the transfer complete flag */
+        dmax->INTFCR |= 2u << (4 * channel_offset);
+        struct ch32_uart *uart = (struct ch32_uart *)hdma->Parent;
+        /* Call the transfer complete callback */
+        if (hdma->DMA_ITC_Callback != RT_NULL)
+        {
+            hdma->DMA_ITC_Callback(&uart->handle);
+        }
+
+    }
+
+    if(flag_it & (8u << (4 * channel_offset)))
+    {
+        rt_kprintf("DMA error: %d\n", flag_it & (8u << (4 * channel_offset)));
+        dmax->INTFCR |= 8u << (4 * channel_offset);
+    }
+
+
+
+}
+
+static void dma_recv_isr(struct rt_serial_device *serial, rt_uint8_t isr_flag)
+{
+    struct ch32_uart *uart;
+    rt_base_t        level;
+    rt_size_t        recv_len, counter;
+
+    RT_ASSERT(serial != RT_NULL);
+    uart     = rt_container_of(serial, struct ch32_uart, serial);
+    recv_len = 0;
+    counter = uart->dma_rx.handle.Instance->CNTR;
+
+    switch (isr_flag)
+    {
+    case UART_RX_DMA_IT_IDLE_FLAG:
+        if (counter <= uart->dma_rx.remaining_cnt)
+            recv_len = uart->dma_rx.remaining_cnt - counter;
+        else
+            recv_len = serial->config.dma_ping_bufsz + uart->dma_rx.remaining_cnt - counter;
+
+        break;
+    case UART_RX_DMA_IT_HT_FLAG:
+        if (counter < uart->dma_rx.remaining_cnt)
+            recv_len = uart->dma_rx.remaining_cnt - counter;
+        else
+            recv_len = 0;
+        break;
+    case UART_RX_DMA_IT_TC_FLAG:
+        recv_len = uart->dma_rx.remaining_cnt;
+        break;
+
+    default:
+        recv_len = 0;
+        break;
+    }
+
+    if (recv_len)
+    {
+        uart->dma_rx.remaining_cnt = counter;
+
+        rt_hw_serial_isr(serial, RT_SERIAL_EVENT_RX_DMADONE | (recv_len << 8));
+    }
+
+
+}
+
+void HAL_UART_TxCpltCallback(struct UART_HandleTypeDef *huart)
+{
+    RT_ASSERT(huart != NULL);
+    struct ch32_uart *uart = (struct ch32_uart *)huart;
+
+    rt_hw_serial_isr(&uart->serial, RT_SERIAL_EVENT_TX_DMADONE);
+}
+
+void HAL_UART_RxCpltCallback(struct UART_HandleTypeDef *huart)
+{
+    struct ch32_uart *uart;
+    RT_ASSERT(huart != NULL);
+    uart = (struct ch32_uart *)huart;
+    dma_recv_isr(&uart->serial, UART_RX_DMA_IT_TC_FLAG);
+}
+#endif /* RT_SERIAL_USING_DMA */
+
+static const struct rt_uart_ops ch32_uart_ops =
+{
+    .configure = ch32_configure,
+    .control   = ch32_control,
+    .putc      = ch32_putc,
+    .getc      = ch32_getc,
+    .transmit  = ch32_transmit
+};
+
+int rt_hw_usart_init(void)
+{
+    rt_err_t  result  = 0;
+    rt_size_t obj_num = sizeof(uart_obj) / sizeof(struct ch32_uart);
+
+    ch32_uart_get_config();
+    for (int i = 0; i < obj_num; i++)
+    {
+        uart_obj[i].config = &uart_config[i];
+        /* init UART object */
+        uart_obj[i].serial.ops = &ch32_uart_ops;
+        /* register UART device */
+        rt_hw_serial_register(&uart_obj[i].serial, uart_obj[i].config->name, RT_DEVICE_FLAG_RDWR | RT_DEVICE_FLAG_INT_RX | RT_DEVICE_FLAG_DMA_RX | RT_DEVICE_FLAG_INT_TX | RT_DEVICE_FLAG_DMA_TX, NULL);
+        RT_ASSERT(result == RT_EOK);
+    }
+
+    return result;
+}
+
+#endif /* RT_USING_SERIAL_V2 */
+

--- a/bsp/wch/risc-v/Libraries/ch32_drivers/drv_usart_v2.h
+++ b/bsp/wch/risc-v/Libraries/ch32_drivers/drv_usart_v2.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2006-2025, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2025-07-16     CYFS         first version
+ */
+
+#ifndef __DRV_USART_V2_H__
+#define __DRV_USART_V2_H__
+
+#include <rtthread.h>
+#include <rtdevice.h>
+#include <rthw.h>
+
+#define __HAL_LINKDMA(__HANDLE__, __PPP_DMA_FIELD__, __DMA_HANDLE__)               \
+        do{                                                        \
+                (__HANDLE__)->__PPP_DMA_FIELD__ = &(__DMA_HANDLE__); \
+                (__DMA_HANDLE__).Parent = (__HANDLE__);             \
+            } while(0U)
+#define UART_RX_DMA_IT_IDLE_FLAG        0x00
+#define UART_RX_DMA_IT_HT_FLAG          0x01
+#define UART_RX_DMA_IT_TC_FLAG          0x02
+
+#endif  /* __DRV_USART_V2_H__ */
+

--- a/bsp/wch/risc-v/ch32v307v-r1/board/Kconfig
+++ b/bsp/wch/risc-v/ch32v307v-r1/board/Kconfig
@@ -51,37 +51,267 @@ menu "On-chip Peripheral Drivers"
         default n
 
         if BSP_USING_UART
-            config BSP_USING_UART1
+            menuconfig BSP_USING_UART1
                 bool "Enable UART1"
                 default n
+                if BSP_USING_UART1
+                    config BSP_UART1_RX_USING_DMA
+                        bool "Enable UART1 RX DMA"
+                        depends on BSP_USING_UART1 && RT_SERIAL_USING_DMA
+                        default n
 
-            config BSP_USING_UART2
+                    config BSP_UART1_TX_USING_DMA
+                        bool "Enable UART1 TX DMA"
+                        depends on BSP_USING_UART1 && RT_SERIAL_USING_DMA
+                        default n
+
+                    config BSP_UART1_RX_BUFSIZE
+                        int "Set UART1 RX buffer size"
+                        range 64 65535
+                        depends on BSP_USING_UART1
+                        default 256
+
+                    config BSP_UART1_TX_BUFSIZE
+                        int "Set UART1 TX buffer size"
+                        range 0 65535
+                        depends on BSP_USING_UART1
+                        default 0
+
+                    config BSP_UART1_DMA_PING_BUFSIZE
+                        int "Set UART1 RX DMA ping-pong buffer size"
+                        range 32 65535
+                        depends on RT_USING_SERIAL_V2 && BSP_UART1_RX_USING_DMA
+                        default 64
+                endif
+            menuconfig BSP_USING_UART2
                 bool "Enable UART2"
                 default n
+                if BSP_USING_UART2
+                    config BSP_UART2_RX_USING_DMA
+                        bool "Enable UART2 RX DMA"
+                        depends on BSP_USING_UART2 && RT_SERIAL_USING_DMA
+                        default n
 
-            config BSP_USING_UART3
+                    config BSP_UART2_TX_USING_DMA
+                        bool "Enable UART2 TX DMA"
+                        depends on BSP_USING_UART2 && RT_SERIAL_USING_DMA
+                        default n
+
+                    config BSP_UART2_RX_BUFSIZE
+                        int "Set UART2 RX buffer size"
+                        range 64 65535
+                        depends on BSP_USING_UART2
+                        default 256
+
+                    config BSP_UART2_TX_BUFSIZE
+                        int "Set UART2 TX buffer size"
+                        range 0 65535
+                        depends on BSP_USING_UART2
+                        default 0
+
+                    config BSP_UART2_DMA_PING_BUFSIZE
+                        int "Set UART2 RX DMA ping-pong buffer size"
+                        range 32 65535
+                        depends on RT_USING_SERIAL_V2 && BSP_UART2_RX_USING_DMA
+                        default 64
+                endif
+            menuconfig BSP_USING_UART3
                 bool "Enable UART3"
                 default n
+                if BSP_USING_UART3
+                    config BSP_UART3_RX_USING_DMA
+                        bool "Enable UART3 RX DMA"
+                        depends on BSP_USING_UART3 && RT_SERIAL_USING_DMA
+                        default n
 
-            config BSP_USING_UART4
+                    config BSP_UART3_TX_USING_DMA
+                        bool "Enable UART3 TX DMA"
+                        depends on BSP_USING_UART3 && RT_SERIAL_USING_DMA
+                        default n
+
+                    config BSP_UART3_RX_BUFSIZE
+                        int "Set UART3 RX buffer size"
+                        range 64 65535
+                        depends on BSP_USING_UART3
+                        default 256
+
+                    config BSP_UART3_TX_BUFSIZE
+                        int "Set UART3 TX buffer size"
+                        range 0 65535
+                        depends on BSP_USING_UART3
+                        default 0
+
+                    config BSP_UART3_DMA_PING_BUFSIZE
+                        int "Set UART3 RX DMA ping-pong buffer size"
+                        range 32 65535
+                        depends on RT_USING_SERIAL_V2 && BSP_UART3_RX_USING_DMA
+                        default 64
+                endif
+
+            menuconfig BSP_USING_UART4
                 bool "Enable UART4"
                 default n
+                if BSP_USING_UART4
+                    config BSP_UART4_RX_USING_DMA
+                        bool "Enable UART4 RX DMA"
+                        depends on BSP_USING_UART4 && RT_SERIAL_USING_DMA
+                        default n
 
-            config BSP_USING_UART5
+                    config BSP_UART4_TX_USING_DMA
+                        bool "Enable UART4 TX DMA"
+                        depends on BSP_USING_UART4 && RT_SERIAL_USING_DMA
+                        default n
+
+                    config BSP_UART4_RX_BUFSIZE
+                        int "Set UART4 RX buffer size"
+                        range 64 65535
+                        depends on BSP_USING_UART4
+                        default 256
+
+                    config BSP_UART4_TX_BUFSIZE
+                        int "Set UART4 TX buffer size"
+                        range 0 65535
+                        depends on BSP_USING_UART4
+                        default 0
+
+                    config BSP_UART4_DMA_PING_BUFSIZE
+                        int "Set UART4 RX DMA ping-pong buffer size"
+                        range 32 65535
+                        depends on RT_USING_SERIAL_V2 && BSP_UART4_RX_USING_DMA
+                        default 64
+                endif
+
+            menuconfig BSP_USING_UART5
                 bool "Enable UART5"
                 default n
+                if BSP_USING_UART5
+                    config BSP_UART5_RX_USING_DMA
+                        bool "Enable UART5 RX DMA"
+                        depends on BSP_USING_UART5 && RT_SERIAL_USING_DMA
+                        default n
 
-            config BSP_USING_UART6
+                    config BSP_UART5_TX_USING_DMA
+                        bool "Enable UART5 TX DMA"
+                        depends on BSP_USING_UART5 && RT_SERIAL_USING_DMA
+                        default n
+
+                    config BSP_UART5_RX_BUFSIZE
+                        int "Set UART5 RX buffer size"
+                        range 64 65535
+                        depends on BSP_USING_UART5
+                        default 256
+
+                    config BSP_UART5_TX_BUFSIZE
+                        int "Set UART5 TX buffer size"
+                        range 0 65535
+                        depends on BSP_USING_UART5
+                        default 0
+
+                    config BSP_UART5_DMA_PING_BUFSIZE
+                        int "Set UART5 RX DMA ping-pong buffer size"
+                        range 32 65535
+                        depends on RT_USING_SERIAL_V2 && BSP_UART5_RX_USING_DMA
+                        default 64
+                endif
+
+            menuconfig BSP_USING_UART6
                 bool "Enable UART6"
                 default n
+                if BSP_USING_UART6
+                    config BSP_UART6_RX_USING_DMA
+                        bool "Enable UART6 RX DMA"
+                        depends on BSP_USING_UART6 && RT_SERIAL_USING_DMA
+                        default n
 
-            config BSP_USING_UART7
+                    config BSP_UART6_TX_USING_DMA
+                        bool "Enable UART6 TX DMA"
+                        depends on BSP_USING_UART6 && RT_SERIAL_USING_DMA
+                        default n
+
+                    config BSP_UART6_RX_BUFSIZE
+                        int "Set UART6 RX buffer size"
+                        range 64 65535
+                        depends on BSP_USING_UART6
+                        default 256
+
+                    config BSP_UART6_TX_BUFSIZE
+                        int "Set UART6 TX buffer size"
+                        range 0 65535
+                        depends on BSP_USING_UART6
+                        default 0
+
+                    config BSP_UART6_DMA_PING_BUFSIZE
+                        int "Set UART6 RX DMA ping-pong buffer size"
+                        range 32 65535
+                        depends on RT_USING_SERIAL_V2 && BSP_UART6_RX_USING_DMA
+                        default 64
+                endif
+
+            menuconfig BSP_USING_UART7
                 bool "Enable UART7"
                 default n
+                if BSP_USING_UART7
+                    config BSP_UART7_RX_USING_DMA
+                        bool "Enable UART7 RX DMA"
+                        depends on BSP_USING_UART7 && RT_SERIAL_USING_DMA
+                        default n
 
-            config BSP_USING_UART8
+                    config BSP_UART7_TX_USING_DMA
+                        bool "Enable UART7 TX DMA"
+                        depends on BSP_USING_UART7 && RT_SERIAL_USING_DMA
+                        default n
+
+                    config BSP_UART7_RX_BUFSIZE
+                        int "Set UART7 RX buffer size"
+                        range 64 65535
+                        depends on BSP_USING_UART7
+                        default 256
+
+                    config BSP_UART7_TX_BUFSIZE
+                        int "Set UART7 TX buffer size"
+                        range 0 65535
+                        depends on BSP_USING_UART7
+                        default 0
+
+                    config BSP_UART7_DMA_PING_BUFSIZE
+                        int "Set UART7 RX DMA ping-pong buffer size"
+                        range 32 65535
+                        depends on RT_USING_SERIAL_V2 && BSP_UART7_RX_USING_DMA
+                        default 64
+                endif
+
+            menuconfig BSP_USING_UART8
                 bool "Enable UART8"
                 default n
+                if BSP_USING_UART8
+                    config BSP_UART8_RX_USING_DMA
+                        bool "Enable UART8 RX DMA"
+                        depends on BSP_USING_UART8 && RT_SERIAL_USING_DMA
+                        default n
+
+                    config BSP_UART8_TX_USING_DMA
+                        bool "Enable UART8 TX DMA"
+                        depends on BSP_USING_UART8 && RT_SERIAL_USING_DMA
+                        default n
+
+                    config BSP_UART8_RX_BUFSIZE
+                        int "Set UART8 RX buffer size"
+                        range 64 65535
+                        depends on BSP_USING_UART8
+                        default 256
+
+                    config BSP_UART8_TX_BUFSIZE
+                        int "Set UART8 TX buffer size"
+                        range 0 65535
+                        depends on BSP_USING_UART8
+                        default 0
+
+                    config BSP_UART8_DMA_PING_BUFSIZE
+                        int "Set UART8 RX DMA ping-pong buffer size"
+                        range 32 65535
+                        depends on RT_USING_SERIAL_V2 && BSP_UART8_RX_USING_DMA
+                        default 64
+                endif
         endif
 
     menuconfig BSP_USING_ADC


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
为WCH RISC系列适配串口V2驱动

#### 你的解决方案是什么 (what is your solution)
目前已经使用测试代码,在ch32v307v-r1测试
``` C
#include <board.h>
#include <rtthread.h>
#include <rtdevice.h>

#define echo_test_buffer_size (1024)
// 测试环境
// 串口2、3开启dma, 5、6不开启
// 缓冲区大小都为 128 字节

// echo test
// 3tx - 6rx
// 3rx - 6tx

// self test
// 2tx - 2rx
// 5tx - 5rx

static rt_device_t u2serial;
static rt_device_t u3serial;
static rt_device_t u5serial;
static rt_device_t u6serial;

static rt_uint32_t u2rx_length = 0;
static rt_uint32_t u2tx_length = 0;

static rt_uint32_t u3rx_length = 0;
static rt_uint32_t u3tx_length = 0;

static rt_uint32_t u5rx_length = 0;
static rt_uint32_t u5tx_length = 0;

static rt_uint32_t u6rx_length = 0;
static rt_uint32_t u6tx_length = 0;

static void echo_test_u3_thread_entry(void *parameter)
{
    char *uart_name = "uart3";
    static char rx_buffer[echo_test_buffer_size + 1];

    /* 查找串口设备 */
    u3serial = rt_device_find(uart_name);
    if (!u3serial)
    {
        rt_kprintf("find %s failed!\n", uart_name);
        return;
    }

    rt_device_open(u3serial, RT_DEVICE_FLAG_RX_BLOCKING | RT_DEVICE_FLAG_TX_BLOCKING);

    rt_ssize_t buf_datalen = 0;
    while (1)
    {
        rt_device_control(u3serial, RT_SERIAL_CTRL_GET_UNREAD_BYTES_COUNT, (void *)&buf_datalen);
        int32_t recbLen = rt_device_read(u3serial, 0, rx_buffer, buf_datalen > 0 ? buf_datalen : 1);
        if (recbLen > 0)
        {
            u3rx_length += recbLen;
            u3tx_length += rt_device_write(u3serial, 0, rx_buffer, recbLen);
        }
    }
}

static void echo_test_u6_thread_entry(void *parameter)
{
    static char rx_buffer[echo_test_buffer_size + 1];
    rt_ssize_t buf_datalen = 0;
    while (1)
    {
        rt_device_control(u6serial, RT_SERIAL_CTRL_GET_UNREAD_BYTES_COUNT, (void *)&buf_datalen);
        int32_t recbLen = rt_device_read(u6serial, 0, rx_buffer, buf_datalen > 0 ? buf_datalen : 1);
        if (recbLen > 0)
        {
            u6rx_length += recbLen;
        }
    }
}

static void echo_test(void *parameter)
{
    static char tx_buffer[echo_test_buffer_size];

    for (uint32_t i = 0; i < sizeof(tx_buffer); i++)
        tx_buffer[i] = i;

    char *uart_name = "uart6";
    u6serial = rt_device_find(uart_name);
    if (!u6serial)
    {
        rt_kprintf("find %s failed!\n", uart_name);
        return;
    }

    rt_device_open(u6serial, RT_DEVICE_FLAG_RX_BLOCKING | RT_DEVICE_FLAG_TX_BLOCKING);

    rt_thread_startup(rt_thread_create("serial3", echo_test_u3_thread_entry, RT_NULL, 2048, 7, 5));
    rt_thread_startup(rt_thread_create("serial6", echo_test_u6_thread_entry, RT_NULL, 2048, 7, 5));

    uint32_t count = 0;
    uint32_t sendTotalCount = 0;
    while (1)
    {
        count++;

        // 不定长发送数据
        uint32_t sendCount = rand() % echo_test_buffer_size;
        u6tx_length += rt_device_write(u6serial, 0, tx_buffer, sendCount);
        sendTotalCount += sendCount;

        // 等待交叉发送完毕
        rt_thread_mdelay(15);

        if (count % 100 == 0)
        {
            srand(rt_tick_get());
            rt_kprintf("echo, uart3: tx: %ld, rx: %ld\r\n", u3tx_length, u3rx_length);
            rt_kprintf("echo, uart6: tx: %ld, rx: %ld\r\n", u6tx_length, u6rx_length);
            if (u3tx_length != u3rx_length || u6tx_length != u6rx_length || u3tx_length != u6tx_length)
            {
                rt_kprintf("echo test error!!!\r\n");
                return;
            }

            // 前面已经判断过4个值是否相等了
            if (u3tx_length != sendTotalCount)
            {
                rt_kprintf("发送数据不对等，echo test error!!!\r\n");
                return;
            }
        }
    }
}

static void self_tx_rx_u2_thread_entry(void *parameter)
{
    static char rx_buffer[1024 + 1];
    rt_ssize_t size;
    int count = 0;
    while (1)
    {
         size = rt_device_read(u2serial, 0, rx_buffer, 1000);

        u2rx_length += size;
    }
}

static void self_tx_rx_u5_thread_entry(void *parameter)
{
    static char rx_buffer[1024 + 1];

    while (1)
    {
        u5rx_length += rt_device_read(u5serial, 0, rx_buffer, 500);
    }
}

/**
 * @brief 测试思路,创建u2和u5线程接收自己的数据并记录接收长度，在当前线程u2和u5发送数据，等待数据发送完毕，判断发送数据长度和接收数据长度是否一致
 *
 * @param parameter
 */
static void self_tx_rx_test(void *parameter)
{
    static char tx_buffer[1024 + 1];
    for (uint32_t i = 0; i < sizeof(tx_buffer); i++)
        tx_buffer[i] = i;

    char *uart_name = "uart2";
    u2serial = rt_device_find(uart_name);
    if (!u2serial)
    {
        rt_kprintf("find %s failed!\n", uart_name);
        return;
    }
    rt_device_open(u2serial, RT_DEVICE_FLAG_RX_BLOCKING | RT_DEVICE_FLAG_TX_BLOCKING);

    char *uart5_name = "uart5";
    u5serial = rt_device_find(uart5_name);
    if (!u5serial)
    {
        rt_kprintf("find %s failed!\n", uart5_name);
        return;
    }
    rt_device_open(u5serial, RT_DEVICE_FLAG_RX_BLOCKING | RT_DEVICE_FLAG_TX_BLOCKING);

    rt_thread_startup(rt_thread_create("serial2", self_tx_rx_u2_thread_entry, RT_NULL, 2048, 6, 5));
    rt_thread_startup(rt_thread_create("serial5", self_tx_rx_u5_thread_entry, RT_NULL, 2048, 6, 5));

    for (uint32_t i = 0;; i++)
    {
        u2tx_length += rt_device_write(u2serial, 0, tx_buffer, 1000);
        u5tx_length += rt_device_write(u5serial, 0, tx_buffer, 500);

        rt_device_control(u2serial, RT_SERIAL_CTRL_TX_FLUSH, RT_NULL);
        rt_device_control(u5serial, RT_SERIAL_CTRL_TX_FLUSH, RT_NULL);

        // rt_thread_mdelay(10);

        if (i % 100 == 0)
        {
            rt_kprintf("self_test, uart2: tx: %ld, rx: %ld\r\n", u2tx_length, u2rx_length);
            rt_kprintf("self_test, uart5: tx: %ld, rx: %ld\r\n", u5tx_length, u5rx_length);
            if (u2tx_length != u2rx_length || u5tx_length != u5rx_length)
            {
                rt_kprintf("self test error!!!\r\n");
                return;
            }

            if (u5rx_length * 2 != u2rx_length)
            {
                rt_kprintf("数据不等长 self test error!!!\r\n");
                return;
            }
        }
    }
}

//
// uart_blocking_rx
// uart_blocking_tx
// testcases.drivers.uart_flush_rx
// testcases.drivers.uart_flush_txb
// testcases.drivers.uart_flush_txnb
// testcases.drivers.uart_get_unread_bytes_count
// uart_nonblocking_rx
// uart_nonblocking_tx
// testcases.drivers.uart_overflow_rxb_txb
// testcases.drivers.uart_rxb_txb
// testcases.drivers.uart_rxb_txnb
// testcases.drivers.uart_rxnb_txb
// testcases.drivers.uart_rxnb_txnb
// testcases.drivers.uart_timeout_rxb_txb

static int uart_test(void)
{
    rt_thread_startup(rt_thread_create("echo_test", echo_test, RT_NULL, 2048, 10, 5));

    rt_thread_startup(rt_thread_create("self_test", self_tx_rx_test, RT_NULL, 2048, 10, 5));
    return 0;
}

MSH_CMD_EXPORT_ALIAS(uart_test, uart_test, uart test);
```
<img width="972" height="1241" alt="ret" src="https://github.com/user-attachments/assets/3932bc85-7156-43bc-b645-36820b8aebee" />


#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
