### PR TITLE
feat(riscv64): add support for restartable system calls

### DIFF
--- a/components/lwp/arch/risc-v/rv64/lwp_gcc.S
+++ b/components/lwp/arch/risc-v/rv64/lwp_gcc.S
@@ -98,6 +98,25 @@ ret_to_user_exit:
     // `RESTORE_ALL` also reset sp to user sp, and setup sscratch
     sret
 
+.global arch_syscall_restart
+arch_syscall_restart:
+    /* discard kernel context by moving stack pointer */
+    addi sp, sp, CTX_REG_NR * REGBYTES
+
+    /* store kernel stack pointer in exception frame (a0 points to frame) */
+    STORE sp, FRAME_OFF_SP(a0)
+
+    /* switch to user exception frame */
+    mv sp, a0
+
+    /* restore all user registers from exception frame (except sp) */
+    RESTORE_ALL
+
+    /* exchange sp and sscratch */
+    csrrw sp, sscratch, sp
+
+    j trap_entry
+
 /**
  * Restore user context from exception frame stroraged in ustack
  * And handle pending signals;

--- a/libcpu/risc-v/common64/syscall_c.c
+++ b/libcpu/risc-v/common64/syscall_c.c
@@ -54,8 +54,8 @@ void syscall_handler(struct rt_hw_stack_frame *regs)
 
     LOG_I("[0x%lx] %s(0x%lx, 0x%lx, 0x%lx, 0x%lx, 0x%lx, 0x%lx, 0x%lx)", rt_thread_self(), syscall_name,
         regs->a0, regs->a1, regs->a2, regs->a3, regs->a4, regs->a5, regs->a6);
+    regs->t0 = regs->a0;
     regs->a0 = syscallfunc(regs->a0, regs->a1, regs->a2, regs->a3, regs->a4, regs->a5, regs->a6);
-    regs->a7 = 0;
     regs->epc += 4; // skip ecall instruction
     LOG_I("[0x%lx] %s ret: 0x%lx", rt_thread_self(), syscall_name, regs->a0);
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
参考aarch64 架构下的系统调用重启实现riscv64架构下的系统调用重启
[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)


#### 你的解决方案是什么 (what is your solution)

在 RISC-V64 架构中，当支持重启的系统调用被信号中断后，内核会在信号处理完成后，在执行 arch_signal_quit 时，恢复用户态保存的异常帧（exception frame），还原寄存器状态。随后，内核将执行流重定向至陷阱处理入口 trap_entry，让系统调用以与首次执行一致的方式重启。

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
