### PR TITLE
doxygen: fix duplicated defgroup for clock

### DIFF
--- a/components/drivers/clk/clk.c
+++ b/components/drivers/clk/clk.c
@@ -14,10 +14,7 @@
 #include <rtdevice.h>
 
 /**
- * @defgroup    group_clk clk
- * @brief       clk driver api
- * @ingroup     group_device_driver
- * @addtogroup  group_clk
+ * @addtogroup group_driver_clock
  * @{
  */
 

--- a/components/drivers/include/drivers/clk.h
+++ b/components/drivers/include/drivers/clk.h
@@ -18,10 +18,13 @@
 #include <drivers/ofw.h>
 
 /**
- * @defgroup    group_clk clk
- * @brief       clk driver api
+ * @defgroup    group_driver_clock Clock
+ * @brief       Clock driver API
  * @ingroup     group_device_driver
- * @addtogroup  group_clk
+ */
+
+/**
+ * @addtogroup  group_driver_clock
  * @{
  */
 


### PR DESCRIPTION
clk.c 和 clk.h中重复定义 group_clk. 

删除 `clk.c` 中的定义，只保留 `clk.h` 中的定义。
同时更改名字 `group_clk` 为 `group_driver_clock`，符合其他 driver 的 group 的命名习惯。

Note：本 PR 只修改了注释文档，不涉及代码逻辑修改。