### PR TITLE
fix serial dma rx ringbuffer position mismatch

### DIFF
--- a/components/drivers/include/ipc/ringbuffer.h
+++ b/components/drivers/include/ipc/ringbuffer.h
@@ -41,10 +41,10 @@ struct rt_ringbuffer
      * read_idx-^ ^-write_idx
      */
 
-    rt_uint32_t read_mirror : 1;
-    rt_uint32_t read_index : 31;
-    rt_uint32_t write_mirror : 1;
-    rt_uint32_t write_index : 31;
+    volatile rt_uint32_t read_mirror : 1;
+    volatile rt_uint32_t read_index : 31;
+    volatile rt_uint32_t write_mirror : 1;
+    volatile rt_uint32_t write_index : 31;
     /* as we use msb of index as mirror bit, the size should be signed and
      * could only be positive. */
     rt_int32_t buffer_size;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
单片机为小华的HC32F4A0，在使用serial v2+dma rx时，发现在erase内部flash时，有概率触发dma rx串口数据的一个bug：
1. erase内部flash是我们软件业务需要做的操作，和这里的bug的关系我们也不清楚，只是观察到出现此bug，必然有erase内部flash的操作，但是反过来不是必然的
2. 我们使用了优化选项-Osize
3. rx indicate回调中，收到的字节数a
4. 在正常的线程中，使用rt_device_read，返回的字节数b
5. 期望a == b，实际上 a != b
6. 出现a != b的现象后，串口读取出来的数据都是两次收buffer拼接的现象，即读出来的字节，一部分是上一次收到的，一部分是这一次收到的，这种现象不能自行恢复，直到重新打开串口

#### 你的解决方案是什么 (what is your solution)

一开始以为是因为线程收取太慢，dma buffer不够用导致的，因为我们的串口收流量比较大，增大dma的buffer size后运行，还是会出现改现象。
这里对ringbuffer做改动后，串口收就没有出现过以上现象。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ √] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ √] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [√ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [√ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ √] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [√ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [√] 代码是高质量的 Code in this PR is of high quality
- [√] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
