### PR TITLE
[bugfix][component/dfs] fix bugs for function _get_parent_path().

### DIFF
--- a/components/dfs/dfs_v2/src/dfs_file.c
+++ b/components/dfs/dfs_v2/src/dfs_file.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2025 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -50,21 +50,34 @@ static int _get_parent_path(const char *fullpath, char *path)
     int len = 0;
     char *str = 0;
 
-    str = strrchr(fullpath, '/');
+    char *full_path = strdup(fullpath);
+    if (full_path == NULL)
+    {
+        rt_set_errno(ENOMEM);
+        return -1;
+    }
+
+    str = strrchr(full_path, '/');
 
     /* skip last '/' */
     if (str && *(str + 1) == '\0')
     {
-        str = strrchr(str - 1, '/');
+        *str = '\0';
+        str = strrchr(full_path, '/');
     }
 
     if (str)
     {
-        len = str - fullpath;
+        len = str - full_path;
         if (len > 0)
         {
-            rt_memcpy(path, fullpath, len);
+            rt_memcpy(path, full_path, len);
             path[len] = '\0';
+        }
+        else if (len == 0) /* parent path is root path. */
+        {
+            rt_memcpy(path, "/", 1);
+            len = 1;
         }
     }
 
@@ -260,7 +273,7 @@ char *dfs_file_realpath(struct dfs_mnt **mnt, const char *fullpath, int mode)
     {
         int len, link_len;
 
-        path = (char *)rt_malloc((DFS_PATH_MAX * 3) + 3); // path + \0 + link_fn + \0 + tmp_path + \0
+        path = (char *)rt_malloc((DFS_PATH_MAX * 3) + 3); /* path + \0 + link_fn + \0 + tmp_path + \0 */
         if (!path)
         {
             return RT_NULL;
@@ -2356,14 +2369,14 @@ void copy(const char *src, const char *dst)
             flag |= FLAG_DST_IS_FILE;
     }
 
-    //2. check status
+    /* 2. check status */
     if ((flag & FLAG_SRC_IS_DIR) && (flag & FLAG_DST_IS_FILE))
     {
         rt_kprintf("cp faild, cp dir to file is not permitted!\n");
         return ;
     }
 
-    //3. do copy
+    /* 3. do copy */
     if (flag & FLAG_SRC_IS_FILE)
     {
         if (flag & FLAG_DST_IS_DIR)
@@ -2383,7 +2396,7 @@ void copy(const char *src, const char *dst)
             copyfile(src, dst);
         }
     }
-    else //flag & FLAG_SRC_IS_DIR
+    else /* flag & FLAG_SRC_IS_DIR */
     {
         if (flag & FLAG_DST_IS_DIR)
         {


### PR DESCRIPTION
… Scenario that parent path is root is not considered.

## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
dfs_file.c中的_get_parent_path函数存在如下问题：
1. 如果输入fullpath路径末尾是“/”，函数本意是忽略这个“/”，如输入路径/home/a/b/，计算其父路径时，应先丢弃末尾的“/”，预期父路径结果应该是/home/a，但实际结果是/home/a/b；
2. 如果输入fullpath路径是类似“/home”，其输出父路径应该为根目录“/”。但函数未考虑这种场景，实际输出结果父路径为空，路径长度为0；

#### 你的解决方案是什么 (what is your solution)
修复上述问题，并自测正常。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:

- .config:

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
