### PR TITLE
[arm_compiler_v4/v5] define rt_packed as __packed

### DIFF
--- a/bsp/hc32/tools/sdk_dist.py
+++ b/bsp/hc32/tools/sdk_dist.py
@@ -13,8 +13,9 @@ def dist_do_building(BSP_ROOT, dist_dir):
     print("=> copy hc32 bsp library")
     library_dir = os.path.join(dist_dir, 'libraries')
     library_path = os.path.join(os.path.dirname(BSP_ROOT), 'libraries')
-    bsp_copy_files(os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE),
-                   os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE))
+    if rtconfig.BSP_LIBRARY_TYPE is not None:
+        bsp_copy_files(os.path.join(library_path, rtconfig.BSP_LIBRARY_TYPE),
+                    os.path.join(library_dir, rtconfig.BSP_LIBRARY_TYPE))
 
     print("=> copy bsp drivers")
     bsp_copy_files(os.path.join(library_path, 'hc32_drivers'), os.path.join(library_dir, 'hc32_drivers'))

--- a/components/drivers/block/partitions/efi.h
+++ b/components/drivers/block/partitions/efi.h
@@ -30,14 +30,14 @@
 #ifndef __UUID_H__
 #define UUID_SIZE 16
 
-typedef struct
+typedef rt_packed(struct
 {
     rt_uint8_t b[UUID_SIZE];
-} guid_t;
+} guid_t);
 #endif /* __UUID_H__ */
 
 #ifndef __EFI_H__
-typedef guid_t efi_guid_t rt_align(4);
+typedef rt_packed(guid_t) efi_guid_t rt_align(4);
 
 #define EFI_GUID(a, b, c, d...) (efi_guid_t)                                \
 {{                                                                          \

--- a/components/drivers/include/drivers/nvme.h
+++ b/components/drivers/include/drivers/nvme.h
@@ -717,12 +717,12 @@ enum
     RT_NVME_CTRL_CTRATT_UUID_LIST               = 1 << 9,
 };
 
-struct rt_nvme_lba_format
+rt_packed(struct rt_nvme_lba_format
 {
     rt_le16_t   ms;         /* Metadata size */
     rt_uint8_t  ds;         /* Data size */
     rt_uint8_t  rp;         /* Relative performance */
-};
+});
 
 rt_packed(struct rt_nvme_id_ns
 {

--- a/include/rtcompiler.h
+++ b/include/rtcompiler.h
@@ -19,7 +19,7 @@
 #if __ARMCC_VERSION >= 6010050
 #define rt_packed(declare)          declare __attribute__((packed))
 #else
-#define rt_packed(declare)          declare
+#define rt_packed(declare)          __packed declare
 #endif
 #define rt_weak                     __attribute__((weak))
 #define rt_typeof                   __typeof


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
使用MDK5编译器编译工程后，在运行find_valid_gpt函数时， 因sizeof (legacy_mbr)得出的长度未按1字节对齐而出现内存覆盖问题

#### 你的解决方案是什么 (what is your solution)
1、当 __ARMCC_VERSION < 6010050 时定义 rt_packed 为 __packed
2、参考文档:
1）ARM Compiler toolchain Using the Compiler Version 5.01
https://developer.arm.com/documentation/dui0472/g/compiler-coding-practices/the---packed-qualifier-and-unaligned-data-access-in-c-and-c---code?lang=en
2）ARM Compiler toolchain Using the Compiler Version 4.1
https://developer.arm.com/documentation/dui0472/c/compiler-coding-practices/the---packed-qualifier-and-unaligned-data-access-in-c-and-c---code?lang=en
3）ARM Software Development Toolkit Reference Guide Version 2.50
https://developer.arm.com/documentation/dui0041/c/ARM-Compiler-Reference/Compiler-specific-features/Type-qualifiers?lang=en

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:bsp\hc32\ev_hc32f4a0_lqfp176

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

-.config:CONFIG_RT_USING_DFS=y,CONFIG_RT_USING_BLK=y,CONFIG_RT_BLK_PARTITION_EFI=y,CONFIG_BSP_USING_SDIO=y,CONFIG_BSP_USING_SDIO1=y

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:https://github.com/cmbjxxiao/rt-thread/actions/runs/16517125437

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
