### PR TITLE
fix(kernel): properly release mutexes in _thread_detach_from_mutex()

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -465,6 +465,7 @@ rt_err_t rt_mutex_trytake(rt_mutex_t mutex);
 rt_err_t rt_mutex_take_interruptible(rt_mutex_t mutex, rt_int32_t time);
 rt_err_t rt_mutex_take_killable(rt_mutex_t mutex, rt_int32_t time);
 rt_err_t rt_mutex_release(rt_mutex_t mutex);
+rt_err_t rt_mutex_force_release(rt_mutex_t mutex);
 rt_err_t rt_mutex_control(rt_mutex_t mutex, int cmd, void *arg);
 
 rt_inline rt_thread_t rt_mutex_get_owner(rt_mutex_t mutex)

--- a/src/thread.c
+++ b/src/thread.c
@@ -101,9 +101,7 @@ static void _thread_detach_from_mutex(rt_thread_t thread)
     {
         mutex = rt_list_entry(node, struct rt_mutex, taken_list);
         LOG_D("Thread [%s] exits while holding mutex [%s].\n", thread->parent.name, mutex->parent.parent.name);
-        /* recursively take */
-        mutex->hold = 1;
-        rt_mutex_release(mutex);
+        rt_mutex_force_release(mutex);
     }
 
     rt_spin_unlock_irqrestore(&thread->spinlock, level);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

fix(kernel): properly release mutexes in _thread_detach_from_mutex()

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

 在RT-Thread中，rt_thread_detach通过调用链_thread_detach_from_mutex->rt_mutex_release无法释放被分离线程持有的互斥锁，原因在于：rt_thread_detach要求调用线程与被分离线程不同，而rt_mutex_release则要求调用线程必须为锁的持有者，这两个相互矛盾的条件导致锁无法被正常释放。

#### 你的解决方案是什么 (what is your solution)

可以通过重构互斥锁释放逻辑来解决这个问题：首先提取原始rt_mutex_release的核心实现为_rt_mutex_release函数，然后基于此实现新的rt_mutex_release，确保其行为与旧版本完全一致。这样既保持了原有接口的兼容性，又为后续扩展奠定了基础。

基于_rt_mutex_release，可以实现新的rt_mutex_force_release函数，该函数将绕过持有者检查逻辑。在_thread_detach_from_mutex流程中，用这个新函数替换原来的rt_mutex_release调用，这样即使当前线程不是互斥锁的持有者，也能正确释放被分离线程持有的锁资源。

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/workflows/bsp_buildings.yml](workflows/bsp_buildings.yml)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
