### PR TITLE
doxygen: fix build error

### DIFF
--- a/src/cpu_mp.c
+++ b/src/cpu_mp.c
@@ -59,6 +59,8 @@ RTM_EXPORT(rt_spin_lock)
 /**
  * @brief   This function will unlock the spinlock, will unlock the thread scheduler.
  *
+ * @note    If the scheduling function is called before unlocking, it will be scheduled in this function.
+ *
  * @param   lock is a pointer to the spinlock.
  */
 void rt_spin_unlock(struct rt_spinlock *lock)
@@ -94,6 +96,8 @@ RTM_EXPORT(rt_spin_lock_irqsave)
 
 /**
  * @brief   This function will unlock the spinlock and then restore current cpu interrupt status, will unlock the thread scheduler.
+ *
+ * @note    If the scheduling function is called before unlocking, it will be scheduled in this function.
  *
  * @param   lock is a pointer to the spinlock.
  *

--- a/src/cpu_up.c
+++ b/src/cpu_up.c
@@ -40,7 +40,8 @@ void rt_spin_lock(struct rt_spinlock *lock)
 
 /**
  * @brief   This function will unlock the spinlock, will unlock the thread scheduler.
- *          If the scheduling function is called before unlocking, it will be scheduled in this function.
+ *
+ * @note    If the scheduling function is called before unlocking, it will be scheduled in this function.
  *
  * @param   lock is a pointer to the spinlock.
  */
@@ -73,7 +74,8 @@ rt_base_t rt_spin_lock_irqsave(struct rt_spinlock *lock)
 
 /**
  * @brief   This function will unlock the spinlock and then restore current cpu interrupt status, will unlock the thread scheduler.
- *          If the scheduling function is called before unlocking, it will be scheduled in this function.
+ *
+ * @note    If the scheduling function is called before unlocking, it will be scheduled in this function.
  *
  * @param   lock is a pointer to the spinlock.
  *


### PR DESCRIPTION
导致问题的 commit：b084503b6d "[kernel] add UP scheduler critical switch flag."

这个提交会导致 doxygen build 产生告警，导致失败：
```
include/rtthread.h:658: warning: argument 'lock' from the argument list of rt_spin_unlock has multiple @param documentation sections 
include/rtthread.h:660: warning: argument 'lock' from the argument list of rt_spin_unlock_irqrestore has multiple @param documentation sections 
include/rtthread.h:660: warning: argument 'level' from the argument list of rt_spin_unlock_irqrestore has multiple @param documentation sections
```

原因分析：
`src/cpu_up.c` 和 `src/cpu_mp.c` 定义了两套完全相同的函数，因为目前 `documentation/Doxyfile` 中的 INPUT 参数会将 `./src` 下的文件全部加入编译，这导致 `src/cpu_up.c` 和 `src/cpu_mp.c` 都会参与 doxygen 的编译，Doxygen 在处理它们的过程中如果发现这同名函数的 doxygen 注释不同的话会自动进行合并操作，导致形成多个 param 的告警。

以前这两个文件中的 API 注释都是相同的，目前看上去如果注释相同，doxygen 在编译时的合并不会有问题，所以一直以来没有问题，但 b084503b6d 的修改在修改注释时只改了 `src/cpu_up.c` 中的 `rt_spin_unlock` 和 `rt_spin_unlock_irqrestore ` 的注释，但没有改 `src/cpu_mp.c` 中对应函数的注释，从而导致问题。

另外 b084503b6d 中的修改还有一个不好的地方在于 Doxygen 的 `@brief` 建议只写一行的，多行不是建议的写法。

解决方案：
针对 `@brief` 只写一行的要求，这个问题解决比较简单，将多加的内容作为 `@note` 列出即可。

对于 warning 的解决：比较完美的解决方案暂时没有想好。一种可行的做法就是如果内核中这种一套 API 两套实现的情况，原则上 API 的 doxygen 注释应该只写一份就好了。所以一种可行的做法是只在一个文件，譬如 `src/cpu_up.c` 中写 doxygen 注释，而另一个文件 `src/cpu_mp.c` 中的 doxygen 注释不写。
还有一种解决方案是将 API 的注释写到 `include/rtthread.h` 中去(只有一份)，但是目前 `include/rtthread.h` 这个文件本身已经很大了，如果再将注释加进去会更难看。

最终我采用的是临时的解决方案，就是确保同一个 API 的 doxygen 注释在 `src/cpu_up.c` 和 `src/cpu_mp.c`  中一样(这也是以前的做法)。这样 doxygen 编译不会有告警，而且其自动合并后只有一份在 html 中。

更好的解决方案以后再考虑吧。

