### PR TITLE
fix: warnings generated by Kconfig.

### DIFF
--- a/components/dfs/Kconfig
+++ b/components/dfs/Kconfig
@@ -34,7 +34,7 @@ endif
         int "The maximal number of opened files"
         default 16
 
-    choice
+    choice RT_USING_DFS_VERSION
         prompt "The version of DFS"
         default RT_USING_DFS_V1
         default RT_USING_DFS_V2 if RT_USING_SMART
@@ -74,7 +74,7 @@ endif
             bool "Using RT_DFS_ELM_WORD_ACCESS"
             default y
 
-        choice
+        choice RT_DFS_ELM_USE_LFN_NAME
             prompt "Support long file name"
             default RT_DFS_ELM_USE_LFN_3
 
@@ -98,7 +98,7 @@ endif
             default 2 if RT_DFS_ELM_USE_LFN_2
             default 3 if RT_DFS_ELM_USE_LFN_3
 
-        choice
+        choice RT_DFS_ELM_LFN_UNICODE_NAME
             prompt "Support unicode for long file name"
             default RT_DFS_ELM_LFN_UNICODE_0
 

--- a/components/drivers/serial/Kconfig
+++ b/components/drivers/serial/Kconfig
@@ -5,7 +5,7 @@ menuconfig RT_USING_SERIAL
     default y
 
     if RT_USING_SERIAL
-        choice
+        choice RT_USING_SERIAL_VERSION
             prompt "Choice Serial version"
             default RT_USING_SERIAL_V1
             config RT_USING_SERIAL_V1
@@ -14,7 +14,7 @@ menuconfig RT_USING_SERIAL
                 bool "RT_USING_SERIAL_V2"
         endchoice
 
-        choice
+        choice RT_USING_SERIAL_MODE
             prompt "Choice Serial version"
             depends on RT_USING_SERIAL_V2
             default RT_SERIAL_BUF_STRATEGY_OVERWRITE

--- a/components/drivers/usb/cherryusb/Kconfig
+++ b/components/drivers/usb/cherryusb/Kconfig
@@ -10,7 +10,7 @@ if CHERRYUSB
         default n
 
     if CHERRYUSB_DEVICE
-        choice
+        choice CHERRYUSB_DEVICE_SPEED
             prompt "Select usb device speed"
             default CHERRYUSB_DEVICE_SPEED_FS
             config CHERRYUSB_DEVICE_SPEED_FS
@@ -21,7 +21,7 @@ if CHERRYUSB
                 bool "AUTO"
         endchoice
 
-        choice
+        choice CHERRYUSB_DEVICE_IP
             prompt "Select usb device ip, and some ip need config in usb_config.h, please check"
             default CHERRYUSB_DEVICE_CUSTOM
             config CHERRYUSB_DEVICE_CUSTOM
@@ -158,7 +158,7 @@ if CHERRYUSB
             prompt "Enable usb cdc ecm device with lwip for lan"
             default n
 
-        choice
+        choice CHERRYUSB_DEVICE_TEMPLATE
             prompt "Select usb device template, please select class driver first"
             default CHERRYUSB_DEVICE_TEMPLATE_NONE
             config CHERRYUSB_DEVICE_TEMPLATE_NONE
@@ -235,7 +235,7 @@ if CHERRYUSB
         default n
 
     if CHERRYUSB_HOST
-        choice
+        choice CHERRYUSB_HOST_IP
             prompt "Select usb host ip, and some ip need config in usb_config.h, please check"
             default CHERRYUSB_HOST_CUSTOM
             config CHERRYUSB_HOST_CUSTOM

--- a/components/drivers/virtio/Kconfig
+++ b/components/drivers/virtio/Kconfig
@@ -3,7 +3,7 @@ menuconfig RT_USING_VIRTIO
     default n
 
     if RT_USING_VIRTIO
-        choice
+        choice RT_USING_VIRTIO_VERSION
             prompt "VirtIO Version"
             default RT_USING_VIRTIO10
 

--- a/components/legacy/usb/Kconfig
+++ b/components/legacy/usb/Kconfig
@@ -50,7 +50,7 @@ menu "Using USB legacy version"
             config RT_USB_DEVICE_COMPOSITE
                 bool "Enable composite device"
                 default n
-                choice
+                choice RT_USING_COMPOSITE_DEVICE
                     prompt "Device type"
                     default _RT_USB_DEVICE_NONE
                     depends on !RT_USB_DEVICE_COMPOSITE

--- a/components/net/lwip/Kconfig
+++ b/components/net/lwip/Kconfig
@@ -13,7 +13,7 @@ if RT_USING_LWIP
             If don't select this option, both local version and upstream
             version can be selected. If select this option, only local version
             can be selected.
-    choice
+    choice RT_USING_LWIP_VERSION
         prompt "lwIP version"
         default RT_USING_LWIP203
         help

--- a/components/utilities/Kconfig
+++ b/components/utilities/Kconfig
@@ -21,7 +21,7 @@ menuconfig RT_USING_ULOG
 
     if RT_USING_ULOG
         if !ULOG_USING_SYSLOG
-            choice
+            choice ULOG_OUTPUT_LOG_LEVEL
                 prompt "The static output log level."
                 default ULOG_OUTPUT_LVL_D
                 help
@@ -42,7 +42,7 @@ menuconfig RT_USING_ULOG
         endif
 
         if ULOG_USING_SYSLOG
-            choice
+            choice ULOG_OUTPUT_LOG_LEVEL
                 prompt "The static output log level."
                 default ULOG_OUTPUT_LVL_DEBUG
                 help

--- a/components/utilities/rt-link/Kconfig
+++ b/components/utilities/rt-link/Kconfig
@@ -4,7 +4,7 @@ menuconfig RT_USING_RT_LINK
     default n
 
 if RT_USING_RT_LINK
-    choice
+    choice RT_LINK_USING_CRC
         prompt"use hw crc device or not"
         default RT_LINK_USING_SF_CRC
 

--- a/libcpu/Kconfig
+++ b/libcpu/Kconfig
@@ -228,7 +228,7 @@ config ARCH_RISCV_VECTOR
     bool
 
     if ARCH_RISCV_VECTOR
-        choice
+        choice ARCH_VECTOR_VLEN
             prompt "RISCV Vector Vlen"
             default ARCH_VECTOR_VLEN_128
 

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -55,7 +55,7 @@ config RT_USING_AMP
     bool "Enable AMP (Asymmetric Multi-Processing)"
     default n
     if RT_USING_AMP
-        choice
+        choice RT_USING_AMP_ROLE
             prompt "Select the AMP role"
             default RT_AMP_SLAVE
 
@@ -89,7 +89,7 @@ config RT_ALIGN_SIZE
     help
         Alignment size for CPU architecture data access
 
-choice
+choice RT_THREAD_PRIORITY_VAL_MAX
     prompt "The maximal level value of priority of thread"
     default RT_THREAD_PRIORITY_32
 
@@ -312,7 +312,7 @@ menu "Memory Management"
         default n
 
         if RT_USING_MEMHEAP
-            choice
+            choice RT_MEMHEAP_MODE
                 prompt "Memheap memory allocation mode"
                 default RT_MEMHEAP_FAST_MODE
 
@@ -330,7 +330,7 @@ menu "Memory Management"
             endchoice
         endif
 
-    choice
+    choice RT_USING_HEAP_TYPE
         prompt "System Heap Memory Management"
         default RT_USING_SMALL_MEM_AS_HEAP
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
<img width="2749" height="200" alt="image" src="https://github.com/user-attachments/assets/556dde7a-d77e-4c09-ba69-ad414c9f6dc6" />

没有名字的 choice → 在 Kconfig 里它就是一个匿名 choice，kconfiglib 内部会分配一个临时对象 ID。

这时 default RT_USING_DFS_V1 指向 V1，但在 _check_choice_sanity() 时，它会检查 default.choice is choice，结果可能对不上（匿名 choice 在解析时会生成两个对象副本），于是报 warning。

有名字的 choice RT_USING_DFS_VERSION → 这个 choice 成了一个有名字的 symbol，kconfiglib 会把它注册进符号表，所有地方引用的都是同一个对象。

所以 default.choice 和 choice 指向的就是同一个实例，不会触发警告

#### 你的解决方案是什么 (what is your solution)

给 choice 显式命名（choice XXX）就能保证引用一致。


#### 请提供验证的bsp和config (provide the config and bsp) 

无

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
