### PR TITLE
fix(ioctl): `_IOR()` overflows in `switch (int)`

### DIFF
--- a/components/drivers/ipc/pipe.c
+++ b/components/drivers/ipc/pipe.c
@@ -190,7 +190,7 @@ static int pipe_fops_ioctl(struct dfs_file *fd, int cmd, void *args)
 
     pipe = (rt_pipe_t *)fd->vnode->data;
 
-    switch (cmd)
+    switch ((unsigned int) cmd)
     {
     case FIONREAD:
         *((int*)args) = rt_ringbuffer_data_len(pipe->fifo);

--- a/components/drivers/serial/dev_serial.c
+++ b/components/drivers/serial/dev_serial.c
@@ -125,7 +125,7 @@ static int serial_fops_ioctl(struct dfs_file *fd, int cmd, void *args)
     int mask  = O_NONBLOCK | O_APPEND;
 
     device = (rt_device_t)fd->vnode->data;
-    switch (cmd)
+    switch ((unsigned int) cmd)
     {
     case FIONREAD:
         break;
@@ -1074,7 +1074,7 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
     RT_ASSERT(dev != RT_NULL);
     serial = (struct rt_serial_device *)dev;
 
-    switch (cmd)
+    switch ((unsigned int) cmd)
     {
         case RT_DEVICE_CTRL_SUSPEND:
             /* suspend device */

--- a/components/drivers/serial/dev_serial_v2.c
+++ b/components/drivers/serial/dev_serial_v2.c
@@ -121,7 +121,7 @@ static int serial_fops_ioctl(struct dfs_file *fd, int cmd, void *args)
     int         mask  = O_NONBLOCK | O_APPEND;
 
     device = (rt_device_t)fd->vnode->data;
-    switch (cmd)
+    switch ((unsigned int) cmd)
     {
     case FIONREAD:
         break;
@@ -1385,7 +1385,7 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
     RT_ASSERT(dev != RT_NULL);
     serial = (struct rt_serial_device *)dev;
 
-    switch (cmd)
+    switch ((unsigned int) cmd)
     {
     case RT_DEVICE_CTRL_SUSPEND:
         /* suspend device */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.



并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

`_IOR()` 宏会扩展到 0x8xxxxxxx，这个数字超过了 `int` 的表示范围。在 switch 语句里，使用相关宏（如 `FIONREAD`、`FIONWRITE` 等）会产生数据溢出。这在 clang 下会产生 `overflow converting case value to switch condition type` warning，存在潜在风险。在 RT-Thread 代码中，已有部分代码使用了 `long` 或 `unsigned` 类型规避这一问题，这个 PR 是为了解决尚未规避的部分。

#### 你的解决方案是什么 (what is your solution)

在 `switch` 语句中，使用强制类型转换，将 switch 变量转换成 `unsigned` 类型后再进行 `case` 判断。

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

基于 virt riscv bsp 进行测试，但修改了部分代码以适配 clang 编译，相关修改如下。

```diff
diff --git a/bsp/qemu-virt64-riscv/rtconfig.py b/bsp/qemu-virt64-riscv/rtconfig.py
index 09d530af4a..7dec52efc0 100644
--- a/bsp/qemu-virt64-riscv/rtconfig.py
+++ b/bsp/qemu-virt64-riscv/rtconfig.py
@@ -3,15 +3,15 @@ import os
 # toolchains options
 ARCH        ='risc-v'
 CPU         ='virt64'
-CROSS_TOOL  ='gcc'
+CROSS_TOOL  ='llvm-riscv'
 
 RTT_ROOT = os.getenv('RTT_ROOT') or os.path.join(os.getcwd(), '..', '..')
 
 if os.getenv('RTT_CC'):
     CROSS_TOOL = os.getenv('RTT_CC')
 
-if  CROSS_TOOL == 'gcc':
-    PLATFORM    = 'gcc'
+if  CROSS_TOOL == 'llvm-riscv':
+    PLATFORM    = 'llvm-riscv'
     EXEC_PATH   = os.getenv('RTT_EXEC_PATH') or '/usr/bin'
 else:
     print('Please make sure your toolchains is GNU GCC!')
@@ -19,28 +19,28 @@ else:
 
 BUILD = 'debug'
 
-if PLATFORM == 'gcc':
+if PLATFORM == 'llvm-riscv':
     # toolchains
     PREFIX  = os.getenv('RTT_CC_PREFIX') or 'riscv64-unknown-elf-'
-    CC      = PREFIX + 'gcc'
-    CXX     = PREFIX + 'g++'
-    AS      = PREFIX + 'gcc'
-    AR      = PREFIX + 'ar'
-    LINK    = PREFIX + 'gcc'
+    CC      = PREFIX + 'clang'
+    CXX     = PREFIX + 'clang++'
+    AS      = PREFIX + 'clang'
+    AR      = PREFIX + 'llvm-ar'
+    LINK    = PREFIX + 'clang++'
     TARGET_EXT = 'elf'
     SIZE    = PREFIX + 'size'
     OBJDUMP = PREFIX + 'objdump'
     OBJCPY  = PREFIX + 'objcopy'
 
     DEVICE  = ' -mcmodel=medany -march=rv64imafdc -mabi=lp64 '
-    CFLAGS  = DEVICE + '-ffreestanding -flax-vector-conversions -Wno-cpp -fno-common -ffunction-sections -fdata-sections -fstrict-volatile-bitfields -fdiagnostics-color=always'
+    CFLAGS  = DEVICE + '-flax-vector-conversions -Wno-cpp -fno-common -ffunction-sections -fdata-sections -fdiagnostics-color=always -Xclang -fexperimental-max-bitint-width=65536'
     AFLAGS  = ' -c' + DEVICE + ' -x assembler-with-cpp -D__ASSEMBLY__ '
-    LFLAGS  = DEVICE + ' -nostartfiles -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,_start -T link.lds' + ' -lsupc++ -lgcc -static'
+    LFLAGS  = DEVICE + ' -nostartfiles -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,_start -T link.lds' + ' -stdlib=libstdc++ -lc -lsupc++ -lgcc -lstdc++ -static'
     CPATH   = ''
     LPATH   = ''
 
     if BUILD == 'debug':
-        CFLAGS += ' -O0 -ggdb -fvar-tracking '
+        CFLAGS += ' -O0 -ggdb '
         AFLAGS += ' -ggdb'
     else:
         CFLAGS += ' -O2 -Os'
diff --git a/components/libc/compilers/common/extension/SConscript b/components/libc/compilers/common/extension/SConscript
index 58e43dd62e..2f35bb0d47 100644
--- a/components/libc/compilers/common/extension/SConscript
+++ b/components/libc/compilers/common/extension/SConscript
@@ -9,7 +9,7 @@ group = []
 
 src += Glob('*.c')
 
-if rtconfig.PLATFORM not in ['gcc', 'llvm-arm']:
+if rtconfig.PLATFORM not in ['gcc', 'llvm-arm', 'llvm-riscv']:
     group = DefineGroup('Compiler', src, depend = [''], CPPPATH = CPPPATH)
 
 list = os.listdir(cwd)
```

- BSP: bsp/qemu-virt64-riscv

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config: 默认配置，无需额外修改

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
