### PR TITLE
fix(riscv, cpp): remove `rt_hw_cpu_id` in `cpuport.h` to fix error

### DIFF
--- a/libcpu/risc-v/common64/cpuport.h
+++ b/libcpu/risc-v/common64/cpuport.h
@@ -43,8 +43,6 @@ rt_inline void rt_hw_isb(void)
     __asm__ volatile(OPC_FENCE_I:::"memory");
 }
 
-int rt_hw_cpu_id(void);
-
 #endif
 
 #endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

在编译 bsp/qemu-virt64-riscv 时，我尝试打开了 cpp 支持：

```diff
diff --git a/bsp/qemu-virt64-riscv/.config b/bsp/qemu-virt64-riscv/.config
index 3a1a2558f1..9db5bc73fa 100644
--- a/bsp/qemu-virt64-riscv/.config
+++ b/bsp/qemu-virt64-riscv/.config
@@ -392,7 +392,7 @@ CONFIG_RT_USING_POSIX_PIPE_SIZE=512
 # end of Interprocess Communication (IPC)
 # end of POSIX (Portable Operating System Interface) layer
 
-# CONFIG_RT_USING_CPLUSPLUS is not set
+CONFIG_RT_USING_CPLUSPLUS=y
 # end of C/C++ and POSIX layer
 
 #
```

在这一操作过后，编译时遇到了 (1) 一个error 和 (2) 一个warning。这个 PR 是为了解决问题 (1)，问题 (2) 将在另一个 PR 中完成解决。

##### 问题现象

开启 `CONFIG_RT_USING_CPLUSPLUS` 后，编译报错：

```
/nfs/home/tanghaojin/rt-thread-3/include/rthw.h:197:5: error: conflicting declaration of 'int rt_hw_cpu_id()' with 'C' linkage
  197 | int rt_hw_cpu_id(void);
      |     ^~~~~~~~~~~~
/nfs/home/tanghaojin/rt-thread-3/libcpu/risc-v/common64/cpuport.h:46:5: note: previous declaration with 'C++' linkage
   46 | int rt_hw_cpu_id(void);
      |     ^~~~~~~~~~~~
```

#### 你的解决方案是什么 (what is your solution)

删去 `libcpu/risc-v/common64/cpuport.h` 中的 `int rt_hw_cpu_id(void);` 函数声明。

##### 为什么可以直接删掉

简而言之，该函数已经在其他头文件中声明，并且所有调用该函数的相关文件均已包含这些头文件中的至少一个。以下是详细说明：

1. `int rt_hw_cpu_id(void)` 在 `rthw.h` 中已经声明过了；`rtthread.h` 中包含的 `rtatomic.h` 中，包含了 `rthw.h`；`smp_call.h` 中包含了 `rtthread.h`；

```bash
# rthw.h
$ grep -rnw 'int rt_hw_cpu_id(void);' include/rthw.h
197:int rt_hw_cpu_id(void);

# rtthread.h
$ grep -rnw '#include <rtatomic.h>' include/rtthread.h
35:#include <rtatomic.h>
$ grep -rnw '#include <rthw.h>' include/rtatomic.h
14:#include <rthw.h>
62:#include <rthw.h>

# smp_call.h
$ grep -rnw '#include <rtthread.h>' components/drivers/smp_call/smp_call.h
14:#include <rtthread.h>
```

2. 找出所有 `int rt_hw_cpu_id(void);` 的函数调用；

```bash
$ find . -type f -exec grep -l 'rt_hw_cpu_id()' {} \;
./components/drivers/nvme/nvme.c
./components/drivers/smp_call/smp_call.c
./components/drivers/ofw/fdt.c
./components/drivers/pic/pic-gicv3-its.c
./components/drivers/pic/pic-gicv3.c
./components/drivers/pic/pic.c
./components/drivers/pic/pic-gicv2.c
./libcpu/arm/cortex-r52/gicv3.c
./libcpu/arm/cortex-a/trap.c
./libcpu/arm/cortex-a/gicv3.c
./libcpu/arm/cortex-a/cpuport.c
./libcpu/aarch64/common/interrupt.c
./libcpu/aarch64/common/trap.c
./libcpu/aarch64/common/gicv3.c
./libcpu/aarch64/common/setup.c
./examples/utest/testcases/smp_call/smp_003_tc.c
./examples/utest/testcases/smp_call/smp_004_tc.c
./examples/utest/testcases/smp_call/smp_002_tc.c
./examples/utest/testcases/smp_call/smp_001_tc.c
./examples/utest/testcases/kernel/smp/smp_bind_affinity_tc.c
./examples/utest/testcases/kernel/smp/smp_affinity_pri2_tc.c
./examples/utest/testcases/kernel/smp/smp_affinity_pri1_tc.c
./examples/utest/testcases/kernel/sched_sem_tc.c
./src/scheduler_mp.c
./src/cpu_mp.c
./ChangeLog.md
./bsp/renesas/libraries/HAL_Drivers/drv_common.c
./bsp/raspberry-pi/raspi4-64/drivers/drv_gtimer.c
./bsp/raspberry-pi/raspi4-64/drivers/board.c
./bsp/raspberry-pi/raspi3-64/driver/board.c
./bsp/raspberry-pi/raspi3-32/applications/test_device.c
./bsp/raspberry-pi/raspi3-32/cpu/interrupt.c
./bsp/raspberry-pi/raspi3-32/cpu/trap.c
./bsp/raspberry-pi/raspi3-32/driver/board.c
./bsp/phytium/libraries/common/phytium_interrupt.c
./bsp/phytium/libraries/drivers/drv_i2c_msg.c
./bsp/phytium/libraries/drivers/drv_i2s.c
./bsp/phytium/libraries/drivers/drv_gpio.c
./bsp/phytium/libraries/drivers/drv_can.c
./bsp/phytium/libraries/drivers/drv_spi.c
./bsp/phytium/libraries/drivers/drv_sdif.c
./bsp/phytium/libraries/drivers/drv_sdif_msg.c
./bsp/phytium/libraries/drivers/drv_spi_msg.c
./bsp/phytium/aarch32/applications/main.c
./bsp/phytium/board/smp_sgi_test.c
./bsp/phytium/board/secondary_cpu.c
./bsp/phytium/board/board.c
./bsp/phytium/aarch64/applications/main.c
./bsp/raspberry-pico/RP2040/libcpu/cpuport.c
./bsp/qemu-vexpress-a9/drivers/secondary_cpu.c
./bsp/nuvoton/libraries/ma35/rtt_port/drv_common_aarch32.c
./bsp/nuvoton/libraries/ma35/rtt_port/drv_hwsem.c
./bsp/nuvoton/libraries/nu_packages/Demo/smp_demo.c
./bsp/nuvoton/libraries/nu_packages/Demo/hwsem_counter.c
./bsp/nuvoton/numaker-hmi-ma35d1/applications/main.c
./bsp/nuvoton/numaker-iot-ma35d1/applications/main.c
./bsp/rockchip/rk3568/driver/board.c
```

3. 排除和 `libcpu/risc-v/common64` 无关的文件（即非代码文件或与 RISC-V 无关的 bsp/libcpu），剩下的文件列表 (`file.f`) 如下：

```
./components/drivers/nvme/nvme.c
./components/drivers/smp_call/smp_call.c
./components/drivers/ofw/fdt.c
./components/drivers/pic/pic-gicv3-its.c
./components/drivers/pic/pic-gicv3.c
./components/drivers/pic/pic.c
./components/drivers/pic/pic-gicv2.c
./examples/utest/testcases/smp_call/smp_003_tc.c
./examples/utest/testcases/smp_call/smp_004_tc.c
./examples/utest/testcases/smp_call/smp_002_tc.c
./examples/utest/testcases/smp_call/smp_001_tc.c
./examples/utest/testcases/kernel/smp/smp_bind_affinity_tc.c
./examples/utest/testcases/kernel/smp/smp_affinity_pri2_tc.c
./examples/utest/testcases/kernel/smp/smp_affinity_pri1_tc.c
./examples/utest/testcases/kernel/sched_sem_tc.c
./src/scheduler_mp.c
./src/cpu_mp.c
```

4. 在文件中查找 `rthw.h`、`rtthread.h` 或 `smp_call.h`，发现文件列表里的所有文件均包含了上述头文件中的至少一个：

```bash
$ grep -rnwE --max-count 1 '(rthw.h|rtthread.h|smp_call.h)' $(cat file.f)
./components/drivers/nvme/nvme.c:11:#include <rthw.h>
./components/drivers/smp_call/smp_call.c:13:#include "smp_call.h"
./components/drivers/ofw/fdt.c:11:#include <rthw.h>
./components/drivers/pic/pic-gicv3-its.c:11:#include <rthw.h>
./components/drivers/pic/pic-gicv3.c:17:#include <rthw.h>
./components/drivers/pic/pic.c:11:#include <rthw.h>
./components/drivers/pic/pic-gicv2.c:16:#include <rthw.h>
./examples/utest/testcases/smp_call/smp_003_tc.c:14:#include <smp_call.h>
./examples/utest/testcases/smp_call/smp_004_tc.c:14:#include <smp_call.h>
./examples/utest/testcases/smp_call/smp_002_tc.c:14:#include <smp_call.h>
./examples/utest/testcases/smp_call/smp_001_tc.c:15:#include <smp_call.h>
./examples/utest/testcases/kernel/smp/smp_bind_affinity_tc.c:11:#include <rtthread.h>
./examples/utest/testcases/kernel/smp/smp_affinity_pri2_tc.c:11:#include <rtthread.h>
./examples/utest/testcases/kernel/smp/smp_affinity_pri1_tc.c:11:#include <rtthread.h>
./examples/utest/testcases/kernel/sched_sem_tc.c:12:#include <rtthread.h>
./src/scheduler_mp.c:39:#include <rtthread.h>
./src/cpu_mp.c:13:#include <rthw.h>
```





#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: bsp/qemu-virt64-riscv

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config: `CONFIG_RT_USING_CPLUSPLUS=y`

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
