### PR TITLE
fix(risc-v, virt64, plic): use volatile rw for claim and complete

### DIFF
--- a/bsp/xuantie/virt64/c906/libcpu/plic.c
+++ b/bsp/xuantie/virt64/c906/libcpu/plic.c
@@ -93,7 +93,7 @@ void plic_set_threshold(int threshold)
 int plic_claim(void)
 {
     int hart = __raw_hartid();
-    int irq = *(uint32_t *)PLIC_CLAIM(hart);
+    int irq = readl((uint32_t *)PLIC_CLAIM(hart));
     return irq;
 }
 
@@ -110,7 +110,7 @@ int plic_claim(void)
 void plic_complete(int irq)
 {
     int hart = __raw_hartid();
-    *(uint32_t *)PLIC_COMPLETE(hart) = irq;
+    writel(irq, (uint32_t *)PLIC_COMPLETE(hart));
 }
 
 void plic_set_ie(rt_uint32_t word_index, rt_uint32_t val)

--- a/libcpu/risc-v/virt64/plic.c
+++ b/libcpu/risc-v/virt64/plic.c
@@ -93,7 +93,7 @@ void plic_set_threshold(int threshold)
 int plic_claim(void)
 {
     int hart = __raw_hartid();
-    int irq = *(uint32_t *)PLIC_CLAIM(hart);
+    int irq = readl((uint32_t *)PLIC_CLAIM(hart));
     return irq;
 }
 
@@ -110,7 +110,7 @@ int plic_claim(void)
 void plic_complete(int irq)
 {
     int hart = __raw_hartid();
-    *(uint32_t *)PLIC_COMPLETE(hart) = irq;
+    writel(irq, (uint32_t *)PLIC_COMPLETE(hart));
 }
 
 void plic_set_ie(rt_uint32_t word_index, rt_uint32_t val)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

观察到开启编译优化时，中断只能触发一次。定位到是由于对 plic 的 claim/complete 寄存器的操作没有被标记为 volatile，导致编译器优化掉了对 mmio 寄存器的写。

- 问题代码序列

```c++
void plic_handle_irq(void)
{
    int plic_irq = plic_claim();
    plic_complete(plic_irq);
    irq_desc[plic_irq].handler(plic_irq, irq_desc[plic_irq].param);
}
```

- 反汇编

```asm
00000000802264e6 <plic_handle_irq>:
    802264e6:	0001e797          	auipc	a5,0x1e
    802264ea:	b627a783          	lw	a5,-1182(a5) # 80244048 <__text_end>
    802264ee:	8181b683          	ld	a3,-2024(gp) # 80245720 <plic_base>
    802264f2:	00201737          	lui	a4,0x201
    802264f6:	00d7979b          	slliw	a5,a5,0xd
    802264fa:	97b6                	add	a5,a5,a3
    802264fc:	97ba                	add	a5,a5,a4
    802264fe:	43c8                	lw	a0,4(a5)
    80226500:	00037797          	auipc	a5,0x37
    80226504:	69078793          	addi	a5,a5,1680 # 8025db90 <irq_desc>
    80226508:	00451713          	slli	a4,a0,0x4
    8022650c:	97ba                	add	a5,a5,a4
    8022650e:	6398                	ld	a4,0(a5)
    80226510:	678c                	ld	a1,8(a5)
    80226512:	8702                	jr	a4
```

可以看到，对寄存器的写（sw）操作被优化掉了。

#### 你的解决方案是什么 (what is your solution)

使用 `readl()` 和 `writel()` 对 mmio 寄存器进行操作。

- 修改后的反汇编

```asm
00000000802264e6 <plic_handle_irq>:
    802264e6:	0001e697          	auipc	a3,0x1e
    802264ea:	b7a68693          	addi	a3,a3,-1158 # 80244060 <__text_end>
    802264ee:	81818613          	addi	a2,gp,-2024 # 80245738 <plic_base>
    802264f2:	4288                	lw	a0,0(a3)
    802264f4:	621c                	ld	a5,0(a2)
    802264f6:	00201737          	lui	a4,0x201
    802264fa:	0711                	addi	a4,a4,4 # 201004 <__text_size+0x1bcfa4>
    802264fc:	97ba                	add	a5,a5,a4
    802264fe:	00d5151b          	slliw	a0,a0,0xd
    80226502:	953e                	add	a0,a0,a5
    80226504:	4108                	lw	a0,0(a0)
    80226506:	2501                	sext.w	a0,a0
    80226508:	0820000f          	fence	i,r
    8022650c:	4294                	lw	a3,0(a3)
    8022650e:	0140000f          	fence	w,o
    80226512:	621c                	ld	a5,0(a2)
    80226514:	00d6969b          	slliw	a3,a3,0xd
    80226518:	97ba                	add	a5,a5,a4
    8022651a:	97b6                	add	a5,a5,a3
    8022651c:	c388                	sw	a0,0(a5)
    8022651e:	00037797          	auipc	a5,0x37
    80226522:	6b278793          	addi	a5,a5,1714 # 8025dbd0 <irq_desc>
    80226526:	00451713          	slli	a4,a0,0x4
    8022652a:	97ba                	add	a5,a5,a4
    8022652c:	6398                	ld	a4,0(a5)
    8022652e:	678c                	ld	a1,8(a5)
    80226530:	8702                	jr	a4
```

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: bsp/qemu-virt64-riscv

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config: 无变化

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
