### PR TITLE
Pass rt_tick_t for RT_TIMER_CTRL_SET_TIME and RT_TIMER_CTRL_GET_TIME

### DIFF
--- a/bsp/allwinner/libraries/sunxi-hal/hal/source/sdmmc/osal/os/RT-Thread/os_timer.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/source/sdmmc/osal/os/RT-Thread/os_timer.c
@@ -128,6 +128,7 @@ OS_Status OS_TimerStart(OS_Timer_t *timer)
 OS_Status OS_TimerChangePeriod(OS_Timer_t *timer, OS_Time_t periodMS)
 {
     rt_err_t ret;
+    rt_tick_t period_tick = rt_tick_from_millisecond(periodMS);
 
     OS_DBG("%s(), handle %p\n", __func__, timer->handle);
     OS_HANDLE_ASSERT(OS_TimerIsValid(timer), timer->handle);
@@ -139,7 +140,7 @@ OS_Status OS_TimerChangePeriod(OS_Timer_t *timer, OS_Time_t periodMS)
             return OS_FAIL;
         }
     }
-    ret = rt_timer_control(timer->handle, RT_TIMER_CTRL_SET_TIME, &periodMS);
+    ret = rt_timer_control(timer->handle, RT_TIMER_CTRL_SET_TIME, &period_tick);
     if (ret != RT_EOK) {
         OS_ERR("err %"OS_BASETYPE_F"\n", ret);
         return OS_FAIL;

--- a/bsp/allwinner/libraries/sunxi-hal/hal/source/usb/host/ehci-timer.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/source/usb/host/ehci-timer.c
@@ -97,8 +97,8 @@ static unsigned long event_delays_ns[] = {
 static void ehci_enable_event(struct ehci_hcd *ehci, unsigned event,
         bool resched)
 {
-    unsigned long *timeout = &ehci->hr_timeouts[event];
-    unsigned long time_interval = 0;
+    rt_tick_t *timeout = &ehci->hr_timeouts[event];
+    rt_tick_t time_interval = 0;
 
     if (resched)
     {

--- a/bsp/allwinner/libraries/sunxi-hal/hal/source/usb/host/ehci.h
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/source/usb/host/ehci.h
@@ -119,7 +119,7 @@ struct ehci_hcd {           /* one per controller */
     /* timing support */
     enum ehci_hrtimer_event next_hrtimer_event;
     unsigned                enabled_hrtimer_events;
-    unsigned long           hr_timeouts[EHCI_HRTIMER_NUM_EVENTS];
+    rt_tick_t               hr_timeouts[EHCI_HRTIMER_NUM_EVENTS];
     osal_timer_t            hrtimer;
 
     int         PSS_poll_count;

--- a/bsp/at91/at91sam9260/drivers/at91_mci.c
+++ b/bsp/at91/at91sam9260/drivers/at91_mci.c
@@ -430,7 +430,7 @@ static void at91_mci_process_next(struct at91_mci *mci)
  */
 static void at91_mci_request(struct rt_mmcsd_host *host, struct rt_mmcsd_req *req)
 {
-    rt_uint32_t timeout = RT_TICK_PER_SECOND;
+    rt_tick_t timeout = RT_TICK_PER_SECOND;
     struct at91_mci *mci = host->private_data;
     mci->req = req;
     mci->current_status = REQ_ST_INIT;

--- a/bsp/at91/at91sam9g45/drivers/at91_mci.c
+++ b/bsp/at91/at91sam9g45/drivers/at91_mci.c
@@ -430,7 +430,7 @@ static void at91_mci_process_next(struct at91_mci *mci)
  */
 static void at91_mci_request(struct rt_mmcsd_host *host, struct rt_mmcsd_req *req)
 {
-    rt_uint32_t timeout = RT_TICK_PER_SECOND;
+    rt_tick_t timeout = RT_TICK_PER_SECOND;
     struct at91_mci *mci = host->private_data;
     mci->req = req;
     mci->current_status = REQ_ST_INIT;

--- a/components/drivers/ipc/completion_mp.c
+++ b/components/drivers/ipc/completion_mp.c
@@ -242,10 +242,11 @@ static rt_err_t _comp_susp_thread(struct rt_completion *completion,
         /* start timer */
         if (timeout > 0)
         {
+            rt_tick_t timeout_tick = timeout;
             /* reset the timeout of thread timer and start it */
             rt_timer_control(&(thread->thread_timer),
                              RT_TIMER_CTRL_SET_TIME,
-                             &timeout);
+                             &timeout_tick);
             rt_timer_start(&(thread->thread_timer));
         }
 

--- a/components/drivers/ipc/completion_up.c
+++ b/components/drivers/ipc/completion_up.c
@@ -108,10 +108,11 @@ __try_again:
                 /* start timer */
                 if (timeout > 0)
                 {
+                    rt_tick_t timeout_tick = timeout;
                     /* reset the timeout of thread timer and start it */
                     rt_timer_control(&(thread->thread_timer),
                                      RT_TIMER_CTRL_SET_TIME,
-                                     &timeout);
+                                     &timeout_tick);
                     rt_timer_start(&(thread->thread_timer));
                 }
                 /* enable interrupt */

--- a/components/drivers/ipc/condvar.c
+++ b/components/drivers/ipc/condvar.c
@@ -47,7 +47,7 @@ static int _waitq_inqueue(rt_wqueue_t *queue, struct rt_wqueue_node *node,
         if (ret == RT_EOK)
         {
             rt_wqueue_add(queue, node);
-            if (timeout != RT_WAITING_FOREVER)
+            if (timeout != (rt_tick_t)RT_WAITING_FOREVER)
             {
                 rt_timer_control(timer, RT_TIMER_CTRL_SET_TIME, &timeout);
 

--- a/components/drivers/ipc/dataqueue.c
+++ b/components/drivers/ipc/dataqueue.c
@@ -129,10 +129,11 @@ rt_err_t rt_data_queue_push(struct rt_data_queue *queue,
             /* start timer */
             if (timeout > 0)
             {
+                rt_tick_t timeout_tick = timeout;
                 /* reset the timeout of thread timer and start it */
                 rt_timer_control(&(thread->thread_timer),
                                 RT_TIMER_CTRL_SET_TIME,
-                                &timeout);
+                                &timeout_tick);
                 rt_timer_start(&(thread->thread_timer));
             }
 
@@ -247,10 +248,11 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
             /* start timer */
             if (timeout > 0)
             {
+                rt_tick_t timeout_tick = timeout;
                 /* reset the timeout of thread timer and start it */
                 rt_timer_control(&(thread->thread_timer),
                                 RT_TIMER_CTRL_SET_TIME,
-                                &timeout);
+                                &timeout_tick);
                 rt_timer_start(&(thread->thread_timer));
             }
 

--- a/components/drivers/ipc/waitqueue.c
+++ b/components/drivers/ipc/waitqueue.c
@@ -198,7 +198,7 @@ void rt_wqueue_wakeup_all(rt_wqueue_t *queue, void *key)
  */
 static int _rt_wqueue_wait(rt_wqueue_t *queue, int condition, int msec, int suspend_flag)
 {
-    int tick;
+    rt_tick_t tick;
     rt_thread_t tid = rt_thread_self();
     rt_timer_t  tmr = &(tid->thread_timer);
     struct rt_wqueue_node __wait;
@@ -241,7 +241,7 @@ static int _rt_wqueue_wait(rt_wqueue_t *queue, int condition, int msec, int susp
     rt_list_insert_before(&(queue->waiting_list), &(__wait.list));
 
     /* start timer */
-    if (tick != RT_WAITING_FOREVER)
+    if (tick != (rt_tick_t)RT_WAITING_FOREVER)
     {
         rt_timer_control(tmr,
                          RT_TIMER_CTRL_SET_TIME,

--- a/components/libc/posix/io/epoll/epoll.c
+++ b/components/libc/posix/io/epoll/epoll.c
@@ -700,9 +700,10 @@ static int epoll_wait_timeout(struct rt_eventpoll *ep, int msec)
         {
             if (timeout > 0)
             {
+                rt_tick_t timeout_tick = timeout;
                 rt_timer_control(&(thread->thread_timer),
                         RT_TIMER_CTRL_SET_TIME,
-                        &timeout);
+                        &timeout_tick);
                 rt_timer_start(&(thread->thread_timer));
             }
 

--- a/components/libc/posix/io/poll/poll.c
+++ b/components/libc/posix/io/poll/poll.c
@@ -23,7 +23,7 @@
 #include "poll.h"
 
 
-enum rt_poll_status 
+enum rt_poll_status
 {
     RT_POLL_STAT_INIT,     /**< Poll operation initialization status. */
     RT_POLL_STAT_TRIG,     /**< Poll operation triggered status. */
@@ -31,7 +31,7 @@ enum rt_poll_status
 };
 
 
-struct rt_poll_table 
+struct rt_poll_table
 {
     rt_pollreq_t req;               /**< Poll request. */
     enum rt_poll_status status;     /**< Status of the poll operation. */
@@ -40,7 +40,7 @@ struct rt_poll_table
 };
 
 
-struct rt_poll_node 
+struct rt_poll_node
 {
     struct rt_wqueue_node wqn;     /**< Wait queue node for the poll node. */
     struct rt_poll_table *pt;       /**< Pointer to the parent poll table. */

--- a/components/libc/posix/io/poll/poll.c
+++ b/components/libc/posix/io/poll/poll.c
@@ -158,9 +158,10 @@ static int poll_wait_timeout(struct rt_poll_table *pt, int msec)
         {
             if (timeout > 0)
             {
+                rt_tick_t timeout_tick = timeout;
                 rt_timer_control(&(thread->thread_timer),
                         RT_TIMER_CTRL_SET_TIME,
-                        &timeout);
+                        &timeout_tick);
                 rt_timer_start(&(thread->thread_timer));
                 rt_set_errno(RT_ETIMEOUT);
             }

--- a/components/libc/posix/pthreads/pthread_cond.c
+++ b/components/libc/posix/pthreads/pthread_cond.c
@@ -418,10 +418,11 @@ rt_err_t _pthread_cond_timedwait(pthread_cond_t *cond,
                 /* has waiting time, start thread timer */
                 if (time > 0)
                 {
+                    rt_tick_t time_tick = time;
                     /* reset the timeout of thread timer and start it */
                     rt_timer_control(&(thread->thread_timer),
                                      RT_TIMER_CTRL_SET_TIME,
-                                     &time);
+                                     &time_tick);
                     rt_timer_start(&(thread->thread_timer));
                 }
 

--- a/components/lwp/lwp_ipc.c
+++ b/components/lwp/lwp_ipc.c
@@ -553,6 +553,7 @@ static rt_err_t _do_send_recv_timeout(rt_channel_t ch, rt_channel_msg_t data, in
                 rt_thread_wakeup_set(thread_send, wakeup_sender_wait_recv, (void *)ch);
                 if (time > 0)
                 {
+                    rt_tick_t time_tick = time;
                     rt_timer_control(&(thread_send->thread_timer),
                                      RT_TIMER_CTRL_GET_FUNC,
                                      &old_timeout_func);
@@ -562,7 +563,7 @@ static rt_err_t _do_send_recv_timeout(rt_channel_t ch, rt_channel_msg_t data, in
                     /* reset the timeout of thread timer and start it */
                     rt_timer_control(&(thread_send->thread_timer),
                                      RT_TIMER_CTRL_SET_TIME,
-                                     &time);
+                                     &time_tick);
                     rt_timer_start(&(thread_send->thread_timer));
                 }
             }
@@ -597,6 +598,7 @@ static rt_err_t _do_send_recv_timeout(rt_channel_t ch, rt_channel_msg_t data, in
                 rt_thread_wakeup_set(thread_send, wakeup_sender_wait_reply, (void *)ch);
                 if (time > 0)
                 {
+                    rt_tick_t time_tick = time;
                     rt_timer_control(&(thread_send->thread_timer),
                                      RT_TIMER_CTRL_GET_FUNC,
                                      &old_timeout_func);
@@ -606,7 +608,7 @@ static rt_err_t _do_send_recv_timeout(rt_channel_t ch, rt_channel_msg_t data, in
                     /* reset the timeout of thread timer and start it */
                     rt_timer_control(&(thread_send->thread_timer),
                                      RT_TIMER_CTRL_SET_TIME,
-                                     &time);
+                                     &time_tick);
                     rt_timer_start(&(thread_send->thread_timer));
                 }
             }
@@ -870,6 +872,7 @@ static rt_err_t _rt_raw_channel_recv_timeout(rt_channel_t ch, rt_channel_msg_t d
                 thread->error = RT_EOK;
                 if (time > 0)
                 {
+                    rt_tick_t time_tick = time;
                     rt_timer_control(&(thread->thread_timer),
                                      RT_TIMER_CTRL_GET_FUNC,
                                      &old_timeout_func);
@@ -879,7 +882,7 @@ static rt_err_t _rt_raw_channel_recv_timeout(rt_channel_t ch, rt_channel_msg_t d
                     /* reset the timeout of thread timer and start it */
                     rt_timer_control(&(thread->thread_timer),
                                      RT_TIMER_CTRL_SET_TIME,
-                                     &time);
+                                     &time_tick);
                     rt_timer_start(&(thread->thread_timer));
                 }
                 rt_spin_unlock_irqrestore(&ch->slock, level);

--- a/components/utilities/rt-link/src/rtlink.c
+++ b/components/utilities/rt-link/src/rtlink.c
@@ -302,7 +302,7 @@ static rt_err_t rt_link_frame_send(rt_slist_t *slist)
     }
     else
     {
-        rt_int32_t timeout = RT_LINK_SENT_FRAME_TIMEOUT;
+        rt_tick_t timeout = RT_LINK_SENT_FRAME_TIMEOUT;
         rt_timer_control(&rt_link_scb->sendtimer, RT_TIMER_CTRL_SET_TIME, &timeout);
         rt_timer_start(&rt_link_scb->sendtimer);
     }
@@ -536,7 +536,7 @@ static void _long_handle_second(struct rt_link_frame *receive_frame)
         }
         else if (rt_link_hw_recv_len(rt_link_scb->rx_buffer) < (receive_frame->data_len % RT_LINK_MAX_DATA_LENGTH))
         {
-            rt_int32_t timeout = RT_LINK_LONG_FRAME_TIMEOUT;
+            rt_tick_t timeout = RT_LINK_LONG_FRAME_TIMEOUT;
             rt_timer_control(&rt_link_scb->longframetimer, RT_TIMER_CTRL_SET_TIME, &timeout);
             rt_timer_start(&rt_link_scb->longframetimer);
         }
@@ -879,7 +879,7 @@ static void rt_link_send_ready(void)
         rt_link_command_frame_send(RT_LINK_SERVICE_RTLINK, seq,
                                    RT_LINK_HANDSHAKE_FRAME, rt_link_scb->rx_record.rx_seq);
 
-        rt_int32_t timeout = 50;
+        rt_tick_t timeout = 50;
         rt_timer_control(&rt_link_scb->sendtimer, RT_TIMER_CTRL_SET_TIME, &timeout);
         rt_timer_start(&rt_link_scb->sendtimer);
     }

--- a/components/vbus/prio_queue.c
+++ b/components/vbus/prio_queue.c
@@ -209,9 +209,10 @@ rt_err_t rt_prio_queue_pop(struct rt_prio_queue *que,
 
         if (timeout > 0)
         {
+            rt_tick_t timeout_tick = timeout;
             rt_timer_control(&(thread->thread_timer),
                              RT_TIMER_CTRL_SET_TIME,
-                             &timeout);
+                             &timeout_tick);
             rt_timer_start(&(thread->thread_timer));
         }
 

--- a/components/vbus/vbus.c
+++ b/components/vbus/vbus.c
@@ -339,9 +339,10 @@ rt_err_t rt_vbus_post(rt_uint8_t id,
         rt_list_insert_after(&_chn_suspended_threads[id], &RT_THREAD_LIST_NODE(thread));
         if (timeout > 0)
         {
+            rt_tick_t timeout_tick = timeout;
             rt_timer_control(&(thread->thread_timer),
                              RT_TIMER_CTRL_SET_TIME,
-                             &timeout);
+                             &timeout_tick);
             rt_timer_start(&(thread->thread_timer));
         }
         /* rt_exit_critical will do schedule on need. */

--- a/components/vbus/watermark_queue.h
+++ b/components/vbus/watermark_queue.h
@@ -67,9 +67,10 @@ rt_inline rt_err_t rt_wm_que_inc(struct rt_watermark_queue *wg,
         rt_list_insert_after(&wg->suspended_threads, &RT_THREAD_LIST_NODE(thread));
         if (timeout > 0)
         {
+            rt_tick_t timeout_tick = timeout;
             rt_timer_control(&(thread->thread_timer),
                              RT_TIMER_CTRL_SET_TIME,
-                             &timeout);
+                             &timeout_tick);
             rt_timer_start(&(thread->thread_timer));
         }
         rt_hw_interrupt_enable(level);

--- a/examples/utest/testcases/kernel/timer_tc.c
+++ b/examples/utest/testcases/kernel/timer_tc.c
@@ -233,8 +233,8 @@ static void timer_control(void *param)
 static void test_static_timer_control(void)
 {
     rt_err_t result;
-    int set_data;
-    int get_data;
+    rt_tick_t set_data;
+    rt_tick_t get_data;
 
     timer.callbacks = 0;
     timer.is_static = RT_TRUE;
@@ -473,8 +473,8 @@ static void test_dynamic_timer(void)
 static void test_dynamic_timer_control(void)
 {
     rt_err_t result;
-    int set_data;
-    int get_data;
+    rt_tick_t set_data;
+    rt_tick_t get_data;
 
     timer.callbacks = 0;
     timer.is_static = RT_FALSE;

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -614,12 +614,13 @@ static rt_err_t _rt_sem_take(rt_sem_t sem, rt_int32_t timeout, int suspend_flag)
             /* has waiting time, start thread timer */
             if (timeout > 0)
             {
+                rt_tick_t timeout_tick = timeout;
                 LOG_D("set thread:%s to timer list", thread->parent.name);
 
                 /* reset the timeout of thread timer and start it */
                 rt_timer_control(&(thread->thread_timer),
                                  RT_TIMER_CTRL_SET_TIME,
-                                 &timeout);
+                                 &timeout_tick);
                 rt_timer_start(&(thread->thread_timer));
             }
 
@@ -1433,13 +1434,14 @@ static rt_err_t _rt_mutex_take(rt_mutex_t mutex, rt_int32_t timeout, int suspend
                 /* has waiting time, start thread timer */
                 if (timeout > 0)
                 {
+                    rt_tick_t timeout_tick = timeout;
                     LOG_D("mutex_take: start the timer of thread:%s",
                           thread->parent.name);
 
                     /* reset the timeout of thread timer and start it */
                     rt_timer_control(&(thread->thread_timer),
                                      RT_TIMER_CTRL_SET_TIME,
-                                     &timeout);
+                                     &timeout_tick);
                     rt_timer_start(&(thread->thread_timer));
                 }
 
@@ -2186,10 +2188,11 @@ static rt_err_t _rt_event_recv(rt_event_t   event,
         /* if there is a waiting timeout, active thread timer */
         if (timeout > 0)
         {
+            rt_tick_t timeout_tick = timeout;
             /* reset the timeout of thread timer and start it */
             rt_timer_control(&(thread->thread_timer),
                              RT_TIMER_CTRL_SET_TIME,
-                             &timeout);
+                             &timeout_tick);
             rt_timer_start(&(thread->thread_timer));
         }
 
@@ -2621,6 +2624,7 @@ static rt_err_t _rt_mb_send_wait(rt_mailbox_t mb,
         /* has waiting time, start thread timer */
         if (timeout > 0)
         {
+            rt_tick_t timeout_tick = timeout;
             /* get the start tick of timer */
             tick_delta = rt_tick_get();
 
@@ -2630,7 +2634,7 @@ static rt_err_t _rt_mb_send_wait(rt_mailbox_t mb,
             /* reset the timeout of thread timer and start it */
             rt_timer_control(&(thread->thread_timer),
                              RT_TIMER_CTRL_SET_TIME,
-                             &timeout);
+                             &timeout_tick);
             rt_timer_start(&(thread->thread_timer));
         }
         rt_spin_unlock_irqrestore(&(mb->spinlock), level);
@@ -2901,6 +2905,7 @@ static rt_err_t _rt_mb_recv(rt_mailbox_t mb, rt_ubase_t *value, rt_int32_t timeo
         /* has waiting time, start thread timer */
         if (timeout > 0)
         {
+            rt_tick_t timeout_tick = timeout;
             /* get the start tick of timer */
             tick_delta = rt_tick_get();
 
@@ -2910,7 +2915,7 @@ static rt_err_t _rt_mb_recv(rt_mailbox_t mb, rt_ubase_t *value, rt_int32_t timeo
             /* reset the timeout of thread timer and start it */
             rt_timer_control(&(thread->thread_timer),
                              RT_TIMER_CTRL_SET_TIME,
-                             &timeout);
+                             &timeout_tick);
             rt_timer_start(&(thread->thread_timer));
         }
 
@@ -3446,6 +3451,7 @@ static rt_err_t _rt_mq_send_wait(rt_mq_t mq,
         /* has waiting time, start thread timer */
         if (timeout > 0)
         {
+            rt_tick_t timeout_tick = timeout;
             /* get the start tick of timer */
             tick_delta = rt_tick_get();
 
@@ -3455,7 +3461,7 @@ static rt_err_t _rt_mq_send_wait(rt_mq_t mq,
             /* reset the timeout of thread timer and start it */
             rt_timer_control(&(thread->thread_timer),
                              RT_TIMER_CTRL_SET_TIME,
-                             &timeout);
+                             &timeout_tick);
             rt_timer_start(&(thread->thread_timer));
         }
 
@@ -3825,6 +3831,7 @@ static rt_ssize_t _rt_mq_recv(rt_mq_t mq,
         /* has waiting time, start thread timer */
         if (timeout > 0)
         {
+            rt_tick_t timeout_tick = timeout;
             /* get the start tick of timer */
             tick_delta = rt_tick_get();
 
@@ -3834,7 +3841,7 @@ static rt_ssize_t _rt_mq_recv(rt_mq_t mq,
             /* reset the timeout of thread timer and start it */
             rt_timer_control(&(thread->thread_timer),
                              RT_TIMER_CTRL_SET_TIME,
-                             &timeout);
+                             &timeout_tick);
             rt_timer_start(&(thread->thread_timer));
         }
 

--- a/src/mempool.c
+++ b/src/mempool.c
@@ -314,13 +314,14 @@ void *rt_mp_alloc(rt_mp_t mp, rt_int32_t time)
 
         if (time > 0)
         {
+            rt_tick_t time_tick = time;
             /* get the start tick of timer */
             before_sleep = rt_tick_get();
 
             /* init thread timer and start it */
             rt_timer_control(&(thread->thread_timer),
                              RT_TIMER_CTRL_SET_TIME,
-                             &time);
+                             &time_tick);
             rt_timer_start(&(thread->thread_timer));
         }
 

--- a/src/signal.c
+++ b/src/signal.c
@@ -369,10 +369,11 @@ int rt_signal_wait(const rt_sigset_t *set, rt_siginfo_t *si, rt_int32_t timeout)
     /* start timeout timer */
     if (timeout != RT_WAITING_FOREVER)
     {
+        rt_tick_t timeout_tick = timeout;
         /* reset the timeout of thread timer and start it */
         rt_timer_control(&(tid->thread_timer),
                          RT_TIMER_CTRL_SET_TIME,
-                         &timeout);
+                         &timeout_tick);
         rt_timer_start(&(tid->thread_timer));
     }
     rt_spin_unlock_irqrestore(&_thread_signal_lock, level);


### PR DESCRIPTION
## Pass rt_tick_t for RT_TIMER_CTRL_SET_TIME and RT_TIMER_CTRL_GET_TIME

<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
RT_TIMER_CTRL_SET_TIME  and RT_TIMER_CTRL_GET_TIME only accept rt_tick_t, but the current code base pass int/rt_int32_t
randomly.

#### 你的解决方案是什么 (what is your solution)
Check all place that use RT_TIMER_CTRL_SET_TIME /RT_TIMER_CTRL_GET_TIME  and fixes it accordingly


<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
