### PR TITLE
improve[clang-format]: optimize the formatting logic for RT-Thread coding standard

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,9 +8,9 @@ Language: Cpp
 BasedOnStyle: LLVM
 AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
-AlignArrayOfStructures: Right
+AlignArrayOfStructures: None
 AlignConsecutiveAssignments:
-  Enabled: true
+  Enabled: false
   AcrossEmptyLines: false
   AcrossComments: false
   AlignCompound: true
@@ -22,7 +22,7 @@ AlignConsecutiveBitFields:
   AlignCompound: true
   PadOperators: true
 AlignConsecutiveDeclarations:
-  Enabled: true
+  Enabled: false
   AcrossEmptyLines: false
   AcrossComments: false
   AlignCompound: false
@@ -41,14 +41,14 @@ AlignConsecutiveShortCaseStatements:
 AlignEscapedNewlines: Left
 AlignOperands: Align
 AlignTrailingComments:
-  Kind: Always
+  Kind: Leave
   OverEmptyLines: 1
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortEnumsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
+AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
@@ -63,7 +63,7 @@ BinPackParameters: true
 BitFieldColonSpacing: Both
 BreakBeforeBraces: Custom
 BraceWrapping:
-  AfterCaseLabel: false
+  AfterCaseLabel: true
   AfterClass: true
   AfterControlStatement: Always
   AfterEnum: true
@@ -153,7 +153,7 @@ LineEnding: DeriveLF
 MacroBlockBegin: ""
 MacroBlockEnd: ""
 MaxEmptyLinesToKeep: 2
-NamespaceIndentation: None
+NamespaceIndentation: All
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

优化clang-format规则，使其更加满足RT-Thread编码规范

**主要修改内容：**
1. **对齐规则调整**：禁用连续赋值和声明对齐（`AlignConsecutiveAssignments`、`AlignConsecutiveDeclarations` 设为 `false`），数组结构对齐改为 `None`。
2. **注释与换行**：尾随注释对齐改为保留原样（`Leave`），`case` 标签后换行（`AfterCaseLabel: true`）。
3. **函数与命名空间**：允许短函数内联显示（`Inline`），命名空间内容全部缩进（`All`）。

]