### PR TITLE
utest: remove RT_UTEST_USING_ALL_CASES

### DIFF
--- a/bsp/k230/drivers/utest/SConscript
+++ b/bsp/k230/drivers/utest/SConscript
@@ -2,7 +2,7 @@ from building import *
 
 src = []
 
-if GetDepend('RT_UTEST_USING_ALL_CASES') or GetDepend('BSP_UTEST_DRIVERS'):
+if GetDepend('BSP_UTEST_DRIVERS'):
     src += ['test_gpio.c']
     src += ['test_gpio_irq.c']
 

--- a/components/drivers/audio/utest/SConscript
+++ b/components/drivers/audio/utest/SConscript
@@ -5,7 +5,7 @@ cwd     = GetCurrentDir()
 src     = []
 CPPPATH = [cwd]
 
-if GetDepend('RT_UTEST_USING_ALL_CASES') or GetDepend('RT_UTEST_USING_AUDIO_DRIVER'):
+if GetDepend('RT_UTEST_USING_AUDIO_DRIVER'):
     src += Glob('tc_*.c')
 
 group = DefineGroup('utestcases', src, depend = ['RT_USING_UTESTCASES', 'RT_USING_AUDIO'], CPPPATH = CPPPATH)

--- a/components/net/utest/SConscript
+++ b/components/net/utest/SConscript
@@ -5,7 +5,7 @@ cwd     = GetCurrentDir()
 src     = []
 CPPPATH = [cwd]
 
-if GetDepend('RT_UTEST_USING_ALL_CASES') or GetDepend('RT_UTEST_TC_USING_LWIP') or GetDepend('RT_UTEST_TC_USING_NETDEV'):
+if GetDepend('RT_UTEST_TC_USING_LWIP') or GetDepend('RT_UTEST_TC_USING_NETDEV'):
 
     if GetDepend('RT_UTEST_TC_USING_LWIP'):
         # Add lwIP test source if enabled

--- a/components/utilities/Kconfig
+++ b/components/utilities/Kconfig
@@ -216,13 +216,6 @@ config RT_USING_UTEST
             default n
             help
                 If enable this option, the test cases will be run automatically when board boot up.
-
-        config RT_UTEST_USING_ALL_CASES
-            bool "Enable all selected modules' test cases"
-            default n
-            help
-                If enable this option, all selected modules' test cases will be run.
-                Otherwise, only the test cases that are explicitly enabled will be run.
     endif
 
 config RT_USING_VAR_EXPORT

--- a/components/utilities/utest/utest/SConscript
+++ b/components/utilities/utest/utest/SConscript
@@ -2,7 +2,7 @@ from building import *
 
 src = []
 
-if GetDepend('RT_UTEST_USING_ALL_CASES') or GetDepend('UTEST_SELF_PASS_TC'):
+if GetDepend('UTEST_SELF_PASS_TC'):
     src += Glob('TC_*.c')
 
 group = DefineGroup('utc_UTest', src, depend = [''])

--- a/documentation/6.components/utest/utest.md
+++ b/documentation/6.components/utest/utest.md
@@ -314,7 +314,7 @@ For each module, you can maintain unit testcases in a unified manner in the foll
 
   - `Kconfig` file, which defining configuration options for the unit test cases of this module, the recommended option is named `RT_UTEST_TC_USING_XXXX`, XXXX is the global unique module name of this module.
 
-  - `SConscript` file, note that when adding src files, in addition to relying on `RT_UTEST_TC_USING_XXXX`, you must also rely on `RT_UTEST_USING_ALL_CASES`, the two dependencies are in an "or" relationship. The role of `RT_UTEST_USING_ALL_CASES` is that once this option is turned on, all unit-testcases will be enabled to avoid selecting one by one.
+  - `SConscript` file, when adding src files, you need to rely on `RT_UTEST_TC_USING_XXXX`.
     
 After completing the above steps, rsource the path of the Kconfig file of utest of this module to the file `Kconfig.utestcases`.
 

--- a/examples/utest/testcases/cpp11/SConscript
+++ b/examples/utest/testcases/cpp11/SConscript
@@ -5,7 +5,7 @@ cwd     = GetCurrentDir()
 src     = []
 CPPPATH = [cwd]
 
-if GetDepend('RT_UTEST_USING_ALL_CASES') or GetDepend('UTEST_CPP11_THREAD_TC'):
+if GetDepend('UTEST_CPP11_THREAD_TC'):
     src += Glob('tc_*.cpp')
 
 group = DefineGroup('utestcases', src, depend = ['RT_USING_UTESTCASES', 'RT_USING_CPLUSPLUS'], CPPPATH = CPPPATH)

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -242,7 +242,6 @@ config RT_USING_CI_ACTION
     bool "Enable CI Action build mode"
     select RT_USING_UTEST
     select RT_UTEST_USING_AUTO_RUN
-    select RT_UTEST_USING_ALL_CASES
     default n
     help
         Identify that the environment is CI Action.

--- a/src/klibc/utest/SConscript
+++ b/src/klibc/utest/SConscript
@@ -2,7 +2,7 @@ from building import *
 
 src = []
 
-if GetDepend('RT_UTEST_USING_ALL_CASES') or GetDepend('RT_UTEST_TC_USING_KLIBC'):
+if GetDepend('RT_UTEST_TC_USING_KLIBC'):
     src += Glob('TC_*.c')
 
 group = DefineGroup('utestcases', src, depend = [''])


### PR DESCRIPTION
Fixed: #10734

由于目前很多模块的 utest 并不打算支持一次性统一开启，另外有些模块的测试由于比较复杂，譬如对其他模块有很多依赖，这导致简单通过一个全局开关来控制使能所有测试变得几乎不可能。这导致过去定义的 `RT_UTEST_USING_ALL_CASES` 已经失去了它最初的含义。

建议淘汰掉这个配置开关。如果某些模块内部觉得需要自己通过配置 enable 一批功能测试，那这种局部的 enable all 交给模块自己去实现，不再提供一个 RTT 全局的 enable 开关了。

如果以后再有此类一次性使能所有单元测试的需求，建议仔细设计一下，特别是要考虑从易用性上如何保证通过打开一个开关就能将所有涉及的模块的依赖关系全部都打开。

特别的 `src/Kconfig` 的这个改动请看一下是否合适？
<img width="1189" height="423" alt="519c9aa4d10981bb15ef7d619da42c13" src="https://github.com/user-attachments/assets/349fa1a2-bce9-4a06-bf40-1280268ea6da" />

