### PR TITLE
fix: make rt_tick_t 64-bit on ARCH_CPU_64BIT and improve clock time precision

### DIFF
--- a/bsp/rockchip/dm/hwtimer/clock_timer-rockchip_timer.c
+++ b/bsp/rockchip/dm/hwtimer/clock_timer-rockchip_timer.c
@@ -359,14 +359,9 @@ static const struct rk_timer_data rk3399_timer_data =
 
 #ifdef RT_USING_CLOCK_TIME
 
-uint64_t rt_clock_hrtimer_getfrq(void)
+rt_uint64_t rt_clock_hrtimer_getfrq(void)
 {
     return OSC_HZ;
-}
-
-uint64_t rt_clock_hrtimer_getres(void)
-{
-    return ((1000UL * 1000 * 1000) * RT_CLOCK_TIME_RESMUL) / OSC_HZ;
 }
 
 /**
@@ -377,7 +372,7 @@ uint64_t rt_clock_hrtimer_getres(void)
  * @param cnt the count of timer dealy
  * @return rt_err_t 0 forever
  */
-rt_err_t rt_clock_hrtimer_settimeout(unsigned long cnt)
+rt_err_t rt_clock_hrtimer_settimeout(rt_uint64_t cnt)
 {
     struct hrt_timer *timer = &_timer0;
     struct rk_timer *time = timer->timer;

--- a/components/drivers/clock_time/arch/aarch64/cputimer.c
+++ b/components/drivers/clock_time/arch/aarch64/cputimer.c
@@ -50,7 +50,6 @@ void rt_clock_time_source_init(void)
         rt_uint8_t caps = RT_CLOCK_TIME_CAP_SOURCE;
 
         _aarch64_clock_dev.ops = &_aarch64_clock_ops;
-        _aarch64_clock_dev.res_scale = RT_CLOCK_TIME_RESMUL;
         _aarch64_clock_dev.caps = caps;
         rt_clock_time_device_register(&_aarch64_clock_dev, "clock_time_gtimer", caps);
         rt_clock_time_set_default_source(&_aarch64_clock_dev);

--- a/components/drivers/clock_time/arch/risc-v/virt64/cputimer.c
+++ b/components/drivers/clock_time/arch/risc-v/virt64/cputimer.c
@@ -54,7 +54,6 @@ void rt_clock_time_source_init(void)
         rt_uint8_t caps = RT_CLOCK_TIME_CAP_SOURCE;
 
         _riscv_clock_dev.ops = &_riscv_clock_ops;
-        _riscv_clock_dev.res_scale = RT_CLOCK_TIME_RESMUL;
         _riscv_clock_dev.caps = caps;
         rt_clock_time_device_register(&_riscv_clock_dev, "clock_time_rdtime", caps);
         rt_clock_time_set_default_source(&_riscv_clock_dev);

--- a/components/drivers/clock_time/clock_boottime.c
+++ b/components/drivers/clock_time/clock_boottime.c
@@ -9,26 +9,24 @@
  */
 
 #include <drivers/clock_time.h>
+#include <sys/time.h>
 
 rt_err_t rt_clock_boottime_get_us(struct timeval *tv)
 {
     rt_uint64_t cnt;
-    rt_uint64_t res;
-    rt_uint64_t ns;
+    rt_uint64_t freq;
 
     RT_ASSERT(tv != RT_NULL);
 
     cnt = rt_clock_time_get_counter();
-    res = rt_clock_time_get_res_scaled();
-    if (res == 0)
+    freq = rt_clock_time_get_freq();
+    if (freq == 0)
     {
         return -RT_ERROR;
     }
 
-    ns = (cnt * res) / RT_CLOCK_TIME_RESMUL;
-
-    tv->tv_sec  = ns / (1000ULL * 1000 * 1000);
-    tv->tv_usec = (ns % (1000ULL * 1000 * 1000)) / 1000;
+    tv->tv_sec = (time_t)(cnt / freq);
+    tv->tv_usec = rt_muldiv_u64(cnt % freq, MICROSECOND_PER_SECOND, freq, NULL);
 
     return RT_EOK;
 }
@@ -36,20 +34,18 @@ rt_err_t rt_clock_boottime_get_us(struct timeval *tv)
 rt_err_t rt_clock_boottime_get_s(time_t *t)
 {
     rt_uint64_t cnt;
-    rt_uint64_t res;
-    rt_uint64_t ns;
+    rt_uint64_t freq;
 
     RT_ASSERT(t != RT_NULL);
 
     cnt = rt_clock_time_get_counter();
-    res = rt_clock_time_get_res_scaled();
-    if (res == 0)
+    freq = rt_clock_time_get_freq();
+    if (freq == 0)
     {
         return -RT_ERROR;
     }
 
-    ns = (cnt * res) / RT_CLOCK_TIME_RESMUL;
-    *t = ns / (1000ULL * 1000 * 1000);
+    *t = (time_t)(cnt / freq);
 
     return RT_EOK;
 }
@@ -57,22 +53,19 @@ rt_err_t rt_clock_boottime_get_s(time_t *t)
 rt_err_t rt_clock_boottime_get_ns(struct timespec *ts)
 {
     rt_uint64_t cnt;
-    rt_uint64_t res;
-    rt_uint64_t ns;
+    rt_uint64_t freq;
 
     RT_ASSERT(ts != RT_NULL);
 
     cnt = rt_clock_time_get_counter();
-    res = rt_clock_time_get_res_scaled();
-    if (res == 0)
+    freq = rt_clock_time_get_freq();
+    if (freq == 0)
     {
         return -RT_ERROR;
     }
 
-    ns = (cnt * res) / RT_CLOCK_TIME_RESMUL;
-
-    ts->tv_sec  = ns / (1000ULL * 1000 * 1000);
-    ts->tv_nsec = ns % (1000ULL * 1000 * 1000);
+    ts->tv_sec = (time_t)(cnt / freq);
+    ts->tv_nsec = rt_muldiv_u64(cnt % freq, NANOSECOND_PER_SECOND, freq, NULL);
 
     return RT_EOK;
 }

--- a/components/drivers/clock_time/clock_boottime.c
+++ b/components/drivers/clock_time/clock_boottime.c
@@ -11,6 +11,8 @@
 #include <drivers/clock_time.h>
 #include <sys/time.h>
 
+#include "clock_time_internal.h"
+
 rt_err_t rt_clock_boottime_get_us(struct timeval *tv)
 {
     rt_uint64_t cnt;
@@ -26,7 +28,7 @@ rt_err_t rt_clock_boottime_get_us(struct timeval *tv)
     }
 
     tv->tv_sec = (time_t)(cnt / freq);
-    tv->tv_usec = rt_muldiv_u64(cnt % freq, MICROSECOND_PER_SECOND, freq, NULL);
+    tv->tv_usec = rt_clock_time_muldiv_u64(cnt % freq, MICROSECOND_PER_SECOND, freq, RT_NULL, RT_NULL);
 
     return RT_EOK;
 }
@@ -65,7 +67,7 @@ rt_err_t rt_clock_boottime_get_ns(struct timespec *ts)
     }
 
     ts->tv_sec = (time_t)(cnt / freq);
-    ts->tv_nsec = rt_muldiv_u64(cnt % freq, NANOSECOND_PER_SECOND, freq, NULL);
+    ts->tv_nsec = rt_clock_time_muldiv_u64(cnt % freq, NANOSECOND_PER_SECOND, freq, RT_NULL, RT_NULL);
 
     return RT_EOK;
 }

--- a/components/drivers/clock_time/clock_hrtimer.c
+++ b/components/drivers/clock_time/clock_hrtimer.c
@@ -11,20 +11,13 @@
 #include <rtdevice.h>
 #include <rthw.h>
 #include <rtthread.h>
+#include <sys/time.h>
 
 #include <drivers/clock_time.h>
 
 #define DBG_SECTION_NAME               "drv.clock_time"
 #define DBG_LEVEL                      DBG_INFO
 #include <rtdbg.h>
-
-#define CLOCK_TIME_NSEC_PER_SEC (1000000000ULL)
-
-#ifdef ARCH_CPU_64BIT
-#define _HRTIMER_MAX_CNT UINT64_MAX
-#else
-#define _HRTIMER_MAX_CNT UINT32_MAX
-#endif
 
 static rt_list_t          _timer_list   = RT_LIST_OBJECT_INIT(_timer_list);
 static RT_DEFINE_SPINLOCK(_spinlock);
@@ -34,57 +27,51 @@ rt_inline rt_clock_hrtimer_t _first_hrtimer(void)
     return rt_list_isempty(&_timer_list) ? RT_NULL : rt_list_first_entry(&_timer_list, struct rt_clock_hrtimer, node);
 }
 
-rt_inline unsigned long _clock_time_get_cnt(void)
+rt_inline rt_tick_t _clock_time_get_cnt(void)
 {
-    return rt_clock_time_get_counter();
+    return (rt_tick_t)rt_clock_time_get_counter();
 }
 
-rt_inline rt_bool_t _cnt_before(unsigned long a, unsigned long b)
+rt_inline rt_bool_t _cnt_before(rt_tick_t a, rt_tick_t b)
 {
     return ((rt_base_t)(a - b)) < 0;
 }
 
-rt_inline rt_bool_t _cnt_after(unsigned long a, unsigned long b)
+rt_inline rt_bool_t _cnt_after(rt_tick_t a, rt_tick_t b)
 {
     return _cnt_before(b, a);
 }
 
-rt_weak rt_uint64_t rt_clock_hrtimer_getres(void)
+rt_weak rt_uint64_t rt_clock_hrtimer_getfrq(void)
 {
-    return rt_clock_time_get_event_res_scaled();
+    return rt_clock_time_get_event_freq();
 }
 
-rt_weak unsigned long rt_clock_hrtimer_getfrq(void)
+static rt_tick_t _hrtimer_cnt_to_tick(rt_uint64_t cnt)
 {
-    return (unsigned long)rt_clock_time_get_event_freq();
-}
+    rt_uint64_t freq = rt_clock_hrtimer_getfrq();
+    rt_uint64_t rem = 0;
+    rt_uint64_t tick;
 
-static rt_tick_t _hrtimer_cnt_to_tick(unsigned long cnt)
-{
-    rt_uint64_t res = rt_clock_hrtimer_getres();
-    rt_uint64_t ns;
-
-    if (res == 0)
+    if (freq == 0)
     {
         return 0;
     }
 
-    ns = ((rt_uint64_t)cnt * res) / RT_CLOCK_TIME_RESMUL;
-    if (ns == 0)
+    tick = rt_muldiv_u64(cnt, RT_TICK_PER_SECOND, freq, &rem);
+    if (rem != 0)
     {
-        return 1;
+        tick += 1; /* round up so a non-zero cnt never collapses to a 0-tick timeout */
+    }
+    if (tick == 0)
+    {
+        tick = 1; /* at least one tick */
     }
 
-    ns = (ns * RT_TICK_PER_SECOND + CLOCK_TIME_NSEC_PER_SEC - 1) / CLOCK_TIME_NSEC_PER_SEC;
-    if (ns == 0)
-    {
-        return 1;
-    }
-
-    return (rt_tick_t)ns;
+    return (rt_tick_t)tick;
 }
 
-rt_weak rt_err_t rt_clock_hrtimer_settimeout(unsigned long cnt)
+rt_weak rt_err_t rt_clock_hrtimer_settimeout(rt_uint64_t cnt)
 {
     static rt_timer_t timer = RT_NULL;
     static struct rt_timer _sh_rtimer;
@@ -124,29 +111,18 @@ rt_weak rt_err_t rt_clock_hrtimer_settimeout(unsigned long cnt)
     return RT_EOK;
 }
 
-static unsigned long _cnt_convert(unsigned long cnt)
+static rt_uint64_t _cnt_convert(rt_tick_t cnt)
 {
-    unsigned long count;
-    rt_uint64_t src_res;
-    rt_uint64_t event_res;
-    rt_uint64_t result;
+    rt_uint64_t rtn = 0;
+    rt_tick_t count = cnt - _clock_time_get_cnt();
 
-    count = cnt - _clock_time_get_cnt();
-    if (count > (_HRTIMER_MAX_CNT / 2))
+    if (count > (RT_TICK_MAX / 2))
     {
         return 0;
     }
 
-    src_res = rt_clock_time_get_res_scaled();
-    event_res = rt_clock_hrtimer_getres();
-    if (src_res == 0 || event_res == 0)
-    {
-        return 0;
-    }
-
-    result = ((rt_uint64_t)count * src_res) / event_res;
-
-    return result == 0 ? 1 : (unsigned long)result;
+    rtn = rt_muldiv_u64(count, rt_clock_hrtimer_getfrq(), rt_clock_time_get_freq(), NULL);
+    return rtn == 0 ? 1 : rtn;
 }
 
 static void _sleep_timeout(void *parameter)
@@ -177,7 +153,7 @@ static void _hrtimer_process_locked(void)
 
     while ((timer = _first_hrtimer()) != RT_NULL)
     {
-        unsigned long now = _clock_time_get_cnt();
+        rt_tick_t now = _clock_time_get_cnt();
 
         if (_cnt_before(now, timer->timeout_cnt))
         {
@@ -206,7 +182,7 @@ static void _hrtimer_process_locked(void)
 static void _set_next_timeout_locked(void)
 {
     rt_clock_hrtimer_t timer;
-    rt_ubase_t next_timeout_cnt;
+    rt_uint64_t next_timeout_cnt;
     rt_bool_t find_next;
 
     do
@@ -258,12 +234,12 @@ void rt_clock_hrtimer_init(rt_clock_hrtimer_t timer,
     rt_completion_init(&timer->completion);
 }
 
-rt_err_t rt_clock_hrtimer_start(rt_clock_hrtimer_t timer, unsigned long delay_cnt)
+rt_err_t rt_clock_hrtimer_start(rt_clock_hrtimer_t timer, rt_tick_t delay_cnt)
 {
     rt_base_t  level;
 
     RT_ASSERT(timer != RT_NULL);
-    RT_ASSERT(delay_cnt < (_HRTIMER_MAX_CNT / 2));
+    RT_ASSERT(delay_cnt < (RT_TICK_MAX / 2));
 
     timer->delay_cnt    = delay_cnt;
     timer->timeout_cnt  = timer->delay_cnt + _clock_time_get_cnt();
@@ -317,13 +293,13 @@ rt_err_t rt_clock_hrtimer_control(rt_clock_hrtimer_t timer, int cmd, void *arg)
     switch (cmd)
     {
     case RT_TIMER_CTRL_GET_TIME:
-        *(unsigned long *)arg = timer->delay_cnt;
+        *(rt_tick_t *)arg = timer->delay_cnt;
         break;
 
     case RT_TIMER_CTRL_SET_TIME:
-        RT_ASSERT((*(unsigned long *)arg) < (_HRTIMER_MAX_CNT / 2));
-        timer->delay_cnt    = *(unsigned long *)arg;
-        timer->timeout_cnt  = *(unsigned long *)arg + _clock_time_get_cnt();
+        RT_ASSERT((*(rt_tick_t *)arg) < (RT_TICK_MAX / 2));
+        timer->delay_cnt    = *(rt_tick_t *)arg;
+        timer->timeout_cnt  = *(rt_tick_t *)arg + _clock_time_get_cnt();
         break;
 
     case RT_TIMER_CTRL_SET_ONESHOT:
@@ -346,7 +322,7 @@ rt_err_t rt_clock_hrtimer_control(rt_clock_hrtimer_t timer, int cmd, void *arg)
         break;
 
     case RT_TIMER_CTRL_GET_REMAIN_TIME:
-        *(unsigned long *)arg = timer->timeout_cnt;
+        *(rt_tick_t *)arg = timer->timeout_cnt;
         break;
     case RT_TIMER_CTRL_GET_FUNC:
         if (arg != RT_NULL)
@@ -408,7 +384,7 @@ void rt_clock_hrtimer_delay_detach(struct rt_clock_hrtimer *timer)
     rt_clock_hrtimer_detach(timer);
 }
 
-rt_err_t rt_clock_hrtimer_sleep(struct rt_clock_hrtimer *timer, unsigned long cnt)
+rt_err_t rt_clock_hrtimer_sleep(struct rt_clock_hrtimer *timer, rt_tick_t cnt)
 {
     rt_err_t err;
 
@@ -430,23 +406,19 @@ rt_err_t rt_clock_hrtimer_sleep(struct rt_clock_hrtimer *timer, unsigned long cn
     return err;
 }
 
-rt_err_t rt_clock_hrtimer_ndelay(struct rt_clock_hrtimer *timer, unsigned long ns)
+rt_err_t rt_clock_hrtimer_ndelay(struct rt_clock_hrtimer *timer, rt_uint64_t ns)
 {
-    rt_uint64_t res = rt_clock_time_get_res_scaled();
-    if (res == 0)
-    {
-        return -RT_ERROR;
-    }
+    rt_tick_t cputimer_tick = (rt_tick_t)rt_muldiv_u64(ns, rt_clock_time_get_freq(), NANOSECOND_PER_SECOND, NULL);
 
-    return rt_clock_hrtimer_sleep(timer, (ns * RT_CLOCK_TIME_RESMUL) / res);
+    return rt_clock_hrtimer_sleep(timer, cputimer_tick);
 }
 
-rt_err_t rt_clock_hrtimer_udelay(struct rt_clock_hrtimer *timer, unsigned long us)
+rt_err_t rt_clock_hrtimer_udelay(struct rt_clock_hrtimer *timer, rt_uint64_t us)
 {
     return rt_clock_hrtimer_ndelay(timer, us * 1000);
 }
 
-rt_err_t rt_clock_hrtimer_mdelay(struct rt_clock_hrtimer *timer, unsigned long ms)
+rt_err_t rt_clock_hrtimer_mdelay(struct rt_clock_hrtimer *timer, rt_uint64_t ms)
 {
     return rt_clock_hrtimer_ndelay(timer, ms * 1000000);
 }

--- a/components/drivers/clock_time/clock_hrtimer.c
+++ b/components/drivers/clock_time/clock_hrtimer.c
@@ -14,6 +14,7 @@
 #include <sys/time.h>
 
 #include <drivers/clock_time.h>
+#include "clock_time_internal.h"
 
 #define DBG_SECTION_NAME               "drv.clock_time"
 #define DBG_LEVEL                      DBG_INFO
@@ -52,16 +53,26 @@ static rt_tick_t _hrtimer_cnt_to_tick(rt_uint64_t cnt)
     rt_uint64_t freq = rt_clock_hrtimer_getfrq();
     rt_uint64_t rem = 0;
     rt_uint64_t tick;
+    rt_bool_t overflow = RT_FALSE;
 
     if (freq == 0)
     {
         return 0;
     }
 
-    tick = rt_muldiv_u64(cnt, RT_TICK_PER_SECOND, freq, &rem);
+    tick = rt_clock_time_muldiv_u64(cnt, RT_TICK_PER_SECOND, freq, &rem, &overflow);
+    if (overflow)
+    {
+        /* soft-timer path: clamp overflowed delay into the legal half-range */
+        return (rt_tick_t)(RT_TICK_MAX / 2 - 1);
+    }
     if (rem != 0)
     {
         tick += 1; /* round up so a non-zero cnt never collapses to a 0-tick timeout */
+    }
+    if (tick >= (RT_TICK_MAX / 2))
+    {
+        tick = RT_TICK_MAX / 2 - 1;
     }
     if (tick == 0)
     {
@@ -115,13 +126,30 @@ static rt_uint64_t _cnt_convert(rt_tick_t cnt)
 {
     rt_uint64_t rtn = 0;
     rt_tick_t count = cnt - _clock_time_get_cnt();
+    rt_uint64_t src_freq;
+    rt_uint64_t event_freq;
+    rt_bool_t overflow = RT_FALSE;
 
     if (count > (RT_TICK_MAX / 2))
     {
         return 0;
     }
 
-    rtn = rt_muldiv_u64(count, rt_clock_hrtimer_getfrq(), rt_clock_time_get_freq(), NULL);
+    src_freq = rt_clock_time_get_freq();
+    event_freq = rt_clock_hrtimer_getfrq();
+    if ((src_freq == 0) || (event_freq == 0))
+    {
+        /* frequency unavailable: never return 0, or the caller treats the
+         * timer as already expired and may busy-loop reprocessing it */
+        return 1;
+    }
+
+    rtn = rt_clock_time_muldiv_u64(count, event_freq, src_freq, RT_NULL, &overflow);
+    if (overflow)
+    {
+        /* keep a long delay; truncated overflow could schedule too soon */
+        return RT_UINT64_MAX;
+    }
     return rtn == 0 ? 1 : rtn;
 }
 
@@ -408,18 +436,33 @@ rt_err_t rt_clock_hrtimer_sleep(struct rt_clock_hrtimer *timer, rt_tick_t cnt)
 
 rt_err_t rt_clock_hrtimer_ndelay(struct rt_clock_hrtimer *timer, rt_uint64_t ns)
 {
-    rt_tick_t cputimer_tick = (rt_tick_t)rt_muldiv_u64(ns, rt_clock_time_get_freq(), NANOSECOND_PER_SECOND, NULL);
+    rt_uint64_t count = rt_clock_time_ns_to_counter(ns);
 
-    return rt_clock_hrtimer_sleep(timer, cputimer_tick);
+    if ((count == 0) || (count >= (RT_TICK_MAX / 2)))
+    {
+        return -RT_EINVAL;
+    }
+
+    return rt_clock_hrtimer_sleep(timer, (rt_tick_t)count);
 }
 
 rt_err_t rt_clock_hrtimer_udelay(struct rt_clock_hrtimer *timer, rt_uint64_t us)
 {
+    if (us > (RT_UINT64_MAX / 1000))
+    {
+        return -RT_EINVAL;
+    }
+
     return rt_clock_hrtimer_ndelay(timer, us * 1000);
 }
 
 rt_err_t rt_clock_hrtimer_mdelay(struct rt_clock_hrtimer *timer, rt_uint64_t ms)
 {
+    if (ms > (RT_UINT64_MAX / 1000000))
+    {
+        return -RT_EINVAL;
+    }
+
     return rt_clock_hrtimer_ndelay(timer, ms * 1000000);
 }
 

--- a/components/drivers/clock_time/clock_time_core.c
+++ b/components/drivers/clock_time/clock_time_core.c
@@ -14,8 +14,6 @@
 
 #include <drivers/clock_time.h>
 
-#define CLOCK_TIME_NSEC_PER_SEC (1000000000ULL)
-
 static rt_uint64_t _clock_time_tick_get_freq(struct rt_clock_time_device *dev)
 {
     RT_UNUSED(dev);
@@ -45,7 +43,6 @@ static const struct rt_clock_time_ops _clock_time_tick_ops =
 static struct rt_clock_time_device _clock_time_tick_dev =
 {
     .ops = &_clock_time_tick_ops,
-    .res_scale = RT_CLOCK_TIME_RESMUL,
     .caps = RT_CLOCK_TIME_CAP_SOURCE,
 };
 
@@ -57,27 +54,6 @@ rt_weak void rt_clock_time_source_init(void)
     return;
 }
 
-static rt_uint64_t _clock_time_get_res_scaled(struct rt_clock_time_device *dev)
-{
-    rt_uint64_t freq;
-    rt_uint64_t scale;
-
-    if (dev == RT_NULL || dev->ops == RT_NULL || dev->ops->get_freq == RT_NULL)
-    {
-        return 0;
-    }
-
-    freq = dev->ops->get_freq(dev);
-    if (freq == 0)
-    {
-        return 0;
-    }
-
-    scale = dev->res_scale ? dev->res_scale : RT_CLOCK_TIME_RESMUL;
-
-    return (CLOCK_TIME_NSEC_PER_SEC * scale) / freq;
-}
-
 rt_err_t rt_clock_time_device_register(struct rt_clock_time_device *dev, const char *name, rt_uint8_t caps)
 {
     rt_err_t result = RT_EOK;
@@ -86,10 +62,6 @@ rt_err_t rt_clock_time_device_register(struct rt_clock_time_device *dev, const c
     RT_ASSERT(dev->ops != RT_NULL);
 
     dev->caps = caps;
-    if (dev->res_scale == 0)
-    {
-        dev->res_scale = RT_CLOCK_TIME_RESMUL;
-    }
 
     if (name != RT_NULL)
     {
@@ -161,11 +133,6 @@ rt_uint64_t rt_clock_time_get_counter(void)
     return src->ops->get_counter(src);
 }
 
-rt_uint64_t rt_clock_time_get_res_scaled(void)
-{
-    return _clock_time_get_res_scaled(rt_clock_time_get_default_source());
-}
-
 rt_uint64_t rt_clock_time_get_event_freq(void)
 {
     struct rt_clock_time_device *event = rt_clock_time_get_default_event();
@@ -183,40 +150,28 @@ rt_uint64_t rt_clock_time_get_event_freq(void)
     return event->ops->get_freq(event);
 }
 
-rt_uint64_t rt_clock_time_get_event_res_scaled(void)
-{
-    struct rt_clock_time_device *event = rt_clock_time_get_default_event();
-
-    if (event == RT_NULL)
-    {
-        return rt_clock_time_get_res_scaled();
-    }
-
-    return _clock_time_get_res_scaled(event);
-}
-
 rt_uint64_t rt_clock_time_counter_to_ns(rt_uint64_t cnt)
 {
-    rt_uint64_t res = rt_clock_time_get_res_scaled();
+    rt_uint64_t freq = rt_clock_time_get_freq();
 
-    if (res == 0)
+    if (freq == 0)
     {
         return 0;
     }
 
-    return (cnt * res) / RT_CLOCK_TIME_RESMUL;
+    return rt_muldiv_u64(cnt, NANOSECOND_PER_SECOND, freq, NULL);
 }
 
 rt_uint64_t rt_clock_time_ns_to_counter(rt_uint64_t ns)
 {
-    rt_uint64_t res = rt_clock_time_get_res_scaled();
+    rt_uint64_t freq = rt_clock_time_get_freq();
 
-    if (res == 0)
+    if (freq == 0)
     {
         return 0;
     }
 
-    return (ns * RT_CLOCK_TIME_RESMUL) / res;
+    return rt_muldiv_u64(ns, freq, NANOSECOND_PER_SECOND, NULL);
 }
 
 rt_err_t rt_clock_time_set_timeout(rt_uint64_t delta)

--- a/components/drivers/clock_time/clock_time_core.c
+++ b/components/drivers/clock_time/clock_time_core.c
@@ -13,6 +13,14 @@
 #include <rtdevice.h>
 
 #include <drivers/clock_time.h>
+#include "clock_time_internal.h"
+/*
+ * The muldiv implementation is textually included so it compiles as part of
+ * this translation unit. Keil/IAR project files list clock_time sources one
+ * by one; including the .c here keeps clock_time_internal.c out of build
+ * scripts and IDE projects while producing a single definition.
+ */
+#include "clock_time_internal.c"
 
 static rt_uint64_t _clock_time_tick_get_freq(struct rt_clock_time_device *dev)
 {
@@ -150,28 +158,55 @@ rt_uint64_t rt_clock_time_get_event_freq(void)
     return event->ops->get_freq(event);
 }
 
-rt_uint64_t rt_clock_time_counter_to_ns(rt_uint64_t cnt)
+/**
+ * @brief Get the default clock source resolution in nanoseconds.
+ *
+ * @return Non-zero resolution on success, or 0 when frequency is unavailable.
+ */
+rt_uint64_t rt_clock_time_get_res(void)
 {
     rt_uint64_t freq = rt_clock_time_get_freq();
+    rt_uint64_t res;
 
     if (freq == 0)
     {
         return 0;
     }
 
-    return rt_muldiv_u64(cnt, NANOSECOND_PER_SECOND, freq, NULL);
+    res = NANOSECOND_PER_SECOND / freq;
+    return res == 0 ? 1 : res;
+}
+
+rt_uint64_t rt_clock_time_counter_to_ns(rt_uint64_t cnt)
+{
+    rt_uint64_t freq = rt_clock_time_get_freq();
+    rt_bool_t overflow = RT_FALSE;
+    rt_uint64_t ns;
+
+    if (freq == 0)
+    {
+        return 0;
+    }
+
+    ns = rt_clock_time_muldiv_u64(cnt, NANOSECOND_PER_SECOND, freq, RT_NULL, &overflow);
+    /* Call-site policy: report unrepresentable results as the max value. */
+    return overflow ? RT_UINT64_MAX : ns;
 }
 
 rt_uint64_t rt_clock_time_ns_to_counter(rt_uint64_t ns)
 {
     rt_uint64_t freq = rt_clock_time_get_freq();
+    rt_bool_t overflow = RT_FALSE;
+    rt_uint64_t cnt;
 
     if (freq == 0)
     {
         return 0;
     }
 
-    return rt_muldiv_u64(ns, freq, NANOSECOND_PER_SECOND, NULL);
+    cnt = rt_clock_time_muldiv_u64(ns, freq, NANOSECOND_PER_SECOND, RT_NULL, &overflow);
+    /* Call-site policy: report unrepresentable delays as the max value. */
+    return overflow ? RT_UINT64_MAX : cnt;
 }
 
 rt_err_t rt_clock_time_set_timeout(rt_uint64_t delta)

--- a/components/drivers/clock_time/clock_time_internal.c
+++ b/components/drivers/clock_time/clock_time_internal.c
@@ -1,18 +1,24 @@
 /*
- * Copyright (c) 2006-2025, RT-Thread Development Team
+ * Copyright (c) 2006-2026, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author        Notes
  * 2025-09-25     Yonggang Luo  the first version
+ * 2026-07-14     Yonggang Luo  keep muldiv private to clock_time
  */
 
-#include "rttypes.h"
-#include <rtdef.h>
+#include "clock_time_internal.h"
 
-/* Function to count leading zeros for an rt_uint64_t */
-static rt_int32_t u64_count_leading_zeros(rt_uint64_t n)
+/**
+ * @brief Count leading zero bits in a 64-bit value.
+ *
+ * @param n Input value.
+ *
+ * @return Number of leading zero bits; 64 when @p n is 0.
+ */
+static rt_int32_t _u64_count_leading_zeros(rt_uint64_t n)
 {
     if (n == 0)
     {
@@ -22,8 +28,7 @@ static rt_int32_t u64_count_leading_zeros(rt_uint64_t n)
     return __builtin_clzll(n);
 #else
     rt_int32_t count = 0;
-    rt_uint64_t mask =
-        1ULL << (sizeof(rt_uint64_t) * 8 - 1); // Most significant bit
+    rt_uint64_t mask = 1ULL << (sizeof(rt_uint64_t) * 8 - 1);
 
     while ((n & mask) == 0)
     {
@@ -35,19 +40,29 @@ static rt_int32_t u64_count_leading_zeros(rt_uint64_t n)
 }
 
 /**
- * https://ridiculousfish.com/blog/posts/labor-of-division-episode-v.html
- * Perform a narrowing division: 128 / 64 -> 64, and 64 / 32 -> 32.
- * The dividend's low and high words are given by \p numhi and \p numlo,
- * respectively. The divisor is given by \p den.
- * \return the quotient, and the remainder by reference in \p r, if not null.
- * If the quotient would require more than 64 bits, or if denom is 0, then
- * return the max value for both quotient and remainder.
+ * @brief Narrowing division of a 128-bit numerator by a 64-bit denominator.
  *
- * These functions are released into the public domain, where applicable, or the
- * CC0 license.
+ * Algorithm from:
+ * https://ridiculousfish.com/blog/posts/labor-of-division-episode-v.html
+ *
+ * The dividend is formed by high word @p numhi and low word @p numlo.
+ * When @p den is 0, both the quotient and the optional remainder are 0 and
+ * @p overflow is set. When the full quotient needs more than 64 bits,
+ * @c numhi %= den truncates to a 64-bit quotient and @p overflow is set.
+ *
+ * These functions are released into the public domain, where applicable, or
+ * the CC0 license.
+ *
+ * @param numhi    High 64 bits of the numerator.
+ * @param numlo    Low 64 bits of the numerator.
+ * @param den      Denominator.
+ * @param r        Optional remainder output; may be @c RT_NULL.
+ * @param overflow Optional overflow flag; may be @c RT_NULL.
+ *
+ * @return The truncated 64-bit quotient.
  */
-static rt_uint64_t u128_div_u64_u64(rt_uint64_t numhi, rt_uint64_t numlo, rt_uint64_t den,
-                                    rt_uint64_t *r)
+static rt_uint64_t _u128_div_u64_u64(rt_uint64_t numhi, rt_uint64_t numlo, rt_uint64_t den,
+                                     rt_uint64_t *r, rt_bool_t *overflow)
 {
     /*
      * We work in base 2**32.
@@ -84,8 +99,34 @@ static rt_uint64_t u128_div_u64_u64(rt_uint64_t numhi, rt_uint64_t numlo, rt_uin
     rt_uint64_t c1;
     rt_uint64_t c2;
 
-    /* Check for overflow and divide by 0. */
-    numhi = numhi % den;
+    if (overflow != RT_NULL)
+    {
+        *overflow = RT_FALSE;
+    }
+
+    /* Divide by 0: treat as a zero result. */
+    if (den == 0)
+    {
+        if (r != RT_NULL)
+        {
+            *r = 0;
+        }
+        if (overflow != RT_NULL)
+        {
+            *overflow = RT_TRUE;
+        }
+        return 0;
+    }
+
+    /* Truncate a wider-than-64-bit quotient to 64 bits. */
+    if (numhi >= den)
+    {
+        if (overflow != RT_NULL)
+        {
+            *overflow = RT_TRUE;
+        }
+        numhi = numhi % den;
+    }
 
     /*
      * Determine the normalization factor. We multiply den by this, so that its leading digit is at
@@ -96,7 +137,7 @@ static rt_uint64_t u128_div_u64_u64(rt_uint64_t numhi, rt_uint64_t numlo, rt_uin
      * by 64. The funny bitwise 'and' ensures that numlo does not get shifted into numhi if shift is 0.
      * clang 11 has an x86 codegen bug here: see LLVM bug 50118. The sequence below avoids it.
      */
-    shift = u64_count_leading_zeros(den);
+    shift = _u64_count_leading_zeros(den);
     den <<= shift;
     numhi <<= shift;
     numhi |= (numlo >> (-shift & 63)) & (-(rt_int64_t)shift >> 63);
@@ -137,16 +178,30 @@ static rt_uint64_t u128_div_u64_u64(rt_uint64_t numhi, rt_uint64_t numlo, rt_uin
     q0 = (rt_uint32_t)qhat;
 
     /* Return remainder if requested. */
-    if (r != NULL)
+    if (r != RT_NULL)
         *r = (rem * b + num0 - q0 * den) >> shift;
     return ((rt_uint64_t)q1 << 32) | q0;
 }
 
-rt_uint64_t rt_muldiv_u64(rt_uint64_t a, rt_uint64_t b, rt_uint64_t c, rt_uint64_t *r)
+rt_uint64_t rt_clock_time_muldiv_u64(rt_uint64_t a, rt_uint64_t b, rt_uint64_t c,
+                                     rt_uint64_t *r, rt_bool_t *overflow)
 {
     rt_uint64_t remainder = 0;
-    rt_uint64_t ret = 0;
-    if (c != 0) /* Handle division by zero. */
+    rt_uint64_t ret;
+
+    if (c == 0)
+    {
+        if (r != RT_NULL)
+        {
+            *r = 0;
+        }
+        if (overflow != RT_NULL)
+        {
+            *overflow = RT_TRUE;
+        }
+        return 0;
+    }
+
     {
         rt_uint64_t a_lo = a & 0xFFFFFFFF;
         rt_uint64_t a_hi = a >> 32;
@@ -163,9 +218,12 @@ rt_uint64_t rt_muldiv_u64(rt_uint64_t a, rt_uint64_t b, rt_uint64_t c, rt_uint64
 
         rt_uint64_t lo = (p0 & 0xFFFFFFFFULL) + ((carry & 0xFFFFFFFFULL) << 32);
         rt_uint64_t hi = p3 + (p1 >> 32) + (p2 >> 32) + (carry >> 32);
-        ret = u128_div_u64_u64(hi, lo, c, &remainder);
+        ret = _u128_div_u64_u64(hi, lo, c, &remainder, overflow);
     }
-    if (r)
+
+    if (r != RT_NULL)
+    {
         *r = remainder;
+    }
     return ret;
 }

--- a/components/drivers/clock_time/clock_time_internal.h
+++ b/components/drivers/clock_time/clock_time_internal.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2006-2026, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author        Notes
+ * 2025-09-25     Yonggang Luo  the first version
+ * 2026-07-14     Yonggang Luo  keep muldiv private to clock_time
+ */
+#ifndef __CLOCK_TIME_INTERNAL_H__
+#define __CLOCK_TIME_INTERNAL_H__
+
+#include <rtdef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Compute (a * b) / c with 128-bit intermediate precision.
+ *
+ * Pure arithmetic helper. When @p c is 0, returns 0 and sets @p overflow
+ * (if not @c RT_NULL). When the mathematical quotient does not fit in 64
+ * bits, the high part of the 128-bit product is reduced so the returned
+ * value is the truncated low 64-bit quotient, and @p overflow is set.
+ *
+ * Callers that need wrap, clamp, or error semantics must inspect @p overflow
+ * and apply that policy themselves.
+ *
+ * If @p r is not @c RT_NULL, @c *r receives the remainder of the reduced
+ * division, or 0 when @p c is 0.
+ *
+ * @param a         Multiplicand.
+ * @param b         Multiplier.
+ * @param c         Divisor.
+ * @param r         Optional remainder output; may be @c RT_NULL.
+ * @param overflow  Optional overflow flag; may be @c RT_NULL. Set to
+ *                  @c RT_TRUE when @p c is 0 or the quotient needs more
+ *                  than 64 bits; otherwise @c RT_FALSE.
+ *
+ * @return The truncated 64-bit quotient of (a * b) / c.
+ */
+rt_uint64_t rt_clock_time_muldiv_u64(rt_uint64_t a, rt_uint64_t b, rt_uint64_t c,
+                                     rt_uint64_t *r, rt_bool_t *overflow);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __CLOCK_TIME_INTERNAL_H__ */

--- a/components/drivers/clock_time/clock_timer.c
+++ b/components/drivers/clock_time/clock_timer.c
@@ -506,7 +506,6 @@ rt_err_t rt_clock_timer_register(rt_clock_timer_t *timer, const char *name, void
 
         _clock_timer_owner = timer;
         _clock_timer_clock_dev.ops = &_clock_timer_clock_ops;
-        _clock_timer_clock_dev.res_scale = RT_CLOCK_TIME_RESMUL;
         _clock_timer_clock_dev.caps = caps;
 
         rt_snprintf(ct_name, sizeof(ct_name), "clock_time_%s", name);

--- a/components/drivers/include/drivers/clock_time.h
+++ b/components/drivers/include/drivers/clock_time.h
@@ -161,6 +161,7 @@ void rt_clock_time_source_init(void);
 rt_uint64_t rt_clock_time_get_freq(void);
 rt_uint64_t rt_clock_time_get_counter(void);
 rt_uint64_t rt_clock_time_get_event_freq(void);
+rt_uint64_t rt_clock_time_get_res(void);
 
 rt_uint64_t rt_clock_time_counter_to_ns(rt_uint64_t cnt);
 rt_uint64_t rt_clock_time_ns_to_counter(rt_uint64_t ns);

--- a/components/drivers/include/drivers/clock_time.h
+++ b/components/drivers/include/drivers/clock_time.h
@@ -19,8 +19,6 @@
 extern "C" {
 #endif
 
-#define RT_CLOCK_TIME_RESMUL (1000000ULL)
-
 #define RT_CLOCK_TIME_CAP_SOURCE (1U << 0)
 #define RT_CLOCK_TIME_CAP_EVENT  (1U << 1)
 
@@ -37,7 +35,6 @@ struct rt_clock_time_device
 {
     struct rt_device parent;
     const struct rt_clock_time_ops *ops;
-    rt_uint64_t res_scale;
     rt_uint8_t caps;
 };
 
@@ -144,8 +141,8 @@ struct rt_clock_hrtimer
     char                 name[RT_NAME_MAX];
     rt_list_t            node;
     void                *parameter;
-    unsigned long        delay_cnt;
-    unsigned long        timeout_cnt;
+    rt_tick_t            delay_cnt;
+    rt_tick_t            timeout_cnt;
     rt_err_t             error;
     struct rt_completion completion;
     void (*timeout_func)(void *parameter);
@@ -163,9 +160,7 @@ void rt_clock_time_source_init(void);
 
 rt_uint64_t rt_clock_time_get_freq(void);
 rt_uint64_t rt_clock_time_get_counter(void);
-rt_uint64_t rt_clock_time_get_res_scaled(void);
 rt_uint64_t rt_clock_time_get_event_freq(void);
-rt_uint64_t rt_clock_time_get_event_res_scaled(void);
 
 rt_uint64_t rt_clock_time_counter_to_ns(rt_uint64_t cnt);
 rt_uint64_t rt_clock_time_ns_to_counter(rt_uint64_t ns);
@@ -177,9 +172,8 @@ rt_err_t rt_clock_boottime_get_us(struct timeval *tv);
 rt_err_t rt_clock_boottime_get_s(time_t *t);
 rt_err_t rt_clock_boottime_get_ns(struct timespec *ts);
 
-rt_uint64_t rt_clock_hrtimer_getres(void);
-unsigned long rt_clock_hrtimer_getfrq(void);
-rt_err_t rt_clock_hrtimer_settimeout(unsigned long cnt);
+rt_uint64_t rt_clock_hrtimer_getfrq(void);
+rt_err_t rt_clock_hrtimer_settimeout(rt_uint64_t cnt);
 void     rt_clock_hrtimer_process(void);
 
 void     rt_clock_hrtimer_init(rt_clock_hrtimer_t timer,
@@ -187,7 +181,7 @@ void     rt_clock_hrtimer_init(rt_clock_hrtimer_t timer,
                                     rt_uint8_t         flag,
                                     void (*timeout)(void *parameter),
                                     void *parameter);
-rt_err_t rt_clock_hrtimer_start(rt_clock_hrtimer_t timer, unsigned long cnt);
+rt_err_t rt_clock_hrtimer_start(rt_clock_hrtimer_t timer, rt_tick_t cnt);
 rt_err_t rt_clock_hrtimer_stop(rt_clock_hrtimer_t timer);
 rt_err_t rt_clock_hrtimer_control(rt_clock_hrtimer_t timer, int cmd, void *arg);
 rt_err_t rt_clock_hrtimer_detach(rt_clock_hrtimer_t timer);
@@ -204,10 +198,10 @@ void rt_clock_hrtimer_delay_init(struct rt_clock_hrtimer *timer);
 void rt_clock_hrtimer_delay_detach(struct rt_clock_hrtimer *timer);
 void rt_clock_hrtimer_process(void);
 
-rt_err_t rt_clock_hrtimer_sleep(struct rt_clock_hrtimer *timer, unsigned long cnt);
-rt_err_t rt_clock_hrtimer_ndelay(struct rt_clock_hrtimer *timer, unsigned long ns);
-rt_err_t rt_clock_hrtimer_udelay(struct rt_clock_hrtimer *timer, unsigned long us);
-rt_err_t rt_clock_hrtimer_mdelay(struct rt_clock_hrtimer *timer, unsigned long ms);
+rt_err_t rt_clock_hrtimer_sleep(struct rt_clock_hrtimer *timer, rt_tick_t cnt);
+rt_err_t rt_clock_hrtimer_ndelay(struct rt_clock_hrtimer *timer, rt_uint64_t ns);
+rt_err_t rt_clock_hrtimer_udelay(struct rt_clock_hrtimer *timer, rt_uint64_t us);
+rt_err_t rt_clock_hrtimer_mdelay(struct rt_clock_hrtimer *timer, rt_uint64_t ms);
 
 #ifdef __cplusplus
 }

--- a/components/drivers/rtc/dev_soft_rtc.c
+++ b/components/drivers/rtc/dev_soft_rtc.c
@@ -257,7 +257,7 @@ static rt_err_t soft_rtc_control(rt_device_t dev, int cmd, void *args)
         level = rt_spin_lock_irqsave(&_spinlock);
         ts->tv_sec = 0;
 #ifdef RT_USING_CLOCK_TIME
-        ts->tv_nsec = (rt_clock_time_get_res_scaled() / RT_CLOCK_TIME_RESMUL);
+        ts->tv_nsec = (rt_uint32_t)(NANOSECOND_PER_SECOND / rt_clock_time_get_freq());
 #else
         ts->tv_nsec = (1000UL * 1000 * 1000) / RT_TICK_PER_SECOND;
 #endif

--- a/components/drivers/rtc/dev_soft_rtc.c
+++ b/components/drivers/rtc/dev_soft_rtc.c
@@ -253,11 +253,19 @@ static rt_err_t soft_rtc_control(rt_device_t dev, int cmd, void *args)
     }
     case RT_DEVICE_CTRL_RTC_GET_TIMERES:
     {
+#ifdef RT_USING_CLOCK_TIME
+        rt_uint64_t res_ns = rt_clock_time_get_res();
+
+        if (res_ns == 0)
+        {
+            return -RT_ERROR;
+        }
+#endif
         ts = (struct timespec *)args;
         level = rt_spin_lock_irqsave(&_spinlock);
         ts->tv_sec = 0;
 #ifdef RT_USING_CLOCK_TIME
-        ts->tv_nsec = (rt_uint32_t)(NANOSECOND_PER_SECOND / rt_clock_time_get_freq());
+        ts->tv_nsec = (rt_int32_t)res_ns;
 #else
         ts->tv_nsec = (1000UL * 1000 * 1000) / RT_TICK_PER_SECOND;
 #endif

--- a/components/libc/compilers/common/ctime.c
+++ b/components/libc/compilers/common/ctime.c
@@ -581,7 +581,7 @@ int nanosleep(const struct timespec *rqtp, struct timespec *rmtp)
         rt_set_errno(EINVAL);
         return -1;
     }
-    unsigned long ns = rqtp->tv_sec * NANOSECOND_PER_SECOND + rqtp->tv_nsec;
+    rt_uint64_t ns = (rt_uint64_t)rqtp->tv_sec * NANOSECOND_PER_SECOND + rqtp->tv_nsec;
     rt_clock_boottime_get_ns(&old_ts);
     rt_clock_hrtimer_ndelay(&timer, ns);
     if (rt_get_errno() == RT_EINTR)
@@ -776,7 +776,7 @@ int clock_getres(clockid_t clockid, struct timespec *res)
         case CLOCK_PROCESS_CPUTIME_ID:
         case CLOCK_THREAD_CPUTIME_ID:
             res->tv_sec  = 0;
-            res->tv_nsec = (rt_clock_time_get_res_scaled() / RT_CLOCK_TIME_RESMUL);
+            res->tv_nsec = (rt_uint32_t)(NANOSECOND_PER_SECOND / rt_clock_time_get_freq());
             return 0;
 
         default:
@@ -989,7 +989,7 @@ struct timer_obj
     union sigval val;
     struct timespec interval;              /* Reload value */
     struct timespec value;                 /* Reload value */
-    unsigned long reload;                    /* Reload value in ms */
+    rt_tick_t reload;                    /* Reload value in ms */
     rt_uint32_t status;
     int sigev_signo;
     clockid_t clockid;
@@ -1071,6 +1071,7 @@ int timer_list_free(rt_list_t *timer_list)
 static void rtthread_timer_wrapper(void *timerobj)
 {
     struct timer_obj *timer;
+    rt_uint64_t ns;
 
     timer = (struct timer_obj *)timerobj;
 
@@ -1079,8 +1080,8 @@ static void rtthread_timer_wrapper(void *timerobj)
         timer->status = NOT_ACTIVE;
     }
 
-    timer->reload = ((timer->interval.tv_sec * NANOSECOND_PER_SECOND + timer->interval.tv_nsec) * RT_CLOCK_TIME_RESMUL) /
-                    rt_clock_time_get_res_scaled();
+    ns = timer->interval.tv_sec * NANOSECOND_PER_SECOND + timer->interval.tv_nsec;
+    timer->reload = (rt_tick_t)rt_muldiv_u64(ns, rt_clock_time_get_freq(), NANOSECOND_PER_SECOND, NULL);
     if (timer->reload)
     {
         rt_clock_hrtimer_start(&timer->hrtimer, timer->reload);
@@ -1299,7 +1300,6 @@ int timer_getoverrun(timer_t timerid)
 int timer_gettime(timer_t timerid, struct itimerspec *its)
 {
     struct timer_obj *timer;
-    rt_uint32_t seconds, nanoseconds;
 
     timer = _g_timerid[(rt_ubase_t)timerid];
 
@@ -1317,13 +1317,13 @@ int timer_gettime(timer_t timerid, struct itimerspec *its)
 
     if (timer->status == ACTIVE)
     {
-        unsigned long remain_cnt;
+        rt_tick_t remain_cnt;
+        rt_uint64_t remain_relative_cnt;
+        const rt_uint64_t freq = rt_clock_time_get_freq();
         rt_clock_hrtimer_control(&timer->hrtimer, RT_TIMER_CTRL_GET_REMAIN_TIME, &remain_cnt);
-        nanoseconds = ((remain_cnt - rt_clock_time_get_counter()) * rt_clock_time_get_res_scaled()) / RT_CLOCK_TIME_RESMUL;
-        seconds     = nanoseconds / NANOSECOND_PER_SECOND;
-        nanoseconds = nanoseconds % NANOSECOND_PER_SECOND;
-        its->it_value.tv_sec = (rt_int32_t)seconds;
-        its->it_value.tv_nsec = (rt_int32_t)nanoseconds;
+        remain_relative_cnt = (rt_uint64_t)remain_cnt - rt_clock_time_get_counter();
+        its->it_value.tv_sec = (time_t)(remain_relative_cnt / freq);
+        its->it_value.tv_nsec = (rt_int32_t)rt_muldiv_u64(remain_relative_cnt % freq, NANOSECOND_PER_SECOND, freq, NULL);
     }
     else
     {
@@ -1411,8 +1411,7 @@ int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
     if (ns <= 0)
         return 0;
 
-    unsigned long res       = rt_clock_time_get_res_scaled();
-    timer->reload           = (ns * RT_CLOCK_TIME_RESMUL) / res;
+    timer->reload           = (rt_tick_t)rt_muldiv_u64(ns, rt_clock_time_get_freq(), NANOSECOND_PER_SECOND, NULL);
     timer->interval.tv_sec  = value->it_interval.tv_sec;
     timer->interval.tv_nsec = value->it_interval.tv_nsec;
     timer->value.tv_sec     = value->it_value.tv_sec;

--- a/components/libc/compilers/common/ctime.c
+++ b/components/libc/compilers/common/ctime.c
@@ -775,9 +775,19 @@ int clock_getres(clockid_t clockid, struct timespec *res)
         case CLOCK_BOOTTIME:
         case CLOCK_PROCESS_CPUTIME_ID:
         case CLOCK_THREAD_CPUTIME_ID:
+        {
+            rt_uint64_t res_ns = rt_clock_time_get_res();
+
+            if (res_ns == 0)
+            {
+                rt_set_errno(EINVAL);
+                return -1;
+            }
+
             res->tv_sec  = 0;
-            res->tv_nsec = (rt_uint32_t)(NANOSECOND_PER_SECOND / rt_clock_time_get_freq());
+            res->tv_nsec = (rt_int32_t)res_ns;
             return 0;
+        }
 
         default:
             rt_set_errno(EINVAL);
@@ -989,7 +999,7 @@ struct timer_obj
     union sigval val;
     struct timespec interval;              /* Reload value */
     struct timespec value;                 /* Reload value */
-    rt_tick_t reload;                    /* Reload value in ms */
+    rt_tick_t reload;                      /* Reload value in counter ticks */
     rt_uint32_t status;
     int sigev_signo;
     clockid_t clockid;
@@ -1072,6 +1082,8 @@ static void rtthread_timer_wrapper(void *timerobj)
 {
     struct timer_obj *timer;
     rt_uint64_t ns;
+    rt_uint64_t reload;
+    rt_uint64_t freq;
 
     timer = (struct timer_obj *)timerobj;
 
@@ -1081,7 +1093,34 @@ static void rtthread_timer_wrapper(void *timerobj)
     }
 
     ns = timer->interval.tv_sec * NANOSECOND_PER_SECOND + timer->interval.tv_nsec;
-    timer->reload = (rt_tick_t)rt_muldiv_u64(ns, rt_clock_time_get_freq(), NANOSECOND_PER_SECOND, NULL);
+    if (ns == 0)
+    {
+        /* one-shot timer: no interval means no reload is requested */
+        reload = 0;
+    }
+    else
+    {
+        freq = rt_clock_time_get_freq();
+        if (freq == 0)
+        {
+            reload = 0;
+            timer->status = NOT_ACTIVE;
+        }
+        else
+        {
+            reload = rt_clock_time_ns_to_counter(ns);
+            if (reload >= (RT_TICK_MAX / 2))
+            {
+                reload = 0;
+                timer->status = NOT_ACTIVE;
+            }
+            else if (reload == 0)
+            {
+                reload = 1; /* round up so a non-zero interval never collapses to a 0-tick reload */
+            }
+        }
+    }
+    timer->reload = (rt_tick_t)reload;
     if (timer->reload)
     {
         rt_clock_hrtimer_start(&timer->hrtimer, timer->reload);
@@ -1319,11 +1358,21 @@ int timer_gettime(timer_t timerid, struct itimerspec *its)
     {
         rt_tick_t remain_cnt;
         rt_uint64_t remain_relative_cnt;
+        rt_uint64_t now;
         const rt_uint64_t freq = rt_clock_time_get_freq();
+
+        if (freq == 0)
+        {
+            rt_set_errno(EINVAL);
+            return -1;
+        }
+
         rt_clock_hrtimer_control(&timer->hrtimer, RT_TIMER_CTRL_GET_REMAIN_TIME, &remain_cnt);
-        remain_relative_cnt = (rt_uint64_t)remain_cnt - rt_clock_time_get_counter();
+        now = rt_clock_time_get_counter();
+        /* Clamp to 0 when the timer already expired to avoid u64 underflow. */
+        remain_relative_cnt = ((rt_uint64_t)remain_cnt > now) ? ((rt_uint64_t)remain_cnt - now) : 0;
         its->it_value.tv_sec = (time_t)(remain_relative_cnt / freq);
-        its->it_value.tv_nsec = (rt_int32_t)rt_muldiv_u64(remain_relative_cnt % freq, NANOSECOND_PER_SECOND, freq, NULL);
+        its->it_value.tv_nsec = (rt_int32_t)rt_clock_time_counter_to_ns(remain_relative_cnt % freq);
     }
     else
     {
@@ -1348,6 +1397,7 @@ int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
 {
     struct timespec ts = {0};
     rt_err_t        err = RT_EOK;
+    rt_uint64_t     reload;
 
     struct timer_obj *timer;
     timer = _g_timerid[(rt_ubase_t)timerid];
@@ -1411,7 +1461,24 @@ int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
     if (ns <= 0)
         return 0;
 
-    timer->reload           = (rt_tick_t)rt_muldiv_u64(ns, rt_clock_time_get_freq(), NANOSECOND_PER_SECOND, NULL);
+    if (rt_clock_time_get_freq() == 0)
+    {
+        rt_set_errno(EINVAL);
+        return -1;
+    }
+
+    reload = rt_clock_time_ns_to_counter(ns);
+    if (reload >= (RT_TICK_MAX / 2))
+    {
+        rt_set_errno(EINVAL);
+        return -1;
+    }
+    if (reload == 0)
+    {
+        reload = 1;
+    }
+
+    timer->reload           = (rt_tick_t)reload;
     timer->interval.tv_sec  = value->it_interval.tv_sec;
     timer->interval.tv_nsec = value->it_interval.tv_nsec;
     timer->value.tv_sec     = value->it_value.tv_sec;

--- a/documentation/6.components/device-driver/clock_time/clock_time_core.md
+++ b/documentation/6.components/device-driver/clock_time/clock_time_core.md
@@ -49,13 +49,10 @@ struct rt_clock_time_device
 {
     struct rt_device parent;
     const struct rt_clock_time_ops *ops;
-    rt_uint64_t res_scale;
     rt_uint8_t caps; /* RT_CLOCK_TIME_CAP_SOURCE / RT_CLOCK_TIME_CAP_EVENT */
 };
 ```
 
-- res_scale provides extra precision in the conversion pipeline. If set to 0,
-  RT_CLOCK_TIME_RESMUL is used by default.
 - caps advertises whether the device can be used as a clock source, a clock
   event, or both.
 
@@ -75,7 +72,7 @@ struct rt_clock_time_device *rt_clock_time_get_default_event(void);
 
 - Purpose: register a clock_time device and its capabilities.
 - Parameters:
-  - `dev`: device object with ops and res_scale initialized.
+  - `dev`: device object with ops initialized.
   - `name`: device name; if NULL, only capability registration is performed.
   - `caps`: RT_CLOCK_TIME_CAP_SOURCE and/or RT_CLOCK_TIME_CAP_EVENT.
 - Behavior:
@@ -109,7 +106,6 @@ struct rt_clock_time_device *rt_clock_time_get_default_event(void);
 rt_uint64_t rt_clock_time_get_freq(void);
 rt_uint64_t rt_clock_time_get_counter(void);
 rt_uint64_t rt_clock_time_get_event_freq(void);
-rt_uint64_t rt_clock_time_get_event_res_scaled(void);
 ```
 
 ## rt_clock_time_get_freq
@@ -131,45 +127,25 @@ rt_uint64_t rt_clock_time_get_event_res_scaled(void);
 - Purpose: return the event device frequency in Hz.
 - Behavior: if no event device exists, falls back to the default source.
 
-## rt_clock_time_get_event_res_scaled
-
-- Purpose: return the scaled resolution for the event device.
-- Behavior: if no event device exists, falls back to the default source.
-
 # Conversion Helpers
 
 ```c
-rt_uint64_t rt_clock_time_get_res_scaled(void);
 rt_uint64_t rt_clock_time_counter_to_ns(rt_uint64_t cnt);
 rt_uint64_t rt_clock_time_ns_to_counter(rt_uint64_t ns);
 ```
 
-## rt_clock_time_get_res_scaled
-
-- Purpose: return the scaled resolution for the default source.
-- Return values:
-  - Non-zero scaled resolution when the source is ready.
-  - 0 when the source is missing or frequency is invalid.
-
 ## rt_clock_time_counter_to_ns
 
 - Purpose: convert a counter value to nanoseconds based on the default source.
-- Notes: returns 0 when resolution is unavailable.
+- Notes: returns 0 when frequency is unavailable.
 
 ## rt_clock_time_ns_to_counter
 
 - Purpose: convert nanoseconds to counter units for the default source.
-- Notes: returns 0 when resolution is unavailable.
+- Notes: returns 0 when frequency is unavailable.
 
-Internally, the core computes a scaled resolution:
-
-```
-res_scaled = (1e9 * res_scale) / freq
-```
-
-Nanoseconds are then derived using the scale factor RT_CLOCK_TIME_RESMUL to
-avoid floating-point math. This keeps precision stable even when freq is not a
-power of ten.
+Conversions use the source frequency directly with `rt_muldiv_u64()` to avoid
+floating-point math and preserve precision.
 
 # Event API
 
@@ -220,7 +196,6 @@ static const struct rt_clock_time_ops demo_src_ops =
 static struct rt_clock_time_device demo_src_dev =
 {
     .ops = &demo_src_ops,
-    .res_scale = RT_CLOCK_TIME_RESMUL,
 };
 
 void rt_clock_time_source_init(void)
@@ -250,7 +225,6 @@ static const struct rt_clock_time_ops demo_evt_ops =
 static struct rt_clock_time_device demo_evt_dev =
 {
     .ops = &demo_evt_ops,
-    .res_scale = RT_CLOCK_TIME_RESMUL,
 };
 
 static void demo_timer_isr(void)

--- a/documentation/6.components/device-driver/clock_time/clock_time_core.md
+++ b/documentation/6.components/device-driver/clock_time/clock_time_core.md
@@ -106,6 +106,7 @@ struct rt_clock_time_device *rt_clock_time_get_default_event(void);
 rt_uint64_t rt_clock_time_get_freq(void);
 rt_uint64_t rt_clock_time_get_counter(void);
 rt_uint64_t rt_clock_time_get_event_freq(void);
+rt_uint64_t rt_clock_time_get_res(void);
 ```
 
 ## rt_clock_time_get_freq
@@ -127,6 +128,13 @@ rt_uint64_t rt_clock_time_get_event_freq(void);
 - Purpose: return the event device frequency in Hz.
 - Behavior: if no event device exists, falls back to the default source.
 
+## rt_clock_time_get_res
+
+- Purpose: return the default source resolution in nanoseconds.
+- Return values:
+  - Non-zero resolution on success.
+  - 0 if frequency is unavailable (avoids divide-by-zero).
+
 # Conversion Helpers
 
 ```c
@@ -137,15 +145,19 @@ rt_uint64_t rt_clock_time_ns_to_counter(rt_uint64_t ns);
 ## rt_clock_time_counter_to_ns
 
 - Purpose: convert a counter value to nanoseconds based on the default source.
-- Notes: returns 0 when frequency is unavailable.
+- Notes:
+  - Returns 0 when frequency is unavailable.
+  - Returns `RT_UINT64_MAX` when the result overflows 64-bit range.
 
 ## rt_clock_time_ns_to_counter
 
 - Purpose: convert nanoseconds to counter units for the default source.
-- Notes: returns 0 when frequency is unavailable.
+- Notes:
+  - Returns 0 when frequency is unavailable.
+  - Returns `RT_UINT64_MAX` when the result overflows 64-bit range.
 
-Conversions use the source frequency directly with `rt_muldiv_u64()` to avoid
-floating-point math and preserve precision.
+Conversions use the source frequency directly with an internal
+precision-preserving muldiv helper to avoid floating-point math.
 
 # Event API
 

--- a/documentation/6.components/device-driver/clock_time/clock_time_core_zh.md
+++ b/documentation/6.components/device-driver/clock_time/clock_time_core_zh.md
@@ -45,12 +45,10 @@ struct rt_clock_time_device
 {
     struct rt_device parent;
     const struct rt_clock_time_ops *ops;
-    rt_uint64_t res_scale;
     rt_uint8_t caps; /* RT_CLOCK_TIME_CAP_SOURCE / RT_CLOCK_TIME_CAP_EVENT */
 };
 ```
 
-- res_scale 用于提高换算精度，0 表示使用 RT_CLOCK_TIME_RESMUL 默认值。
 - caps 用于标识设备能力：时钟源或时钟事件。
 
 ## 注册与默认选择
@@ -69,7 +67,7 @@ struct rt_clock_time_device *rt_clock_time_get_default_event(void);
 
 - 作用：注册 clock_time 设备及其能力。
 - 参数：
-  - `dev`：设备对象，需初始化 ops 与 res_scale。
+  - `dev`：设备对象，需初始化 ops。
   - `name`：设备名；为 NULL 时仅注册能力，不进入设备框架。
   - `caps`：RT_CLOCK_TIME_CAP_SOURCE / RT_CLOCK_TIME_CAP_EVENT。
 - 行为：
@@ -100,7 +98,6 @@ struct rt_clock_time_device *rt_clock_time_get_default_event(void);
 rt_uint64_t rt_clock_time_get_freq(void);
 rt_uint64_t rt_clock_time_get_counter(void);
 rt_uint64_t rt_clock_time_get_event_freq(void);
-rt_uint64_t rt_clock_time_get_event_res_scaled(void);
 ```
 
 ## rt_clock_time_get_freq
@@ -118,41 +115,24 @@ rt_uint64_t rt_clock_time_get_event_res_scaled(void);
 - 作用：获取事件设备频率（Hz）。
 - 行为：若无事件设备则回退使用默认时钟源。
 
-## rt_clock_time_get_event_res_scaled
-
-- 作用：获取事件设备的缩放分辨率。
-- 行为：若无事件设备则回退使用默认时钟源。
-
 # 换算接口
 
 ```c
-rt_uint64_t rt_clock_time_get_res_scaled(void);
 rt_uint64_t rt_clock_time_counter_to_ns(rt_uint64_t cnt);
 rt_uint64_t rt_clock_time_ns_to_counter(rt_uint64_t ns);
 ```
 
-## rt_clock_time_get_res_scaled
-
-- 作用：获取默认时钟源的缩放分辨率。
-- 返回值：无有效时钟源时返回 0。
-
 ## rt_clock_time_counter_to_ns
 
 - 作用：将计数值换算为纳秒。
-- 说明：当分辨率不可用时返回 0。
+- 说明：当频率不可用时返回 0。
 
 ## rt_clock_time_ns_to_counter
 
 - 作用：将纳秒换算为计数值。
-- 说明：当分辨率不可用时返回 0。
+- 说明：当频率不可用时返回 0。
 
-核心使用定点缩放换算：
-
-```
-res_scaled = (1e9 * res_scale) / freq
-```
-
-然后用 RT_CLOCK_TIME_RESMUL 进行定点缩放，以避免浮点运算带来的精度损失。
+换算直接使用时钟源频率，并通过 `rt_muldiv_u64()` 避免浮点运算带来的精度损失。
 
 # 事件接口
 
@@ -203,7 +183,6 @@ static const struct rt_clock_time_ops demo_src_ops =
 static struct rt_clock_time_device demo_src_dev =
 {
     .ops = &demo_src_ops,
-    .res_scale = RT_CLOCK_TIME_RESMUL,
 };
 
 void rt_clock_time_source_init(void)
@@ -233,7 +212,6 @@ static const struct rt_clock_time_ops demo_evt_ops =
 static struct rt_clock_time_device demo_evt_dev =
 {
     .ops = &demo_evt_ops,
-    .res_scale = RT_CLOCK_TIME_RESMUL,
 };
 
 static void demo_timer_isr(void)

--- a/documentation/6.components/device-driver/clock_time/clock_time_core_zh.md
+++ b/documentation/6.components/device-driver/clock_time/clock_time_core_zh.md
@@ -98,6 +98,7 @@ struct rt_clock_time_device *rt_clock_time_get_default_event(void);
 rt_uint64_t rt_clock_time_get_freq(void);
 rt_uint64_t rt_clock_time_get_counter(void);
 rt_uint64_t rt_clock_time_get_event_freq(void);
+rt_uint64_t rt_clock_time_get_res(void);
 ```
 
 ## rt_clock_time_get_freq
@@ -115,6 +116,11 @@ rt_uint64_t rt_clock_time_get_event_freq(void);
 - 作用：获取事件设备频率（Hz）。
 - 行为：若无事件设备则回退使用默认时钟源。
 
+## rt_clock_time_get_res
+
+- 作用：获取默认时钟源分辨率（纳秒）。
+- 返回值：成功返回非 0 分辨率；频率不可用时返回 0（避免除零）。
+
 # 换算接口
 
 ```c
@@ -125,14 +131,18 @@ rt_uint64_t rt_clock_time_ns_to_counter(rt_uint64_t ns);
 ## rt_clock_time_counter_to_ns
 
 - 作用：将计数值换算为纳秒。
-- 说明：当频率不可用时返回 0。
+- 说明：
+  - 当频率不可用时返回 0。
+  - 当结果超出 64 位范围时返回 `RT_UINT64_MAX`。
 
 ## rt_clock_time_ns_to_counter
 
 - 作用：将纳秒换算为计数值。
-- 说明：当频率不可用时返回 0。
+- 说明：
+  - 当频率不可用时返回 0。
+  - 当结果超出 64 位范围时返回 `RT_UINT64_MAX`。
 
-换算直接使用时钟源频率，并通过 `rt_muldiv_u64()` 避免浮点运算带来的精度损失。
+换算直接使用时钟源频率，并通过内部高精度 muldiv 辅助函数避免浮点运算带来的精度损失。
 
 # 事件接口
 

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -107,7 +107,11 @@ extern "C" {
 #define RT_UINT64_MAX                   0xFFFFFFFFFFFFFFFFULL /**< Maximum number of UINT64 */
 #endif /* RT_USING_LIBC */
 
+#if defined(ARCH_CPU_64BIT)
+#define RT_TICK_MAX                     RT_UINT64_MAX   /**< Maximum number of tick */
+#else
 #define RT_TICK_MAX                     RT_UINT32_MAX   /**< Maximum number of tick */
+#endif
 
 /* maximum value of ipc type */
 #define RT_SEM_VALUE_MAX                RT_UINT16_MAX   /**< Maximum number of semaphore .value */

--- a/include/rttypes.h
+++ b/include/rttypes.h
@@ -88,7 +88,11 @@ typedef rt_ubase_t                       rt_uintptr_t;   /**< Type for unsigned 
 #endif /* defined(RT_USING_LIBC) && !defined(RT_USING_NANO) */
 
 typedef rt_base_t                       rt_err_t;       /**< Type for error number */
+#if defined(ARCH_CPU_64BIT)
+typedef rt_uint64_t                     rt_tick_t;      /**< Type for tick count */
+#else
 typedef rt_uint32_t                     rt_tick_t;      /**< Type for tick count */
+#endif
 typedef rt_base_t                       rt_flag_t;      /**< Type for flags */
 typedef rt_ubase_t                      rt_dev_t;       /**< Type for device */
 typedef rt_base_t                       rt_off_t;       /**< Type for offset */
@@ -257,6 +261,14 @@ struct rt_spinlock
 typedef struct rt_spinlock rt_spinlock_t;
 
 #define RT_DEFINE_SPINLOCK(x)  struct rt_spinlock x = RT_SPINLOCK_INIT
+
+/**
+ * @brief lossless mul div, return `(a * b) / c`
+ *
+ * if r is not NULL then `*r = (a * b) % c`
+ * @return rt_uint64_t
+ */
+rt_uint64_t rt_muldiv_u64(rt_uint64_t a, rt_uint64_t b, rt_uint64_t c, rt_uint64_t *r);
 
 #ifdef __cplusplus
 }

--- a/include/rttypes.h
+++ b/include/rttypes.h
@@ -262,14 +262,6 @@ typedef struct rt_spinlock rt_spinlock_t;
 
 #define RT_DEFINE_SPINLOCK(x)  struct rt_spinlock x = RT_SPINLOCK_INIT
 
-/**
- * @brief lossless mul div, return `(a * b) / c`
- *
- * if r is not NULL then `*r = (a * b) % c`
- * @return rt_uint64_t
- */
-rt_uint64_t rt_muldiv_u64(rt_uint64_t a, rt_uint64_t b, rt_uint64_t c, rt_uint64_t *r);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/rttypes.c
+++ b/src/rttypes.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2006-2025, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author        Notes
+ * 2025-09-25     Yonggang Luo  the first version
+ */
+
+#include "rttypes.h"
+#include <rtdef.h>
+
+/* Function to count leading zeros for an rt_uint64_t */
+static rt_int32_t u64_count_leading_zeros(rt_uint64_t n)
+{
+    if (n == 0)
+    {
+        return 64;
+    }
+#ifdef __GNUC__
+    return __builtin_clzll(n);
+#else
+    rt_int32_t count = 0;
+    rt_uint64_t mask =
+        1ULL << (sizeof(rt_uint64_t) * 8 - 1); // Most significant bit
+
+    while ((n & mask) == 0)
+    {
+        count++;
+        mask >>= 1;
+    }
+    return count;
+#endif
+}
+
+/**
+ * https://ridiculousfish.com/blog/posts/labor-of-division-episode-v.html
+ * Perform a narrowing division: 128 / 64 -> 64, and 64 / 32 -> 32.
+ * The dividend's low and high words are given by \p numhi and \p numlo,
+ * respectively. The divisor is given by \p den.
+ * \return the quotient, and the remainder by reference in \p r, if not null.
+ * If the quotient would require more than 64 bits, or if denom is 0, then
+ * return the max value for both quotient and remainder.
+ *
+ * These functions are released into the public domain, where applicable, or the
+ * CC0 license.
+ */
+static rt_uint64_t u128_div_u64_u64(rt_uint64_t numhi, rt_uint64_t numlo, rt_uint64_t den,
+                                    rt_uint64_t *r)
+{
+    /*
+     * We work in base 2**32.
+     * A uint32 holds a single digit. A uint64 holds two digits.
+     * Our numerator is conceptually [num3, num2, num1, num0].
+     * Our denominator is [den1, den0].
+     */
+    const rt_uint64_t b = (1ull << 32);
+
+    /* The high and low digits of our computed quotient. */
+    rt_uint32_t q1;
+    rt_uint32_t q0;
+
+    /* The normalization shift factor. */
+    rt_int32_t shift;
+
+    /*
+     * The high and low digits of our denominator (after normalizing).
+     * Also the low 2 digits of our numerator (after normalizing).
+     */
+    rt_uint32_t den1;
+    rt_uint32_t den0;
+    rt_uint32_t num1;
+    rt_uint32_t num0;
+
+    /* A partial remainder. */
+    rt_uint64_t rem;
+
+    /* The estimated quotient, and its corresponding remainder (unrelated to true remainder). */
+    rt_uint64_t qhat;
+    rt_uint64_t rhat;
+
+    /* Variables used to correct the estimated quotient. */
+    rt_uint64_t c1;
+    rt_uint64_t c2;
+
+    /* Check for overflow and divide by 0. */
+    numhi = numhi % den;
+
+    /*
+     * Determine the normalization factor. We multiply den by this, so that its leading digit is at
+     * least half b. In binary this means just shifting left by the number of leading zeros, so that
+     * there's a 1 in the MSB.
+     * We also shift numer by the same amount. This cannot overflow because numhi < den.
+     * The expression (-shift & 63) is the same as (64 - shift), except it avoids the UB of shifting
+     * by 64. The funny bitwise 'and' ensures that numlo does not get shifted into numhi if shift is 0.
+     * clang 11 has an x86 codegen bug here: see LLVM bug 50118. The sequence below avoids it.
+     */
+    shift = u64_count_leading_zeros(den);
+    den <<= shift;
+    numhi <<= shift;
+    numhi |= (numlo >> (-shift & 63)) & (-(rt_int64_t)shift >> 63);
+    numlo <<= shift;
+
+    /* Extract the low digits of the numerator and both digits of the denominator. */
+    num1 = (rt_uint32_t)(numlo >> 32);
+    num0 = (rt_uint32_t)(numlo & 0xFFFFFFFFu);
+    den1 = (rt_uint32_t)(den >> 32);
+    den0 = (rt_uint32_t)(den & 0xFFFFFFFFu);
+
+    /*
+     * We wish to compute q1 = [n3 n2 n1] / [d1 d0].
+     * Estimate q1 as [n3 n2] / [d1], and then correct it.
+     * Note while qhat may be 2 digits, q1 is always 1 digit.
+     */
+    qhat = numhi / den1;
+    rhat = numhi % den1;
+    c1 = qhat * den0;
+    c2 = rhat * b + num1;
+    if (c1 > c2)
+        qhat -= (c1 - c2 > den) ? 2 : 1;
+    q1 = (rt_uint32_t)qhat;
+
+    /* Compute the true (partial) remainder. */
+    rem = numhi * b + num1 - q1 * den;
+
+    /*
+     * We wish to compute q0 = [rem1 rem0 n0] / [d1 d0].
+     * Estimate q0 as [rem1 rem0] / [d1] and correct it.
+     */
+    qhat = rem / den1;
+    rhat = rem % den1;
+    c1 = qhat * den0;
+    c2 = rhat * b + num0;
+    if (c1 > c2)
+        qhat -= (c1 - c2 > den) ? 2 : 1;
+    q0 = (rt_uint32_t)qhat;
+
+    /* Return remainder if requested. */
+    if (r != NULL)
+        *r = (rem * b + num0 - q0 * den) >> shift;
+    return ((rt_uint64_t)q1 << 32) | q0;
+}
+
+rt_uint64_t rt_muldiv_u64(rt_uint64_t a, rt_uint64_t b, rt_uint64_t c, rt_uint64_t *r)
+{
+    rt_uint64_t remainder = 0;
+    rt_uint64_t ret = 0;
+    if (c != 0) /* Handle division by zero. */
+    {
+        rt_uint64_t a_lo = a & 0xFFFFFFFF;
+        rt_uint64_t a_hi = a >> 32;
+        rt_uint64_t b_lo = b & 0xFFFFFFFF;
+        rt_uint64_t b_hi = b >> 32;
+
+        /* Perform partial products */
+        rt_uint64_t p0 = a_lo * b_lo;
+        rt_uint64_t p1 = a_lo * b_hi;
+        rt_uint64_t p2 = a_hi * b_lo;
+        rt_uint64_t p3 = a_hi * b_hi;
+
+        rt_uint64_t carry = (p0 >> 32) + (p1 & 0xFFFFFFFFULL) + (p2 & 0xFFFFFFFFULL);
+
+        rt_uint64_t lo = (p0 & 0xFFFFFFFFULL) + ((carry & 0xFFFFFFFFULL) << 32);
+        rt_uint64_t hi = p3 + (p1 >> 32) + (p2 >> 32) + (carry >> 32);
+        ret = u128_div_u64_u64(hi, lo, c, &remainder);
+    }
+    if (r)
+        *r = remainder;
+    return ret;
+}


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
continue work of https://github.com/RT-Thread/rt-thread/pull/9008

Fixes overflow of `clock_gettime`  `rt_ktime_boottime_get_ns` thoroughly

Currently the return value of clock_gettime and rt_ktime_boottime_get_ns are restricted by `rt_ktime_cputimer_getres`, as the value of `rt_ktime_cputimer_getres` are not exactly represent the `frequency of the clock`, directly using `rt_ktime_cputimer_getfrq` will ensure the return value of rt_ktime_boottime_get_ns be more exact.
And also add function rt_muldiv_u64 rt_muldiv_u32 for not losing precision when convert between `cputimer` and `hrtimer` and `nanoseconds`.

Because `rt_ktime_boottime_get_ns` depends on `rt_ktime_cputimer_getcnt` and `rt_ktime_cputimer_getcnt` depends `rt_tick_get`
So the rt_tick_t should be 64bit for long running program.

Use `#if defined(ARCH_CPU_64BIT)` is for
future allow rt_tick_t can be 64bit on 32bit CPU.

Tick count should not be restricted to the CPU

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)


#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
