### PR TITLE
utest: move driver related case under to drivers

### DIFF
--- a/Kconfig.utestcases
+++ b/Kconfig.utestcases
@@ -21,6 +21,7 @@ rsource "examples/utest/testcases/perf/Kconfig"
 
 rsource "src/klibc/utest/Kconfig"
 
+rsource "components/drivers/core/utest/Kconfig"
 rsource "components/drivers/audio/utest/Kconfig"
 rsource "components/dfs/utest/Kconfig"
 rsource "components/net/utest/Kconfig"

--- a/components/drivers/core/SConscript
+++ b/components/drivers/core/SConscript
@@ -18,4 +18,9 @@ if GetDepend(['RT_USING_OFW']):
 
 group = DefineGroup('DeviceDrivers', src, depend = ['RT_USING_DEVICE'], CPPPATH = CPPPATH)
 
+list = os.listdir(cwd)
+for item in list:
+    if os.path.isfile(os.path.join(cwd, item, 'SConscript')):
+        group = group + SConscript(os.path.join(item, 'SConscript'))
+
 Return('group')

--- a/components/drivers/core/utest/Kconfig
+++ b/components/drivers/core/utest/Kconfig
@@ -1,0 +1,3 @@
+config RT_UTEST_DRIVERS_CORE
+    bool "Enable testcase for drivers core"
+    default n

--- a/components/drivers/core/utest/SConscript
+++ b/components/drivers/core/utest/SConscript
@@ -1,0 +1,13 @@
+Import('rtconfig')
+from building import *
+
+cwd     = GetCurrentDir()
+src     = []
+CPPPATH = [cwd]
+
+if GetDepend('RT_UTEST_DRIVERS_CORE'):
+    src += Glob('*.c')
+
+group = DefineGroup('utestcases', src, depend = ['RT_USING_UTESTCASES'], CPPPATH = CPPPATH)
+
+Return('group')

--- a/components/drivers/core/utest/device_tc.c
+++ b/components/drivers/core/utest/device_tc.c
@@ -56,4 +56,4 @@ static void testcase(void)
 {
     UTEST_UNIT_RUN(test_rt_device_find);
 }
-UTEST_TC_EXPORT(testcase, "core.device_find", utest_tc_init, utest_tc_cleanup, 5);
+UTEST_TC_EXPORT(testcase, "components.drivers.core.device_find", utest_tc_init, utest_tc_cleanup, 5);

--- a/src/utest/Kconfig
+++ b/src/utest/Kconfig
@@ -62,10 +62,6 @@ config UTEST_THREAD_TC
     select RT_USING_TIMER_SOFT
     select RT_USING_THREAD
 
-config UTEST_DEVICE_TC
-    bool "device test"
-    default n
-
 config UTEST_ATOMIC_TC
     bool "atomic test"
     default n

--- a/src/utest/SConscript
+++ b/src/utest/SConscript
@@ -46,9 +46,6 @@ if GetDepend(['UTEST_THREAD_TC']):
     src += ['thread_overflow_tc.c']
     src += ['thread_suspend_tc.c']
 
-if GetDepend(['UTEST_DEVICE_TC']):
-    src += ['device_tc.c']
-
 if GetDepend(['UTEST_ATOMIC_TC']):
     src += ['atomic_tc.c']
 


### PR DESCRIPTION
src/utest/device_tc.c is testing API: rt_device_find(), which is a function defined in components/drivers/core/device.c. So it should be a testcase for drivers core, not for core.

Move it to under components/drivers/core.

此 pr 没有对 device_tc.c 代码内容进行改动。

