### PR TITLE
doxygen: cleanup code for group_object_management

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -267,9 +267,8 @@ typedef int (*init_fn_t)(void);
 
 /**
  * @addtogroup group_object_management
+ * @{
  */
-
-/**@{*/
 
 /*
  * kernel object macros
@@ -512,7 +511,7 @@ struct rt_object_information
 #define RT_OBJECT_HOOKLIST_CALL(name, argv)
 #endif /* RT_USING_HOOKLIST */
 
-/**@}*/
+/** @} group_object_management */
 
 /**
  * @addtogroup group_clock_management

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -49,11 +49,6 @@ extern "C" {
 int entry(void);
 #endif
 
-/**
- * @addtogroup group_object_management
- * @{
- */
-
 /*
  * kernel object interface
  */
@@ -86,8 +81,6 @@ void rt_object_trytake_sethook(void (*hook)(struct rt_object *object));
 void rt_object_take_sethook(void (*hook)(struct rt_object *object));
 void rt_object_put_sethook(void (*hook)(struct rt_object *object));
 #endif /* RT_USING_HOOK */
-
-/**@}*/
 
 /**
  * @addtogroup group_clock_management

--- a/src/object.c
+++ b/src/object.c
@@ -157,9 +157,8 @@ void (*rt_object_put_hook)(struct rt_object *object);
 
 /**
  * @addtogroup group_hook
+ * @{
  */
-
-/**@{*/
 
 /**
  * @brief This function will set a hook function, which will be invoked when object
@@ -231,14 +230,13 @@ void rt_object_put_sethook(void (*hook)(struct rt_object *object))
     rt_object_put_hook = hook;
 }
 
-/**@}*/
+/** @} group_hook */
 #endif /* RT_USING_HOOK */
 
 /**
  * @addtogroup group_object_management
+ * @{
  */
-
-/**@{*/
 
 /**
  * @brief This function will return the specified type of object information.
@@ -814,5 +812,5 @@ rt_err_t rt_custom_object_destroy(rt_object_t obj)
 }
 #endif
 
-/**@}*/
+/** @} group_object_management */
 


### PR DESCRIPTION
清理的工作包括三部分：
- 将独立的 "/**@{*/" 合并到 “@addtogroup group_object_management” 中
- 将 “/**@}*/” 修改为 /** @} group_object_management */，加上 group 名字后方便找到对应匹配的 “@{” 部分。
- 删除 “include/rtthread.h” 中的 “@addtogroup” 命令，因为在这个头文件中并没有 doxygen 注释，针对函数体的 doxygen 注释全部定义在 “src/object.c” 中了。

顺便清理了一下 “src/object.c” 中 group_hook 的格式。和 group_object_management 的格式保持一致。

