### PR TITLE
doxygen: cleanup code for group_thread_management

### DIFF
--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -591,9 +591,8 @@ typedef void (*rt_sighandler_t)(int signo);
 
 /**
  * @addtogroup group_thread_management
+ * @{
  */
-
-/**@{*/
 
 /*
  * Thread
@@ -955,7 +954,7 @@ typedef struct rt_thread *rt_thread_t;
 #define LWP_IS_USER_MODE(t) (0)
 #endif /* RT_USING_SMART */
 
-/**@}*/
+/** @} group_thread_management */
 
 /**
  * @addtogroup group_thread_comm

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -131,11 +131,6 @@ void rt_timer_exit_sethook(void (*hook)(struct rt_timer *timer));
 
 /**@}*/
 
-/**
- * @addtogroup group_thread_management
- * @{
- */
-
 /*
  * thread interface
  */
@@ -187,6 +182,8 @@ void rt_thread_suspend_sethook(void (*hook)(rt_thread_t thread));
 void rt_thread_resume_sethook (void (*hook)(rt_thread_t thread));
 
 /**
+ * @ingroup group_thread_management
+ *
  * @brief Sets a hook function when a thread is initialized.
  *
  * @param thread is the target thread that initializing
@@ -201,11 +198,12 @@ RT_OBJECT_HOOKLIST_DECLARE(rt_thread_inited_hookproto_t, rt_thread_inited);
  */
 void rt_thread_idle_init(void);
 #if defined(RT_USING_HOOK) || defined(RT_USING_IDLE_HOOK)
-// FIXME: Have to write doxygen comment here for rt_thread_idle_sethook/rt_thread_idle_delhook
+// FIXME: Have to write doxygen comment here for rt_thread_idle_sethook
 //        but not in src/idle.c. Because the `rt_align(RT_ALIGN_SIZE)` in src/idle.c
-//        will make wierd output for html document generation, i.e. can not generate
-//        function link to rt_thread_idle_sethook, while function link to rt_thread_idle_delhook is ok.
+//        will make doxygen building failed.
 /**
+ * @ingroup group_thread_management
+ *
  * @brief This function sets a hook function to idle thread loop. When the system performs
  *        idle loop, this hook function should be invoked.
  *
@@ -217,14 +215,6 @@ void rt_thread_idle_init(void);
  * @note the hook function must be simple and never be blocked or suspend.
  */
 rt_err_t rt_thread_idle_sethook(void (*hook)(void));
-/**
- * @brief delete the idle hook on hook list.
- *
- * @param hook the specified hook function.
- *
- * @return `RT_EOK`: delete OK.
- *         `-RT_ENOSYS`: hook was not found.
- */
 rt_err_t rt_thread_idle_delhook(void (*hook)(void));
 #endif /* defined(RT_USING_HOOK) || defined(RT_USING_IDLE_HOOK) */
 rt_thread_t rt_thread_idle_gethandler(void);
@@ -264,8 +254,6 @@ void rt_scheduler_switch_sethook(void (*hook)(struct rt_thread *tid));
 void rt_secondary_cpu_entry(void);
 void rt_scheduler_ipi_handler(int vector, void *param);
 #endif /* RT_USING_SMP */
-
-/**@}*/
 
 /**
  * @addtogroup group_signal

--- a/src/idle.c
+++ b/src/idle.c
@@ -79,6 +79,19 @@ rt_err_t rt_thread_idle_sethook(void (*hook)(void))
     return ret;
 }
 
+/**
+ * @addtogroup group_thread_management
+ * @{
+ */
+
+/**
+ * @brief delete the idle hook on hook list.
+ *
+ * @param hook the specified hook function.
+ *
+ * @return `RT_EOK`: delete OK.
+ *         `-RT_ENOSYS`: hook was not found.
+ */
 rt_err_t rt_thread_idle_delhook(void (*hook)(void))
 {
     rt_size_t i;
@@ -198,3 +211,5 @@ rt_thread_t rt_thread_idle_gethandler(void)
 
     return (rt_thread_t)(&idle_thread[id]);
 }
+
+/** @} group_thread_management */

--- a/src/scheduler_mp.c
+++ b/src/scheduler_mp.c
@@ -1582,7 +1582,7 @@ rt_err_t rt_sched_thread_bind_cpu(struct rt_thread *thread, int cpu)
 }
 
 /**
- * @}
+ * @} group_thread_management
  *
  * @endcond
  */

--- a/src/scheduler_up.c
+++ b/src/scheduler_up.c
@@ -724,7 +724,7 @@ rt_err_t rt_sched_thread_bind_cpu(struct rt_thread *thread, int cpu)
 }
 
 /**
- * @}
+ * @} group_thread_management
  *
  * @endcond
  */

--- a/src/signal.c
+++ b/src/signal.c
@@ -579,6 +579,8 @@ void rt_thread_free_sig(rt_thread_t tid)
 }
 
 /**
+ * @ingroup group_thread_management
+ *
  * @brief    This function can be used to send any signal to any thread.
  *
  * @param    tid is a pointer to the thread that receives the signal.

--- a/src/thread.c
+++ b/src/thread.c
@@ -294,9 +294,8 @@ static rt_err_t _thread_init(struct rt_thread *thread,
 
 /**
  * @addtogroup group_thread_management
+ * @{
  */
-
-/**@{*/
 
 /**
  * @brief   This function will initialize a thread. It's used to initialize a
@@ -1209,4 +1208,4 @@ rt_err_t rt_thread_get_name(rt_thread_t thread, char *name, rt_uint8_t name_size
 }
 RTM_EXPORT(rt_thread_get_name);
 
-/**@}*/
+/** @} group_thread_management */


### PR DESCRIPTION
清理的工作包括三部分：

- 将独立的 "/**@{*/" 合并到 “@addtogroup group_thread_management” 中
- 将 “/@}*/” 修改为 / @} group_thread_management*/，加上 group 名字后方便找到对应匹配的 “@{” 部分。
- 删除 “include/rtthread.h” 中的 “@addtogroup” 命令，因为在这个头文件中并没有 doxygen 注释，针对函数体的 doxygen 注释基本上全部定义在其他 .c 文件中了。除了两个例外，一个是 rt_thread_inited_hookproto_t，这是一个定义在 `include/rtthread.h` 中的函数类型。另一个是 rt_thread_idle_sethook，这是一个已知的问题，具体解释看 `include/rtthread.h` 代码中的 FIXME。
