### PR TITLE
Esp32c3 app update

### DIFF
--- a/bsp/ESP32_C3/Kconfig
+++ b/bsp/ESP32_C3/Kconfig
@@ -9,3 +9,53 @@ PKGS_DIR := packages
 source "$(RTT_DIR)/Kconfig"
 osource "$PKGS_DIR/Kconfig"
 rsource "drivers/Kconfig"
+# In bsp/ESP32_C3/Kconfig
+
+# Look for the section related to board peripherals or drivers
+
+menu "Board Level Drivers"
+
+    # 1. Define the option that allows the user to input the pin number
+    config RT_BSP_LED_PIN
+        int "Onboard LED Pin (GPIO Number)"
+        default 21  # Set a common default (e.g., GPIO 21 is often used on ESP32 boards)
+        range 0 40  # Set a valid range for ESP32 GPIO pins (0-40)
+        help
+          This sets the GPIO number for the on-board LED. 
+          Check your ESP32-C3 board schematic for the correct pin.
+
+endmenu # Board Level Drivers
+
+menu "ESP32-C3 On-Chip Drivers"
+
+    # BLE Dependency
+    config BSP_USING_BLE
+        bool "Enable Bluetooth Low Energy (BLE) Support"
+        default y
+        select ESP32C3_BLE_DRV # Link to the underlying chip driver config (name may vary)
+        help
+          Enable this to include the necessary BLE drivers and compile 
+          the BLE-related code blocks in main.c (via #ifdef BSP_USING_BLE).
+
+    # WiFi Dependency
+    config RT_USING_WIFI
+        bool "Enable Wi-Fi Support"
+        default y
+        select RT_USING_WIFI_DRIVER_ESP32C3 # Link to the underlying driver config (name may vary)
+        help
+          Enable this to include the Wi-Fi framework and driver support 
+          for network functionality.
+
+endmenu # ESP32-C3 On-Chip Drivers
+
+# --------------------------------------------------------------------------
+# Optional: Ensure core features are enabled when necessary
+# --------------------------------------------------------------------------
+
+# If your custom feature requires msh, you can select it like this:
+config BSP_USING_APP_COMMANDS
+    bool "Enable Custom Application Commands (app_data_cmd)"
+    default y
+    select FINSH_USING_MSH # This ensures the FinSH msh mode is enabled if this is selected
+    help
+      This enables the app_data_cmd function in main.c, which relies on the FinSH shell.

--- a/bsp/ESP32_C3/main/SConscript
+++ b/bsp/ESP32_C3/main/SConscript
@@ -9,3 +9,24 @@ CPPPATH = []
 group = DefineGroup('Main', src, depend = [''], CPPPATH = CPPPATH)
 
 Return('group')
+
+# SConscript file content
+
+# Define a list of source files to compile
+src = []
+
+# Add common BSP source files (these lines might already exist)
+# src += ['board.c', 'drivers/drv_gpio.c'] 
+
+# >>> ADD YOUR APPLICATION FILES HERE <<<
+# Ensure your main.c file is in the list.
+src += ['main.c'] 
+# If you add any other custom C files (e.g., app_logic.c), list them too.
+# src += ['app_logic.c'] 
+
+# Pass the source list to the build environment
+from building import *
+# This line tells SCons to compile the files in the 'src' list
+list = SConscript('drivers/SConscript', variant_dir='drivers')
+list.append(src)
+

--- a/bsp/ESP32_C3/main/main.c
+++ b/bsp/ESP32_C3/main/main.c
@@ -1,3 +1,45 @@
+#include <rtthread.h>
+#include <stdlib.h> // For atoi()
+#include <finsh.h>  // For MSH_CMD_EXPORT
+
+// The global variable you want to expose to FinSH
+// NOTE: It must be a global or static global variable.
+int app_data_value = 100;
+
+// Function to handle reading and setting the variable
+// All FinSH commands in msh mode must have this signature: (int argc, char **argv)
+void app_data_cmd(int argc, char **argv)
+{
+    // Check if the FinSH C-style interpreter is disabled
+    #ifndef FINSH_USING_MSH
+    rt_kprintf("Error: This command requires msh mode enabled.\n");
+    return;
+    #endif
+
+    if (argc == 1)
+    {
+        // Case 1: No arguments (e.g., 'app_data_cmd') -> Read the current value
+        rt_kprintf("app_data_value (current): %d\n", app_data_value);
+    }
+    else if (argc == 2)
+    {
+        // Case 2: One argument (e.g., 'app_data_cmd 250') -> Set a new value
+        int new_value = atoi(argv[1]);
+        app_data_value = new_value;
+        rt_kprintf("app_data_value set to: %d\n", app_data_value);
+    }
+    else
+    {
+        // Case 3: Invalid number of arguments
+        rt_kprintf("Usage:\n");
+        rt_kprintf("  Read: app_data_cmd\n");
+        rt_kprintf("  Write: app_data_cmd <value>\n");
+    }
+}
+
+// Export the function as a FinSH command. 
+// Format: MSH_CMD_EXPORT(function_name, description)
+MSH_CMD_EXPORT(app_data_cmd, Get or set the application data value);
 /*
  * Copyright (c) 2021-2022, RT-Thread Development Team
  *
@@ -9,7 +51,7 @@
  * 2022-06-02     supperthomas  fix version
  * 2023-10-20     WCX1024979076 add wifi application
  */
-
+#define RT_BSP_LED_PIN    2
 #include <rtthread.h>
 #include <rtdevice.h>
 #include <board.h>

--- a/bsp/ESP32_C3/main/main.c
+++ b/bsp/ESP32_C3/main/main.c
@@ -1,3 +1,4 @@
+
 #include <rtthread.h>
 #include <stdlib.h> // For atoi()
 #include <finsh.h>  // For MSH_CMD_EXPORT

--- a/bsp/ESP32_C3/rtconfig.h
+++ b/bsp/ESP32_C3/rtconfig.h
@@ -1,6 +1,13 @@
 #ifndef RT_CONFIG_H__
 #define RT_CONFIG_H__
 
+// Inside bsp/ESP32_C3/board.h
+
+// ... other existing definitions ...
+
+// Define the GPIO pin number for the on-board LED
+// *** You must replace 'X' with the correct physical GPIO number (e.g., 2, 8, 15, etc.) ***
+#define RT_BSP_LED_PIN    X
 /* RT-Thread Kernel */
 
 /* klibc options */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
# RT-Thread Board Support Package for ESP32-C3

## 📝 Introduction

This is the Board Support Package (BSP) for the Espressif **ESP32-C3** series of microcontrollers, built to run the RT-Thread Real-Time Operating System.

This BSP is configured to use the [Specify the name of your specific evaluation/dev board, e.g., 'ESP32-C3-DevKitM-1'].

## ✨ Features

This BSP provides the standard RT-Thread kernel and system components, and includes the following application features by default:

1.  **System Initialization:** Initializes basic system clocks and required drivers.
2.  **LED Blinking:** A separate thread is started in `main.c` to blink the onboard LED, demonstrating basic thread management and GPIO control.
3.  **FinSH Shell Access:** Enables command-line access via the serial port for runtime management and debugging.
4.  **Application Demo Command:** Includes a custom FinSH command (`app_data_cmd`) for reading/writing a global application variable.

## 🛠️ Build and Configuration

### 1. Building the Project

1.  Navigate to the BSP directory:
    ```bash
    cd bsp/ESP32_C3
    ```
2.  Run the SCons build tool:
    ```bash
    scons
    ```
    This generates the firmware image (e.g., `rtthread.elf`).

3.  **Flashing:** Use the standard flash command for your environment (e.g., `scons --target=download`).

### 2. Configuration (`menuconfig`)

You can modify system settings and enable features using the `menuconfig` tool:

```bash
menuconfig