### PR TITLE
utest: serial: bypass: add depends on RT_USING_SERIAL_BYPASS

### DIFF
--- a/examples/utest/testcases/drivers/serial_bypass/Kconfig
+++ b/examples/utest/testcases/drivers/serial_bypass/Kconfig
@@ -3,5 +3,6 @@ menu "Serial-Bypass Testcase"
 config UTEST_SERIAL_BYPASS
     bool "Serial testcase"
     default n
+    depends on RT_USING_SERIAL_BYPASS
 
 endmenu


### PR DESCRIPTION
Add dependent of `RT_USING_SERIAL_BYPASS` in Kconfig to make sure utest for serial-bypass is only available when `RT_USING_SERIAL_BYPASS` is enabled.

Otherwise menuconfig allow people enable `UTEST_SERIAL_BYPASS` but building of utestcases failed. It looks weird and better to be fixed.


