### PR TITLE
utest: serial_v2: add depends on RT_USING_SERIAL_V2

### DIFF
--- a/examples/utest/testcases/drivers/serial_v2/Kconfig
+++ b/examples/utest/testcases/drivers/serial_v2/Kconfig
@@ -3,6 +3,7 @@ menu "Utest Serial Testcase"
     config UTEST_SERIAL_TC
         bool "Serial testcase"
         default n
+        depends on RT_USING_SERIAL_V2
 
     if UTEST_SERIAL_TC
 


### PR DESCRIPTION
Add dependent of `RT_USING_SERIAL_V2` in Kconfig to make sure utest for serial_v2 is only available when `RT_USING_SERIAL_V2` is enabled.

Otherwise menuconfig allow people enable `UTEST_SERIAL_TC` but building of utestcases failed. It looks weird and better to be fixed.

