### PR TITLE
fix: make QEMU-VExpress-A9 example compatible with newlib 12.x by han…

### DIFF
--- a/components/libc/posix/io/stdio/stdio.c
+++ b/components/libc/posix/io/stdio/stdio.c
@@ -20,7 +20,7 @@
 #include <sys/errno.h>
 #include "posix/stdio.h"
 
-#define STDIO_DEVICE_NAME_MAX   32
+#define STDIO_DEVICE_NAME_MAX 32
 
 int sys_dup2(int oldfd, int new);
 
@@ -49,8 +49,8 @@ INIT_ENV_EXPORT(rt_posix_stdio_init);
 
 #define NEWLIB_VERSION_NUM (__NEWLIB__ * 10000U + __NEWLIB_MINOR__ * 100U + __NEWLIB_PATCHLEVEL__)
 
-static FILE* std_console = NULL;
-int rt_posix_stdio_set_console(const char* device_name, int mode)
+static FILE *std_console = NULL;
+int rt_posix_stdio_set_console(const char *device_name, int mode)
 {
     FILE *fp;
     char name[STDIO_DEVICE_NAME_MAX];
@@ -86,11 +86,11 @@ int rt_posix_stdio_set_console(const char* device_name, int mode)
 
         if (mode == O_RDWR)
         {
-            _GLOBAL_REENT->_stdin  = std_console;
+            _GLOBAL_REENT->_stdin = std_console;
         }
         else
         {
-            _GLOBAL_REENT->_stdin  = NULL;
+            _GLOBAL_REENT->_stdin = NULL;
         }
 
         if (mode == O_RDONLY)
@@ -107,9 +107,8 @@ int rt_posix_stdio_set_console(const char* device_name, int mode)
 #if defined(_REENT_SMALL) || !defined(__sdidinit)
     // newlib 新版本没有 __sdidinit
 #else
-    _GLOBAL_REENT->__sdidinit = 1;
+        _GLOBAL_REENT->__sdidinit = 1;
 #endif
-
     }
 
     if (std_console)
@@ -128,9 +127,9 @@ int rt_posix_stdio_get_console(void)
 
 #elif defined(RT_USING_MUSLLIBC)
 
-static FILE* std_console = NULL;
+static FILE *std_console = NULL;
 
-int rt_posix_stdio_set_console(const char* device_name, int mode)
+int rt_posix_stdio_set_console(const char *device_name, int mode)
 {
     FILE *fp;
     char name[STDIO_DEVICE_NAME_MAX];
@@ -139,9 +138,12 @@ int rt_posix_stdio_set_console(const char* device_name, int mode)
     rt_snprintf(name, sizeof(name) - 1, "/dev/%s", device_name);
     name[STDIO_DEVICE_NAME_MAX - 1] = '\0';
 
-    if (mode == O_RDWR) file_mode = "r+";
-    else if (mode == O_WRONLY) file_mode = "wb";
-    else file_mode = "rb";
+    if (mode == O_RDWR)
+        file_mode = "r+";
+    else if (mode == O_WRONLY)
+        file_mode = "wb";
+    else
+        file_mode = "rb";
 
     fp = fopen(name, file_mode);
     if (fp)
@@ -180,7 +182,7 @@ int rt_posix_stdio_get_console(void)
 #else
 
 static int std_fd = -1;
-int rt_posix_stdio_set_console(const char* device_name, int mode)
+int rt_posix_stdio_set_console(const char *device_name, int mode)
 {
     int fd;
     char name[STDIO_DEVICE_NAME_MAX];
@@ -201,7 +203,8 @@ int rt_posix_stdio_set_console(const char* device_name, int mode)
     return std_fd;
 }
 
-int rt_posix_stdio_get_console(void) {
+int rt_posix_stdio_get_console(void)
+{
     return std_fd;
 }
 #endif /* defined(RT_USING_NEWLIBC) */


### PR DESCRIPTION
…dling removed __sdidinit

## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
在使用新版本的 newlib 时，RT-Thread 的 QEMU-VExpress-A9 示例在编译过程中出现错误：error: 'struct _reent' has no member named '__sdidinit'。这是因为新版 newlib 移除了 __sdidinit 成员，导致 RT-Thread 的 stdio.c 代码不兼容。本 PR 修复了这一问题，确保示例在新版 newlib 下能够正常编译。

#### 你的解决方案是什么 (what is your solution)
在 components/libc/posix/io/stdio.c 中，添加了条件编译宏以适配 newlib 的版本差异：

#if defined(_REENT_SMALL) || !defined(__sdidinit)
    // newlib 新版本没有 __sdidinit
#else
    _GLOBAL_REENT->__sdidinit = 1;
#endif
此修改确保在新版 newlib 下，标准输入输出初始化代码能够正确编译，同时保持对旧版 newlib 的兼容性。
#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:bsp/qemu-vexpress-a9

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:无需修改 .config 文件，仅涉及代码逻辑的条件编译适配

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:https://github.com/loremmoqi/rt-thread/blob/master/.github/workflows/manual_dist.yml

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
