### PR TITLE
utest: smp_call: move from example to components/drivers/smp_call

### DIFF
--- a/Kconfig.utestcases
+++ b/Kconfig.utestcases
@@ -14,7 +14,6 @@ rsource "examples/utest/testcases/drivers/ipc/Kconfig"
 rsource "examples/utest/testcases/posix/Kconfig"
 rsource "examples/utest/testcases/mm/Kconfig"
 rsource "examples/utest/testcases/tmpfs/Kconfig"
-rsource "examples/utest/testcases/smp_call/Kconfig"
 rsource "examples/utest/testcases/perf/Kconfig"
 
 rsource "src/klibc/utest/Kconfig"
@@ -22,7 +21,7 @@ rsource "src/klibc/utest/Kconfig"
 rsource "components/drivers/core/utest/Kconfig"
 rsource "components/drivers/audio/utest/Kconfig"
 rsource "components/drivers/serial/utest/Kconfig"
-
+rsource "components/drivers/smp_call/utest/Kconfig"
 rsource "components/dfs/utest/Kconfig"
 rsource "components/net/utest/Kconfig"
 

--- a/components/drivers/smp_call/SConscript
+++ b/components/drivers/smp_call/SConscript
@@ -7,4 +7,9 @@ if GetDepend("RT_USING_SMP"):
 CPPPATH = [cwd]
 group = DefineGroup('DeviceDrivers', src, depend = [''], CPPPATH = CPPPATH)
 
+list = os.listdir(cwd)
+for item in list:
+    if os.path.isfile(os.path.join(cwd, item, 'SConscript')):
+        group = group + SConscript(os.path.join(item, 'SConscript'))
+
 Return('group')

--- a/components/drivers/smp_call/utest/Kconfig
+++ b/components/drivers/smp_call/utest/Kconfig
@@ -1,0 +1,8 @@
+menu "SMP-Call Unit Testcases"
+
+config RT_UTEST_SMP_CALL_FUNC
+    bool "SMP-Call smoke test"
+    default n
+    depends on RT_USING_SMP
+
+endmenu

--- a/components/drivers/smp_call/utest/SConscript
+++ b/components/drivers/smp_call/utest/SConscript
@@ -5,7 +5,7 @@ cwd     = GetCurrentDir()
 src     = []
 CPPPATH = [cwd]
 
-if GetDepend(['RT_USING_SMP', 'UTEST_SMP_CALL_FUNC']):
+if GetDepend(['RT_UTEST_SMP_CALL_FUNC']):
     src += Glob('smp*.c')
 
 group = DefineGroup('utestcases', src, depend = ['RT_USING_UTESTCASES'], CPPPATH = CPPPATH)

--- a/components/drivers/smp_call/utest/smp_001_tc.c
+++ b/components/drivers/smp_call/utest/smp_001_tc.c
@@ -87,4 +87,4 @@ static void _testcase(void)
     UTEST_UNIT_RUN(_blocking_call);
 }
 
-UTEST_TC_EXPORT(_testcase, "testcase.smp.smoke.001", utest_tc_init, utest_tc_cleanup, 10);
+UTEST_TC_EXPORT(_testcase, "components.drivers.smp_call.smoke_001", utest_tc_init, utest_tc_cleanup, 10);

--- a/components/drivers/smp_call/utest/smp_002_tc.c
+++ b/components/drivers/smp_call/utest/smp_002_tc.c
@@ -129,4 +129,4 @@ static void _testcase(void)
     UTEST_UNIT_RUN(_blocking_mtsafe_call);
 }
 
-UTEST_TC_EXPORT(_testcase, "testcase.smp.smoke.002", utest_tc_init, utest_tc_cleanup, 10);
+UTEST_TC_EXPORT(_testcase, "components.drivers.smp_call.smoke_002", utest_tc_init, utest_tc_cleanup, 10);

--- a/components/drivers/smp_call/utest/smp_003_tc.c
+++ b/components/drivers/smp_call/utest/smp_003_tc.c
@@ -125,4 +125,4 @@ static void _testcase(void)
     UTEST_UNIT_RUN(_async_call);
 }
 
-UTEST_TC_EXPORT(_testcase, "testcase.smp.smoke.003", utest_tc_init, utest_tc_cleanup, 10);
+UTEST_TC_EXPORT(_testcase, "components.drivers.smp_call.smoke_003", utest_tc_init, utest_tc_cleanup, 10);

--- a/components/drivers/smp_call/utest/smp_004_tc.c
+++ b/components/drivers/smp_call/utest/smp_004_tc.c
@@ -207,4 +207,4 @@ static void _testcase(void)
     UTEST_UNIT_RUN(_test_reentr_isr_main);
 }
 
-UTEST_TC_EXPORT(_testcase, "testcase.smp.smoke.004", utest_tc_init, utest_tc_cleanup, 10);
+UTEST_TC_EXPORT(_testcase, "components.drivers.smp_call.smoke_004", utest_tc_init, utest_tc_cleanup, 10);

--- a/examples/utest/testcases/smp_call/Kconfig
+++ b/examples/utest/testcases/smp_call/Kconfig
@@ -1,6 +1,0 @@
-menu "SMP-Call Testcase"
-
-config UTEST_SMP_CALL_FUNC
-    bool "SMP-Call test cases"
-    default n
-endmenu


### PR DESCRIPTION
Also,
- Rename UTEST_SMP_CALL_FUNC to RT_UTEST_SMP_CALL_FUNC.
- Add depends on RT_USING_SMP in Kconfig for RT_UTEST_SMP_CALL_FUNC
- Follow the naming rules of utest case to update the cases' name.

