### PR TITLE
[bsp/nxp/mcx/mcxa] Fix UART clock configuration type mismatch

### DIFF
--- a/bsp/nxp/mcx/mcxa/Libraries/drivers/drv_uart.c
+++ b/bsp/nxp/mcx/mcxa/Libraries/drivers/drv_uart.c
@@ -64,12 +64,12 @@ static const struct mcx_uart uarts[] =
         &serial0,
         LPUART0,
         LPUART0_IRQn,
+        kCLOCK_Fro12M,
 #if (defined(CPU_MCXA346VLH) || defined(CPU_MCXA346VLL) || defined(CPU_MCXA346VLQ) || defined(CPU_MCXA346VPN))
         kFRO_LF_DIV_to_LPUART0,
 #else
         kFRO12M_to_LPUART0,
 #endif
-        kFRO12M_to_LPUART0,
         kCLOCK_GateLPUART0,
         kCLOCK_DivLPUART0,
         "uart0",
@@ -80,12 +80,12 @@ static const struct mcx_uart uarts[] =
         &serial1,
         LPUART1,
         LPUART1_IRQn,
+        kCLOCK_Fro12M,
 #if (defined(CPU_MCXA346VLH) || defined(CPU_MCXA346VLL) || defined(CPU_MCXA346VLQ) || defined(CPU_MCXA346VPN))
         kFRO_LF_DIV_to_LPUART1,
 #else
         kFRO12M_to_LPUART1,
 #endif
-        kFRO12M_to_LPUART1,
         kCLOCK_GateLPUART1,
         kCLOCK_DivLPUART1,
         "uart1",
@@ -182,7 +182,7 @@ static int mcx_getc(struct rt_serial_device *serial)
 {
     struct mcx_uart *uart = (struct mcx_uart *)serial->parent.user_data;
 
-    if (kLPUART_RxDataRegFullInterruptEnable & LPUART_GetStatusFlags(uart->uart_base))
+    if (kLPUART_RxDataRegFullFlag & LPUART_GetStatusFlags(uart->uart_base))
     {
         return LPUART_ReadByte(uart->uart_base);
     }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[

## Summary

  Fixed implicit type conversion warning in NXP MCXA series UART driver by correctly
  using the appropriate clock enum types.

  ### Problem
  The compiler reported a warning:
  implicit conversion from 'int' to 'clock_name_t' changes value from 16777216 to 0

  This occurred because the code was using `clock_attach_id_t` enum values (like
  `kFRO12M_to_LPUART0`) in a field that expects `clock_name_t` enum type.

  ### Root Cause
  - The `mcx_uart` structure has two separate clock-related fields with different
  purposes:
    - `clock_src` (type: `clock_name_t`): Used for getting clock frequency via
  `CLOCK_GetFreq()`
    - `clock_attach_id` (type: `clock_attach_id_t`): Used for attaching clock source via     
  `CLOCK_AttachClk()`

  - The original code incorrectly used `kFRO12M_to_LPUARTx` (a `clock_attach_id_t` value)    
   for the `clock_src` field.

  ### Changes Made
  1. **Fixed clock source field**: Now correctly uses `kCLOCK_Fro12M` (clock_name_t) for     
  all three UARTs
  2. **Kept clock attach field**: Preserved `kFRO12M_to_LPUARTx` (clock_attach_id_t) for     
  clock routing
  3. **Fixed mcx_getc() function**: Changed from `kLPUART_RxDataRegFullInterruptEnable`      
  to `kLPUART_RxDataRegFullFlag` for correct status checking

  ### Testing
  - Tested on FRDM-MCXA156 board
  - UART transmission and reception working correctly
  - Compiler warning resolved

  ### Impact
  - Fixes compilation warning
  - Ensures correct baud rate calculation by providing the right clock frequency

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
