### PR TITLE
[components][net][lwip][port] 1.修复eth驱动层初始化失败导致lwip初始化不完整；

### DIFF
--- a/components/net/lwip/port/ethernetif.c
+++ b/components/net/lwip/port/ethernetif.c
@@ -485,23 +485,10 @@ static err_t eth_netif_device_init(struct netif *netif)
     ethif = (struct eth_device*)netif->state;
     if (ethif != RT_NULL)
     {
-        rt_device_t device;
-
 #ifdef RT_USING_NETDEV
         /* network interface device register */
         netdev_add(netif);
 #endif /* RT_USING_NETDEV */
-
-        /* get device object */
-        device = (rt_device_t) ethif;
-        if (rt_device_init(device) != RT_EOK)
-        {
-            return ERR_IF;
-        }
-        if (rt_device_open(device, RT_DEVICE_FLAG_RDWR) != RT_EOK)
-        {
-            return ERR_IF;
-        }
 
         /* copy device flags to netif flags */
         netif->flags = (ethif->flags & 0xff);
@@ -544,6 +531,19 @@ static err_t eth_netif_device_init(struct netif *netif)
         /* if this interface uses DHCP, start the DHCP client */
         dhcp_start(netif);
 #endif
+
+        rt_device_t device;
+        /* get device object */
+        device = (rt_device_t) ethif;
+        if (rt_device_init(device) != RT_EOK)
+        {
+            return ERR_IF;
+        }
+        if (rt_device_open(device, RT_DEVICE_FLAG_RDWR) != RT_EOK)
+        {
+            return ERR_IF;
+        }
+        netif->flags |= (ethif->flags & 0xff);
 
         if (ethif->flags & ETHIF_LINK_PHYUP)
         {
@@ -673,23 +673,10 @@ static err_t af_unix_eth_netif_device_init(struct netif *netif)
     ethif = (struct eth_device*)netif->state;
     if (ethif != RT_NULL)
     {
-        rt_device_t device;
-
 #ifdef RT_USING_NETDEV
         /* network interface device register */
         netdev_add(netif);
 #endif /* RT_USING_NETDEV */
-
-        /* get device object */
-        device = (rt_device_t) ethif;
-        if (rt_device_init(device) != RT_EOK)
-        {
-            return ERR_IF;
-        }
-        if (rt_device_open(device, RT_DEVICE_FLAG_RDWR) != RT_EOK)
-        {
-            return ERR_IF;
-        }
 
         /* copy device flags to netif flags */
         netif->flags = (ethif->flags & 0xff);
@@ -727,6 +714,20 @@ static err_t af_unix_eth_netif_device_init(struct netif *netif)
 
         /* set interface up */
         netif_set_up(netif);
+
+        rt_device_t device;
+        /* get device object */
+        device = (rt_device_t) ethif;
+        if (rt_device_init(device) != RT_EOK)
+        {
+            return ERR_IF;
+        }
+        if (rt_device_open(device, RT_DEVICE_FLAG_RDWR) != RT_EOK)
+        {
+            return ERR_IF;
+        }
+
+        netif->flags |= (ethif->flags & 0xff);
 
         if (ethif->flags & ETHIF_LINK_PHYUP)
         {


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

[
#### 你的解决方案是什么 (what is your solution)
- ETH驱动层初始化失败不影响lwip的功能；在ETH驱动层改变link的状态前请检查ETH的device是否初始化成功，否则需要再次初始化一次；
```          
       if (!(xxx_eth_device.parent.parent.flag & RT_DEVICE_FLAG_ACTIVATED))
            {
                if (RT_EOK != xxx_eth_device.parent.parent.init(&xxx_eth_device.parent.parent))
                    return;
            }
            eth_device_linkchange(&xxx_eth_device.parent, RT_TRUE);
```
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
