### PR TITLE
MAINTAINERS: update path for utest of serial_v2

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -186,7 +186,7 @@ owners: Liya Huang(wdfk-prog)<1425075683@qq.com>
 tag: components_driver_serial_v2
 path: components/drivers/serial/dev_serial_v2.c
 path: components/drivers/include/drivers/dev_serial_v2.h
-path: examples/utest/testcases/drivers/serial_v2
+path: components/drivers/serial/utest/v2
 owners: Chen Beidou(Ryan-CW-Code)<1831931681@qq.com>
 
 tag: components_driver_spi


### PR DESCRIPTION
Fixes: 3b97667323 ("utest: serial: move from examples to components/drivers/serial")

修改 serial_v2 的 utest 代码路径后需要同步修改 MAINTAINERS 文件信息。
