### PR TITLE
[fix][gd32/drivers][rsoc]: add support for adc of the gd32f5 series

### DIFF
--- a/bsp/gd32/arm/libraries/gd32_drivers/drv_adc.c
+++ b/bsp/gd32/arm/libraries/gd32_drivers/drv_adc.c
@@ -100,7 +100,7 @@ static void gd32_adc_gpio_init(rcu_periph_enum adc_clk, rt_base_t pin)
     /* enable ADC clock */
     rcu_periph_clock_enable(adc_clk);
 
-#if defined SOC_SERIES_GD32F4xx || defined SOC_SERIES_GD32E23x
+#if defined SOC_SERIES_GD32F4xx || defined SOC_SERIES_GD32E23x || defined SOC_SERIES_GD32F5xx
     /* configure adc pin */
     gpio_mode_set(PIN_GDPORT(pin), GPIO_MODE_ANALOG, GPIO_PUPD_NONE, PIN_GDPIN(pin));
 #else
@@ -139,7 +139,7 @@ static rt_err_t gd32_adc_enabled(struct rt_adc_device *device, rt_int8_t channel
         adc_data_alignment_config(adc_periph, ADC_DATAALIGN_RIGHT);
         #endif
 
-        #if defined SOC_SERIES_GD32F4xx
+        #if defined SOC_SERIES_GD32F4xx || defined SOC_SERIES_GD32F5xx
         adc_channel_length_config(adc_periph, ADC_ROUTINE_CHANNEL, 1);
         adc_external_trigger_source_config(adc_periph, ADC_ROUTINE_CHANNEL, ADC_EXTTRIG_ROUTINE_EXTI_11);
         adc_external_trigger_config(adc_periph, ADC_ROUTINE_CHANNEL, ENABLE);
@@ -202,7 +202,7 @@ static rt_err_t gd32_adc_convert(struct rt_adc_device *device, rt_int8_t channel
     #else
     adc_flag_clear(adc_periph, ADC_FLAG_EOC | ADC_FLAG_STRC);
     #endif
-#if defined SOC_SERIES_GD32F4xx
+#if defined SOC_SERIES_GD32F4xx || defined SOC_SERIES_GD32F5xx
     adc_routine_channel_config(adc_periph, 0, channel, ADC_SAMPLETIME_480);
     adc_software_trigger_enable(adc_periph, ADC_ROUTINE_CHANNEL);
 #elif defined SOC_SERIES_GD32E23x


### PR DESCRIPTION
说明: 修复gd32f527的bsp中的adc适配问题。具体来说，修复了drv_adc.c文件中的API老旧以及不匹配问题。参考GD32F5xx系列的库文件，将老旧的API替换为新的API，并修正了宏定义配置。

为什么提交这份公关
在GD32F527的BSP中，ADC驱动的API与当前GD32F5xx系列的库文件不匹配，导致ADC无法正常工作。

你的解决方案是什么
参考GD32F5xx系列的库文件，更新了ADC驱动的API，使其与最新的库文件保持一致，同时，修正了相关的宏定义配置，并删除了不必要的代码。

请提供验证的bsp和配置
BSP: bsp/gd32/arm/gd32527I-eval
。配置: 使用默认配置，但使能了ADC驱动(如CONFIG_BSP_USING_ADC)
action: 由于是个人仓库的PR，暂时无法提供rt-thread官方仓库的操作链接。但已在本地成功编译并通过基本测试。
测试情况
已在GD32F527I-EVAL开发板上测试ADC功能，工作正常。
]

当前拉取/合并请求的状态您的公关意图
必须选择一项选择一个 (必填):

本拉取/合并请求是一个草稿版本此PR用于代码审查，旨在获得反馈
本拉取/合并请求是一个成熟版本此PR已成熟，并准备集成到repo中
代码质量代码质量:
我在这个拉取/合并请求中已经考虑了作为此请求的一部分，我考虑了以下内容:

已经仔细查看过代码改动的对比已经检查了PR和旧代码之间的区别
代码风格正确，包括缩进空格，命名及其他风格风格指南，包括间距，命名和其他风格
没有垃圾代码，代码尽量精简，不包含#if 0代码，不包含已经被注释了的代码删除和清理所有冗余代码
所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP，所有修改都是合理的，不会影响其他组件或BSP
对难懂代码均提供对应的注释我已经适当地评论了代码是棘手的
此PR中的代码是高质量的代码质量很高
已经使用[格式化](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-线程代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md)本PR符合[RT-线程代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
如果是新增bsp，已经添加ci检查到[。github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json) 详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)