### PR TITLE
feat(ulog): add emergency log flush mechanism

### DIFF
--- a/components/utilities/ulog/backend/console_be.c
+++ b/components/utilities/ulog/backend/console_be.c
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2006-2022, RT-Thread Development Team
+ * Copyright (c) 2006-2025 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes
  * 2018-09-04     armink       the first version
+ * 2025-10-30     wdfk-prog    add emergency log flush mechanism
  */
 
 #include <rthw.h>
@@ -32,6 +33,8 @@ int ulog_console_backend_init(void)
     console.output = ulog_console_backend_output;
 
     ulog_backend_register(&console, "console", RT_TRUE);
+    console.output = ulog_console_backend_output;
+    console.is_emergency_backend = RT_TRUE;
 
     return 0;
 }

--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2006-2024 RT-Thread Development Team
+ * Copyright (c) 2006-2025 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes
  * 2018-08-25     armink       the first version
+ * 2025-10-30     wdfk-prog    add emergency log flush mechanism
  */
 
 #include <stdarg.h>
@@ -501,7 +502,23 @@ rt_weak rt_size_t ulog_hex_formater(char *log_buf, const char *tag, const rt_uin
     return ulog_tail_formater(log_buf, log_len, RT_TRUE, LOG_LVL_DBG);
 }
 
-static void ulog_output_to_all_backend(rt_uint32_t level, const char *tag, rt_bool_t is_raw, const char *log, rt_size_t len)
+/**
+ * @brief Internal helper to broadcast a log to backends.
+ *
+ * @details This is the core broadcasting function. It iterates through all
+ *          registered backends and outputs the log message. It can operate
+ *          in two modes.
+ *
+ * @param emergency_only If RT_TRUE, it will only output to backends marked as
+ *                       `is_emergency_backend`. If RT_FALSE, it will output to
+ *                       all backends that match the filter criteria.
+ * @param level The log level.
+ * @param tag The log tag.
+ * @param is_raw Whether the log is raw data.
+ * @param log The log message buffer.
+ * @param len The length of the log message.
+ */
+static void _ulog_output_to_backends(rt_bool_t emergency_only, rt_uint32_t level, const char *tag, rt_bool_t is_raw, const char *log, rt_size_t len)
 {
     rt_slist_t *node;
     ulog_backend_t backend;
@@ -520,6 +537,13 @@ static void ulog_output_to_all_backend(rt_uint32_t level, const char *tag, rt_bo
     for (node = rt_slist_first(&ulog.backend_list); node; node = rt_slist_next(node))
     {
         backend = rt_slist_entry(node, struct ulog_backend, list);
+
+        if (emergency_only && !backend->is_emergency_backend)
+        {
+            /* In emergency mode, skip any backend not marked as emergency-safe. */
+            continue;
+        }
+
         if (backend->out_level < level)
         {
             continue;
@@ -556,6 +580,11 @@ static void ulog_output_to_all_backend(rt_uint32_t level, const char *tag, rt_bo
         }
 #endif /* !defined(ULOG_USING_COLOR) || defined(ULOG_USING_SYSLOG) */
     }
+}
+
+static void ulog_output_to_all_backend(rt_uint32_t level, const char *tag, rt_bool_t is_raw, const char *log, rt_size_t len)
+{
+    _ulog_output_to_backends(RT_FALSE, level, tag, is_raw, log, len);
 }
 
 static void do_output(rt_uint32_t level, const char *tag, rt_bool_t is_raw, const char *log_buf, rt_size_t log_len)
@@ -1297,6 +1326,7 @@ rt_err_t ulog_backend_register(ulog_backend_t backend, const char *name, rt_bool
     backend->support_color = support_color;
     backend->out_level = LOG_FILTER_LVL_ALL;
     rt_strncpy(backend->name, name, RT_NAME_MAX - 1);
+    backend->is_emergency_backend = RT_FALSE;
 
     level = rt_spin_lock_irqsave(&_spinlock);
     rt_slist_append(&ulog.backend_list, &backend->list);
@@ -1366,13 +1396,54 @@ ulog_backend_t ulog_backend_find(const char *name)
     return RT_NULL;
 }
 
+/**
+ * @brief Sets the emergency-safe status for a specific backend at runtime.
+ *
+ * @details This function allows an application to dynamically mark a backend
+ *          as safe or unsafe for use in emergency contexts (e.g., fault handlers).
+ *          Only backends marked as safe will be used by `ulog_emergency_flush`.
+ *
+ * @param[in] name The name of the target backend.
+ * @param[in] is_emergency RT_TRUE to mark the backend as safe for emergency calls,
+ *                         RT_FALSE otherwise.
+ *
+ * @return rt_err_t RT_EOK on success, -RT_ERROR if the backend with the given name
+ *                  is not found, or -RT_EINVAL if the name is invalid.
+ */
+rt_err_t ulog_backend_set_emergency(const char *name, rt_bool_t is_emergency)
+{
+    ulog_backend_t backend;
+    rt_err_t result = -RT_ERROR;
+
+    if (name == RT_NULL)
+    {
+        return -RT_EINVAL;
+    }
+
+    rt_mutex_take(&ulog.output_locker, RT_WAITING_FOREVER);
+
+    backend = ulog_backend_find(name);
+    if (backend != RT_NULL)
+    {
+        backend->is_emergency_backend = is_emergency;
+        result = RT_EOK;
+    }
+
+    rt_mutex_release(&ulog.output_locker);
+
+    return result;
+}
+
 #ifdef ULOG_USING_ASYNC_OUTPUT
 /**
  * asynchronous output logs to all backends
  *
+ * @param[in] emergency_mode A flag to select the operational mode. RT_FALSE for
+ *            normal operation, RT_TRUE for emergency fault context.
+ *
  * @note you must call this function when ULOG_ASYNC_OUTPUT_BY_THREAD is disable
  */
-void ulog_async_output(void)
+void ulog_async_output(rt_bool_t emergency_mode)
 {
     rt_rbb_blk_t log_blk;
     ulog_frame_t log_frame;
@@ -1387,14 +1458,12 @@ void ulog_async_output(void)
         log_frame = (ulog_frame_t) log_blk->buf;
         if (log_frame->magic == ULOG_FRAME_MAGIC)
         {
-            /* output to all backends */
-            ulog_output_to_all_backend(log_frame->level, log_frame->tag, log_frame->is_raw, log_frame->log,
-                    log_frame->log_len);
+            _ulog_output_to_backends(emergency_mode, log_frame->level, log_frame->tag, log_frame->is_raw, log_frame->log, log_frame->log_len);
         }
         rt_rbb_blk_free(ulog.async_rbb, log_blk);
     }
     /* output the log_raw format log */
-    if (ulog.async_rb)
+    if (ulog.async_rb && !emergency_mode)
     {
         rt_size_t log_len = rt_ringbuffer_data_len(ulog.async_rb);
         char *log = rt_malloc(log_len + 1);
@@ -1434,14 +1503,14 @@ rt_err_t ulog_async_waiting_log(rt_int32_t time)
 
 static void async_output_thread_entry(void *param)
 {
-    ulog_async_output();
+    ulog_async_output(RT_FALSE);
 
     while (1)
     {
         ulog_async_waiting_log(RT_WAITING_FOREVER);
         while (1)
         {
-            ulog_async_output();
+            ulog_async_output(RT_FALSE);
             /* If there is no log output for a certain period of time,
              * refresh the log buffer
              */
@@ -1471,7 +1540,7 @@ void ulog_flush(void)
         return;
 
 #ifdef ULOG_USING_ASYNC_OUTPUT
-    ulog_async_output();
+    ulog_async_output(RT_FALSE);
 #endif
 
     /* flush all backends */
@@ -1479,6 +1548,31 @@ void ulog_flush(void)
     {
         backend = rt_slist_entry(node, struct ulog_backend, list);
         if (backend->flush)
+        {
+            backend->flush(backend);
+        }
+    }
+}
+
+/**
+ * @brief Flushes pending logs and outputs to emergency-safe backends.
+ */
+void ulog_emergency_flush(void)
+{
+    rt_slist_t *node;
+    ulog_backend_t backend;
+
+    if (!ulog.init_ok)
+        return;
+
+#ifdef ULOG_USING_ASYNC_OUTPUT
+    ulog_async_output(RT_TRUE);
+#endif
+
+    rt_slist_for_each(node, &ulog.backend_list)
+    {
+        backend = rt_slist_entry(node, struct ulog_backend, list);
+        if (backend->is_emergency_backend && backend->flush)
         {
             backend->flush(backend);
         }

--- a/components/utilities/ulog/ulog_def.h
+++ b/components/utilities/ulog/ulog_def.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2006-2022, RT-Thread Development Team
+ * Copyright (c) 2006-2025 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
  * Change Logs:
  * Date           Author       Notes
  * 2018-08-25     armink       the first version
+ * 2025-10-30     wdfk-prog    add emergency log flush mechanism
  */
 
 #ifndef _ULOG_DEF_H_
@@ -198,6 +199,7 @@ struct ulog_backend
     char name[RT_NAME_MAX];
     rt_bool_t support_color;
     rt_uint32_t out_level;
+    rt_bool_t is_emergency_backend; /**< Can this backend be called safely in a fault/emergency context? */
     void (*init)  (struct ulog_backend *backend);
     void (*output)(struct ulog_backend *backend, rt_uint32_t level, const char *tag, rt_bool_t is_raw, const char *log, rt_size_t len);
     void (*flush) (struct ulog_backend *backend);

--- a/include/rtdbg.h
+++ b/include/rtdbg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2021, RT-Thread Development Team
+ * Copyright (c) 2006-2025 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -156,6 +156,8 @@ extern "C" {
 #define LOG_RAW(...)         dbg_raw(__VA_ARGS__)
 
 #define LOG_HEX(name, width, buf, size)
+
+#define LOG_EMERGENCY(...)   LOG_E(__VA_ARGS__)
 
 #endif /* defined(RT_USING_ULOG) && define(DBG_ENABLE) */
 

--- a/src/scheduler_comm.c
+++ b/src/scheduler_comm.c
@@ -9,6 +9,7 @@
  * Date           Author       Notes
  * 2024-01-18     Shell        Separate scheduling related codes from thread.c, scheduler_.*
  * 2025-09-01     Rbb666       Add thread stack overflow hook.
+ * 2025-10-30     wdfk-prog    add emergency log flush mechanism
  */
 
 #define DBG_TAG           "kernel.sched"
@@ -484,8 +485,11 @@ void rt_scheduler_stack_check(struct rt_thread *thread)
         rt_base_t dummy = 1;
         rt_err_t hook_result = -RT_ERROR;
 
-        LOG_E("thread:%s stack overflow\n", thread->parent.name);
-
+        LOG_EMERGENCY("thread:%s stack overflow\n", thread->parent.name);
+#ifdef RT_USING_FINSH
+        extern long list_thread(void);
+        list_thread();
+#endif
 #if defined(RT_USING_HOOK) && defined(RT_HOOK_USING_FUNC_PTR)
         if (rt_stack_overflow_hook != RT_NULL)
         {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
- 在系统发生严重故障（例如线程栈溢出、硬件故障中断）时，标准的 ulog_flush() 函数可能无法被安全调用。这是因为常规的日志后端可能依赖于操作系统服务，如互斥锁、信号量、动态内存分配或复杂的文件系统操作，这些服务在中断上下文或系统锁定状态下可能不可用或导致系统彻底崩溃。这使得开发者无法在系统临终前获取到最关键的调试信息。

- 例如检测线程溢出函数中使用LOG_E打印线程溢出,在启用ULOG+异步输出的情况下将不会显示
- 就算LOG_E之后加入ULOG_FLUSH,将会打印异常.因为可能挂载了不同的后端输出函数,可能具有异常操作导致一直不断刷新或者输出其他异常情况

- 开启ULOG+异步输出+文件后端(输出到littlefs文件系统路径下)
- 线程溢出时,未修复的输出日志如下
```sh
[2025/10/30 8:38:23 876]  \ | /
[2025/10/30 8:38:23 876] - RT -     Thread Operating System
[2025/10/30 8:38:23 876]  / | \     5.2.2 build Oct 29 2025 17:11:57
[2025/10/30 8:38:23 877]  2006 - 2024 Copyright by RT-Thread team
[2025/10/30 8:38:24 523] msh />01-01 00:00:00 SFUD: Found a Winbond flash chip. Size is 8388608 bytes.
[2025/10/30 8:38:24 523] 01-01 00:00:00 SFUD: norflash0 flash device initialized successfully.
[2025/10/30 8:38:24 523] 01-01 00:00:00 SFUD: Probe SPI flash norflash0 by SPI device spi10 success.
[2025/10/30 8:38:24 523] 01-01 00:00:00 FAL: Flash device |                norflash0 | addr: 0x00000000 | len: 0x00800000 | blk_size: 0x00001000 |init
[2025/10/30 8:38:24 523] 01-01 00:00:00 FAL: ==================== FAL partition table ====================
[2025/10/30 8:38:24 523] 01-01 00:00:00 FAL: | name       | flash_dev |   offset   |    length  |
[2025/10/30 8:38:24 524] 01-01 00:00:00 FAL: -------------------------------------------------------------
[2025/10/30 8:38:25 739] 01-01 00:00:00 FAL: | filesystem | norflash0 | 0x00000000 | 0x00800000 |
[2025/10/30 8:38:25 739] thread             pri  status      sp     stack size max used left tick   error  tcb addr   usage
[2025/10/30 8:38:25 739] ------------------ ---  ------- ---------- ----------  ------  ---------- ------- ---------- -----
[2025/10/30 8:38:25 739]  
[2025/10/30 8:38:25 739] Firmware name: rtt, hardware version: 1.0, software version: 1.0
[2025/10/30 8:38:25 740] Fault on thread tidle0
[2025/10/30 8:38:25 740] stack_pointer: 0x2000dc50, stack_start_addr: 0x20003e00, stack_end_addr: 0x20003f00
[2025/10/30 8:38:25 740] Error: Thread stack(20003e5c) was overflow
[2025/10/30 8:38:25 740] ===== Thread stack information =====
[2025/10/30 8:38:25 740]   addr: 20003e5c    data: 00000000
[2025/10/30 8:38:25 740]   addr: 20003e60    data: deadbeef
[2025/10/30 8:38:25 740]   addr: 20003e64    data: deadbeef
[2025/10/30 8:38:25 740]   addr: 20003e68    data: deadbeef
[2025/10/30 8:38:25 740]   addr: 20003e6c    data: 20003ea0
[2025/10/30 8:38:25 740]   addr: 20003e70    data: deadbeef
[2025/10/30 8:38:25 740]   addr: 20003e74    data: deadbeef
[2025/10/30 8:38:25 740]   addr: 20003e78    data: deadbeef
[2025/10/30 8:38:25 740]   addr: 20003e7c    data: deadbeef
[2025/10/30 8:38:25 740]   addr: 20003e80    data: 00000000
[2025/10/30 8:38:25 740]   addr: 20003e84    data: 20004100
[2025/10/30 8:38:25 740]   addr: 20003e88    data: 00000000
[2025/10/30 8:38:25 740]   addr: 20003e8c    data: 00000000
[2025/10/30 8:38:25 740]   addr: 20003e90    data: 00000000
[2025/10/30 8:38:25 740]   addr: 20003e94    data: 08023f63
[2025/10/30 8:38:25 740]   addr: 20003e98    data: 08023f62
[2025/10/30 8:38:25 741] ====================================
[2025/10/30 8:38:25 741] =================== Registers information ====================
[2025/10/30 8:38:25 741]   R0 : 00000001  R1 : 20004100  R2 : 00000005  R3 : 09478048
[2025/10/30 8:38:25 741]   R12: 00000000  LR : 08028153  PC : 0802cd5a  PSR: 81030000
[2025/10/30 8:38:25 741] ==============================================================
[2025/10/30 8:38:25 741] Bus fault is caused by precise data access violation
[2025/10/30 8:38:25 741] The bus fault occurred address is 09478048
[2025/10/30 8:38:25 741] Show more call stack info by run: addr2line -e 5axis.elf -afpiC 08023f62 080240a0 080240be 08024156 
[2025/10/30 8:38:25 741] Current system tick: 69
```

- https://github.com/armink-rtt-pkgs/CmBacktrace/pull/22
- 修复后日志如下
```sh
2025/10/30 8:52:51 493]  \ | /
[2025/10/30 8:52:51 493] - RT -     Thread Operating System
[2025/10/30 8:52:51 493]  / | \     5.2.2 build Oct 30 2025 08:50:01
[2025/10/30 8:52:51 494]  2006 - 2024 Copyright by RT-Thread team
[2025/10/30 8:54:29 940] msh />01-01 00:00:00 SFUD: Found a Winbond flash chip. Size is 8388608 bytes.
[2025/10/30 8:54:29 940] 01-01 00:00:00 SFUD: norflash0 flash device initialized successfully.
[2025/10/30 8:54:29 940] 01-01 00:00:00 SFUD: Probe SPI flash norflash0 by SPI device spi10 success.
[2025/10/30 8:54:29 941] 01-01 00:00:00 FAL: Flash device |                norflash0 | addr: 0x00000000 | len: 0x00800000 | blk_size: 0x00001000 |init
[2025/10/30 8:54:29 941] 01-01 00:00:00 FAL: ==================== FAL partition table ====================
[2025/10/30 8:54:29 941] 01-01 00:00:00 FAL: | name       | flash_dev |   offset   |    length  |
[2025/10/30 8:54:29 941] 01-01 00:00:00 FAL: -------------------------------------------------------------
[2025/10/30 8:54:33 343] 01-01 00:00:00 FAL: | filesystem | norflash0 | 0x00000000 | 0x00800000 |
[2025/10/30 8:54:33 343] 01-01 00:00:00 FAL: =============================================================
[2025/10/30 8:54:33 343] 01-01 00:00:00 FAL: RT-Thread Flash Abstraction Layer initialize success.
[2025/10/30 8:54:33 343] 01-01 00:00:00 FAL: The FAL MTD NOR device (filesystem) created successfully
[2025/10/30 8:54:33 344] 01-01 00:00:00 NO_TAG: Mount to '/flash' success!
[2025/10/30 8:54:33 344] 01-01 00:00:00 drv.i2c.hw: transmit time out
[2025/10/30 8:54:33 344] 01-01 00:00:00 drv.i2c.hw: transmit time out
[2025/10/30 8:54:33 344] 01-01 00:00:00 drv.i2c.hw: transmit time out
[2025/10/30 8:54:33 344] 01-01 00:00:00 drv.i2c.hw: receive time out
[2025/10/30 8:54:33 344] 01-01 00:00:00 24cxx: 24cxx check failed
[2025/10/30 8:54:33 344] 01-01 00:00:00 kernel.sched: thread:ulog_async stack overflow
```

#### 你的解决方案是什么 (what is your solution)
- 为了解决这个问题，本次提交为 ulog 组件引入了一套“紧急日志刷新”机制。该机制允许在不依赖不安全OS服务的情况下，将日志刷新到指定的、被标记为“紧急情况安全”的后端。

#### 主要变更 (Key Changes)
1. 新增 is_emergency_backend 标志: 在 ulog_backend 结构体中增加一个 rt_bool_t 类型的标志，用于标识该后端是否可以在紧急/故障上下文中被安全调用。
2. 新增 ulog_emergency_flush() API: 这是一个新的 flush 函数，它会：
  - 在关闭中断的情况下执行。
  - 只调用那些被标记为 is_emergency_backend = RT_TRUE 的后端的 flush 方法。
  - 在异步模式下，它会以“紧急模式”刷新缓冲区，避免了不安全的操作（如 rt_malloc）。
3. 新增 ulog_backend_set_emergency() API: 允许用户在运行时动态地将某个后端设置为紧急后端。
4. 将 console 后端设为默认紧急后端: console 后端实现简单，依赖少，是理想的紧急日志输出通道，因此默认开启此标志。
5. 应用示例: 在 rt_scheduler_stack_check 检测到线程栈溢出后，调用 ulog_emergency_flush() 来确保溢出告警能够被可靠输出。

通过这些变更，系统的可调试性和健壮性得到了显著提升，尤其是在处理和诊断严重系统故障时。
#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
