### PR TITLE
feat[spi]: enable interrupt-safe operations using spinlocks

### DIFF
--- a/components/drivers/include/drivers/dev_spi.h
+++ b/components/drivers/include/drivers/dev_spi.h
@@ -8,6 +8,7 @@
  * 2012-11-23     Bernard      Add extern "C"
  * 2020-06-13     armink       fix the 3 wires issue
  * 2022-09-01     liYony       fix api rt_spi_sendrecv16 about MSB and LSB bug
+ * 2025-10-30     wdfk-prog    enable interrupt-safe operations using spinlocks
  */
 
 #ifndef __DEV_SPI_H__
@@ -181,6 +182,10 @@ struct rt_spi_bus
 #endif /* RT_USING_DM */
 
     struct rt_mutex lock;
+#ifdef RT_USING_SPI_ISR
+    rt_base_t _isr_lvl;
+    struct rt_spinlock _spinlock;
+#endif /* RT_USING_SPI_ISR */
     struct rt_spi_device *owner;
 };
 

--- a/components/drivers/spi/Kconfig
+++ b/components/drivers/spi/Kconfig
@@ -4,6 +4,10 @@ menuconfig RT_USING_SPI
 
     if RT_USING_SPI
 
+        menuconfig RT_USING_SPI_ISR
+            bool "Enable interrupt-safe SPI operations (using spinlocks in ISR context)"
+            default y
+
         menuconfig RT_USING_SOFT_SPI
             bool "Use GPIO to simulate SPI"
             default n

--- a/components/drivers/spi/dev_spi_flash.h
+++ b/components/drivers/spi/dev_spi_flash.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2025 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2016/5/20      bernard      the first version
  * 2020/1/7       redoc        add include
+ * 2025-10-30     wdfk-prog    enable interrupt-safe operations using spinlocks
  */
 
 #ifndef __DEV_SPI_FLASH_H__
@@ -20,6 +21,10 @@ struct spi_flash_device
     struct rt_device_blk_geometry   geometry;
     struct rt_spi_device *          rt_spi_device;
     struct rt_mutex                 lock;
+#ifdef RT_USING_SPI_ISR
+    rt_base_t _isr_lvl;
+    struct rt_spinlock _spinlock;
+#endif /* RT_USING_SPI_ISR */
     void *                          user_data;
 };
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
- 当前的 SPI 驱动框架使用 rt_mutex 作为总线和设备的保护锁。由于互斥锁在获取不到时会导致线程挂起，因此它不能在中断服务程序（ISR）或其他禁止调度的上下文中使用。这限制了 SPI 设备（如 SPI Flash）在某些需要高实时性响应（例如，在中断中紧急写入日志或数据）的场景下的应用。

- 此外，SFUD 驱动中的 retry_delay 函数使用了 rt_thread_delay，该函数同样依赖于线程调度器，无法在中断中调用。

#### 你的解决方案是什么 (what is your solution)

- 为了使 SPI 驱动框架能够安全地在中断上下文中使用，本次提交引入了一套上下文感知的混合锁机制，并对相关代码进行了适应性修改。

#### 主要变更 (Key Changes)
1. 引入混合锁机制:
  - 通过新增的 spi_lock 和 spi_unlock 辅助函数，封装了锁的获取与释放逻辑。
  - 函数内部通过 rt_scheduler_is_available() 判断当前环境：
    - 线程环境: 继续使用 rt_mutex，允许任务调度。
    - 中断环境: 切换为使用 rt_spin_lock_irqsave，通过禁用中断和忙等来保证资源访问的原子性。
2. 数据结构更新:
  - 为 rt_spi_bus 和 spi_flash_device 结构体增加了 rt_spinlock 成员，并通过 RT_USING_SPI_ISR 宏进行条件编译。
3. SFUD 驱动适配:
  - 对 SFUD 驱动中的 spi_lock/spi_unlock 回调进行了同样的改造，使其支持中断调用。
  - 修改了 retry_delay_100us 函数，使其在中断上下文中改用 rt_hw_us_delay 进行硬件忙等延时。
4. 新增 Kconfig 选项:
  - 增加了 RT_USING_SPI_ISR 选项，用户可以按需开启或关闭此功能。

- 通过这些修改，SPI 驱动现在是完全的线程安全和中断安全的，极大地扩展了其应用范围。

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: STM32F4
- STM32需要修改适配可以在中断环境下使用
- 参考此处修改实现:https://github.com/RT-Thread/rt-thread/pull/9124/commits/2bbee8b1f44b10e49a768bf85e2b9a7ac7553fc6
- https://github.com/RT-Thread/rt-thread/pull/9124

- https://github.com/armink-rtt-pkgs/CmBacktrace/pull/22
- 验证结果
```sh
[2025/10/30 15:48:38 253] msh />
[2025/10/30 15:48:38 460] msh />
[2025/10/30 15:48:42 356] msh />cmb
[2025/10/30 15:48:42 358] cmb_test
[2025/10/30 15:48:42 893] msh />cmb_test
[2025/10/30 15:48:42 896] Please input 'cmb_test <DIVBYZERO|UNALIGNED|ASSERT>' 
[2025/10/30 15:48:47 737] msh />cmb_test UNALIGNED
[2025/10/30 15:48:47 739] addr:0x00 value:0x20002A28
[2025/10/30 15:48:47 739] addr:0x04 value:0x08000229
[2025/10/30 15:48:47 739] 01-01 00:00:00 cmb:  
[2025/10/30 15:48:47 925] 01-01 00:00:00 cmb: Firmware name: 5axis, hardware version: 1.0, software version: 1.0
[2025/10/30 15:48:47 925] 01-01 00:00:00 cmb: Fault on interrupt or bare metal(no OS) environment
[2025/10/30 15:48:47 925] 01-01 00:00:00 cmb: ===== Thread stack information =====
[2025/10/30 15:48:47 925] 01-01 00:00:00 cmb:   addr: 20003cf4    data: 2000415c
[2025/10/30 15:48:47 925] 01-01 00:00:00 cmb:   addr: 20003cf8    data: 00000000
[2025/10/30 15:48:47 925] 01-01 00:00:00 cmb:   addr: 20003cfc    data: 08027db9
[2025/10/30 15:48:47 925] 01-01 00:00:00 cmb:   addr: 20003d00    data: 08020270
[2025/10/30 15:48:47 925] 01-01 00:00:00 cmb:   addr: 20003d04    data: 01000200
[2025/10/30 15:48:47 926] 01-01 00:00:00 cmb:   addr: 20003d08    data: 080554e7
[2025/10/30 15:48:47 926] 01-01 00:00:00 cmb: ====================================
[2025/10/30 15:48:47 926] 01-01 00:00:00 cmb: =================== Registers information ====================
[2025/10/30 15:48:47 926] 01-01 00:00:00 cmb:   R0 : 2000c5d4  R1 : 2000c5f8  R2 : 2000c618  R3 : 080202c3
[2025/10/30 15:48:47 926] 01-01 00:00:00 cmb:   R12: fffffffd  LR : 00000000  PC : 10000000  PSR: f0000000
[2025/10/30 15:48:47 926] 01-01 00:00:00 cmb: ==============================================================
[2025/10/30 15:48:47 926] 01-01 00:00:00 cmb: Usage fault is caused by indicates that an unaligned access fault has taken place
[2025/10/30 15:48:47 926] 01-01 00:00:00 cmb: Show more call stack info by run: addr2line -e 5axis.elf -afpiC 10000000 08027db8 080554e6 
[2025/10/30 15:48:47 926] 01-01 00:00:00 cmb: Current system tick: 11837
[2025/10/30 15:48:57 939] rcc_csr = 0x1e000000(Reset flag for system reset through CPU)

[2025/10/30 15:49:04 968] cd f
[2025/10/30 15:49:05 624] msh />cd flash/l
[2025/10/30 15:49:05 847] msh />cd flash/log/
[2025/10/30 15:49:06 453] msh /flash/log>ls
[2025/10/30 15:49:06 469] Directory /flash/log:
[2025/10/30 15:49:06 549] cmb.log              1685                     
[2025/10/30 15:49:06 549] flash_sys.log        14296                    
[2025/10/30 15:49:07 789] msh /flash/log>cat c
[2025/10/30 15:49:08 124] msh /flash/log>cat cmb.log
[2025/10/30 15:49:08 309] 01-01 00:00:00 cmb:  
[2025/10/30 15:49:08 309] ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿXÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ01-01 00:00:00 cmb:  
[2025/10/30 15:49:08 309] ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿXÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ01-01 00:00:00 cmb:  
[2025/10/30 15:49:08 309] ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿXÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ01-01 00:00:00 cmb:  
[2025/10/30 15:49:08 309] 01-01 00:00:00 cmb: Firmware name: 5axis, hardware version: 1.0, software version: 1.0
[2025/10/30 15:49:08 309] 01-01 00:00:00 cmb: Fault on interrupt or bare metal(no OS) environment
[2025/10/30 15:49:08 309] 01-01 00:00:00 cmb: ===== Thread stack information =====
[2025/10/30 15:49:08 309] 01-01 00:00:00 cmb:   addr: 20003cf4    data: 2000415c
[2025/10/30 15:49:08 309] 01-01 00:00:00 cmb:   addr: 20003cf8    data: 00000000
[2025/10/30 15:49:08 309] 01-01 00:00:00 cmb:   addr: 20003cfc    data: 08027db9
[2025/10/30 15:49:08 309] 01-01 00:00:00 cmb:   addr: 20003d00    data: 08020270
[2025/10/30 15:49:08 309] 01-01 00:00:00 cmb:   addr: 20003d04    data: 01000200
[2025/10/30 15:49:08 309] 01-01 00:00:00 cmb:   addr: 20003d08    data: 080554e7
[2025/10/30 15:49:08 309] 01-01 00:00:00 cmb: ====================================
[2025/10/30 15:49:08 310] 01-01 00:00:00 cmb: =================== Registers information ====================
[2025/10/30 15:49:08 310] 01-01 00:00:00 cmb:   R0 : 2000c5d4  R1 : 2000c5f8  R2 : 2000c618  R3 : 080202c3
[2025/10/30 15:49:08 310] 01-01 00:00:00 cmb:   R12: fffffffd  LR : 00000000  PC : 10000000  PSR: f0000000
[2025/10/30 15:49:08 310] 01-01 00:00:00 cmb: ==============================================================
[2025/10/30 15:49:08 310] 01-01 00:00:00 cmb: Usage fault is caused by indicates that an unaligned access fault has taken place
[2025/10/30 15:49:08 310] 01-01 00:00:00 cmb: Show more call stack info by run: addr2line -e 5axis.elf -afpiC 10000000 08027db8 080554e6 
[2025/10/30 15:49:08 310] 01-01 00:00:00 cmb: Current system tick: 11837
[2025/10/30 15:49:08 310] 

```
<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
