### PR TITLE
feat[ulog]: 增加 Kconfig 选项以控制 Finsh/MSH 命令

### DIFF
--- a/components/utilities/Kconfig
+++ b/components/utilities/Kconfig
@@ -192,6 +192,14 @@ menuconfig RT_USING_ULOG
                 It will enable the log filter.
                 Such as level filter, log tag filter, log kw filter and tag's level filter.
 
+        config ULOG_USING_FINSH_CMD
+            bool "Enable ulog finsh/msh commands"
+            depends on ULOG_USING_FILTER && RT_USING_FINSH
+            default y
+            help
+                Enable this option to use ulog commands in finsh/msh,
+                such as ulog_lvl, ulog_tag, ulog_kw and so on.
+
         config ULOG_USING_SYSLOG
             bool "Enable syslog format log and API."
             select ULOG_OUTPUT_TIME

--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -1084,7 +1084,7 @@ const char *ulog_global_filter_kw_get(void)
     return ulog.filter.keyword;
 }
 
-#ifdef RT_USING_FINSH
+#if defined(RT_USING_FINSH) && defined(ULOG_USING_FINSH_CMD)
 #include <finsh.h>
 
 static void _print_lvl_info(void)
@@ -1259,7 +1259,7 @@ static void ulog_filter(uint8_t argc, char **argv)
     }
 }
 MSH_CMD_EXPORT(ulog_filter, Show ulog filter settings);
-#endif /* RT_USING_FINSH */
+#endif /* RT_USING_FINSH && ULOG_USING_FINSH_CMD */
 #endif /* ULOG_USING_FILTER */
 
 /**


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
当前，只要系统中开启了 RT_USING_FINSH，ulog 组件就会默认将其相关的 Finsh/MSH 命令（如 ulog_lvl, ulog_tag, ulog_kw 等）注册到系统中。
在某些对资源占用（ROM）有严格要求的场景下，开发者可能希望使用 ulog 的日志功能，但并不需要通过命令行对其进行动态配置。目前没有提供一个便捷的开关来禁用这些命令，导致这部分代码被强制编译，占用了不必要的空间。

#### 你的解决方案是什么 (what is your solution)
1. 在 components/utilities/Kconfig 中，于 RT_USING_ULOG 菜单下增加了一个新的配置项 ULOG_USING_FINSH_CMD。
该选项依赖于 ULOG_USING_FILTER 和 RT_USING_FINSH，只有在这两者都开启时才可见。
2. 为了保持与之前行为的兼容性，该选项默认设置为 y（开启）。
3. 在 ulog.c 中，使用 #if defined(RT_USING_FINSH) && defined(ULOG_USING_FINSH_CMD) 宏来条件编译所有与 Finsh/MSH 命令相关的代码。

使用效果
-- 默认行为：保持不变。对于现有配置，ulog 命令仍然可用。
- 提供灵活性：开发者现在可以通过在 menuconfig 中关闭 ULOG_USING_FINSH_CMD 选项，来轻松地移除所有 ulog 相关的命令行功能，从而减少固件的最终体积。

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
