### PR TITLE
fix(finsh): Correct stack usage display format in list_thread command

### DIFF
--- a/components/finsh/cmd.c
+++ b/components/finsh/cmd.c
@@ -262,7 +262,7 @@ long list_thread(void)
 #else
                     ptr = (rt_uint8_t *)thread->stack_addr;
                     while (*ptr == '#') ptr ++;
-                    rt_kprintf(" 0x%08x 0x%08x    %02d%%   0x%08x %s %p",
+                    rt_kprintf(" 0x%08x 0x%08x    %3d%%   0x%08x %s %p",
                                thread->stack_size + ((rt_ubase_t)thread->stack_addr - (rt_ubase_t)thread->sp),
                                thread->stack_size,
                                (thread->stack_size - ((rt_ubase_t) ptr - (rt_ubase_t) thread->stack_addr)) * 100


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
在使用 Finsh/MSH 的 list_thread 命令查看线程状态时，用于显示栈使用率的格式化字符串是 %02d。这个格式化方式只能正确处理两位数（0-99）的百分比。当某个线程的栈使用率恰好为100%时，会导致显示异常，破坏了输出的对齐格式，降低了调试信息的可读性。

#### 你的解决方案是什么 (what is your solution)
为了解决这个问题，本 PR 将 rt_kprintf 中用于打印栈使用率的格式化字符串从 %02d 修改为 %3d。
这个简单的改动可以确保：
  1. 当栈使用率为100%时，能够被完整且正确地显示。
  2. 对于低于100%的数值，会使用空格进行左填充，从而保证了整个“栈使用率”列的输出始终对齐，提升了 list_thread 命令输出的美观性和可读性。

- 修复前效果
```sh
[2025/11/5 11:39:18 820] thread             pri  status      sp     stack size max used left tick   error  tcb addr   usage
[2025/11/5 11:39:18 820] ------------------ ---  ------- ---------- ----------  ------  ---------- ------- ---------- -----
[2025/11/5 11:39:18 820] isotp_client        22  suspend 0x000001ac 0x00000800    58%   0x00000008 EINTRPT 0x200167f8   0%
[2025/11/5 11:39:18 820] isotp_logger        23  running 0x0000010c 0x00000400    100%   0x00000009 OK      0x20016328   0%
[2025/11/5 11:39:18 820] isotp_server        22  suspend 0x000002c4 0x00000800    69%   0x00000006 OK      0x2000a5f0   0%
[2025/11/5 11:39:18 820] isotp_consumer      15  suspend 0x000000dc 0x00000800    19%   0x00000009 EINTRPT 0x20009c20   0%
```

- 修复后效果
```sh
[2025/11/5 11:50:48 399] thread             pri  status      sp     stack size max used left tick   error  tcb addr   usage
[2025/11/5 11:50:48 399] ------------------ ---  ------- ---------- ----------  ------  ---------- ------- ---------- -----
[2025/11/5 11:50:48 399] isotp_client        22  suspend 0x000001ac 0x00000800     58%   0x00000008 EINTRPT 0x200167d8   0%
[2025/11/5 11:50:48 399] isotp_logger        23  running 0x0000010c 0x00000400    100%   0x00000009 OK      0x20016308   0%
[2025/11/5 11:50:48 399] isotp_server        22  suspend 0x000002dc 0x00000800     69%   0x00000006 OK      0x2000a610   0%
[2025/11/5 11:50:48 399] isotp_consumer      15  suspend 0x000000dc 0x00000800     19%   0x00000008 EINTRPT 0x20009c40   0%
```

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
