### PR TITLE
[libcpu][arm] fix: correct FPU stack initialization order and alignment on Cortex-A

### DIFF
--- a/libcpu/arm/cortex-a/stack.c
+++ b/libcpu/arm/cortex-a/stack.c
@@ -82,7 +82,7 @@ rt_uint8_t *rt_hw_stack_init(void *tentry, void *parameter,
     *(--stk) = 0x00000000;
 
     /* 4. FPEXC: EN=1 */
-    *(--stk) = 0x40000000; 
+    *(--stk) = 0x40000000;
 #endif
 
     /* return task's current stack address */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
修复了 `libcpu/arm/cortex-a/common/stack.c` 中 FPU 上下文初始化顺序与汇编恢复顺序不一致的问题。
原始实现的压栈顺序和栈对齐未与 `context_gcc.S` 保持一致，导致在 **-O2 优化、硬浮点 ABI (-mfloat-abi=hard)** 环境下，
执行包含浮点/NEON 指令的线程时出现 **Data Abort** 异常。

#### 你的解决方案是什么 (what is your solution)
- 调整 FPU 上下文压栈顺序以符合 `context_gcc.S` 的恢复顺序：
  D0–D15 → D16–D31 → FPSCR → FPEXC。
- 初始化 FPEXC 寄存器 (`0x40000000`) 以确保 FPU 处于启用状态。
- 确保最终栈指针 8 字节对齐，符合 NEON/VFP 对齐要求。
- 已在 Cortex-A15 平台上验证，未影响通用寄存器栈初始化逻辑。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
  - 自研板卡：`bsp/ft-m6678e`（Cortex-A15 平台，基于 RT-Thread 5.1.0）
- .config:
  - 启用项（示例）：
    ```
    CONFIG_RT_USING_FPU=y
    CONFIG_ARCH_MM_MMU=y
    CONFIG_ARCH_ARM=y
    CONFIG_ARCH_ARM_MMU=y
    CONFIG_ARCH_ARM_CORTEX_A=y
    ```
- action:
  - 本地验证（尚未合入官方 BSP CI）
  - 后续将补充 BSP 并提交至官方仓库验证

#### 测试验证 (testing and verification)

- 编译选项：`-O2 -Wall -mfloat-abi=hard -mfpu=neon-vfpv4`
- 运行示例：函数中包含浮点加减、乘法、`sqrtf()` 调用。
- 在 Cortex-A15 (ft-m6678e) 板卡上验证通过：
  - Debug 模式 (`-O0`) 与 Release 模式 (`-O2`) 均运行稳定；
  - 无需 `-fno-schedule-insns2` workaround；
  - 线程切换过程中 FPU 上下文恢复正常。

#### 影响范围 (impact scope)

- 仅影响使用 VFP/NEON 且启用 `RT_USING_FPU` 的 Cortex-A 系列处理器。
- 对 Cortex-M 和 AArch64 架构无影响。

#### 后续计划 (follow-up)
- 将在 BSP/ft-m6678e（Cortex-A15）正式提交时，补充 Action CI 测试与回归验证。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。 The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
