### PR TITLE
[utest]Fixed assertion failure in the smp_affinity_pri1_tc use case caused by improper priority configuration.

### DIFF
--- a/src/utest/smp/smp_affinity_pri1_tc.c
+++ b/src/utest/smp/smp_affinity_pri1_tc.c
@@ -24,7 +24,7 @@
 static int run_num = 10;
 #define THREAD_STACK_SIZE UTEST_THR_STACK_SIZE
 #define THREAD_PRIORITY   2
-#define LOW_PRIORITY  50
+#define LOW_PRIORITY  30
 #define THIGH_PRIORITY  10
 static rt_thread_t        threads[RT_CPUS_NR];
 static rt_thread_t        temp_thread;


### PR DESCRIPTION
修复 [ci](https://github.com/RT-Thread/rt-thread/actions/runs/19460078950/job/55681983291?pr=10953) 问题

将LOW_PRIORITY调整为合适的数值，避免断言