### PR TITLE
fix(finsh): Fix crash in 'tail' command with insufficient '-n' arguments

### DIFF
--- a/components/finsh/msh_file.c
+++ b/components/finsh/msh_file.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2025 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -738,6 +738,18 @@ static int cmd_echo(int argc, char **argv)
 }
 MSH_CMD_EXPORT_ALIAS(cmd_echo, echo, echo string to file);
 
+/**
+ * @brief  Print the last part of a file (tail command).
+ *
+ * @note   Supported Usage:
+ *         1. tail <file>               : Print last 10 lines.
+ *         2. tail -n <num> <file>      : Print last <num> lines.
+ *         3. tail -n +<num> <file>     : Print starting from line <num>.
+ *
+ * @param  argc  Argument count
+ * @param  argv  Argument vector
+ * @return 0 on success, -1 on failure
+ */
 static int cmd_tail(int argc, char **argv)
 {
     int fd;
@@ -751,7 +763,7 @@ static int cmd_tail(int argc, char **argv)
 
     if (argc < 2)
     {
-        rt_kprintf("Usage: tail [-n numbers] <filename>\n");
+        rt_kprintf("Usage: tail [-n [+]numbers] <filename>\n");
         return -1;
     }
     else if (argc == 2)
@@ -761,19 +773,31 @@ static int cmd_tail(int argc, char **argv)
     }
     else if (rt_strcmp(argv[1], "-n") == 0)
     {
+        /*
+         * Check if enough arguments are provided to avoid crash.
+         * The command requires: "tail" + "-n" + "number" + "file" = 4 args.
+         */
+        if (argc < 4)
+        {
+            rt_kprintf("Error: Missing arguments.\n");
+            rt_kprintf("Usage: tail -n [+]numbers <filename>\n");
+            return -1;
+        }
+
+        /* Check for explicit start line syntax (e.g., +100) */
         if (argv[2][0] != '+')
         {
             required_lines = atoi(argv[2]);
         }
         else
         {
-            start_line = atoi(&argv[2][1]); /* eg: +100, to get the 100 */
+            start_line = atoi(&argv[2][1]); /* eg: +100, skip '+' to get 100 */
         }
         file_name = argv[3];
     }
     else
     {
-        rt_kprintf("Usage: tail [-n numbers] <filename>\n");
+        rt_kprintf("Usage: tail [-n [+]numbers] <filename>\n");
         return -1;
     }
 
@@ -839,7 +863,7 @@ static int cmd_tail(int argc, char **argv)
     close(fd);
     return 0;
 }
-MSH_CMD_EXPORT_ALIAS(cmd_tail, tail, print the last N - lines data of the given file);
+MSH_CMD_EXPORT_ALIAS(cmd_tail, tail, Print the last N lines. Usage: tail -n [+]numbers <filename>);
 
 #ifdef RT_USING_DFS_V2
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
- MSH shell 中的 tail 命令存在一个bug：当用户错误地使用 -n 参数时，会导致设备崩溃。
- 复现步骤：
执行 tail -n <filename> 或 tail -n 这种缺少必要参数的命令。
tail -n flash_sys.log 命令将 flash_sys.log 误解析为行数，然后尝试访问不存在的 argv[3] 来获取文件名，这导致了异常。


#### 你的解决方案是什么 (what is your solution)
- 本次提交的核心是增加了一道安全防线来修复这个崩溃问题：
1. 增加参数数量校验：在解析 -n 选项的逻辑分支中，强制检查 argc 是否小于 4。如果参数数量不足以同时提供 -n、行数和文件名，则立即打印错误信息并安全返回，彻底杜绝了访问越界内存的可能性。
2. 优化用户提示：同步更新了错误提示和 MSH 命令导出宏中的帮助文本，更清晰地向用户展示了 tail -n [+]numbers <filename> 的正确用法，以减少误操作的可能。
3. 补充代码文档：为 cmd_tail 函数添加了 Doxygen 注释，方便后续开发者理解和维护


#### 请提供验证的bsp和config (provide the config and bsp) 

- 此修复为 shell 通用组件更新，不依赖特定硬件。已进行如下专项测试：
1. 异常情况：执行 tail -n、tail -n 10、tail -n flash_sys.log，均能正确打印用法提示并安全退出，崩溃问题已解决。
2. 正常功能：执行 tail file、tail -n 20 file、tail -n +50 file，功能均与修复前一致，表现正常。

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
