### PR TITLE
[dm][core] Update the OFW CLk init flow

### DIFF
--- a/components/drivers/core/platform_ofw.c
+++ b/components/drivers/core/platform_ofw.c
@@ -267,6 +267,12 @@ static int platform_ofw_device_probe(void)
 
     if (ofw_node_root)
     {
+        if ((node = rt_ofw_find_node_by_path("/clocks")))
+        {
+            platform_ofw_device_probe_once(node);
+            rt_ofw_node_put(node);
+        }
+
         rt_ofw_node_get(ofw_node_root);
 
         err = platform_ofw_device_probe_once(ofw_node_root);
@@ -274,12 +280,6 @@ static int platform_ofw_device_probe(void)
         rt_ofw_node_put(ofw_node_root);
 
         if ((node = rt_ofw_find_node_by_path("/firmware")))
-        {
-            platform_ofw_device_probe_once(node);
-            rt_ofw_node_put(node);
-        }
-
-        if ((node = rt_ofw_find_node_by_path("/clocks")))
         {
             platform_ofw_device_probe_once(node);
             rt_ofw_node_put(node);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
Update the OFW CLk init flow: The clock should init before common platform devices.

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
