### PR TITLE
feat[nxp][can]：add mcxa346 can device

### DIFF
--- a/bsp/nxp/mcx/mcxa/Libraries/drivers/SConscript
+++ b/bsp/nxp/mcx/mcxa/Libraries/drivers/SConscript
@@ -37,6 +37,9 @@ if GetDepend('BSP_USING_PWM'):
 if GetDepend('BSP_USING_FLASH'):
     src += ['drv_chipflash.c']
 
+if GetDepend('BSP_USING_CAN'):
+    src += ['drv_can.c']
+
 path =  [cwd,cwd + '/config']
 
 group = DefineGroup('Drivers', src, depend = [''], CPPPATH = path)

--- a/bsp/nxp/mcx/mcxa/Libraries/drivers/drv_can.c
+++ b/bsp/nxp/mcx/mcxa/Libraries/drivers/drv_can.c
@@ -1,0 +1,551 @@
+/*
+ * Copyright (c) 2006-2025, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2025-12-23     CYFS         the first version.
+ */
+
+#include <rtdevice.h>
+
+#ifdef RT_USING_CAN
+
+#include "fsl_common.h"
+#include "fsl_flexcan.h"
+
+#define TX_MB_IDX       (6)
+#define RX_MB_COUNT     (1)
+static flexcan_frame_t frame[RX_MB_COUNT];    /* one frame buffer per RX MB */
+static rt_uint32_t filter_mask = 0;
+
+enum
+{
+#ifdef BSP_USING_CAN0
+    CAN0_INDEX,
+#endif
+#ifdef BSP_USING_CAN1
+    CAN1_INDEX,
+#endif
+};
+
+struct imxrt_can
+{
+    char                    *name;
+    CAN_Type                *base;
+    IRQn_Type               irqn;
+    uint32_t                instance;
+    clock_div_name_t        clock_div_name;
+    clock_attach_id_t       clock_attach_id;
+    flexcan_handle_t        handle;
+    struct rt_can_device    can_dev;
+};
+
+struct imxrt_can flexcans[] =
+{
+#ifdef BSP_USING_CAN0
+    {
+        .name = "can0",
+        .base = CAN0,
+        .instance = 0,
+        .irqn = CAN0_IRQn,
+        .clock_div_name = kCLOCK_DivFLEXCAN0,
+        .clock_attach_id = kFRO_HF_DIV_to_FLEXCAN0,
+    },
+#endif
+#ifdef BSP_USING_CAN1
+    {
+        .name = "can1",
+        .base = CAN1,
+        .instance = 1,
+        .irqn = CAN1_IRQn,
+        .clock_div_name = kCLOCK_DivFLEXCAN1,
+        .clock_attach_id = kFRO_HF_DIV_to_FLEXCAN1,
+    },
+#endif
+};
+
+static void flexcan_callback(CAN_Type *base, flexcan_handle_t *handle, status_t status, uint64_t result, void *userData)
+{
+    struct imxrt_can *can;
+    flexcan_mb_transfer_t rxXfer;
+
+    can = (struct imxrt_can *)userData;
+
+    switch (status)
+    {
+        case kStatus_FLEXCAN_RxIdle:
+            rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_RX_IND | result << 8);
+            rxXfer.frame = &frame[result - 1];
+            rxXfer.mbIdx = result;
+            FLEXCAN_TransferReceiveNonBlocking(can->base, &can->handle, &rxXfer);
+            break;
+
+        case kStatus_FLEXCAN_TxIdle:
+            rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_TX_DONE | result << 8);
+            break;
+        default:
+            break;
+    }
+}
+
+static rt_err_t _can_config(struct rt_can_device *can_dev, struct can_configure *cfg)
+{
+    struct imxrt_can *can =  (struct imxrt_can *)can_dev->parent.user_data;
+    flexcan_config_t config;
+    rt_uint32_t res = RT_EOK;
+    flexcan_rx_mb_config_t mbConfig;
+    flexcan_mb_transfer_t rxXfer;
+    rt_uint8_t i, mailbox;
+
+    FLEXCAN_GetDefaultConfig(&config);
+    config.baudRate = cfg->baud_rate;
+    config.enableIndividMask = true;    /* one filter per MB */
+    config.disableSelfReception = true;
+
+    switch (cfg->mode)
+    {
+    case RT_CAN_MODE_NORMAL:
+        /* default mode */
+        break;
+    case RT_CAN_MODE_LISTEN:
+        break;
+    case RT_CAN_MODE_LOOPBACK:
+        config.enableLoopBack = true;
+        break;
+    case RT_CAN_MODE_LOOPBACKANLISTEN:
+        break;
+    }
+
+    flexcan_timing_config_t timing_config;
+    rt_memset(&timing_config, 0, sizeof(flexcan_timing_config_t));
+
+    if(FLEXCAN_CalculateImprovedTimingValues(can->base, config.baudRate, CLOCK_GetFlexcanClkFreq(can->instance), &timing_config))
+    {
+        /* Update the improved timing configuration*/
+        rt_memcpy(&(config.timingConfig), &timing_config, sizeof(flexcan_timing_config_t));
+    }
+    else
+    {
+        //rt_kprintf("No found Improved Timing Configuration. Just used default configuration\n");
+    }
+
+    FLEXCAN_Init(can->base, &config, CLOCK_GetFlexcanClkFreq(can->instance));
+    FLEXCAN_TransferCreateHandle(can->base, &can->handle, flexcan_callback, can);
+
+    /* init RX_MB_COUNT RX MB to default status */
+    mbConfig.format = kFLEXCAN_FrameFormatStandard;  /* standard ID */
+    mbConfig.type = kFLEXCAN_FrameTypeData;          /* data frame */
+    mbConfig.id = FLEXCAN_ID_STD(0);                 /* default ID is 0 */
+    for (i = 0; i < RX_MB_COUNT; i++)
+    {
+        /* the used MB index from 1 to RX_MB_COUNT */
+        mailbox = i + 1;
+
+        /* all ID bit in the filter is "don't care" */
+        FLEXCAN_SetRxIndividualMask(can->base, mailbox, FLEXCAN_RX_MB_STD_MASK(0, 0, 0));
+        FLEXCAN_SetRxMbConfig(can->base, mailbox, &mbConfig, true);
+        /* one frame buffer per MB */
+        rxXfer.frame = &frame[i];
+        rxXfer.mbIdx = mailbox;
+        FLEXCAN_TransferReceiveNonBlocking(can->base, &can->handle, &rxXfer);
+    }
+
+    return res;
+}
+
+static rt_err_t _can_control(struct rt_can_device *can_dev, int cmd, void *arg)
+{
+    struct imxrt_can *can;
+    rt_uint32_t argval, mask;
+    rt_uint32_t res = RT_EOK;
+    flexcan_rx_mb_config_t mbConfig;
+    struct rt_can_filter_config  *cfg;
+    struct rt_can_filter_item *item;
+    rt_uint8_t i, count, index;
+
+    RT_ASSERT(can_dev != RT_NULL);
+
+    can = (struct imxrt_can *)can_dev->parent.user_data;
+    RT_ASSERT(can != RT_NULL);
+
+    switch (cmd)
+    {
+    case RT_DEVICE_CTRL_SET_INT:
+        argval = (rt_uint32_t) arg;
+        if (argval == RT_DEVICE_FLAG_INT_RX)
+        {
+            mask = kFLEXCAN_RxWarningInterruptEnable;
+        }
+        else if (argval == RT_DEVICE_FLAG_INT_TX)
+        {
+            mask = kFLEXCAN_TxWarningInterruptEnable;
+        }
+        else if (argval == RT_DEVICE_CAN_INT_ERR)
+        {
+            mask = kFLEXCAN_ErrorInterruptEnable;
+        }
+        FLEXCAN_EnableInterrupts(can->base, mask);
+        EnableIRQ(can->irqn);
+        break;
+    case RT_DEVICE_CTRL_CLR_INT:
+        /* each CAN device have one IRQ number. */
+        DisableIRQ(can->irqn);
+        break;
+    case RT_CAN_CMD_SET_FILTER:
+        cfg = (struct rt_can_filter_config *)arg;
+        item = cfg->items;
+        count = cfg->count;
+
+        if (filter_mask == 0xffffffff)
+        {
+            rt_kprintf("%s filter is full!\n", can->name);
+            res = -RT_ERROR;
+            break;
+        }
+        else if (filter_mask == 0)
+        {
+            /* deinit all init RX MB */
+            for (i = 0; i < RX_MB_COUNT; i++)
+            {
+                FLEXCAN_SetRxMbConfig(can->base, i + 1, RT_NULL, false);
+            }
+        }
+
+        while (count)
+        {
+            if (item->ide)
+            {
+                mbConfig.format = kFLEXCAN_FrameFormatExtend;
+                mbConfig.id = FLEXCAN_ID_EXT(item->id);
+                mask = FLEXCAN_RX_MB_EXT_MASK(item->mask, 0, 0);
+            }
+            else
+            {
+                mbConfig.format = kFLEXCAN_FrameFormatStandard;
+                mbConfig.id = FLEXCAN_ID_STD(item->id);
+                mask = FLEXCAN_RX_MB_STD_MASK(item->mask, 0, 0);
+            }
+
+            if (item->rtr)
+            {
+                mbConfig.type = kFLEXCAN_FrameTypeRemote;
+            }
+            else
+            {
+                mbConfig.type = kFLEXCAN_FrameTypeData;
+            }
+
+            /* user does not specify hdr index,set hdr_bank from RX MB 1 */
+            if (item->hdr_bank == -1)
+            {
+
+                for (i = 0; i < 32; i++)
+                {
+                    if (!(filter_mask & (1 << i)))
+                    {
+                        index = i;
+                        break;
+                    }
+                }
+            }
+            else    /* use user specified hdr_bank */
+            {
+                if (filter_mask & (1 << item->hdr_bank))
+                {
+                    res = -RT_ERROR;
+                    rt_kprintf("%s hdr%d filter already set!\n", can->name, item->hdr_bank);
+                    break;
+                }
+                else
+                {
+                    index = item->hdr_bank;
+                }
+            }
+
+            /* RX MB index from 1 to 32,hdr index 0~31 map RX MB index 1~32. */
+            FLEXCAN_SetRxIndividualMask(can->base, index + 1, mask);
+            FLEXCAN_SetRxMbConfig(can->base, index + 1, &mbConfig, true);
+            filter_mask |= 1 << index;
+
+            item++;
+            count--;
+        }
+
+        break;
+
+    case RT_CAN_CMD_SET_BAUD:
+        {
+            struct can_configure *cfg = (struct can_configure *)arg;
+            if (cfg != RT_NULL)
+            {
+                can->can_dev.config = *cfg;
+                _can_config(can_dev, cfg);
+                res = RT_EOK;
+            }
+            else
+            {
+                res = -RT_ERROR;
+            }
+            break;
+        }
+    case RT_CAN_CMD_SET_MODE:
+        res = -RT_ERROR;
+        break;
+
+    case RT_CAN_CMD_SET_PRIV:
+        res = -RT_ERROR;
+        break;
+    case RT_CAN_CMD_GET_STATUS:
+        FLEXCAN_GetBusErrCount(can->base, (rt_uint8_t *)(&can->can_dev.status.snderrcnt), (rt_uint8_t *)(&can->can_dev.status.rcverrcnt));
+        rt_memcpy(arg, &can->can_dev.status, sizeof(can->can_dev.status));
+        break;
+    case RT_CAN_CMD_START:
+        /* already started in can_cfg */
+        break;
+    default:
+        res = -RT_ERROR;
+        break;
+    }
+
+    return res;
+}
+
+static rt_ssize_t _can_sendmsg(struct rt_can_device *can_dev, const void *buf, rt_uint32_t boxno)
+{
+    struct imxrt_can *can;
+    struct rt_can_msg *msg;
+    status_t ret;
+    flexcan_frame_t frame;
+    flexcan_mb_transfer_t txXfer;
+
+    RT_ASSERT(can_dev != RT_NULL);
+    RT_ASSERT(buf != RT_NULL);
+
+    can = (struct imxrt_can *)can_dev->parent.user_data;
+    msg = (struct rt_can_msg *) buf;
+
+    RT_ASSERT(can != RT_NULL);
+    RT_ASSERT(msg != RT_NULL);
+
+    FLEXCAN_SetTxMbConfig(can->base, boxno, true);
+
+    if (RT_CAN_STDID == msg->ide)
+    {
+        frame.id = FLEXCAN_ID_STD(msg->id);
+        frame.format = kFLEXCAN_FrameFormatStandard;
+    }
+    else if (RT_CAN_EXTID == msg->ide)
+    {
+        frame.id = FLEXCAN_ID_EXT(msg->id);
+        frame.format = kFLEXCAN_FrameFormatExtend;
+    }
+
+    if (RT_CAN_DTR == msg->rtr)
+    {
+        frame.type = kFLEXCAN_FrameTypeData;
+    }
+    else if (RT_CAN_RTR == msg->rtr)
+    {
+        frame.type = kFLEXCAN_FrameTypeRemote;
+    }
+
+    frame.length = msg->len;
+    frame.dataByte0 = msg->data[0];
+    frame.dataByte1 = msg->data[1];
+    frame.dataByte2 = msg->data[2];
+    frame.dataByte3 = msg->data[3];
+    frame.dataByte4 = msg->data[4];
+    frame.dataByte5 = msg->data[5];
+    frame.dataByte6 = msg->data[6];
+    frame.dataByte7 = msg->data[7];
+
+    txXfer.mbIdx = boxno;
+    txXfer.frame = &frame;
+    ret = FLEXCAN_TransferSendBlocking(can->base, boxno, txXfer.frame);
+    switch (ret)
+    {
+    case kStatus_Success:
+        ret = RT_EOK;
+        rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_TX_DONE | boxno << 8);
+        break;
+    case kStatus_Fail:
+        ret = -RT_ERROR;
+        break;
+    }
+
+    return (rt_ssize_t)ret;
+}
+
+static rt_ssize_t _can_recvmsg(struct rt_can_device *can_dev, void *buf, rt_uint32_t boxno)
+{
+    struct imxrt_can *can;
+    struct rt_can_msg *pmsg;
+    rt_uint8_t index;
+
+    RT_ASSERT(can_dev != RT_NULL);
+
+    can = (struct imxrt_can *)can_dev->parent.user_data;
+    pmsg = (struct rt_can_msg *) buf;
+    RT_ASSERT(can != RT_NULL);
+
+    index = boxno - 1;
+
+    if (frame[index].format == kFLEXCAN_FrameFormatStandard)
+    {
+        pmsg->ide = RT_CAN_STDID;
+        pmsg->id = frame[index].id >> CAN_ID_STD_SHIFT;
+    }
+    else
+    {
+        pmsg->ide = RT_CAN_EXTID;
+        pmsg->id = frame[index].id >> CAN_ID_EXT_SHIFT;
+    }
+
+    if (frame[index].type == kFLEXCAN_FrameTypeData)
+    {
+        pmsg->rtr = RT_CAN_DTR;
+    }
+    else if (frame[index].type == kFLEXCAN_FrameTypeRemote)
+    {
+        pmsg->rtr = RT_CAN_RTR;
+    }
+    pmsg->hdr_index = index;      /* one hdr filter per MB */
+    pmsg->len = frame[index].length;
+    pmsg->data[0] = frame[index].dataByte0;
+    pmsg->data[1] = frame[index].dataByte1;
+    pmsg->data[2] = frame[index].dataByte2;
+    pmsg->data[3] = frame[index].dataByte3;
+    pmsg->data[4] = frame[index].dataByte4;
+    pmsg->data[5] = frame[index].dataByte5;
+    pmsg->data[6] = frame[index].dataByte6;
+    pmsg->data[7] = frame[index].dataByte7;
+
+    return 0;
+}
+
+static uint8_t FLEXCAN_GetFirstValidMb(CAN_Type *base)
+{
+    uint8_t firstValidMbNum;
+
+    if (0U != (base->MCR & CAN_MCR_RFEN_MASK))
+    {
+        firstValidMbNum = (uint8_t)((base->CTRL2 & CAN_CTRL2_RFFN_MASK) >> CAN_CTRL2_RFFN_SHIFT);
+        firstValidMbNum = ((firstValidMbNum + 1U) * 2U) + 6U;
+    }
+    else
+    {
+        firstValidMbNum = 0U;
+    }
+
+    return firstValidMbNum;
+}
+
+rt_ssize_t _can_sendmsg_nonblocking(struct rt_can_device *can_dev, const void *buf)
+{
+    struct imxrt_can *can;
+    struct rt_can_msg *msg;
+    status_t ret;
+    flexcan_frame_t frame;
+    flexcan_mb_transfer_t txXfer;
+    rt_uint32_t boxno;
+    RT_ASSERT(can_dev != RT_NULL);
+    RT_ASSERT(buf != RT_NULL);
+
+    can = (struct imxrt_can *)can_dev->parent.user_data;
+    msg = (struct rt_can_msg *) buf;
+
+    RT_ASSERT(can != RT_NULL);
+    RT_ASSERT(msg != RT_NULL);
+
+    boxno = FLEXCAN_GetFirstValidMb(can->base);
+
+    if (boxno == 0xFF)
+    {
+        return -RT_EBUSY;
+    }
+
+    if (RT_CAN_STDID == msg->ide)
+    {
+        frame.id = FLEXCAN_ID_STD(msg->id);
+        frame.format = kFLEXCAN_FrameFormatStandard;
+    }
+    else if (RT_CAN_EXTID == msg->ide)
+    {
+        frame.id = FLEXCAN_ID_EXT(msg->id);
+        frame.format = kFLEXCAN_FrameFormatExtend;
+    }
+
+    if (RT_CAN_DTR == msg->rtr)
+    {
+        frame.type = kFLEXCAN_FrameTypeData;
+    }
+    else if (RT_CAN_RTR == msg->rtr)
+    {
+        frame.type = kFLEXCAN_FrameTypeRemote;
+    }
+
+    frame.length = msg->len;
+    frame.dataByte0 = msg->data[0];
+    frame.dataByte1 = msg->data[1];
+    frame.dataByte2 = msg->data[2];
+    frame.dataByte3 = msg->data[3];
+    frame.dataByte4 = msg->data[4];
+    frame.dataByte5 = msg->data[5];
+    frame.dataByte6 = msg->data[6];
+    frame.dataByte7 = msg->data[7];
+
+    txXfer.mbIdx = boxno;
+    txXfer.frame = &frame;
+    ret = FLEXCAN_TransferSendNonBlocking(can->base, &can->handle, &txXfer);
+    switch (ret)
+    {
+    case kStatus_Success:
+        ret = RT_EOK;
+        break;
+    case kStatus_Fail:
+        ret = -RT_ERROR;
+        break;
+    }
+
+    return (rt_ssize_t)ret;
+}
+
+static struct rt_can_ops imxrt_can_ops =
+{
+    .configure    = _can_config,
+    .control      = _can_control,
+    .sendmsg      = _can_sendmsg,
+    .recvmsg      = _can_recvmsg,
+    .sendmsg_nonblocking = _can_sendmsg_nonblocking
+};
+
+int rt_hw_can_init(void)
+{
+    int i;
+    rt_err_t ret = RT_EOK;
+    struct can_configure config = CANDEFAULTCONFIG;
+
+    config.privmode = 0;
+    config.ticks = 50;
+    config.sndboxnumber = 1;
+    config.msgboxsz = RX_MB_COUNT;
+#ifdef RT_CAN_USING_HDR
+    config.maxhdr = RX_MB_COUNT;          /* filter count,one filter per MB */
+#endif
+
+    for (i = 0; i < sizeof(flexcans) / sizeof(flexcans[0]); i++)
+    {
+        flexcans[i].can_dev.config = config;
+        CLOCK_SetClockDiv(flexcans[i].clock_div_name, 1u);
+        CLOCK_AttachClk(flexcans[i].clock_attach_id);
+
+        ret = rt_hw_can_register(&flexcans[i].can_dev, flexcans[i].name, &imxrt_can_ops, &flexcans[i]);
+    }
+
+    return ret;
+}
+INIT_BOARD_EXPORT(rt_hw_can_init);
+
+#endif /*RT_USING_CAN */

--- a/bsp/nxp/mcx/mcxa/frdm-mcxa346/.ci/attachconfig/ci.attachconfig.yml
+++ b/bsp/nxp/mcx/mcxa/frdm-mcxa346/.ci/attachconfig/ci.attachconfig.yml
@@ -1,0 +1,9 @@
+scons.args: &scons
+    scons_arg:
+      - '--strict'
+
+# ------ component CI ------
+component.can:
+    kconfig:
+      - CONFIG_BSP_USING_CAN
+      - CONFIG_BSP_USING_CAN0

--- a/bsp/nxp/mcx/mcxa/frdm-mcxa346/board/Kconfig
+++ b/bsp/nxp/mcx/mcxa/frdm-mcxa346/board/Kconfig
@@ -104,23 +104,39 @@ menu "On-chip Peripheral Drivers"
                     default n
             endif
 
-        menuconfig BSP_USING_PWM
-            config BSP_USING_PWM
-                bool "Enable PWM"
-                select RT_USING_PWM
-                default n
-    
-                if BSP_USING_PWM
-                    config BSP_USING_PWM0
-                        bool "Enable eFlex PWM0"
-                        default n
-                    config BSP_USING_PWM1
-                        bool "Enable eFlex PWM1"
-                        default n
-                    config BSP_USING_PWM2
-                        bool "Enable eFlex PWM2"
-                        default n
-                endif
+    menuconfig BSP_USING_PWM
+        config BSP_USING_PWM
+            bool "Enable PWM"
+            select RT_USING_PWM
+            default n
+
+            if BSP_USING_PWM
+                config BSP_USING_PWM0
+                    bool "Enable eFlex PWM0"
+                    default n
+                config BSP_USING_PWM1
+                    bool "Enable eFlex PWM1"
+                    default n
+                config BSP_USING_PWM2
+                    bool "Enable eFlex PWM2"
+                    default n
+            endif
+
+    menuconfig BSP_USING_CAN
+        config BSP_USING_CAN
+            bool "Enable CAN"
+            select RT_USING_CAN
+            default n
+            if BSP_USING_CAN
+                config BSP_USING_CAN0
+                    bool "Enable CAN0"
+                    default n
+                
+                config BSP_USING_CAN1
+                    bool "Enable CAN1"
+                    default n
+            endif
+
 endmenu
 
 

--- a/bsp/nxp/mcx/mcxa/frdm-mcxa346/board/MCUX_Config/board/pin_mux.c
+++ b/bsp/nxp/mcx/mcxa/frdm-mcxa346/board/MCUX_Config/board/pin_mux.c
@@ -48,6 +48,7 @@ void BOARD_InitPins(void)
     static const reset_ip_name_t i2c_resets[] = LPI2C_RSTS;
     static const reset_ip_name_t spi_resets[] = LPSPI_RSTS;
     static const reset_ip_name_t dma_resets[] = DMA_RSTS_N;
+    static const reset_ip_name_t can_resets[] = FLEXCAN_RSTS_N;
 
     // Release resets
     release_reset_array(port_resets, ARRAY_SIZE(port_resets));
@@ -56,7 +57,7 @@ void BOARD_InitPins(void)
     release_reset_array(i2c_resets, ARRAY_SIZE(i2c_resets));
     release_reset_array(spi_resets, ARRAY_SIZE(spi_resets));
     release_reset_array(dma_resets, ARRAY_SIZE(dma_resets));
-
+    release_reset_array(can_resets, ARRAY_SIZE(can_resets));
 
     const port_pin_config_t port2_2_pin35_config = {/* Internal pull-up resistor is enabled */
                                                     .pullSelect = kPORT_PullUp,
@@ -285,107 +286,6 @@ void BOARD_InitPins(void)
     /* PORT3_28 (pin 73) is configured as LPI2C3_SDA */
     PORT_SetPinConfig(PORT3, 28U, &port3_28_pin73_config);
 
-
-    const port_pin_config_t port1_0_pin135_config = {/* Internal pull-up/down resistor is disabled */
-                                                     .pullSelect = kPORT_PullDisable,
-                                                     /* Low internal pull resistor value is selected. */
-                                                     .pullValueSelect = kPORT_LowPullResistor,
-                                                     /* Fast slew rate is configured */
-                                                     .slewRate = kPORT_FastSlewRate,
-                                                     /* Passive input filter is disabled */
-                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
-                                                     /* Open drain output is disabled */
-                                                     .openDrainEnable = kPORT_OpenDrainDisable,
-                                                     /* Low drive strength is configured */
-                                                     .driveStrength = kPORT_LowDriveStrength,
-                                                     /* Normal drive strength is configured */
-                                                     .driveStrength1 = kPORT_NormalDriveStrength,
-                                                     /* Pin is configured as LPSPI0_SDO */
-                                                     .mux = kPORT_MuxAlt2,
-                                                     /* Digital input enabled */
-                                                     .inputBuffer = kPORT_InputBufferEnable,
-                                                     /* Digital input is not inverted */
-                                                     .invertInput = kPORT_InputNormal,
-                                                     /* Pin Control Register fields [15:0] are not locked */
-                                                     .lockRegister = kPORT_UnlockRegister};
-    /* PORT1_0 (pin 135) is configured as LPSPI0_SDO */
-    PORT_SetPinConfig(PORT1, 0U, &port1_0_pin135_config);
-
-    const port_pin_config_t port1_1_pin136_config = {/* Internal pull-up/down resistor is disabled */
-                                                     .pullSelect = kPORT_PullDisable,
-                                                     /* Low internal pull resistor value is selected. */
-                                                     .pullValueSelect = kPORT_LowPullResistor,
-                                                     /* Fast slew rate is configured */
-                                                     .slewRate = kPORT_FastSlewRate,
-                                                     /* Passive input filter is disabled */
-                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
-                                                     /* Open drain output is disabled */
-                                                     .openDrainEnable = kPORT_OpenDrainDisable,
-                                                     /* Low drive strength is configured */
-                                                     .driveStrength = kPORT_LowDriveStrength,
-                                                     /* Normal drive strength is configured */
-                                                     .driveStrength1 = kPORT_NormalDriveStrength,
-                                                     /* Pin is configured as LPSPI0_SCK */
-                                                     .mux = kPORT_MuxAlt2,
-                                                     /* Digital input enabled */
-                                                     .inputBuffer = kPORT_InputBufferEnable,
-                                                     /* Digital input is not inverted */
-                                                     .invertInput = kPORT_InputNormal,
-                                                     /* Pin Control Register fields [15:0] are not locked */
-                                                     .lockRegister = kPORT_UnlockRegister};
-    /* PORT1_1 (pin 136) is configured as LPSPI0_SCK */
-    PORT_SetPinConfig(PORT1, 1U, &port1_1_pin136_config);
-
-    const port_pin_config_t port1_2_pin137_config = {/* Internal pull-up/down resistor is disabled */
-                                                     .pullSelect = kPORT_PullDisable,
-                                                     /* Low internal pull resistor value is selected. */
-                                                     .pullValueSelect = kPORT_LowPullResistor,
-                                                     /* Fast slew rate is configured */
-                                                     .slewRate = kPORT_FastSlewRate,
-                                                     /* Passive input filter is disabled */
-                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
-                                                     /* Open drain output is disabled */
-                                                     .openDrainEnable = kPORT_OpenDrainDisable,
-                                                     /* Low drive strength is configured */
-                                                     .driveStrength = kPORT_LowDriveStrength,
-                                                     /* Normal drive strength is configured */
-                                                     .driveStrength1 = kPORT_NormalDriveStrength,
-                                                     /* Pin is configured as LPSPI0_SDI */
-                                                     .mux = kPORT_MuxAlt2,
-                                                     /* Digital input enabled */
-                                                     .inputBuffer = kPORT_InputBufferEnable,
-                                                     /* Digital input is not inverted */
-                                                     .invertInput = kPORT_InputNormal,
-                                                     /* Pin Control Register fields [15:0] are not locked */
-                                                     .lockRegister = kPORT_UnlockRegister};
-    /* PORT1_2 (pin 137) is configured as LPSPI0_SDI */
-    PORT_SetPinConfig(PORT1, 2U, &port1_2_pin137_config);
-
-    const port_pin_config_t port1_3_pin138_config = {/* Internal pull-up/down resistor is disabled */
-                                                     .pullSelect = kPORT_PullDisable,
-                                                     /* Low internal pull resistor value is selected. */
-                                                     .pullValueSelect = kPORT_LowPullResistor,
-                                                     /* Fast slew rate is configured */
-                                                     .slewRate = kPORT_FastSlewRate,
-                                                     /* Passive input filter is disabled */
-                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
-                                                     /* Open drain output is disabled */
-                                                     .openDrainEnable = kPORT_OpenDrainDisable,
-                                                     /* Low drive strength is configured */
-                                                     .driveStrength = kPORT_LowDriveStrength,
-                                                     /* Normal drive strength is configured */
-                                                     .driveStrength1 = kPORT_NormalDriveStrength,
-                                                     /* Pin is configured as LPSPI0_PCS0 */
-                                                     .mux = kPORT_MuxAlt2,
-                                                     /* Digital input enabled */
-                                                     .inputBuffer = kPORT_InputBufferEnable,
-                                                     /* Digital input is not inverted */
-                                                     .invertInput = kPORT_InputNormal,
-                                                     /* Pin Control Register fields [15:0] are not locked */
-                                                     .lockRegister = kPORT_UnlockRegister};
-    /* PORT1_3 (pin 138) is configured as LPSPI0_PCS0 */
-    PORT_SetPinConfig(PORT1, 3U, &port1_3_pin138_config);
-
     const port_pin_config_t port3_10_pin96_config = {/* Internal pull-up/down resistor is disabled */
                                                      .pullSelect = kPORT_PullDisable,
                                                      /* Low internal pull resistor value is selected. */
@@ -485,4 +385,54 @@ void BOARD_InitPins(void)
                                                     .lockRegister = kPORT_UnlockRegister};
     /* PORT3_9 (pin 97) is configured as LPSPI1_SDI */
     PORT_SetPinConfig(PORT3, 9U, &port3_9_pin97_config);
+
+    const port_pin_config_t port1_11_pin4_config = {/* Internal pull-up/down resistor is disabled */
+                                                    .pullSelect = kPORT_PullDisable,
+                                                    /* Low internal pull resistor value is selected. */
+                                                    .pullValueSelect = kPORT_LowPullResistor,
+                                                    /* Fast slew rate is configured */
+                                                    .slewRate = kPORT_FastSlewRate,
+                                                    /* Passive input filter is disabled */
+                                                    .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                    /* Open drain output is disabled */
+                                                    .openDrainEnable = kPORT_OpenDrainDisable,
+                                                    /* Low drive strength is configured */
+                                                    .driveStrength = kPORT_LowDriveStrength,
+                                                    /* Normal drive strength is configured */
+                                                    .driveStrength1 = kPORT_NormalDriveStrength,
+                                                    /* Pin is configured as CAN0_RXD */
+                                                    .mux = kPORT_MuxAlt11,
+                                                    /* Digital input enabled */
+                                                    .inputBuffer = kPORT_InputBufferEnable,
+                                                    /* Digital input is not inverted */
+                                                    .invertInput = kPORT_InputNormal,
+                                                    /* Pin Control Register fields [15:0] are not locked */
+                                                    .lockRegister = kPORT_UnlockRegister};
+    /* PORT1_11 (pin 4) is configured as CAN0_RXD */
+    PORT_SetPinConfig(PORT1, 11U, &port1_11_pin4_config);
+
+    const port_pin_config_t port1_2_pin137_config = {/* Internal pull-up/down resistor is disabled */
+                                                     .pullSelect = kPORT_PullDisable,
+                                                     /* Low internal pull resistor value is selected. */
+                                                     .pullValueSelect = kPORT_LowPullResistor,
+                                                     /* Fast slew rate is configured */
+                                                     .slewRate = kPORT_FastSlewRate,
+                                                     /* Passive input filter is disabled */
+                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                     /* Open drain output is disabled */
+                                                     .openDrainEnable = kPORT_OpenDrainDisable,
+                                                     /* Low drive strength is configured */
+                                                     .driveStrength = kPORT_LowDriveStrength,
+                                                     /* Normal drive strength is configured */
+                                                     .driveStrength1 = kPORT_NormalDriveStrength,
+                                                     /* Pin is configured as CAN0_TXD */
+                                                     .mux = kPORT_MuxAlt11,
+                                                     /* Digital input enabled */
+                                                     .inputBuffer = kPORT_InputBufferEnable,
+                                                     /* Digital input is not inverted */
+                                                     .invertInput = kPORT_InputNormal,
+                                                     /* Pin Control Register fields [15:0] are not locked */
+                                                     .lockRegister = kPORT_UnlockRegister};
+    /* PORT1_2 (pin 137) is configured as CAN0_TXD */
+    PORT_SetPinConfig(PORT1, 2U, &port1_2_pin137_config);
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
测试用例
~~~
#include <rtthread.h>
#include <rtdevice.h>

#define CAN_DEV_NAME       "can0"      // The name of the CAN device

static rt_device_t can_dev;            // CAN device handle
static struct rt_semaphore rx_sem;     // Semaphore for message reception

// Callback function for CAN reception
static rt_err_t can_rx_callback(rt_device_t dev, rt_size_t size)
{
    // The CAN interrupt calls this callback when data is received.
    // Release the semaphore to notify the receiving thread.
    rt_sem_release(&rx_sem);
    return RT_EOK;
}

static void can_rx_thread(void *parameter)
{
    rt_err_t res;
    struct rt_can_msg rx_msg = {0};

    // Set the receive callback function
    rt_device_set_rx_indicate(can_dev, can_rx_callback);

#ifdef RT_CAN_USING_HDR
    // Example of configuring multiple hardware filters
    struct rt_can_filter_item items[] =
    {
        // Filter 1: Match standard frames with IDs from 0x100 to 0x1FF. hdr_index will be -1.
        RT_CAN_FILTER_ITEM_INIT(0x100, 0, 0, 0, 0x700, RT_NULL, RT_NULL),
        // Filter 2: Match standard frames with IDs from 0x300 to 0x3FF. hdr_index will be -1.
        RT_CAN_FILTER_ITEM_INIT(0x300, 0, 0, 0, 0x700, RT_NULL, RT_NULL),
        // Filter 3: Exactly match standard frame with ID 0x211. hdr_index will be -1.
        RT_CAN_FILTER_ITEM_INIT(0x211, 0, 0, 0, 0x7FF, RT_NULL, RT_NULL),
        // Filter 4: Exactly match standard frame with ID 0x486 using a helper macro. hdr_index will be -1.
        RT_CAN_FILTER_STD_INIT(0x486, RT_NULL, RT_NULL),
        // Filter 5: Exactly match standard frame with ID 0x555 and explicitly assign it to filter bank #7.
        // This uses direct struct initialization: {id, ide, rtr, mode, mask, hdr_bank}.
        {0x555, 0, 0, 0, 0x7FF, 7}
    };
    // Create the filter configuration structure with 5 active filters.
    struct rt_can_filter_config cfg = {sizeof(items)/sizeof(items[0]), 1, items};
    // Set the hardware filters for the CAN device.
    res = rt_device_control(can_dev, RT_CAN_CMD_SET_FILTER, &cfg);
    RT_ASSERT(res == RT_EOK);
#endif

    // Some drivers might require an explicit start command.
    // This is driver-specific.
    rt_uint32_t cmd_arg = 1; // Argument to enable the controller
    res = rt_device_control(can_dev, RT_CAN_CMD_START, &cmd_arg);
    RT_ASSERT(res == RT_EOK);

    while (1)
    {
        // Block and wait for the semaphore, which is released by the receive callback.
        rt_sem_take(&rx_sem, RT_WAITING_FOREVER);

        // Read one frame of data from the CAN device's general message queue.
        rx_msg.hdr_index = -1;
        rt_device_read(can_dev, 0, &rx_msg, sizeof(rx_msg));

        // Print the received message's ID and data.
        rt_kprintf("Received a message. ID: 0x%x, Data: ", rx_msg.id);
        for (int i = 0; i < rx_msg.len; i++)
        {
            rt_kprintf("%02x ", rx_msg.data[i]);
        }
        rt_kprintf("\n");
    }
}

int can_sample(int argc, char *argv[])
{
    rt_err_t res;
    rt_thread_t thread;
    char can_name[RT_NAME_MAX];

    // Allow specifying the CAN device name from the command line, e.g., "can_sample can2"
    if (argc == 2)
    {
        rt_strncpy(can_name, argv[1], RT_NAME_MAX);
    }
    else
    {
        rt_strncpy(can_name, CAN_DEV_NAME, RT_NAME_MAX);
    }

    // Find the CAN device by name
    can_dev = rt_device_find(can_name);
    if (!can_dev)
    {
        rt_kprintf("find device %s failed!\n", can_name);
        return -RT_ERROR;
    }

    // Initialize the receive semaphore
    rt_sem_init(&rx_sem, "rx_sem", 0, RT_IPC_FLAG_FIFO);

    // Open the CAN device in interrupt-driven TX/RX mode
    res = rt_device_open(can_dev, RT_DEVICE_FLAG_INT_TX | RT_DEVICE_FLAG_INT_RX);
    RT_ASSERT(res == RT_EOK);


    // Create and start the data receiving thread
    thread = rt_thread_create("can_rx", can_rx_thread, RT_NULL, 1024, 25, 10);
    if (thread != RT_NULL)
    {
        rt_thread_startup(thread);
    }
    else
    {
        rt_kprintf("create can_rx thread failed!\n");
        return -RT_ERROR;
    }

    rt_kprintf("CAN device %s opened successfully.\n", can_name);

    // --- Demonstrate Blocking Send ---
    struct rt_can_msg blocking_msg = {0};
    blocking_msg.id = 0x78;
    blocking_msg.ide = RT_CAN_STDID;
    blocking_msg.rtr = RT_CAN_DTR;
    blocking_msg.len = 8;
    // The `nonblocking` flag is 0 by default for blocking mode.
    for(int i = 0; i < 8; i++) blocking_msg.data[i] = i;

    rt_kprintf("Attempting to send a message in BLOCKING mode...\n");
    if (rt_device_write(can_dev, 0, &blocking_msg, sizeof(blocking_msg)) == sizeof(blocking_msg))
    {
        rt_kprintf("Blocking message sent successfully.\n");
    }
    else
    {
        rt_kprintf("Blocking message send failed.\n");
    }

    rt_thread_mdelay(100); // Wait a moment for clarity in the log

    // --- Demonstrate Non-Blocking Send ---
    struct rt_can_msg nonblocking_msg = {0};
    nonblocking_msg.id = 0x79;
    nonblocking_msg.ide = RT_CAN_STDID;
    nonblocking_msg.rtr = RT_CAN_DTR;
    nonblocking_msg.len = 4;
    nonblocking_msg.data[0] = 0xDE;
    nonblocking_msg.data[1] = 0xAD;
    nonblocking_msg.data[2] = 0xBE;
    nonblocking_msg.data[3] = 0xEF;
    nonblocking_msg.nonblocking = 1; // <-- Key: Set the non-blocking flag

    rt_kprintf("Attempting to send a message in NON-BLOCKING mode...\n");
    if (rt_device_write(can_dev, 0, &nonblocking_msg, sizeof(nonblocking_msg)) == sizeof(nonblocking_msg))
    {
        rt_kprintf("Non-blocking message was accepted (sent or enqueued).\n");
    }
    else
    {
        rt_kprintf("Non-blocking send failed (buffer was full).\n");
    }

    return res;
}
// Export the function to the MSH command line
MSH_CMD_EXPORT(can_sample, can device usage example);


~~~
<img width="2482" height="890" alt="image" src="https://github.com/user-attachments/assets/5b3fec3f-13f8-4e82-b47c-a6c8ebe34cff" />

#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
