### PR TITLE
fix:[dfsv2][dentry]Locking for dfs_dentry_dump must be consistent with that of all other dentry functions.

### DIFF
--- a/components/dfs/dfs_v2/src/dfs_dentry.c
+++ b/components/dfs/dfs_v2/src/dfs_dentry.c
@@ -499,16 +499,19 @@ int dfs_dentry_dump(int argc, char** argv)
 {
     int index = 0;
     struct dfs_dentry *entry = RT_NULL;
+    rt_err_t ret = dfs_file_lock();
 
-    dfs_lock();
-    for (index = 0; index < DFS_DENTRY_HASH_NR; index ++)
+    if (ret == RT_EOK)
     {
-        rt_list_for_each_entry(entry, &hash_head.head[index], hashlist)
+        for (index = 0; index < DFS_DENTRY_HASH_NR; index ++)
         {
-            printf("dentry: %s%s @ %p, ref_count = %zd\n", entry->mnt->fullpath, entry->pathname, entry, (size_t)rt_atomic_load(&entry->ref_count));
+            rt_list_for_each_entry(entry, &hash_head.head[index], hashlist)
+            {
+                printf("dentry: %s%s @ %p, ref_count = %zd\n", entry->mnt->fullpath, entry->pathname, entry, (size_t)rt_atomic_load(&entry->ref_count));
+            }
         }
+        dfs_file_unlock();
     }
-    dfs_unlock();
 
     return 0;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

dfs_dentry_dump使用的锁与其他dentry操作函数使用的锁不一致，多线程环境无法保证安全性。
#### 你的解决方案是什么 (what is your solution)

dfs_dentry_dump使用的锁与其他dentry操作函数使用的锁修改一致

#### 请提供验证的bsp和config (provide the config and bsp) 
- BSP:
- .config:
- action:

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
