### PR TITLE
[FIX][DFSv2][ELMFAT]修复多线程环境下lseek返回值概率性被篡改的问题

### DIFF
--- a/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
@@ -629,7 +629,7 @@ int dfs_elm_flush(struct dfs_file *file)
 off_t dfs_elm_lseek(struct dfs_file *file, off_t offset, int wherece)
 {
     FRESULT result = FR_OK;
-
+    off_t pos = 0;
     switch (wherece)
     {
     case SEEK_SET:
@@ -656,11 +656,12 @@ off_t dfs_elm_lseek(struct dfs_file *file, off_t offset, int wherece)
         RT_ASSERT(fd != RT_NULL);
         rt_mutex_take(&file->vnode->lock, RT_WAITING_FOREVER);
         result = f_lseek(fd, offset);
+        pos = fd->fptr;
         rt_mutex_release(&file->vnode->lock);
         if (result == FR_OK)
         {
             /* return current position */
-            return fd->fptr;
+            return pos;
         }
     }
     else if (file->vnode->type == FT_DIRECTORY)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

多线程环境下对于同一文件的读写fd概率性出现偏移混乱，lseek对文件系统对象的保护锁释放后去获取文件系统对象的偏移导致。
#### 你的解决方案是什么 (what is your solution)

新增中间变量，在文件系统对象的保护锁生效逻辑区间内，中间变量对文件系统对象的偏移进行拷贝，最终安全返回中间变量。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
- .config:
- action:

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
