### PR TITLE
[docs][libcpu][arm][cortex-a] update comment for start_gcc.S

### DIFF
--- a/libcpu/arm/cortex-a/start_gcc.S
+++ b/libcpu/arm/cortex-a/start_gcc.S
@@ -28,11 +28,11 @@
 .equ F_Bit,           0x40   /* when F bit is set, FIQ is disabled */
 
 /**
- * @brief get the physical address of the symbol
+ * @brief   Get the physical address of the symbol
  *
- * @param reg register to store the physical address
- * @param symbol symbol name
- * @param _pvoff the offset between the physical address and the virtual address
+ * @param   reg is the register to store the physical address
+ * @param   symbol is symbol name
+ * @param   _pvoff is the offset between the physical address and the virtual address
  */
 .macro get_phy, reg, symbol, _pvoff
     ldr \reg, =\symbol
@@ -40,10 +40,10 @@
 .endm
 
 /**
- * @brief calculate the offset between the physical address and the virtual address of the "_reset"
+ * @brief   Calculate the offset between the physical address and the virtual address of the "_reset"
  *
- * @param tmp register which will be used to store the virtual address of the "_reset"
- * @param out register which will be used to store the pv_off (paddr - vaddr)
+ * @param   tmp is the register which will be used to store the virtual address of the "_reset"
+ * @param   out is the register which will be used to store the pv_off (paddr - vaddr)
  */
 .macro get_pvoff, tmp, out
     ldr     \tmp, =_reset


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
我认为注释不够准确,所以修改部分注释。

#### 你的解决方案是什么 (what is your solution)
1 删除不必要的注释。
2 优化我认为可以详细的注释。
3 添加部分注释。


#### 请提供验证的bsp和config (provide the config and bsp) 



- BSP:      none
- .config:  none
- action:   none

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)


## 改动声明

### 1 删除不必要的注释
 我认为这些注释是不必要的，因为只是对语法的解释。所以删除掉了。
```asm
    mov r0,#0                   /* get a zero      */
    bic r0, r0, #0x7                    /* clear bit1~3 */
```

### 2 优化我认为可以详细的注释
我觉得宏定义的注释可以更详细，所以修改如下
```asm
/* 更改前 */

/*Load the physical address of a symbol into a register. 
  Through pv_off calculates the offset of the physical address */
.macro get_phy, reg, symbol, _pvoff
    ldr \reg, =\symbol
    add \reg, \_pvoff
.endm
/*Calculate the offset between the physical address and the virtual address of the "_reset".*/
.macro get_pvoff, tmp, out
    ldr     \tmp, =_reset
    adr     \out, _reset
    sub     \out, \out, \tmp
.endm

/* 更改后 */

/**
 * @brief get the physical address of the symbol
 *
 * @param reg register to store the physical address
 * @param symbol symbol name
 * @param _pvoff the offset between the physical address and the virtual address
 */
.macro get_phy, reg, symbol, _pvoff
    ldr \reg, =\symbol
    add \reg, \_pvoff
.endm

/**
 * @brief calculate the offset between the physical address and the virtual address of the "_reset"
 *
 * @param tmp register which will be used to store the virtual address of the "_reset"
 * @param out register which will be used to store the pv_off (paddr - vaddr)
 */
.macro get_pvoff, tmp, out
    ldr     \tmp, =_reset
    adr     \out, _reset
    sub     \out, \out, \tmp
.endm

```


还有我认为不准确的注释。
这部分的作用是先禁用MMU,然后再失效TLB I-cache和分支预测。
但是原注释的内容是 /* invalid tlb before enable mmu */ 在使能MMU前失效TLB。
我认为不准确。

```asm
/* 更改前 */



    /* invalid tlb before enable mmu */
    mrc p15, 0, r0, c1, c0, 0
    bic r0, #1
    mcr p15, 0, r0, c1, c0, 0
    dsb
    isb

    mov r0, #0
    mcr p15, 0, r0, c8, c7, 0
    mcr p15, 0, r0, c7, c5, 0    /* iciallu */
    mcr p15, 0, r0, c7, c5, 6    /* bpiall */
    dsb
    isb

/* 更改后 */

    /* disable MMU  */
    mrc p15, 0, r0, c1, c0, 0   /* SCTLR */
    bic r0, #1                  /* M=0 */
    mcr p15, 0, r0, c1, c0, 0
    dsb
    isb

    /* invalidate TLB, I-cache and branch predictor */
    mov r0, #0
    mcr p15, 0, r0, c8, c7, 0    /* ITLBIALL */
    mcr p15, 0, r0, c7, c5, 0    /* ICIALLU */
    mcr p15, 0, r0, c7, c5, 6    /* BPIALL */
    dsb
    isb

```




### 3 添加部分注释

在CP15寄存器组的旁边加上操作的寄存器名称。
对于CPACR和MPIDR这种有多种实现的寄存器，读写值不添加注释。
对于SCTLR这种通用的寄存器，写入值时添加写入了具体字段。

```asm
    mov r4, #0xfffffff
    mcr p15, 0, r4, c1, c0, 2   /* CPACR */


    mcr p15, 0, r0, c8, c7, 0           /* ITLBIALL */
    mcr p15, 0, r0, c7, c5, 0           /* ICIALLU */
    mcr p15, 0, r0, c7, c5, 6           /* BPIALL */


    mrc p15, 0, r0, c1, c0, 0   /* SCTLR */
    bic r0, #1                  /* M=0 */


    /* set all domains with client mode */
    ldr     r0,=#0x55555555         /* client */
    mcr     p15, #0, r0, c3, c0, #0 /* DACR */


 /*
 * void rt_hw_mmu_switch(rt_uint32_t* mmutable_p);
 * r0 --> mmutable_p (mmu table address)
 */
.global rt_hw_mmu_switch
rt_hw_mmu_switch:
    orr r0, #0x18                   /* RGN=0b11 (Outer WB-WA) */
    mcr p15, 0, r0, c2, c0, 0       /* TTBR0 */

    /* invalidate TLB, I-cache and branch predictor */
    mov r0, #0
    mcr p15, 0, r0, c8, c7, 0       /* ITLBIALL */
    mcr p15, 0, r0, c7, c5, 0       /* ICIALLU */
    mcr p15, 0, r0, c7, c5, 6       /* BPIALL */

    dsb
    isb
    mov pc, lr
```


## 测试

纯注释修改
<img width="885" height="279" alt="image" src="https://github.com/user-attachments/assets/d633ca47-57ff-48a2-ac8d-a44421f7f516" />
