### PR TITLE
[fix] drivers: spi: refactor SPI bit operations into independent conf…

### DIFF
--- a/components/drivers/spi/Kconfig
+++ b/components/drivers/spi/Kconfig
@@ -7,11 +7,16 @@ menuconfig RT_USING_SPI
         menuconfig RT_USING_SPI_ISR
             bool "Enable interrupt-safe SPI operations (using spinlocks in ISR context)"
             default y
+        
+        config RT_USING_SPI_BITOPS
+            bool "Enable SPI bit-bang operation functions"
+            default n
 
         menuconfig RT_USING_SOFT_SPI
             bool "Use GPIO to simulate SPI"
             default n
             select RT_USING_PIN
+            select RT_USING_SPI_BITOPS
             if RT_USING_SOFT_SPI
                 menuconfig RT_USING_SOFT_SPI0
                     bool "Enable SPI0 Bus (software simulation)"

--- a/components/drivers/spi/SConscript
+++ b/components/drivers/spi/SConscript
@@ -7,8 +7,10 @@ src = ['dev_spi_core.c', 'dev_spi.c']
 CPPPATH = [cwd, cwd + '/../include']
 LOCAL_CFLAGS = ''
 
-if GetDepend('RT_USING_SOFT_SPI'):
+if GetDepend('RT_USING_SPI_BITOPS'):
     src += ['dev_spi_bit_ops.c']
+
+if GetDepend('RT_USING_SOFT_SPI'):
     src += ['dev_soft_spi.c']
 
 if GetDepend('RT_USING_QSPI'):

--- a/components/drivers/spi/dev_soft_spi.c
+++ b/components/drivers/spi/dev_soft_spi.c
@@ -19,7 +19,7 @@
     #error "Please define at least one RT_USING_SOFT_SPIx"
     /*
     This driver can be disabled at:
-    menuconfig -> RT-Thread Components -> Device Drivers -> Using I2C device drivers
+    menuconfig -> RT-Thread Components -> Device Drivers -> Using SPI Bus/Device device drivers -> Use GPIO to simulate SPI
     */
 #endif
 


### PR DESCRIPTION
…iguration

将 SPI 位操作重构为独立配置选项

- 添加 RT_USING_SPI_BITOPS 作为独立可配置选项
- 使 RT_USING_SOFT_SPI 依赖于 RT_USING_SPI_BITOPS
- 调整 SConscript 中的构建顺序以确保正确编译
- 修正 dev_soft_spi.c 中的错误提示信息
## 拉取/合并请求描述：(PR description)


并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

HPM6800EVK

#### 为什么提交这份PR (why to submit this PR)
当用户只需要RT_USING_SPI_BITOPS时，想自己弄一个drv_soft_spi，但是会强加进来dev_soft_spi，导致有两份soft spi。

#### 你的解决方案是什么 (what is your solution)

1、RT_USING_SPI_BITOPS 作为独立可配置选项
2、保留原先配置不动，当使能RT_USING_SOFT_SPI 会使能RT_USING_SPI_BITOPS 

