### PR TITLE
[FIX][fal]char设备类型补充缺失的入参，适配DFSv2框架

### DIFF
--- a/components/fal/src/fal_rtt.c
+++ b/components/fal/src/fal_rtt.c
@@ -434,13 +434,14 @@ static int char_dev_fopen(struct dfs_file *fd)
 
     return RT_EOK;
 }
+
 #ifdef RT_USING_DFS_V2
-static ssize_t char_dev_fread(struct dfs_file *fd, void *buf, size_t count, off_t *pos)
+static rt_ssize_t char_dev_fread(struct dfs_file *fd, void *buf, size_t count, off_t *pos)
 #else
-static ssize_t char_dev_fread(struct dfs_file *fd, void *buf, size_t count)
+static rt_ssize_t char_dev_fread(struct dfs_file *fd, void *buf, size_t count)
 #endif
 {
-    ssize_t ret = 0;
+    rt_ssize_t ret = 0;
     struct fal_char_device *part = (struct fal_char_device *) fd->vnode->data;
 #ifndef RT_USING_DFS_V2
     off_t *pos = &(fd->pos);
@@ -453,20 +454,21 @@ static ssize_t char_dev_fread(struct dfs_file *fd, void *buf, size_t count)
 
     ret = fal_partition_read(part->fal_part, *pos, buf, count);
 
-    if (ret != (ssize_t)(count))
+    if (ret != (rt_ssize_t)(count))
         return 0;
 
     *pos += ret;
 
     return ret;
 }
+
 #ifdef RT_USING_DFS_V2
-static ssize_t char_dev_fwrite(struct dfs_file *fd, const void *buf, size_t count, off_t *pos)
+static rt_ssize_t char_dev_fwrite(struct dfs_file *fd, const void *buf, size_t count, off_t *pos)
 #else
-static ssize_t char_dev_fwrite(struct dfs_file *fd, const void *buf, size_t count)
+static rt_ssize_t char_dev_fwrite(struct dfs_file *fd, const void *buf, size_t count)
 #endif
 {
-    ssize_t ret = 0;
+    rt_ssize_t ret = 0;
     struct fal_char_device *part = (struct fal_char_device *) fd->vnode->data;
 #ifndef RT_USING_DFS_V2
     off_t *pos = &(fd->pos);
@@ -479,7 +481,7 @@ static ssize_t char_dev_fwrite(struct dfs_file *fd, const void *buf, size_t coun
 
     ret = fal_partition_write(part->fal_part, *pos, buf, count);
 
-    if (ret != (ssize_t) count)
+    if (ret != (rt_ssize_t) count)
         return 0;
 
     *pos += ret;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

FAL的char类型设备结构体注册到DFSv2框架存在，实现函数与框架结构体的函数指针入参数量不齐的问题
#### 你的解决方案是什么 (what is your solution)

通过DFSv2宏补齐DFSv2框架注册函数的入参数量
#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:

- .config:

- action:

]


### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
