### PR TITLE
[libcpu][arm][cortex-a] Fixup mmu setup early #11094

### DIFF
--- a/libcpu/arm/cortex-a/mmu.c
+++ b/libcpu/arm/cortex-a/mmu.c
@@ -112,7 +112,7 @@ void rt_hw_mem_setup_early(rt_uint32_t *early_mmu_talbe,
     extern unsigned char _reset;
     rt_uint32_t va = (rt_uint32_t) &_reset;
     /* The starting virtual address is aligned along 0x1000000. */
-    va &= (0x1000000 - 1);
+    va &= ~(0x1000000 - 1);
     size -= va;
     _init_map_section(early_mmu_talbe, va, size, va + pv_off, normal_attr);
 #endif


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

在 `rt_hw_mem_setup_early()` 函数中，用于对齐 `_reset` 符号起始虚拟地址的代码存在错误。原代码使用 `va &= (0x1000000 - 1);` 执行的是取模运算（保留低24位），而不是向下对齐到16MB边界。这会导致虚拟地址对齐错误，影响早期MMU内存映射的正确设置，可能导致系统启动失败或内存映射异常。

In the `rt_hw_mem_setup_early()` function, the code used to align the starting virtual address of the `_reset` symbol is incorrect. The original code `va &= (0x1000000 - 1);` performs a modulo operation (keeping the lower 24 bits) instead of aligning down to the 16MB boundary. This causes incorrect virtual address alignment, which affects the correct setup of early MMU memory mapping and may lead to system boot failure or memory mapping exceptions.

#### 你的解决方案是什么 (what is your solution)

将错误的取模运算 `va &= (0x1000000 - 1);` 修正为正确的向下对齐操作 `va &= ~(0x1000000 - 1);`。

Change the incorrect modulo operation `va &= (0x1000000 - 1);` to the correct alignment-down operation `va &= ~(0x1000000 - 1);`.



#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP: none
- .config: none
- action: none

]


### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)



## 改动说明
之前误删分支。已重新推送相同代码。请求重新审查。

