### PR TITLE
[docs][libcpu][arm][cortex-a] add comment for gic.c

### DIFF
--- a/libcpu/arm/cortex-a/gic.c
+++ b/libcpu/arm/cortex-a/gic.c
@@ -260,7 +260,7 @@ void arm_gic_clear_pending_irq(rt_uint32_t index, int irq)
  *        which have fully programmable configuration registers.
  *
  * @param index  GIC controller index
- * @param irq    The actual interrupt number(with offset)
+ * @param irq    The actual interrupt number (with offset)
  * @param config 0: level-sensitive, 1: edge-triggered
  */
 void arm_gic_set_configuration(rt_uint32_t index, int irq, rt_uint32_t config)
@@ -367,7 +367,7 @@ rt_uint32_t arm_gic_get_target_cpu(rt_uint32_t index, int irq)
  * @note The lower the value, the greater the priority of the corresponding interrupt.
  *
  * @param index    GIC controller index
- * @param irq      The actual interrupt number(with offset)
+ * @param irq      The actual interrupt number (with offset)
  * @param priority The priority to set.Only the lower 8 bits are valid (bits [7:0]).
  */
 void arm_gic_set_priority(rt_uint32_t index, int irq, rt_uint32_t priority)
@@ -695,7 +695,7 @@ int arm_gic_dist_init(rt_uint32_t index, rt_uint32_t dist_base, int irq_start)
  * @brief Initialize the GIC CPU Interface (GICC)
  *
  * @note: The exact bit definitions and behavior may vary depending on
- *        the GIC implementation (GICv1/GICv2) and security context..
+ *        the GIC implementation (GICv1/GICv2) and security context.
  *
  * @param index    GIC controller index
  * @param cpu_base Base address of the GIC CPU Interface (GICC)
@@ -721,7 +721,7 @@ int arm_gic_cpu_init(rt_uint32_t index, rt_uint32_t cpu_base)
 }
 
 /**
- * @brief Print the GIC infomations(version, base addr, max irq nums, security extension)
+ * @brief Print the GIC information (version, base addr, max irq nums, security extension)
  *
  * @param index GIC controller index
  */
@@ -739,7 +739,7 @@ void arm_gic_dump_type(rt_uint32_t index)
 }
 
 /**
- * @brief Print the GIC status(highest priority pending interrupt, enable status, pending status , active status)
+ * @brief Print the GIC status (highest priority pending interrupt, enable status, pending status , active status)
  *
  * @param index
  */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
添加gic.c的注释，我认为可以辅助理解代码。

#### 你的解决方案是什么 (what is your solution)
1 在对GIC寄存器宏定义处添加文档寄存器名称。
2 补全函数注释。
3 删除部分注释。


#### 请提供验证的bsp和config (provide the config and bsp) 



- BSP:none
- .config:none
- action:none

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)


## 改动说明

### 1 在对GIC寄存器读写的宏定义处添加寄存器名称

参照 `ARM
® Generic Interrupt Controller Architecture Specification(Architecture version 2.0)`，给出寄存器在文档中的关键字，便于查看文档。

```c
#define GIC_DIST_ACTIVE_CLEAR(hw_base, n)   __REG32((hw_base) + 0x380U + ((n)/32U) * 4U)    /* GICD_ICACTIVERn  */
#define GIC_DIST_PRI(hw_base, n)            __REG32((hw_base) + 0x400U +  ((n)/4U) * 4U)    /* GICD_IPRIORITYRn */
#define GIC_DIST_TARGET(hw_base, n)         __REG32((hw_base) + 0x800U +  ((n)/4U) * 4U)    /* GICD_ITARGETSRn  */
#define GIC_DIST_CONFIG(hw_base, n)         __REG32((hw_base) + 0xc00U + ((n)/16U) * 4U)    /* GICD_ICFGRn      */
#define GIC_DIST_SOFTINT(hw_base)           __REG32((hw_base) + 0xf00U)                     /* GICD_SGIR        */
#define GIC_DIST_CPENDSGI(hw_base, n)       __REG32((hw_base) + 0xf10U + ((n)/4U) * 4U)     /* GICD_CPENDSGIRn  */
#define GIC_DIST_SPENDSGI(hw_base, n)       __REG32((hw_base) + 0xf20U + ((n)/4U) * 4U)     /* GICD_SPENDSGIRn  */
#define GIC_DIST_ICPIDR2(hw_base)           __REG32((hw_base) + 0xfe8U)                     /* ICPIDR2          */
```
<img width="460" height="391" alt="image" src="https://github.com/user-attachments/assets/1fbd61ec-eb49-45a2-88d8-3a8c8b962ba8" />


### 2 补全函数注释
```c
/**
 * @brief Get the active interrupt number
 *
 * @note Read the GICC_IAR register and add the interrupt number offset to get
 *       the actual interrupt number.
 *       This read acts as an acknowledge for the interrupt, changing the interrupt
 *       state from pending to active.
 *
 *       GICC_IAR register bit fields:
 *       - GICC_IAR[31:13]: Reserved, read as 0
 *       - GICC_IAR[12:10]: CPUID
 *                          For SGIs: This value is the CPUID that requested the interrupt.
 *                          For other interrupts: This value reads as 0 (RAZ).
 *       - GICC_IAR[9:0]:  Interrupt ID
 *
 * @param index GIC controller index
 *
 * @return The actual interrupt number (with offset added).
 *         Note: For SGIs, the return value may include CPUID information in the upper bits.
 */
int arm_gic_get_active_irq(rt_uint32_t index)
{
    int irq;

    RT_ASSERT(index < ARM_GIC_MAX_NR);

    irq = GIC_CPU_INTACK(_gic_table[index].cpu_hw_base);
    irq += _gic_table[index].offset;
    return irq;
}

/**
 * @brief Initialize the GIC CPU Interface (GICC)
 *
 * @note: The exact bit definitions and behavior may vary depending on
 *        the GIC implementation (GICv1/GICv2) and security context..
 *
 * @param index    GIC controller index
 * @param cpu_base Base address of the GIC CPU Interface (GICC)
 *
 * @return 0
 */
int arm_gic_cpu_init(rt_uint32_t index, rt_uint32_t cpu_base)
{
    RT_ASSERT(index < ARM_GIC_MAX_NR);

    if (!_gic_table[index].cpu_hw_base)
    {
        _gic_table[index].cpu_hw_base = cpu_base;
    }
    cpu_base = _gic_table[index].cpu_hw_base;

    GIC_CPU_PRIMASK(cpu_base) = 0xf0U;
    GIC_CPU_BINPOINT(cpu_base) = 0x7U;
    /* Enable CPU interrupt */
    GIC_CPU_CTRL(cpu_base) = 0x01U;

    return 0;
}

```

### 3 删除部分注释
我认为 ARM_GIC_MAX_NR 不是核心数，多核smp也可以只有1个GIC控制器。
我认为注释不准确所以删除。

```c
/* 'ARM_GIC_MAX_NR' is the number of cores */   /* 删除此处注释 */
static struct arm_gic _gic_table[ARM_GIC_MAX_NR];
```

## 测试
纯注释改动
<img width="936" height="252" alt="image" src="https://github.com/user-attachments/assets/94d904b4-61e8-4505-b3c0-1b3576aa4995" />

