### PR TITLE
fix(rtc): 用 SecondFraction/SubSeconds 计算 tv_usec，并在 shift pending 时跳过

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_rtc.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_rtc.c
@@ -10,6 +10,7 @@
  * 2021-02-05   Meco Man      fix the problem of mixing local time and UTC time
  * 2021-07-05   iysheng       implement RTC framework V2.0
  * 2025-06-05   RCSN          add local time conversion for get timeval and set stamp
+ * 0206-02-03   wdfk_prog     compute tv_usec from SecondFraction/SubSeconds
  */
 
 #include "board.h"
@@ -85,10 +86,30 @@ static rt_err_t stm32_rtc_get_timeval(struct timeval *tv)
 #else
     tv->tv_sec = timegm(&tm_new);
 #endif
-#if defined(SOC_SERIES_STM32H7)
-    tv->tv_usec = (255.0 - RTC_TimeStruct.SubSeconds * 1.0) / 256.0 * 1000.0 * 1000.0;
-#endif
-
+    tv->tv_usec = 0U;
+/* F1 RTC does not have SSR/PRER */
+#if defined(RTC_SSR_SS) && defined(RTC_PRER_PREDIV_S)
+    /*
+    * You can use SubSeconds and SecondFraction (sTime structure fields
+    * returned) to convert SubSeconds value in second fraction ratio with
+    * time unit following generic formula:
+    * Second fraction ratio * time_unit =
+    *    [(SecondFraction - SubSeconds) / (SecondFraction + 1)] * time_unit
+    * This conversion can be performed only if no shift operation is pending
+    * (ie. SHFP=0) when PREDIV_S >= SS
+    */
+#if defined(RTC_ISR_SHPF)
+    if (READ_BIT(RTC->ISR, RTC_ISR_SHPF) == 0U)
+#endif /* RTC_ISR_SHPF */
+    {
+        uint32_t sf = RTC_TimeStruct.SecondFraction;
+        uint32_t ss = RTC_TimeStruct.SubSeconds;
+        if ((sf != 0U) && (ss <= sf))
+        {
+            tv->tv_usec = (uint32_t)(((sf - ss) * 1000000ULL) / (sf + 1U));
+        }
+    }
+#endif /* defined(RTC_SSR_SS) && defined(RTC_PRER_PREDIV_S) */
     return RT_EOK;
 }
 


### PR DESCRIPTION

Use the generic SecondFraction/SubSeconds formula when SSR/PRER are available. If SHPF is present and a shift is pending, keep tv_usec at 0. Platforms without SSR/PRER (e.g. F1) default to 0.

## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
修正 RTC `gettimeofday` 微秒字段计算逻辑：
- 当 MCU 支持 `SSR/PRER`（`RTC_SSR_SS` & `RTC_PRER_PREDIV_S`）时，使用 HAL 返回的 `SecondFraction/SubSeconds` 按通用公式计算 `tv_usec`
- 若平台提供 `RTC_ISR_SHPF`，当 shift 操作 pending（SHPF=1）时跳过换算，保持 `tv_usec=0`
- 对不支持 `SSR/PRER` 的系列（如 STM32F1）默认 `tv_usec=0`

#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
