### PR TITLE
fix[stm32][spi]: add usage_freq and compute transfer timeout by frequency

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_spi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_spi.c
@@ -138,54 +138,54 @@ static rt_err_t stm32_spi_init(struct stm32_spi *spi_drv, struct rt_spi_configur
 
     spi_handle->Init.NSS = SPI_NSS_SOFT;
 
-    uint32_t SPI_CLOCK = 0UL;
+    uint32_t spi_clock = 0UL;
     /* Some series may only have APBPERIPH_BASE, but don't have HAL_RCC_GetPCLK2Freq */
 #if defined(APBPERIPH_BASE)
-    SPI_CLOCK = HAL_RCC_GetPCLK1Freq();
+    spi_clock = HAL_RCC_GetPCLK1Freq();
 #elif defined(APB1PERIPH_BASE) || defined(APB2PERIPH_BASE)
     /* The SPI clock for H7 cannot be configured with a peripheral bus clock, so it needs to be written separately */
 #if defined(SOC_SERIES_STM32H7)
     /* When the configuration is generated using CUBEMX, the configuration for the SPI clock is placed in the HAL_SPI_Init function.
     Therefore, it is necessary to initialize and configure the SPI clock to automatically configure the frequency division */
     HAL_SPI_Init(spi_handle);
-    SPI_CLOCK = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI123);
+    spi_clock = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI123);
 #else
     if ((rt_uint32_t)spi_drv->config->Instance >= APB2PERIPH_BASE)
     {
-        SPI_CLOCK = HAL_RCC_GetPCLK2Freq();
+        spi_clock = HAL_RCC_GetPCLK2Freq();
     }
     else
     {
-        SPI_CLOCK = HAL_RCC_GetPCLK1Freq();
+        spi_clock = HAL_RCC_GetPCLK1Freq();
     }
 #endif /* SOC_SERIES_STM32H7) */
 #endif /* APBPERIPH_BASE */
 
-    if (cfg->max_hz >= SPI_CLOCK / 2)
+    if (cfg->max_hz >= spi_clock / 2)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_2;
     }
-    else if (cfg->max_hz >= SPI_CLOCK / 4)
+    else if (cfg->max_hz >= spi_clock / 4)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_4;
     }
-    else if (cfg->max_hz >= SPI_CLOCK / 8)
+    else if (cfg->max_hz >= spi_clock / 8)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_8;
     }
-    else if (cfg->max_hz >= SPI_CLOCK / 16)
+    else if (cfg->max_hz >= spi_clock / 16)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_16;
     }
-    else if (cfg->max_hz >= SPI_CLOCK / 32)
+    else if (cfg->max_hz >= spi_clock / 32)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_32;
     }
-    else if (cfg->max_hz >= SPI_CLOCK / 64)
+    else if (cfg->max_hz >= spi_clock / 64)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_64;
     }
-    else if (cfg->max_hz >= SPI_CLOCK / 128)
+    else if (cfg->max_hz >= spi_clock / 128)
     {
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_128;
     }
@@ -195,15 +195,21 @@ static rt_err_t stm32_spi_init(struct stm32_spi *spi_drv, struct rt_spi_configur
         spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256;
     }
 
+#if defined(SOC_SERIES_STM32H7)
+    cfg->usage_freq = spi_clock / (rt_size_t)(1 << ((spi_handle->Init.BaudRatePrescaler >> SPI_CFG1_MBR_Pos) + 1));
+#else
+    cfg->usage_freq = spi_clock / (rt_size_t)(1 << ((spi_handle->Init.BaudRatePrescaler >> SPI_CR1_BR_Pos) + 1));
+#endif /* SOC_SERIES_STM32H7 */
+
     LOG_D("sys freq: %d, pclk freq: %d, SPI limiting freq: %d, SPI usage freq: %d",
 #if defined(SOC_SERIES_STM32MP1)
           HAL_RCC_GetSystemCoreClockFreq(),
 #else
           HAL_RCC_GetSysClockFreq(),
 #endif
-          SPI_CLOCK,
+          spi_clock,
           cfg->max_hz,
-          SPI_CLOCK / (rt_size_t)pow(2,(spi_handle->Init.BaudRatePrescaler >> 28) + 1));
+          cfg->usage_freq);
 
     if (cfg->mode & RT_SPI_MSB)
     {
@@ -294,6 +300,15 @@ static rt_ssize_t spixfer(struct rt_spi_device *device, struct rt_spi_message *m
 
     struct stm32_spi *spi_drv =  rt_container_of(device->bus, struct stm32_spi, spi_bus);
     SPI_HandleTypeDef *spi_handle = &spi_drv->handle;
+    rt_uint64_t total_byte_ms = (rt_uint64_t)message->length * 1000;
+    rt_uint32_t speed_bytes_per_sec = spi_drv->cfg->usage_freq / 8;
+    if (speed_bytes_per_sec == 0)
+    {
+        speed_bytes_per_sec = 1;
+    }
+
+    rt_uint32_t timeout_ms = total_byte_ms / speed_bytes_per_sec + 100;
+    rt_tick_t timeout_tick = rt_tick_from_millisecond(timeout_ms);
 
     if (message->cs_take && !(device->config.mode & RT_SPI_NO_CS) && (device->cs_pin != PIN_NONE))
     {
@@ -424,7 +439,7 @@ static rt_ssize_t spixfer(struct rt_spi_device *device, struct rt_spi_message *m
             }
             else
             {
-                state = HAL_SPI_TransmitReceive(spi_handle, (uint8_t *)send_buf, (uint8_t *)recv_buf, send_length, 1000);
+                state = HAL_SPI_TransmitReceive(spi_handle, (uint8_t *)send_buf, (uint8_t *)recv_buf, send_length, timeout_ms);
             }
         }
         else if (message->send_buf)
@@ -435,7 +450,7 @@ static rt_ssize_t spixfer(struct rt_spi_device *device, struct rt_spi_message *m
             }
             else
             {
-                state = HAL_SPI_Transmit(spi_handle, (uint8_t *)send_buf, send_length, 1000);
+                state = HAL_SPI_Transmit(spi_handle, (uint8_t *)send_buf, send_length, timeout_ms);
             }
 
             if (message->cs_release && (device->config.mode & RT_SPI_3WIRE))
@@ -455,7 +470,7 @@ static rt_ssize_t spixfer(struct rt_spi_device *device, struct rt_spi_message *m
             {
                 /* clear the old error flag */
                 __HAL_SPI_CLEAR_OVRFLAG(spi_handle);
-                state = HAL_SPI_Receive(spi_handle, (uint8_t *)recv_buf, send_length, 1000);
+                state = HAL_SPI_Receive(spi_handle, (uint8_t *)recv_buf, send_length, timeout_ms);
             }
         }
         else
@@ -482,7 +497,7 @@ static rt_ssize_t spixfer(struct rt_spi_device *device, struct rt_spi_message *m
         if ((spi_drv->spi_dma_flag & (SPI_USING_TX_DMA_FLAG | SPI_USING_RX_DMA_FLAG)) && (send_length >= DMA_TRANS_MIN_LEN))
         {
             /* blocking the thread,and the other tasks can run */
-            if (rt_completion_wait(&spi_drv->cpt, 1000) != RT_EOK)
+            if (rt_completion_wait(&spi_drv->cpt, timeout_tick) != RT_EOK)
             {
                 state = HAL_ERROR;
                 LOG_E("wait for DMA interrupt overtime!");
@@ -491,7 +506,20 @@ static rt_ssize_t spixfer(struct rt_spi_device *device, struct rt_spi_message *m
         }
         else
         {
-            while (HAL_SPI_GetState(spi_handle) != HAL_SPI_STATE_READY);
+            rt_uint32_t timeout = timeout_ms;
+            while (HAL_SPI_GetState(spi_handle) != HAL_SPI_STATE_READY)
+            {
+                if (timeout-- > 0)
+                {
+                    rt_thread_mdelay(1);
+                }
+                else
+                {
+                    LOG_E("timeout! SPI state did not become READY.");
+                    state = HAL_TIMEOUT;
+                    break;
+                }
+            }
         }
 
         if(dma_aligned_buffer != RT_NULL) /* re-aligned, so need to copy the data to recv_buf */

--- a/components/drivers/include/drivers/dev_spi.h
+++ b/components/drivers/include/drivers/dev_spi.h
@@ -161,6 +161,7 @@ struct rt_spi_configuration
 #endif
 
     rt_uint32_t max_hz;
+    rt_uint32_t usage_freq;
 };
 
 struct rt_spi_ops;


### PR DESCRIPTION
#### 为什么提交这份PR (why to submit this PR)

当前 STM32 SPI 驱动中，阻塞发送、接收、收发以及 DMA 等待完成时使用固定的 1000ms 超时。
当 SPI 传输数据量较大、配置频率较低，或者实际 SPI 工作频率低于预期时，固定超时可能过短，导致正常传输被误判为超时。
另外，驱动日志中计算 SPI 实际使用频率时使用了运行时表达式，结果不够直观，也不便于后续复用。

#### 你的解决方案是什么 (what is your solution)

本 PR 对 STM32 SPI 驱动做了如下调整：

1. 将局部变量 `SPI_CLOCK` 重命名为 `spi_clock`，使代码风格更符合规范；
2. 在 SPI 初始化阶段，根据分频配置计算实际 SPI 使用频率，并保存到 `cfg->usage_freq`；
3. 将日志中的 SPI usage frequency 统一改为输出 `cfg->usage_freq`；
4. 在 `spixfer()` 中根据本次传输长度和实际 SPI 使用频率动态计算超时时间：
   - 先根据 `usage_freq / 8` 计算理论字节传输速率；
   - 再根据报文长度推导所需传输时间；
   - 最后增加一定冗余量，生成本次传输使用的 `timeout_ms`；
5. 将 `HAL_SPI_TransmitReceive()`、`HAL_SPI_Transmit()`、`HAL_SPI_Receive()` 的固定 1000ms 超时替换为动态超时；
6. 将 DMA 完成等待 `rt_completion_wait()` 的固定超时替换为动态 tick 超时；
7. 对非 DMA 场景下等待 `HAL_SPI_STATE_READY` 的死等逻辑增加超时退出机制，避免异常情况下无限阻塞。

这样可以让 SPI 超时与实际配置频率、传输长度相匹配，降低误超时风险，并提升驱动健壮性。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
  - bsp/stm32/xxx

- .config:
  - CONFIG_RT_USING_SPI
  - 与目标板 SPI 外设相关的配置项

- action:
  - 请填写你自己仓库 PR 分支触发的 CI / Action 链接