### PR TITLE
feat[i2c]: add bus configuration and max-hz control

### DIFF
--- a/components/drivers/i2c/dev_i2c_core.c
+++ b/components/drivers/i2c/dev_i2c_core.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2024, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -7,6 +7,7 @@
  * Date           Author        Notes
  * 2012-04-25     weety         first version
  * 2021-04-20     RiceChen      added support for bus control api
+ * 2024-06-23     wdfk-prog     Add max_hz setting
  */
 
 #include <rtdevice.h>
@@ -101,16 +102,42 @@ rt_err_t rt_i2c_control(struct rt_i2c_bus_device *bus,
 {
     rt_err_t ret;
 
-    if(bus->ops->i2c_bus_control)
+    switch (cmd)
     {
-        ret = bus->ops->i2c_bus_control(bus, cmd, args);
-        return ret;
+        case RT_I2C_CTRL_SET_MAX_HZ:
+        {
+            if (args == RT_NULL)
+            {
+                return -RT_ERROR;
+            }
+
+            rt_uint32_t max_hz = *(rt_uint32_t *)args;
+            if(max_hz > 0)
+            {
+                bus->config.max_hz = max_hz;
+            }
+            else
+            {
+                return -RT_ERROR;
+            }
+            break;
+        }
+        default:
+        {
+            if(bus->ops->i2c_bus_control)
+            {
+                ret = bus->ops->i2c_bus_control(bus, cmd, args);
+                return ret;
+            }
+            else
+            {
+                LOG_E("I2C bus operation not supported");
+                return -RT_EINVAL;
+            }
+            break;
+        }
     }
-    else
-    {
-        LOG_E("I2C bus operation not supported");
-        return -RT_EINVAL;
-    }
+    return RT_EOK;
 }
 
 rt_ssize_t rt_i2c_master_send(struct rt_i2c_bus_device *bus,

--- a/components/drivers/include/drivers/dev_i2c.h
+++ b/components/drivers/include/drivers/dev_i2c.h
@@ -7,6 +7,7 @@
  * Date           Author        Notes
  * 2012-04-25     weety         first version
  * 2021-04-20     RiceChen      added support for bus control api
+ * 2024-06-23     wdfk-prog     Add the config struct
  */
 
 #ifndef __DEV_I2C_H__
@@ -185,6 +186,8 @@ extern "C" {
 #define RT_I2C_NO_READ_ACK      (1u << 6)  /* when I2C reading, we do not ACK */
 #define RT_I2C_NO_STOP          (1u << 7)  /*!< do not generate STOP condition */
 
+#define RT_I2C_CTRL_SET_MAX_HZ  0x20
+
 #define RT_I2C_DEV_CTRL_10BIT        (RT_DEVICE_CTRL_BASE(I2CBUS) + 0x01)
 #define RT_I2C_DEV_CTRL_ADDR         (RT_DEVICE_CTRL_BASE(I2CBUS) + 0x02)
 #define RT_I2C_DEV_CTRL_TIMEOUT      (RT_DEVICE_CTRL_BASE(I2CBUS) + 0x03)
@@ -234,6 +237,21 @@ struct rt_i2c_bus_device_ops
 };
 
 /**
+ * I2C configuration structure.
+ * mode : master: 0x00; slave: 0x01;
+ * max_hz: Maximum limit baud rate.
+ * usage_freq: Actual usage baud rate.
+ */
+struct rt_i2c_configuration
+{
+    rt_uint8_t  mode;
+    rt_uint8_t  reserved[3];
+
+    rt_uint32_t max_hz;
+    rt_uint32_t usage_freq;
+};
+
+/**
  * @brief I2C Bus Device
  */
 struct rt_i2c_bus_device
@@ -244,6 +262,7 @@ struct rt_i2c_bus_device
     struct rt_mutex lock;
     rt_uint32_t  timeout;
     rt_uint32_t  retries;
+    struct rt_i2c_configuration config;
     void *priv;
 };
 


### PR DESCRIPTION
#### 为什么提交这份PR (why to submit this PR)

当前 I2C 框架层缺少统一的总线频率配置接口，I2C bus device 本身也没有用于保存运行配置的结构体。
这使得上层在需要限制 I2C 最大通信频率时，缺少通用控制入口，也不便于底层驱动记录和复用实际工作频率等配置信息。

为了给 I2C 总线提供统一的最大频率设置能力，并为后续驱动适配提供基础配置结构，提交此 PR。

#### 你的解决方案是什么 (what is your solution)

本 PR 在 I2C 核心层做了以下改动：

1. 新增控制命令 `RT_I2C_CTRL_SET_MAX_HZ`，用于设置 I2C 总线最大通信频率；
2. 在 `rt_i2c_control()` 中增加对 `RT_I2C_CTRL_SET_MAX_HZ` 的处理逻辑：
   - 当传入频率值大于 0 时，保存到 `bus->config.max_hz`；
   - 当传入值无效时，返回错误码；
3. 保留原有 `i2c_bus_control` 回调分发逻辑，确保其他控制命令行为不变；
4. 在 `dev_i2c.h` 中新增 `struct rt_i2c_configuration`：
   - `mode`：I2C 工作模式；
   - `max_hz`：最大限制波特率；
   - `usage_freq`：实际使用波特率；
5. 在 `struct rt_i2c_bus_device` 中新增 `config` 成员，用于保存 I2C 总线配置；
6. 同步更新文件头注释和修改记录。

通过这些调整，I2C 核心层具备了统一保存和设置总线频率参数的能力，也为后续底层驱动根据 `max_hz` 配置实际时钟提供了基础支持。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
  - 请填写已验证的 BSP 路径，例如 `bsp/stm32/stm32l496-st-nucleo`

- .config:
  - CONFIG_RT_USING_I2C
  - 与目标 I2C 控制器或板级驱动相关的配置项

- action:
  - 请填写你自己仓库 PR 分支触发的 CI / Action 链接