### PR TITLE
refactor(core): Move __rt_fls to kservice

### DIFF
--- a/components/drivers/include/drivers/dev_mmcsd_core.h
+++ b/components/drivers/include/drivers/dev_mmcsd_core.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2026 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -174,50 +174,6 @@ struct rt_mmcsd_req
 #define R5_OUT_OF_RANGE     (1 << 8)
 #define R5_STATUS(x)        (x & 0xCB00)
 #define R5_IO_CURRENT_STATE(x)  ((x & 0x3000) >> 12)
-
-
-
-/**
- * fls - find last (most-significant) bit set
- * @x: the word to search
- *
- * This is defined the same way as ffs.
- * Note fls(0) = 0, fls(1) = 1, fls(0x80000000) = 32.
- */
-
-rt_inline rt_uint32_t __rt_fls(rt_uint32_t val)
-{
-    rt_uint32_t  bit = 32;
-
-    if (!val)
-        return 0;
-    if (!(val & 0xffff0000u))
-    {
-        val <<= 16;
-        bit -= 16;
-    }
-    if (!(val & 0xff000000u))
-    {
-        val <<= 8;
-        bit -= 8;
-    }
-    if (!(val & 0xf0000000u))
-    {
-        val <<= 4;
-        bit -= 4;
-    }
-    if (!(val & 0xc0000000u))
-    {
-        val <<= 2;
-        bit -= 2;
-    }
-    if (!(val & 0x80000000u))
-    {
-        bit -= 1;
-    }
-
-    return bit;
-}
 
 #define MMCSD_HOST_PLUGED       0
 #define MMCSD_HOST_UNPLUGED     1

--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -809,6 +809,7 @@ rt_device_t rt_console_get_device(void);
 #endif /* RT_USING_THREADSAFE_PRINTF */
 #endif /* defined(RT_USING_DEVICE) && defined(RT_USING_CONSOLE) */
 
+int __rt_fls(int val);
 int __rt_ffs(int value);
 unsigned long __rt_ffsl(unsigned long value);
 unsigned long __rt_clz(unsigned long value);

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -1103,6 +1103,50 @@ rt_weak void rt_free_align(void *ptr)
 RTM_EXPORT(rt_free_align);
 #endif /* RT_USING_HEAP */
 
+/**
+ * fls - find last (most-significant) bit set
+ * @x: the word to search
+ *
+ * This is defined the same way as ffs.
+ * Note fls(0) = 0, fls(1) = 1, fls(0x80000000) = 32.
+ */
+
+int __rt_fls(int val)
+{
+    int bit = 32;
+
+    if (!val)
+    {
+        return 0;
+    }
+    if (!(val & 0xffff0000u))
+    {
+        val <<= 16;
+        bit -= 16;
+    }
+    if (!(val & 0xff000000u))
+    {
+        val <<= 8;
+        bit -= 8;
+    }
+    if (!(val & 0xf0000000u))
+    {
+        val <<= 4;
+        bit -= 4;
+    }
+    if (!(val & 0xc0000000u))
+    {
+        val <<= 2;
+        bit -= 2;
+    }
+    if (!(val & 0x80000000u))
+    {
+        bit -= 1;
+    }
+
+    return bit;
+}
+
 #ifndef RT_USING_CPU_FFS
 #ifdef RT_USING_TINY_FFS
 const rt_uint8_t __lowest_bit_bitmap[] =


### PR DESCRIPTION
#### 为什么提交这份PR (why to submit this PR)

当前 `__rt_fls` 的实现位于 `components/drivers/include/drivers/dev_mmcsd_core.h` 中，
属于 MMC/SD 相关头文件中的局部内联实现。

但 `fls` 本质上是一个通用的位操作辅助函数，不应只存在于 mmcsd 模块内部。
将这类通用能力保留在驱动私有头文件中，会带来以下问题：

1. 通用函数与模块职责边界不清晰；
2. 其他子系统如果需要类似能力，无法方便复用；
3. 在头文件中保留实现也会增加耦合，不利于统一维护。

因此，提交此 PR，将 `__rt_fls` 从 mmcsd 私有头文件中抽离，放到公共内核服务层。

#### 你的解决方案是什么 (what is your solution)

本 PR 做了以下调整：

1. 从 `components/drivers/include/drivers/dev_mmcsd_core.h` 中删除 `__rt_fls` 的内联实现；
2. 在 `include/rtthread.h` 中新增 `__rt_fls(int val)` 的函数声明；
3. 在 `src/kservice.c` 中新增 `__rt_fls()` 的统一实现；
4. 保留原有函数逻辑和行为不变：
   - `fls(0) = 0`
   - `fls(1) = 1`
   - `fls(0x80000000) = 32`
5. 同步更新相关文件头版权年份。

通过以上调整，`__rt_fls` 从 mmcsd 私有实现变为可复用的公共基础函数，降低了模块间耦合，也更便于后续统一维护和复用。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
  - 请填写已验证的 BSP 路径，例如 `bsp/stm32/stm32l496-st-nucleo`

- .config:
  - 请填写用于验证的配置项
  - 如涉及 MMC/SD 相关场景，可补充对应存储驱动配置项

- action:
  - 请填写你自己仓库 PR 分支触发的 CI / Action 链接