### PR TITLE
components: libc: fix reset static variable unsolved in dlmodule_load…

### DIFF
--- a/components/libc/posix/libdl/dlelf.c
+++ b/components/libc/posix/libdl/dlelf.c
@@ -205,7 +205,10 @@ rt_err_t dlmodule_load_shared_object(struct rt_dlmodule* module, void *module_pt
         }
 
         if (unsolved)
+        {
+            unsolved = RT_FALSE;
             return -RT_ERROR;
+        }
     }
 
     /* construct module symbol table */


### PR DESCRIPTION
…_shared_object

[Problem Description]
In the dlmodule_load_shared_object function,
if a module loading fails once due to an unresolved symbol, all subsequent attempts to load any module will fail. The system becomes unable to load modules correctly until a reboot.

[Problem Analysis]
The root cause is that the variable unsolved is defined as static. Static variables retain their value between function calls. If a relocation error occurs, unsolved is set to RT_TRUE. However, when the function returns with an error, the value of unsolved is not reset. Consequently, on the next function call, unsolved remains RT_TRUE from the previous execution. This causes the check if (unsolved) to trigger immediately (or after the loop), forcing the function to return an error regardless of whether the current module is valid or not.

[Solution]
Reset the unsolved variable to RT_FALSE before returning the error code -RT_ERROR. This ensures the variable is in a clean state for the next function call, preventing state leakage between invocations.

## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
在 dlmodule_load_shared_object 函数中，如果模块因为符号未解析导致加载失败一次，后续所有的模块加载尝试都会失败。系统在重启前无法再正常加载模块。原因是 unsolved 变量被定义为了 static 类型。

#### 你的解决方案是什么 (what is your solution)
在返回 -RT_ERROR 之前，显式将 unsolved 变量重置为 RT_FALSE。这确保了变量在函数退出时处于初始状态，防止状态残留影响下一次调用。


#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
