### PR TITLE
[libcpu][cortex-m7]Canonical alignment

### DIFF
--- a/libcpu/arm/cortex-m7/cpu_cache.c
+++ b/libcpu/arm/cortex-m7/cpu_cache.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2024 RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -36,7 +36,7 @@ rt_base_t rt_hw_cpu_icache_status(void)
 
 void rt_hw_cpu_icache_ops(int ops, void* addr, int size)
 {
-    rt_uint32_t address = (rt_uint32_t)addr & (rt_uint32_t) ~(L1CACHE_LINESIZE_BYTE - 1);
+    rt_uint32_t address = RT_ALIGN_DOWN((rt_uint32_t)addr, L1CACHE_LINESIZE_BYTE);
     rt_int32_t size_byte = size + address - (rt_uint32_t)addr;
     rt_uint32_t linesize = 32U;
     if (ops & RT_HW_CACHE_INVALIDATE)
@@ -70,7 +70,7 @@ rt_base_t rt_hw_cpu_dcache_status(void)
 
 void rt_hw_cpu_dcache_ops(int ops, void* addr, int size)
 {
-    rt_uint32_t startAddr = (rt_uint32_t)addr & (rt_uint32_t)~(L1CACHE_LINESIZE_BYTE - 1);
+    rt_uint32_t startAddr = RT_ALIGN_DOWN((rt_uint32_t)addr, L1CACHE_LINESIZE_BYTE);
     rt_uint32_t size_byte = size + (rt_uint32_t)addr - startAddr;
     rt_uint32_t clean_invalid = RT_HW_CACHE_FLUSH | RT_HW_CACHE_INVALIDATE;
 


### PR DESCRIPTION
#### 为什么提交这份PR (why to submit this PR)

当前 Cortex-M7 cache 操作实现中，在 I-Cache 和 D-Cache 地址对齐时使用了手工位运算写法：

```c
(rt_uint32_t)addr & ~(L1CACHE_LINESIZE_BYTE - 1)
````

虽然该实现本身是正确的，但这种写法可读性较弱，也不够统一。
RT-Thread 已经提供了通用的地址对齐辅助宏 `RT_ALIGN_DOWN()`，继续保留手工位运算会增加风格不一致和维护成本。

因此，提交此 PR，将 cache 操作中的地址向下对齐逻辑统一替换为公共宏实现，提升代码可读性和一致性。

#### 你的解决方案是什么 (what is your solution)

本 PR 做了以下调整：

1. 在 `rt_hw_cpu_icache_ops()` 中，将：

   * 手工位运算地址对齐逻辑
   * 替换为 `RT_ALIGN_DOWN((rt_uint32_t)addr, L1CACHE_LINESIZE_BYTE)`

2. 在 `rt_hw_cpu_dcache_ops()` 中，将：

   * 手工位运算地址对齐逻辑
   * 替换为 `RT_ALIGN_DOWN((rt_uint32_t)addr, L1CACHE_LINESIZE_BYTE)`

3. 保持后续 `size_byte` 的计算方式和 cache 操作流程不变，确保行为逻辑一致；

4. 同步更新文件头版权年份。

通过以上调整，代码语义更加直观，也更符合 RT-Thread 中通用对齐宏的使用习惯，便于后续维护。

#### 请提供验证的bsp和config (provide the config and bsp)

* BSP:

  * 请填写已验证的 BSP 路径，例如 `bsp/stm32/stm32h750-artpi`

* .config:

  * 与 Cortex-M7 和 cache 相关的配置项
  * 例如启用 cache 的相关配置

* action:

  * 请填写你自己仓库 PR 分支触发的 CI / Action 链接
