### PR TITLE
fix(can): 连续多包发送，使传输顺序与应用层调用一致

### DIFF
--- a/components/drivers/can/dev_can.c
+++ b/components/drivers/can/dev_can.c
@@ -229,7 +229,7 @@ rt_inline int _can_int_tx(struct rt_can_device *can, const struct rt_can_msg *da
         }
         else
         {
-err_ret:
+        err_ret:
             level = rt_hw_local_irq_disable();
             can->status.dropedsndpkg++;
             rt_hw_local_irq_enable(level);
@@ -345,34 +345,41 @@ static rt_ssize_t _can_nonblocking_tx(struct rt_can_device *can, const struct rt
     {
         return -RT_EINVAL;
     }
-
+    level = rt_hw_local_irq_disable();
     while (sent_size < size)
     {
-        if (can->ops->sendmsg_nonblocking(can, pmsg) == RT_EOK)
+        if (rt_ringbuffer_data_len(&can->nb_tx_rb) >= sizeof(struct rt_can_msg))
         {
-            pmsg++;
-            sent_size += sizeof(struct rt_can_msg);
-            continue;
-        }
-
-        level = rt_hw_local_irq_disable();
-        if (rt_ringbuffer_space_len(&can->nb_tx_rb) >= sizeof(struct rt_can_msg))
-        {
-            rt_ringbuffer_put(&can->nb_tx_rb, (rt_uint8_t *)pmsg, sizeof(struct rt_can_msg));
-            rt_hw_local_irq_enable(level);
-
-            pmsg++;
-            sent_size += sizeof(struct rt_can_msg);
+            if (rt_ringbuffer_space_len(&can->nb_tx_rb) >= sizeof(struct rt_can_msg))
+            {
+                rt_ringbuffer_put(&can->nb_tx_rb, (rt_uint8_t *)pmsg, sizeof(struct rt_can_msg));
+                pmsg++;
+                sent_size += sizeof(struct rt_can_msg);
+                continue;
+            }
+            else
+            {
+                /* Buffer is full, cannot process this message or subsequent ones. */
+                can->status.dropedsndpkg += (size - sent_size) / sizeof(struct rt_can_msg);
+                break;
+            }
         }
         else
         {
-            /* Buffer is full, cannot process this message or subsequent ones. */
-            can->status.dropedsndpkg += (size - sent_size) / sizeof(struct rt_can_msg);
             rt_hw_local_irq_enable(level);
-            break;
+            if (can->ops->sendmsg_nonblocking(can, pmsg) != RT_EOK)
+            {
+                level = rt_hw_local_irq_disable();
+                rt_ringbuffer_put_force(&can->nb_tx_rb, (rt_uint8_t *)pmsg, sizeof(struct rt_can_msg));
+                rt_hw_local_irq_enable(level);
+            }
+
+            pmsg++;
+            sent_size += sizeof(struct rt_can_msg);
+            level = rt_hw_local_irq_disable();
         }
     }
-
+    rt_hw_local_irq_enable(level);
     return sent_size;
 }
 
@@ -409,7 +416,7 @@ static rt_err_t rt_can_open(struct rt_device *dev, rt_uint16_t oflag)
             struct rt_can_rx_fifo *rx_fifo;
 
             rx_fifo = (struct rt_can_rx_fifo *) rt_malloc(sizeof(struct rt_can_rx_fifo) +
-                      can->config.msgboxsz * sizeof(struct rt_can_msg_list));
+                                                         can->config.msgboxsz * sizeof(struct rt_can_msg_list));
             RT_ASSERT(rx_fifo != RT_NULL);
 
             rx_fifo->buffer = (struct rt_can_msg_list *)(rx_fifo + 1);
@@ -441,12 +448,12 @@ static rt_err_t rt_can_open(struct rt_device *dev, rt_uint16_t oflag)
             struct rt_can_tx_fifo *tx_fifo;
 
             tx_fifo = (struct rt_can_tx_fifo *) rt_malloc(sizeof(struct rt_can_tx_fifo) +
-                      can->config.sndboxnumber * sizeof(struct rt_can_sndbxinx_list));
+                                                         can->config.sndboxnumber * sizeof(struct rt_can_sndbxinx_list));
             RT_ASSERT(tx_fifo != RT_NULL);
 
             tx_fifo->buffer = (struct rt_can_sndbxinx_list *)(tx_fifo + 1);
             rt_memset(tx_fifo->buffer, 0,
-                    can->config.sndboxnumber * sizeof(struct rt_can_sndbxinx_list));
+                      can->config.sndboxnumber * sizeof(struct rt_can_sndbxinx_list));
             rt_list_init(&tx_fifo->freelist);
             for (i = 0;  i < can->config.sndboxnumber; i++)
             {
@@ -725,7 +732,6 @@ static rt_err_t rt_can_control(struct rt_device *dev,
                     }
                     rt_hw_local_irq_enable(level);
                 }
-
             }
             else
             {
@@ -1057,7 +1063,6 @@ void rt_hw_can_isr(struct rt_can_device *can, int event)
                     listmsg->owner = &can->hdr[hdr];
                     can->hdr[hdr].msgs++;
                 }
-
             }
 #endif
             rt_hw_local_irq_enable(level);
@@ -1132,7 +1137,8 @@ void rt_hw_can_isr(struct rt_can_device *can, int event)
                 level = rt_hw_local_irq_disable();
                 if (rt_ringbuffer_data_len(&can->nb_tx_rb) >= sizeof(struct rt_can_msg))
                 {
-                    rt_ringbuffer_get(&can->nb_tx_rb, (rt_uint8_t *)&msg_to_send, sizeof(struct rt_can_msg));
+                    struct rt_ringbuffer rb_shadow = can->nb_tx_rb;
+                    rt_ringbuffer_get(&rb_shadow, (rt_uint8_t *)&msg_to_send, sizeof(struct rt_can_msg));
                     msg_was_present = RT_TRUE;
                 }
                 rt_hw_local_irq_enable(level);
@@ -1141,14 +1147,13 @@ void rt_hw_can_isr(struct rt_can_device *can, int event)
                 {
                     break;
                 }
-
                 if (can->ops->sendmsg_nonblocking(can, &msg_to_send) != RT_EOK)
                 {
-                    level = rt_hw_local_irq_disable();
-                    rt_ringbuffer_put_force(&can->nb_tx_rb, (rt_uint8_t *)&msg_to_send, sizeof(struct rt_can_msg));
-                    rt_hw_local_irq_enable(level);
                     break;
                 }
+                level = rt_hw_local_irq_disable();
+                rt_ringbuffer_get(&can->nb_tx_rb, (rt_uint8_t *)&msg_to_send, sizeof(struct rt_can_msg));
+                rt_hw_local_irq_enable(level);
             }
         }
         break;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
当调用CAN通信连续发送N包数据（如序号1 2 3 4 5 6 7 8 ），当发送超过硬件缓存区(3个)时，会将多余的 4 5 6 7 8依次存入ringbuff,并在发送完成中断再次从ringbuff中取出数据写入硬件缓存区，但是由于_can_nonblocking_tx中处理逻辑，每次优先请求硬件是否有空间，再考虑写入缓存区，后发的数据可能先进入硬件缓存区而发送出去
在中断处理RT_CAN_EVENT_TX_DONE中检测ringbuff中是否有数据，先弹出再尝试发送，如果失败又重新压入队列中，也导致了顺序错乱

#### 你的解决方案是什么 (what is your solution)
1. _can_nonblocking_tx 中逻辑更换为先尝试硬件能否写入，写入失败后转存缓存区，如果缓存区有数据排队，后续数据只写入ringbuff，而不再尝试请求硬件写入
2. RT_CAN_EVENT_TX_DONE事件中，由于无法确认是否成功写入硬件，因此第一个数据先拿到尝试发送，发送成功后再弹出数据，否则等下次中断


#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
