### PR TITLE
docs: trim trailing space in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,4 @@ If you are interested in RT-Thread and want to join in the development of RT-Thr
 <a href="https://github.com/RT-Thread/rt-thread/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=RT-Thread/rt-thread" />
 </a>
+ 


### PR DESCRIPTION
Removes trailing whitespace.