### PR TITLE
fix(ci): prevent expression injection in pr_format_bot.yml

### DIFF
--- a/.github/workflows/pr_format_bot.yml
+++ b/.github/workflows/pr_format_bot.yml
@@ -20,14 +20,19 @@ jobs:
       - name: Check if first commit and add comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ACTION: ${{ github.event.action }}
+          REPO_FULL_NAME: ${{ github.repository }}
         run: |
-          echo "Event action: ${{ github.event.action }}"
+          echo "Event action: $PR_ACTION"
           
           # 获取 PR 的提交信息
           commits=$(curl -s \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits")
+            "https://api.github.com/repos/${REPO_FULL_NAME}/pulls/${PR_NUMBER}/commits")
 
           # 检查 API 响应是否为数组
           if echo "$commits" | jq -e 'type == "array"' > /dev/null; then
@@ -35,9 +40,9 @@ jobs:
             echo "PR commit count: $commit_count"
 
             should_comment=false
-            if [ "${{ github.event.action }}" = "opened" ]; then
+            if [ "$PR_ACTION" = "opened" ]; then
               should_comment=true
-            elif [ "${{ github.event.action }}" = "synchronize" ] && [ "$commit_count" -eq 1 ]; then
+            elif [ "$PR_ACTION" = "synchronize" ] && [ "$commit_count" -eq 1 ]; then
               should_comment=true
             fi
 
@@ -45,8 +50,8 @@ jobs:
               echo "Adding format notification comment..."
               
               # 构建工作流链接
-              branch="${{ github.event.pull_request.head.ref }}"
-              fork_repo="${{ github.event.pull_request.head.repo.full_name }}"
+              branch="$PR_HEAD_REF"
+              fork_repo="$PR_HEAD_REPO"
               workflow_url="https://github.com/${fork_repo}/actions/workflows/pr_clang_format.yml"
               direct_link="${workflow_url}?branch=${branch}"
 
@@ -69,7 +74,7 @@ jobs:
                 "- 设置需排除的文件/目录（目录请以\"/\"结尾）"
                 "Set files/directories to exclude (directories should end with \"/\")"
                 "- 将目标分支设置为 \ Set the target branch to：**\`${branch}\`**"
-                "- 设置PR number为 \ Set the PR number to：**\`${{ github.event.pull_request.number }}\`**"
+                "- 设置PR number为 \ Set the PR number to：**\`${PR_NUMBER}\`**"
                 ""
                 "3. **等待工作流完成 | Wait for the workflow to complete**"
                 "格式化后的代码将自动推送至你的分支。"
@@ -92,7 +97,7 @@ jobs:
               existing_comment=$(curl -s \
                 -H "Accept: application/vnd.github.v3+json" \
                 -H "Authorization: Bearer $GITHUB_TOKEN" \
-                "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" | \
+                "https://api.github.com/repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/comments" | \
                 jq -r '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- PR Format Notification Comment -->"))) | {id: .id, body: .body} | @base64')
 
               # 使用 jq 安全地构建 JSON 负载
@@ -107,7 +112,7 @@ jobs:
                   -H "Accept: application/vnd.github.v3+json" \
                   -H "Authorization: Bearer $GITHUB_TOKEN" \
                   -d "$json_payload" \
-                  "https://api.github.com/repos/${{ github.repository }}/issues/comments/$comment_id")
+                  "https://api.github.com/repos/${REPO_FULL_NAME}/issues/comments/$comment_id")
               else
                 # 创建新评论
                 echo "Creating new comment"
@@ -116,7 +121,7 @@ jobs:
                   -H "Accept: application/vnd.github.v3+json" \
                   -H "Authorization: Bearer $GITHUB_TOKEN" \
                   -d "$json_payload" \
-                  "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments")
+                  "https://api.github.com/repos/${REPO_FULL_NAME}/issues/${PR_NUMBER}/comments")
               fi
 
               # 提取 HTTP 状态码和响应体


### PR DESCRIPTION
## Summary

Fixes a **critical CI/CD expression injection vulnerability** in `pr_format_bot.yml` reported in #11282.

## What Changed

Moved all user-controlled GitHub Actions context expressions from direct `${{ }}` interpolation inside `run:` blocks to `env:` variables:

| Expression | Before (vulnerable) | After (safe) |
|---|---|---|
| `github.event.pull_request.head.ref` | `branch="${{ github.event.pull_request.head.ref }}"` | `branch="$PR_HEAD_REF"` |
| `github.event.pull_request.head.repo.full_name` | `fork_repo="${{ ... }}"` | `fork_repo="$PR_HEAD_REPO"` |
| `github.event.pull_request.number` | Direct interpolation in URLs | `$PR_NUMBER` |
| `github.event.action` | Direct interpolation in conditions | `$PR_ACTION` |
| `github.repository` | Direct interpolation in URLs | `$REPO_FULL_NAME` |

## Why This Matters

When `${{ }}` expressions are interpolated directly in `run:` blocks, the values are **text-substituted before the shell runs**. Under `pull_request_target`, an attacker-controlled branch name like:

```
$(malicious${IFS}command)
```

...executes as a shell command in the base repository's CI context with the base repo's `GITHUB_TOKEN`.

By moving these values to `env:`, they become **shell environment variables** — treated as literal strings, preventing injection.

## References

- Issue: #11282
- [GitHub Security Lab: Script injection](https://securitylab.github.com/research/github-actions-untrusted-input/)
- [GitHub Docs: Security hardening for Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)

## Credit

Reported by **Wilson Cyber Research** ([@sourcecodereviewer](https://github.com/sourcecodereviewer))
