### PR TITLE
[HUST CSE][lwp] reject wrapped user copy ranges

### DIFF
--- a/components/lwp/lwp_user_mm.c
+++ b/components/lwp/lwp_user_mm.c
@@ -672,21 +672,46 @@ void *lwp_mremap(struct rt_lwp *lwp, void *old_address, size_t old_size,
     return rt_aspace_mremap_range(lwp->aspace, old_address, old_size, new_size, flags, new_address);
 }
 
+static rt_bool_t _lwp_user_range_is_valid(const void *addr, size_t size)
+{
+    uintptr_t start;
+    uintptr_t end;
+
+    if (addr == RT_NULL)
+    {
+        return RT_FALSE;
+    }
+
+    start = (uintptr_t)addr;
+    if (start < (uintptr_t)USER_VADDR_START)
+    {
+        return RT_FALSE;
+    }
+    if (start >= (uintptr_t)USER_VADDR_TOP)
+    {
+        return RT_FALSE;
+    }
+
+    end = start + size;
+    if (end < start)
+    {
+        return RT_FALSE;
+    }
+    if (end > (uintptr_t)USER_VADDR_TOP)
+    {
+        return RT_FALSE;
+    }
+
+    return RT_TRUE;
+}
+
 size_t lwp_get_from_user(void *dst, void *src, size_t size)
 {
     struct rt_lwp *lwp = RT_NULL;
 
     /* check src */
 
-    if (src < (void *)USER_VADDR_START)
-    {
-        return 0;
-    }
-    if (src >= (void *)USER_VADDR_TOP)
-    {
-        return 0;
-    }
-    if ((void *)((char *)src + size) > (void *)USER_VADDR_TOP)
+    if (!_lwp_user_range_is_valid(src, size))
     {
         return 0;
     }
@@ -705,15 +730,7 @@ size_t lwp_put_to_user(void *dst, void *src, size_t size)
     struct rt_lwp *lwp = RT_NULL;
 
     /* check dst */
-    if (dst < (void *)USER_VADDR_START)
-    {
-        return 0;
-    }
-    if (dst >= (void *)USER_VADDR_TOP)
-    {
-        return 0;
-    }
-    if ((void *)((char *)dst + size) > (void *)USER_VADDR_TOP)
+    if (!_lwp_user_range_is_valid(dst, size))
     {
         return 0;
     }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

lwp_get_from_user() 和 lwp_put_to_user() 在校验用户缓冲区尾地址时，直接使用了 `addr + size`。当 size 足够大时，这个加法可能发生回绕，可能导致越界范围被错误地判断为合法用户地址区间。

#### 你的解决方案是什么 (what is your solution)

直接将用户地址范围检查统一到 lwp_user_range_is_valid()函数，并在检查中显式拒绝以下情况：

- addr == RT_NULL
- 起始地址落在用户地址空间之外
- addr + size 发生整数回绕
- 结束地址越过 USER_VADDR_TOP

lwp_get_from_user和 lwp_put_to_user()均复用该检查逻辑，非法范围继续返回 0

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: bsp/qemu-vexpress-a9

- .config: 使用 bsp/qemu-vexpress-a9/.config进行基础编译验证，不引入新的功能配置项。

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json) 详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
