### PR TITLE
[libcpu][risc-v] Fix PLIC interrupt processing order

### DIFF
--- a/libcpu/risc-v/virt64/plic.c
+++ b/libcpu/risc-v/virt64/plic.c
@@ -151,6 +151,6 @@ extern struct rt_irq_desc irq_desc[MAX_HANDLERS];
 void plic_handle_irq(void)
 {
     int plic_irq = plic_claim();
-    plic_complete(plic_irq);
     irq_desc[plic_irq].handler(plic_irq, irq_desc[plic_irq].param);
+    plic_complete(plic_irq);
 }


### PR DESCRIPTION
## Description / 描述
This PR fixes the PLIC interrupt handling order in the RISC-V virt64 libcpu. The previous code called `plic_complete` before executing the interrupt handler, which violated the correct interrupt flow. According to Section 1.5 Interrupt Flow of the RISC-V Platform-Level Interrupt Controller Specification, the interrupt should be handled first and then completed.

本次 PR 修复了 RISC-V virt64 中的 PLIC 中断处理顺序。以往的代码在执行中断 handler 之前调用了 `plic_complete`。根据 RISC-V Platform-Level Interrupt Controller Specification 的 1.5. Interrupt Flow 节的说明，应当先运行 handler，然后再 complete。

## Modified Files / 修改文件
- `libcpu/risc-v/virt64/plic.c`: Fixed `plic_handle_irq` by moving `plic_complete` after the handler call.
