### PR TITLE
[HUST CSE][components][net]fix formatted output length bounds handling

### DIFF
--- a/components/net/at/src/at_utils.c
+++ b/components/net/at/src/at_utils.c
@@ -63,9 +63,36 @@ rt_weak rt_size_t at_utils_send(rt_device_t dev,
 {
     return rt_device_write(dev, pos, buffer, size);
 }
+
+static rt_size_t _at_vsnprintf_len(char *send_buf, rt_size_t buf_size, rt_size_t suffix_size,
+                                   const char *format, va_list args)
+{
+    int len;
+    rt_size_t text_size;
+
+    if (buf_size <= suffix_size)
+    {
+        return 0;
+    }
+
+    text_size = buf_size - suffix_size;
+    len = vsnprintf(send_buf, text_size, format, args);
+    if (len <= 0)
+    {
+        return 0;
+    }
+
+    if ((rt_size_t)len >= text_size)
+    {
+        return text_size - 1;
+    }
+
+    return len;
+}
+
 rt_size_t at_vprintf(rt_device_t device, char *send_buf, rt_size_t buf_size, const char *format, va_list args)
 {
-    rt_size_t len = vsnprintf(send_buf, buf_size, format, args);
+    rt_size_t len = _at_vsnprintf_len(send_buf, buf_size, 0, format, args);
     if (len == 0)
     {
         return 0;
@@ -79,7 +106,7 @@ rt_size_t at_vprintf(rt_device_t device, char *send_buf, rt_size_t buf_size, con
 }
 rt_size_t at_vprintfln(rt_device_t device, char *send_buf, rt_size_t buf_size, const char *format, va_list args)
 {
-    rt_size_t len = vsnprintf(send_buf, buf_size - 2, format, args);
+    rt_size_t len = _at_vsnprintf_len(send_buf, buf_size, 2, format, args);
     if (len == 0)
     {
         return 0;
@@ -96,7 +123,7 @@ rt_size_t at_vprintfln(rt_device_t device, char *send_buf, rt_size_t buf_size, c
 }
 rt_size_t at_vprintfcr(rt_device_t device, char *send_buf, rt_size_t buf_size, const char *format, va_list args)
 {
-    rt_size_t len = vsnprintf(send_buf, buf_size - 1, format, args);
+    rt_size_t len = _at_vsnprintf_len(send_buf, buf_size, 1, format, args);
     if (len == 0)
     {
         return 0;
@@ -112,7 +139,7 @@ rt_size_t at_vprintfcr(rt_device_t device, char *send_buf, rt_size_t buf_size, c
 }
 rt_size_t at_vprintflf(rt_device_t device, char *send_buf, rt_size_t buf_size, const char *format, va_list args)
 {
-    rt_size_t len = vsnprintf(send_buf, buf_size - 1, format, args);
+    rt_size_t len = _at_vsnprintf_len(send_buf, buf_size, 1, format, args);
     if (len == 0)
     {
         return 0;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
AT 组件在格式化发送数据时，直接使用 vsnprintf() 的返回值作为后续发送长度和追加 `\r` / `\n` 的位置。  
当结果被截断时，vsnprintf() 返回的是期望写入长度而不是实际写入长度，这会导致：
- 发送长度大于缓冲区实际有效数据长度，存在越界读取风险
- 在 at_vprintfln / at_vprintfcr / at_vprintflf 中追加结尾字符时，存在越界写风险
- 当缓冲区长度很小时，buf_size - 1 / buf_size - 2还可能出现下溢

#### 你的解决方案是什么 (what is your solution)
本 PR 在 components/net/at/src/at_utils.c 中增加统一的长度裁剪逻辑：

- 在调用 vsnprintf 前先根据结尾附加字符长度计算可用正文空间；
- 当 buf_size <= suffix_size 时直接返回，避免无符号下溢；
- 当 vsnprintf返回值超过可用正文空间时，将实际使用长度修改到 text_size - 1；
- 将该逻辑统一应用到：at_vprintf，at_vprintfln，at_vprintfcr，at_vprintflf


#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:bsp/qemu-vexpress-a9

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:  CONFIG_RT_USING_AT=y

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:暂无

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
