### PR TITLE
feat(kernel): Check interrupt-disabled context in RT_DEBUG_SCHEDULER_…

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -860,17 +860,37 @@ do                                                                            \
 }                                                                             \
 while (0)
 
+#if defined(RT_USING_SMP)
+/**
+ * @brief Check whether disabled interrupts make scheduler unavailable.
+ *
+ * In SMP builds, some kernel-internal lockless wait paths may disable local
+ * interrupts while still using scheduler-related operations legally. Keep this
+ * IRQ-disabled context assertion for UP builds only.
+ */
+#define RT_DEBUG_SCHEDULER_IRQ_DISABLED() (RT_FALSE)
+#else
+/**
+ * @brief Check whether disabled interrupts make scheduler unavailable.
+ *
+ * In UP builds, globally disabled interrupts prevent normal scheduling and
+ * timeout progress, so blocking scheduler paths must reject this context.
+ */
+#define RT_DEBUG_SCHEDULER_IRQ_DISABLED() rt_hw_interrupt_is_disabled()
+#endif /* defined(RT_USING_SMP) */
+
 /* "scheduler available" means:
  *     1) the scheduler has been started.
  *     2) not in interrupt context.
  *     3) scheduler is not locked.
+ *     4) interrupts are not disabled on UP.
  */
 #define RT_DEBUG_SCHEDULER_AVAILABLE(need_check)                              \
 do                                                                            \
 {                                                                             \
     if (need_check)                                                           \
     {                                                                         \
-        if (rt_critical_level() != 0)                                         \
+        if ((rt_critical_level() != 0) || RT_DEBUG_SCHEDULER_IRQ_DISABLED())  \
         {                                                                     \
             rt_kprintf("Function[%s]: scheduler is not available\n",          \
                     __FUNCTION__);                                            \


### PR DESCRIPTION
#### 为什么提交这份PR (why to submit this PR)

修复 `RT_DEBUG_SCHEDULER_AVAILABLE()` 对“调度器可用上下文”的判断不完整问题。

当前实现仅检查：
- `rt_critical_level() == 0`，即 scheduler lock 已释放；
- 当前处于线程上下文，而非中断上下文。

但它没有覆盖这样一种场景：
- 当前仍在线程上下文；
- scheduler lock 已释放；
- **但全局中断已经通过 `rt_hw_interrupt_disable()` 关闭**。

在这种情况下，代码路径表面上满足“线程上下文 + 非 scheduler lock”条件，但实际上已经不适合进入可能触发挂起、超时等待或调度切换的逻辑。对于 `rt_mutex_take()`、`rt_sem_take()` 等阻塞型接口，这会放过一类非法调用场景，可能进一步导致状态不一致、异常断言或系统卡死。

因此提交本 PR，在 `RT_DEBUG_SCHEDULER_AVAILABLE()` 中补充 `rt_hw_interrupt_is_disabled()` 检查，使“scheduler available”的判定与实际运行约束保持一致。

#### 你的解决方案是什么 (what is your solution)

本 PR 仅做一处内核检查增强：

1. 补充中断关闭状态检查  
   - 在 `include/rtthread.h` 的 `RT_DEBUG_SCHEDULER_AVAILABLE()` 宏中，增加 `rt_hw_interrupt_is_disabled()` 判断；
   - 当 scheduler lock 未释放，或当前处于全局关中断状态时，统一判定为 `scheduler is not available`。

2. 收紧阻塞型接口的上下文约束  
   - 让依赖 `RT_DEBUG_SCHEDULER_AVAILABLE(RT_TRUE)` 的 IPC / 同步原语接口，在“线程上下文但中断已关闭”的场景下尽早断言；
   - 避免继续进入 suspend / schedule / timeout 相关路径后才暴露问题。

3. 提升问题定位效率  
   - 对调用者来说，错误会在前置条件检查阶段直接暴露；
   - 比进入深层等待逻辑后出现 `thread->error` 异常、owner 状态不一致或断言失败更容易定位。

#### 修改内容 (patch summary)

```diff
-        if (rt_critical_level() != 0)
+        if ((rt_critical_level() != 0) || rt_hw_interrupt_is_disabled())
```

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP:
  - `bsp/stm32/...`（请填写实际验证的 BSP 路径）

- .config:
  - `RT_USING_MUTEX`
  - `RT_USING_SEMAPHORE`
  - `RT_DEBUGING_ASSERT`
  - 以及实际复现问题所需的 BSP / 驱动配置

- 建议验证场景：
  1. 在线程上下文、开中断状态下调用 `rt_mutex_take(..., timeout)`，行为保持不变；
  2. 在 `rt_hw_interrupt_disable()` 保护区内调用可能阻塞的 IPC 接口，能够被前置断言及时捕获；
  3. 验证 `timeout == 0` 的 try-take / 非阻塞路径是否符合预期；
  4. 回归检查常见 BSP 启动与 IPC 基本用例，确认未引入误报。

- action:
  - 请填写你自己仓库 PR branch 对应的 CI / Action 链接

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用格式化工具确保格式符合 RT-Thread 代码规范 This PR complies with RT-Thread code specification
- [ ] 如果是新增bsp, 已经添加ci检查到 `.github/ALL_BSP_COMPILE.json`
