### PR TITLE
feat[libcpu][cortex-m4]: Detect interrupt context from IPSR on Cortex-M4

### DIFF
--- a/libcpu/arm/cortex-m4/cpuport.c
+++ b/libcpu/arm/cortex-m4/cpuport.c
@@ -20,6 +20,10 @@
 
 #include <rtthread.h>
 
+#define DBG_TAG           "cortex.m4"
+#define DBG_LVL           DBG_INFO
+#include <rtdbg.h>
+
 #if               /* ARMCC */ (  (defined ( __CC_ARM ) && defined ( __TARGET_FPU_VFP ))    \
                   /* Clang */ || (defined ( __clang__ ) && defined ( __VFP_FP__ ) && !defined(__SOFTFP__)) \
                   /* IAR */   || (defined ( __ICCARM__ ) && defined ( __ARMVFP__ ))        \
@@ -434,6 +438,107 @@ void rt_hw_hard_fault_exception(struct exception_info *exception_info)
 void rt_hw_cpu_reset(void)
 {
     SCB_AIRCR = SCB_RESET_VALUE;
+}
+
+/**
+  \brief   Get IPSR Register
+  \details Returns the content of the IPSR Register.
+  \return               IPSR Register value
+ */
+rt_inline rt_uint32_t rt_hw_get_ipsr(void)
+{
+#if defined(__CC_ARM)
+    register uint32_t __regIPSR __asm("ipsr");
+    return(__regIPSR);
+#elif defined(__clang__)
+    uint32_t result;
+    __asm volatile ("MRS %0, ipsr" : "=r" (result) );
+    return(result);
+#elif defined(__IAR_SYSTEMS_ICC__)
+    return __iar_builtin_rsr("IPSR");
+#elif defined ( __GNUC__ )
+    uint32_t result;
+    __asm volatile ("MRS %0, ipsr" : "=r" (result) );
+    return(result);
+#endif
+}
+
+/**
+ * @brief This function will be invoked by BSP, when enter interrupt service routine
+ *
+ * @note Please don't invoke this routine in application
+ *
+ * @see rt_interrupt_leave
+ */
+void rt_interrupt_enter(void)
+{
+    extern void (*rt_interrupt_enter_hook)(void);
+    RT_OBJECT_HOOK_CALL(rt_interrupt_enter_hook,());
+    LOG_D("irq has come...");
+}
+
+/**
+ * @brief This function will be invoked by BSP, when leave interrupt service routine
+ *
+ * @note Please don't invoke this routine in application
+ *
+ * @see rt_interrupt_enter
+ */
+void rt_interrupt_leave(void)
+{
+    extern void (*rt_interrupt_leave_hook)(void);
+    LOG_D("irq is going to leave");
+    RT_OBJECT_HOOK_CALL(rt_interrupt_leave_hook,());
+}
+
+/**
+ * @brief This function will return the nest of interrupt.
+ *
+ * User application can invoke this function to get whether current
+ * context is interrupt context.
+ *
+ * @return the number of nested interrupts.
+ */
+rt_uint8_t rt_interrupt_get_nest(void)
+{
+    return (rt_hw_get_ipsr() != 0);
+}
+
+/**
+  \brief   Get PRIMASK Register
+  \details Returns the content of the PRIMASK Register.
+  \return  PRIMASK Register value
+ */
+rt_inline rt_uint32_t rt_hw_get_primask_value(void)
+{
+#if defined(__CC_ARM)
+    register uint32_t __regPRIMASK __asm("primask");
+    return (__regPRIMASK);
+#elif defined(__clang__)
+    uint32_t result;
+    __asm volatile ("MRS %0, primask" : "=r" (result));
+    return result;
+#elif defined(__IAR_SYSTEMS_ICC__)
+    return __iar_builtin_rsr("PRIMASK");
+#elif defined(__GNUC__)
+    uint32_t result;
+    __asm volatile ("MRS %0, primask" : "=r" (result));
+    return result;
+#endif
+}
+
+/**
+ * @brief Check whether maskable interrupts are currently disabled.
+ *
+ * @details
+ * For Cortex-M4, interrupts are considered disabled when either:
+ * - PRIMASK masks all configurable interrupts.
+ *
+ * @return RT_TRUE if interrupts are masked; otherwise RT_FALSE.
+ */
+rt_bool_t rt_hw_interrupt_is_disabled(void)
+{
+    return ((rt_hw_get_primask_value() & 0x1UL) != 0UL);
 }
 
 #ifdef RT_USING_CPU_FFS

--- a/src/irq.c
+++ b/src/irq.c
@@ -26,8 +26,8 @@
 
 #if defined(RT_USING_HOOK) && defined(RT_HOOK_USING_FUNC_PTR)
 
-static void (*rt_interrupt_enter_hook)(void);
-static void (*rt_interrupt_leave_hook)(void);
+void (*rt_interrupt_enter_hook)(void);
+void (*rt_interrupt_leave_hook)(void);
 
 /**
  * @ingroup group_hook

--- a/src/scheduler_up.c
+++ b/src/scheduler_up.c
@@ -284,6 +284,7 @@ void rt_schedule(void)
     struct rt_thread *to_thread;
     struct rt_thread *from_thread;
     struct rt_thread *curr_thread;
+    rt_base_t interrupt_nest;
 
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
@@ -343,16 +344,17 @@ void rt_schedule(void)
                 RT_SCHED_CTX(to_thread).stat = RT_THREAD_RUNNING | (RT_SCHED_CTX(to_thread).stat & ~RT_THREAD_STAT_MASK);
 
                 /* switch to new thread */
+                interrupt_nest = rt_interrupt_get_nest();
                 LOG_D("[%d]switch to priority#%d "
                          "thread:%.*s(sp:0x%08x), "
                          "from thread:%.*s(sp: 0x%08x)",
-                         rt_interrupt_get_nest(), highest_ready_priority,
+                         interrupt_nest, highest_ready_priority,
                          RT_NAME_MAX, to_thread->parent.name, to_thread->sp,
                          RT_NAME_MAX, from_thread->parent.name, from_thread->sp);
 
                 RT_SCHEDULER_STACK_CHECK(to_thread);
 
-                if (rt_interrupt_get_nest() == 0)
+                if (interrupt_nest == 0)
                 {
                     extern void rt_thread_handle_sig(rt_bool_t clean_state);
 

--- a/src/scheduler_up.c
+++ b/src/scheduler_up.c
@@ -50,7 +50,6 @@ rt_uint32_t rt_thread_ready_priority_group;
 rt_uint8_t rt_thread_ready_table[32];
 #endif /* RT_THREAD_PRIORITY_MAX > 32 */
 
-extern volatile rt_atomic_t rt_interrupt_nest;
 static rt_atomic_t rt_scheduler_lock_nest;
 rt_uint8_t rt_current_priority;
 
@@ -347,13 +346,13 @@ void rt_schedule(void)
                 LOG_D("[%d]switch to priority#%d "
                          "thread:%.*s(sp:0x%08x), "
                          "from thread:%.*s(sp: 0x%08x)",
-                         rt_interrupt_nest, highest_ready_priority,
+                         rt_interrupt_get_nest(), highest_ready_priority,
                          RT_NAME_MAX, to_thread->parent.name, to_thread->sp,
                          RT_NAME_MAX, from_thread->parent.name, from_thread->sp);
 
                 RT_SCHEDULER_STACK_CHECK(to_thread);
 
-                if (rt_interrupt_nest == 0)
+                if (rt_interrupt_get_nest() == 0)
                 {
                     extern void rt_thread_handle_sig(rt_bool_t clean_state);
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份 PR (why to submit this PR)

当前补丁的核心目标，是将 Cortex-M4 平台上的中断上下文识别与相关 hook 调用路径显式化，并减少调度器对外部中断嵌套计数变量的直接耦合。

现有实现中，`scheduler_up.c` 直接依赖 `rt_interrupt_nest` 判断当前是否处于中断上下文；而在 Cortex-M4 平台上，这类信息本身可以直接通过 `IPSR` 寄存器判断。与此同时，本补丁还补充了 `rt_interrupt_enter()` / `rt_interrupt_leave()` 的平台侧实现，以及中断屏蔽状态查询接口 `rt_hw_interrupt_is_disabled()`，使 Cortex-M4 平台上的中断相关行为更完整、更清晰。

因此提交本 PR，以完善 Cortex-M4 架构下的中断上下文识别能力、补齐中断 enter/leave hook 调用链，并将调度器中的中断态判断改为通过统一接口获取，降低对内部变量的直接依赖。

#### 你的解决方案是什么 (what is your solution)

本 PR 主要做了以下修改：

1. 补充 Cortex-M4 中断上下文识别能力
   - 在 `libcpu/arm/cortex-m4/cpuport.c` 中新增 `__get_IPSR()`；
   - 基于 `IPSR` 实现 `rt_interrupt_get_nest()`；
   - 当前实现用于判断“是否处于中断上下文”，返回值语义等价于布尔态。

2. 补充 Cortex-M4 中断 enter/leave 路径
   - 在 `cpuport.c` 中新增 `rt_interrupt_enter()`；
   - 在 `cpuport.c` 中新增 `rt_interrupt_leave()`；
   - 两个接口都会调用对应的 hook：
     - `rt_interrupt_enter_hook`
     - `rt_interrupt_leave_hook`

3. 暴露中断 hook 指针供平台侧使用
   - 在 `src/irq.c` 中，将：
     - `rt_interrupt_enter_hook`
     - `rt_interrupt_leave_hook`
     从文件内 `static` 变量改为全局可见符号；
   - 使平台实现能够复用统一的 hook 机制。

4. 增加中断屏蔽状态查询接口
   - 在 `cpuport.c` 中新增 `rt_hw_get_primask_value()`；
   - 基于 `PRIMASK` 实现 `rt_hw_interrupt_is_disabled()`；
   - 用于判断当前 maskable interrupt 是否被关闭。

5. 调整调度器中的中断态判断方式
   - 在 `src/scheduler_up.c` 中移除对 `rt_interrupt_nest` 的直接 extern 依赖；
   - 将日志与调度分支中的判断改为调用 `rt_interrupt_get_nest()`；
   - 避免直接依赖特定内部计数变量。

#### 请提供验证的 BSP 和 config (provide the config and bsp)

- BSP:
  - 任意 ARM Cortex-M4 BSP
  - 建议至少补充 1 个你实际验证过的 BSP，例如：
    - `bsp/stm32/stm32f407-atk-explorer`
    - 或你本次修改实际使用的 Cortex-M4 BSP 路径

- .config:
  - `CONFIG_ARCH_ARM_CORTEX_M4`
  - 如需验证 hook 路径，建议开启：
    - `CONFIG_RT_USING_HOOK`
  - 如需结合日志验证，可补充对应日志宏或调试配置

- 验证方式:
  - 编译通过 Cortex-M4 BSP；
  - 进入线程上下文时，`rt_interrupt_get_nest()` 返回 0；
  - 进入中断处理函数时，`rt_interrupt_get_nest()` 返回非 0；
  - `rt_interrupt_enter()` / `rt_interrupt_leave()` 能正常触发 hook；
  - `rt_schedule()` 在中断上下文下不会走线程态切换路径；
  - `rt_hw_interrupt_is_disabled()` 在关中断/开中断场景下返回值符合预期。

- action:
  - 请填写你自己仓库 PR branch 对应的 CI / Action 链接

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或 BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用 [formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合 [RT-Thread 代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增 bsp, 已经添加 ci 检查到 [.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json) 详细请参考链接 [BSP 自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
