### PR TITLE
fix[tools][eclipse]: avoid unnecessary project file rewrites during eclipse target generation

### DIFF
--- a/tools/targets/eclipse.py
+++ b/tools/targets/eclipse.py
@@ -29,6 +29,26 @@ MODULE_VER_NUM = 6
 source_pattern = ['*.c', '*.cpp', '*.cxx', '*.cc', '*.s', '*.S', '*.asm','*.cmd']
 
 
+def _write_text_if_changed(path, content, encoding='utf-8'):
+    old_content = None
+    if os.path.exists(path):
+        with open(path, 'r', encoding=encoding, errors='ignore') as f:
+            old_content = f.read()
+
+    if old_content == content:
+        return False
+
+    with open(path, 'w', encoding=encoding, newline='\n') as f:
+        f.write(content)
+
+    return True
+
+
+def _serialize_xml(root, xml_decl):
+    xml_indent(root)
+    return xml_decl + etree.tostring(root, encoding='utf-8').decode('utf-8')
+
+
 def OSPath(path):
     import platform
 
@@ -257,11 +277,11 @@ def HandleToolOption(tools, env, project, reset):
         file_tail = '\n#endif /*RTCONFIG_PREINC_H__*/\n'
         rtt_pre_inc_item = '"${workspace_loc:/${ProjName}/rtconfig_preinc.h}"'
         # save the CPPDEFINES in to rtconfig_preinc.h
-        with open('rtconfig_preinc.h', mode = 'w+') as f:
-            f.write(file_header)
-            for cppdef in CPPDEFINES:
-                f.write("#define " + cppdef.replace('=', ' ') + '\n')
-            f.write(file_tail)
+        preinc_content = file_header
+        for cppdef in CPPDEFINES:
+            preinc_content += "#define " + cppdef.replace('=', ' ') + '\n'
+        preinc_content += file_tail
+        _write_text_if_changed('rtconfig_preinc.h', preinc_content)
         #  change the c.compiler.include.files
         files = option.findall('listOptionValue')
         find_ok = False
@@ -380,11 +400,8 @@ def UpdateProjectStructure(env, prj_name):
             name = SubElement(root, 'name')
         name.text = prj_name
 
-    out = open('.project', 'w')
-    out.write('<?xml version="1.0" encoding="UTF-8"?>\n')
-    xml_indent(root)
-    out.write(etree.tostring(root, encoding='utf-8').decode('utf-8'))
-    out.close()
+    project_content = _serialize_xml(root, '<?xml version="1.0" encoding="UTF-8"?>\n')
+    _write_text_if_changed('.project', project_content)
 
     return
 
@@ -518,12 +535,11 @@ def UpdateCproject(env, project, excluding, reset, prj_name):
             SubElement(configuration, 'resource', {'resourceType': "PROJECT", 'workspacePath': prj_name})
 
     # write back to .cproject
-    out = open('.cproject', 'w')
-    out.write('<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n')
-    out.write('<?fileVersion 4.0.0?>')
-    xml_indent(root)
-    out.write(etree.tostring(root, encoding='utf-8').decode('utf-8'))
-    out.close()
+    cproject_content = _serialize_xml(
+        root,
+        '<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<?fileVersion 4.0.0?>'
+    )
+    _write_text_if_changed('.cproject', cproject_content)
 
 
 def TargetEclipse(env, reset=False, prj_name=None):


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

`tools/targets/eclipse.py` 在执行 `scons --target=eclipse` 时，会无条件重写 `.project`、`.cproject` 和 `rtconfig_preinc.h`。

即使这些文件的内容没有发生变化，文件时间戳也会被刷新。在 Eclipse / RT-Thread Studio 场景下，这可能导致 IDE 误判工程配置或预包含头文件已变更，从而在后续构建时触发不必要的全量编译。

本 PR 的目标是避免这种“内容未变但文件被重复写回”带来的副作用，改善 Eclipse 工程生成后的增量编译体验。

#### 你的解决方案是什么 (what is your solution)

本 PR 在 `tools/targets/eclipse.py` 中引入了“内容变化才写回”的策略：

- 新增 `_write_text_if_changed()`，用于比较文件新旧内容，只有内容发生变化时才实际写文件
- 新增 `_serialize_xml()`，统一 `.project` 和 `.cproject` 的 XML 序列化逻辑
- 将 `rtconfig_preinc.h` 的生成逻辑改为先在内存中拼接完整内容，再按需写回
- 将 `.project` 和 `.cproject` 的更新逻辑改为序列化后按需写回

这样在重复执行 `scons --target=eclipse` 时，若工程配置内容未变化，则不会重复改写这些文件，从而减少因为时间戳变化引发的后续全量重编。

- 第一次编译
```sh
(.venv) E:\CODE\RTT\rt-thread\bsp\stm32\stm32f407-atk-explorer 
$ scons --target=eclipse                                                           
scons: Reading SConscript files ...                                                
Newlib version: 4.1.0                                                              
Update eclipse setting...                                                          
done!                                                                              
                                                                                   
(.venv)E:\CODE\RTT\rt-thread\bsp\stm32\stm32f407-atk-explorer 
$ scons                                                                            
scons: Reading SConscript files ...                                                
Newlib version: 4.1.0                                                              
scons: done reading SConscript files.                                              
scons: Building targets ...                                                        
scons: building associated VariantDir targets: build                               
CC build\applications\main.o                                                       
CC build\board\board.o                                                             
CC build\board\CubeMX_Config\Src\stm32f4xx_hal_msp.o                               
CC build\kernel\components\dfs\dfs_v1\filesystems\devfs\devfs.o                    
CC build\kernel\components\dfs\dfs_v1\src\dfs.o                                    
CC build\kernel\components\dfs\dfs_v1\src\dfs_file.o                               
CC build\kernel\components\dfs\dfs_v1\src\dfs_fs.o                                 
CC build\kernel\components\dfs\dfs_v1\src\dfs_posix.o                              
CC build\kernel\components\drivers\core\device.o                                   
CC build\kernel\components\drivers\i2c\dev_i2c_bit_ops.o                           
CC build\kernel\components\drivers\i2c\dev_i2c_core.o                              
CC build\kernel\components\drivers\i2c\dev_i2c_dev.o                               
CC build\kernel\components\drivers\ipc\completion_comm.o                           
CC build\kernel\components\drivers\ipc\completion_up.o                             
CC build\kernel\components\drivers\ipc\condvar.o                                   
CC build\kernel\components\drivers\ipc\dataqueue.o                                 
CC build\kernel\components\drivers\ipc\pipe.o                                      
CC build\kernel\components\drivers\ipc\ringblk_buf.o                               
CC build\kernel\components\drivers\ipc\ringbuffer.o                                
CC build\kernel\components\drivers\ipc\waitqueue.o                                 
CC build\kernel\components\drivers\ipc\workqueue.o                                 
CC build\kernel\components\drivers\pin\dev_pin.o                                   
CC build\kernel\components\drivers\serial\dev_serial.o                             
CC build\kernel\components\finsh\cmd.o                                             
CC build\kernel\components\finsh\msh.o                                             
CC build\kernel\components\finsh\msh_file.o                                        
CC build\kernel\components\finsh\msh_parse.o                                       
CC build\kernel\components\finsh\shell.o                                           
CC build\kernel\components\libc\compilers\common\cctype.o                          
CC build\kernel\components\libc\compilers\common\cstdlib.o                         
CC build\kernel\components\libc\compilers\common\cstring.o                         
CC build\kernel\components\libc\compilers\common\ctime.o                           
CC build\kernel\components\libc\compilers\common\cunistd.o                         
CC build\kernel\components\libc\compilers\common\cwchar.o                          
CC build\kernel\components\libc\compilers\newlib\syscalls.o                        
CC build\kernel\components\libc\posix\io\poll\poll.o                               
CC build\kernel\components\libc\posix\io\poll\select.o                             
CC build\kernel\components\net\lwip\lwip-2.0.3\src\api\api_lib.o                   
CC build\kernel\components\net\lwip\lwip-2.0.3\src\api\api_msg.o                   
CC build\kernel\components\net\lwip\lwip-2.0.3\src\api\err.o                       
CC build\kernel\components\net\lwip\lwip-2.0.3\src\api\netbuf.o                    
CC build\kernel\components\net\lwip\lwip-2.0.3\src\api\netdb.o                     
CC build\kernel\components\net\lwip\lwip-2.0.3\src\api\netifapi.o                  
CC build\kernel\components\net\lwip\lwip-2.0.3\src\api\sockets.o                   
CC build\kernel\components\net\lwip\lwip-2.0.3\src\api\tcpip.o                     
CC build\kernel\components\net\lwip\lwip-2.0.3\src\apps\ping\ping.o                
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\def.o                      
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\dns.o                      
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\inet_chksum.o              
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\init.o                     
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\ip.o                       
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\ipv4\autoip.o              
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\ipv4\dhcp.o                
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\ipv4\etharp.o              
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\ipv4\icmp.o                
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\ipv4\igmp.o                
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\ipv4\ip4.o                 
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\ipv4\ip4_addr.o            
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\ipv4\ip4_frag.o            
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\memp.o                     
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\netif.o                    
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\pbuf.o                     
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\raw.o                      
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\stats.o                    
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\sys.o                      
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\tcp.o                      
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\tcp_in.o                   
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\tcp_out.o                  
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\timeouts.o                 
CC build\kernel\components\net\lwip\lwip-2.0.3\src\core\udp.o                      
CC build\kernel\components\net\lwip\lwip-2.0.3\src\netif\ethernet.o                
CC build\kernel\components\net\lwip\lwip-2.0.3\src\netif\lowpan6.o                 
CC build\kernel\components\net\lwip\port\ethernetif.o                              
CC build\kernel\components\net\lwip\port\sys_arch.o                                
CC build\kernel\components\net\netdev\src\netdev.o                                 
CC build\kernel\components\net\netdev\src\netdev_ipaddr.o                          
CC build\kernel\components\net\sal\dfs_net\dfs_net.o                               
CC build\kernel\components\net\sal\impl\af_inet_lwip.o                             
CC build\kernel\components\net\sal\socket\net_netdb.o                              
CC build\kernel\components\net\sal\socket\net_sockets.o                            
CC build\kernel\components\net\sal\src\sal_socket.o                                
CC build\kernel\libcpu\arm\common\atomic_arm.o                                     
CC build\kernel\libcpu\arm\common\div0.o                                           
CC build\kernel\libcpu\arm\common\showmem.o                                        
AS build\kernel\libcpu\arm\cortex-m4\context_gcc.o                                 
CC build\kernel\libcpu\arm\cortex-m4\cpuport.o                                     
CC build\kernel\src\clock.o                                                        
CC build\kernel\src\components.o                                                   
CC build\kernel\src\cpu_up.o                                                       
CC build\kernel\src\defunct.o                                                      
CC build\kernel\src\idle.o                                                         
CC build\kernel\src\ipc.o                                                          
CC build\kernel\src\irq.o                                                          
CC build\kernel\src\klibc\kerrno.o                                                 
CC build\kernel\src\klibc\kstdio.o                                                 
CC build\kernel\src\klibc\kstring.o                                                
CC build\kernel\src\klibc\rt_vsnprintf_tiny.o                                      
CC build\kernel\src\klibc\rt_vsscanf.o                                             
CC build\kernel\src\kservice.o                                                     
CC build\kernel\src\mem.o                                                          
CC build\kernel\src\mempool.o                                                      
CC build\kernel\src\object.o                                                       
CC build\kernel\src\scheduler_comm.o                                               
CC build\kernel\src\scheduler_up.o                                                 
CC build\kernel\src\thread.o                                                       
CC build\kernel\src\timer.o                                                        
CC build\libraries\HAL_Drivers\drv_common.o                                        
AS packages\stm32f4_cmsis_driver-latest\Source\Templates\gcc\startup_stm32f407xx.o 
CC packages\stm32f4_cmsis_driver-latest\Source\Templates\system_stm32f4xx.o        
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal.o                          
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_cec.o                      
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_cortex.o                   
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_crc.o                      
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_cryp.o                     
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_cryp_ex.o                  
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_dma.o                      
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_dma_ex.o                   
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_gpio.o                     
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_i2c.o                      
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_i2c_ex.o                   
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_pwr.o                      
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_pwr_ex.o                   
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_rcc.o                      
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_rcc_ex.o                   
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_rng.o                      
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_uart.o                     
CC packages\stm32f4_hal_driver-latest\Src\stm32f4xx_hal_usart.o                    
CC E:\CODE\RTT\rt-thread\bsp\stm32\libraries\HAL_Drivers\drivers\drv_gpio.o        
CC E:\CODE\RTT\rt-thread\bsp\stm32\libraries\HAL_Drivers\drivers\drv_soft_i2c.o    
CC E:\CODE\RTT\rt-thread\bsp\stm32\libraries\HAL_Drivers\drivers\drv_usart.o       
LINK rt-thread.elf                                                                 
Memory region         Used Size  Region Size  %age Used                            
            CODE:      155520 B         1 MB     14.83%                            
            RAM1:       49324 B       128 KB     37.63%                            
            RAM2:          0 GB        64 KB      0.00%                            
MCUlcdgrambysram:          0 GB         1 MB      0.00%                            
arm-none-eabi-objcopy -O binary rt-thread.elf rtthread.bin                         
arm-none-eabi-size rt-thread.elf                                                   
   text    data     bss     dec     hex filename                                   
 155520    2148   47172  204840   32028 rt-thread.elf                              
scons: done building targets.                                                      
```

- 未修改代码再次编译
```sh                                     
(.venv) E:\CODE\RTT\rt-thread\bsp\stm32\stm32f407-atk-explorer 
$ scons --target=eclipse                                                           
scons: Reading SConscript files ...                                                
Newlib version: 4.1.0                                                              
Update eclipse setting...                                                          
done!                                                                              
                                                                                   
(.venv) E:\CODE\RTT\rt-thread\bsp\stm32\stm32f407-atk-explorer 
$ scons                                                                            
scons: Reading SConscript files ...                                                
Newlib version: 4.1.0                                                              
scons: done reading SConscript files.                                              
scons: Building targets ...                                                        
scons: building associated VariantDir targets: build                               
scons: `.' is up to date.                                                          
scons: done building targets.                                                                                                                            
```

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
  - N/A（本次修改仅涉及 `tools/targets/eclipse.py`，属于主机侧工程文件生成逻辑，不绑定特定 BSP）

- .config:
  - N/A（本次修改不依赖特定 `.config` 选项，未引入新的 Kconfig 配置项）

- action:
  - N/A（当前变更未提供 fork 仓库对应 action 链接；建议在个人分支触发一次相关构建后补充）

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)