### PR TITLE
[bsp][rk3500] fixup the PCIe INTx IRQ information

### DIFF
--- a/bsp/rockchip/dm/pci/pcie-dw-rockchip.c
+++ b/bsp/rockchip/dm/pci/pcie-dw-rockchip.c
@@ -165,6 +165,7 @@ struct rockchip_pcie
     struct rt_work hot_rst_work;
 
     int intx_irq;
+    int intx_cpu;
     rt_uint32_t intx;
     struct rt_ofw_node *intx_np;
     struct rt_pic intx_pic;
@@ -225,6 +226,7 @@ static void rockchip_pcie_intx_irq_unmask(struct rt_pic_irq *pirq)
 static int rockchip_pcie_intx_irq_map(struct rt_pic *pic, int hwirq, rt_uint32_t mode)
 {
     int irq;
+    struct rockchip_pcie *rk_pcie = pic->priv_data;
     struct rt_pic_irq *pirq = rt_pic_find_irq(pic, hwirq);
 
     if (pirq)
@@ -236,7 +238,8 @@ static int rockchip_pcie_intx_irq_map(struct rt_pic *pic, int hwirq, rt_uint32_t
         else
         {
             irq = rt_pic_config_irq(pic, hwirq, hwirq);
-            rt_pic_irq_set_triger_mode(irq, RT_IRQ_MODE_LEVEL_HIGH);
+            pirq->mode = mode;
+            RT_IRQ_AFFINITY_SET(pirq->affinity, rk_pcie->intx_cpu);
         }
     }
     else
@@ -1486,6 +1489,8 @@ static rt_err_t rockchip_pcie_dw_probe(struct rt_platform_device *pdev)
 
     if (rk_pcie->intx_irq >= 0)
     {
+        RT_IRQ_AFFINITY_DECLARE(intx_affinity);
+
         /* Legacy (INTx) init */
         if (!(intx_np = rt_ofw_get_child_by_tag(np, "legacy-interrupt-controller")))
         {
@@ -1505,6 +1510,11 @@ static rt_err_t rockchip_pcie_dw_probe(struct rt_platform_device *pdev)
 
         rt_hw_interrupt_install(rk_pcie->intx_irq, rockchip_pcie_legacy_isr, rk_pcie, "rk-pcie-legacy");
         rt_hw_interrupt_umask(rk_pcie->intx_irq);
+
+        if (!rt_pic_irq_get_affinity(rk_pcie->intx_irq, intx_affinity))
+        {
+            rk_pcie->intx_cpu = rt_bitmap_next_set_bit(intx_affinity, 0, RT_CPUS_NR);
+        }
     }
     else
     {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
fixup the PCIe INTx IRQ information

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
