### PR TITLE
feat[STM32][USART]: add uart error callback support

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.c
@@ -280,25 +280,39 @@ static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *ar
         {
 #ifdef RT_SERIAL_USING_DMA
             stm32_dma_config(serial, ctrl_arg);
+#else
+            return -RT_ENOSYS;
 #endif
         }
         else
-            stm32_control(serial, RT_DEVICE_CTRL_SET_INT, (void *)ctrl_arg);
+        {
+            return stm32_control(serial, RT_DEVICE_CTRL_SET_INT, (void *)ctrl_arg);
+        }
         break;
 
-    case RT_DEVICE_CHECK_OPTMODE: {
+    case RT_DEVICE_CHECK_OPTMODE:
+    {
         if (ctrl_arg & RT_DEVICE_FLAG_DMA_TX)
             return RT_SERIAL_TX_BLOCKING_NO_BUFFER;
         else
             return RT_SERIAL_TX_BLOCKING_BUFFER;
     }
     case RT_DEVICE_CTRL_CLOSE:
+    {
+        uart->error_indicate = RT_NULL;
         if (HAL_UART_DeInit(&(uart->handle)) != HAL_OK)
         {
             RT_ASSERT(0)
         }
         break;
     }
+    case UART_CTRL_SET_ERROR_CALLBACK:
+    {
+        uart->error_indicate = (rt_err_t (*)(rt_device_t dev, rt_uint32_t error_code))arg;
+        break;
+    }
+    }
+
     return RT_EOK;
 }
 
@@ -1242,6 +1256,10 @@ void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
     struct stm32_uart *uart = (struct stm32_uart *)huart;
     LOG_D("%s: %s %d\n", __FUNCTION__, uart->config->name, huart->ErrorCode);
     UNUSED(uart);
+    if(uart->error_indicate != RT_NULL)
+    {
+        uart->error_indicate(&uart->serial.parent, huart->ErrorCode);
+    }
 }
 
 /**
@@ -1304,12 +1322,13 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
 #endif /* RT_SERIAL_USING_DMA */
 
 static const struct rt_uart_ops stm32_uart_ops =
-    {
-        .configure = stm32_configure,
-        .control   = stm32_control,
-        .putc      = stm32_putc,
-        .getc      = stm32_getc,
-        .transmit  = stm32_transmit};
+{
+    .configure = stm32_configure,
+    .control   = stm32_control,
+    .putc      = stm32_putc,
+    .getc      = stm32_getc,
+    .transmit  = stm32_transmit
+};
 
 int rt_hw_usart_init(void)
 {

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.h
@@ -47,6 +47,7 @@ int rt_hw_usart_init(void);
 #define UART_RX_DMA_IT_HT_FLAG          0x01
 #define UART_RX_DMA_IT_TC_FLAG          0x02
 
+#define UART_CTRL_SET_ERROR_CALLBACK    0x100
 
 /* stm32 config class */
 struct stm32_uart_config
@@ -66,7 +67,8 @@ struct stm32_uart
 {
     UART_HandleTypeDef handle;
     struct stm32_uart_config *config;
-
+    /* device call back */
+    rt_err_t (*error_indicate)(rt_device_t dev, rt_uint32_t error_code);
 #ifdef RT_SERIAL_USING_DMA
     struct
     {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

STM32 USART V2 驱动当前缺少设备级错误回调注册与上报能力，上层很难在 HAL UART 错误回调触发时感知具体错误并执行恢复逻辑。同时，`RT_DEVICE_CTRL_CONFIG` 在非 DMA 构建下请求 DMA 模式时没有显式返回不支持错误码，非 DMA 分支回退到 `RT_DEVICE_CTRL_SET_INT` 时也没有向上传递返回值，导致控制路径语义不够明确。

#### 你的解决方案是什么 (what is your solution)

本 PR 为 STM32 USART V2 驱动新增 `UART_CTRL_SET_ERROR_CALLBACK` 控制命令，并在 `struct stm32_uart` 中增加 `error_indicate` 回调指针，用于注册设备级 UART 错误回调。  
在 `HAL_UART_ErrorCallback()` 中，当回调已注册时调用上层错误通知接口，并在设备关闭路径中先将回调清空再执行 `HAL_UART_DeInit()`，避免关闭过程中继续使用旧回调。  
同时补充控制路径返回值处理：当未启用 DMA 支持却请求 DMA 模式时显式返回 `-RT_ENOSYS`；非 DMA 分支回退到 `RT_DEVICE_CTRL_SET_INT` 时直接返回其处理结果。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
  - 待补充

- .config:
  - 本补丁未新增 Kconfig 选项
  - 待补充用于验证的现有 UART 相关配置

- action:
  - 待补充

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)