### PR TITLE
fix[STM32][I2C]: allow INT and DMA flags to coexist in hard i2c config

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
@@ -650,19 +650,21 @@ static void stm32_get_info(void)
 
 #if defined (BSP_I2C1_TX_USING_INT)
     i2c_objs[I2C1_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_INT_TX;
-#elif defined(BSP_I2C1_TX_USING_DMA)
+#endif /* defined (BSP_I2C1_TX_USING_INT) */
+#if defined(BSP_I2C1_TX_USING_DMA)
     i2c_objs[I2C1_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
     static struct dma_config I2C1_dma_tx = I2C1_TX_DMA_CONFIG;
     i2c_config[I2C1_INDEX].dma_tx = &I2C1_dma_tx;
-#endif /* defined (BSP_I2C1_TX_USING_INT) */
+#endif /* defined (BSP_I2C1_TX_USING_DMA) */
 
 #if defined (BSP_I2C1_RX_USING_INT)
     i2c_objs[I2C1_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_INT_RX;
-#elif defined(BSP_I2C1_RX_USING_DMA)
+#endif /* defined (BSP_I2C1_RX_USING_INT) */
+#if defined(BSP_I2C1_RX_USING_DMA)
     i2c_objs[I2C1_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
     static struct dma_config I2C1_dma_rx = I2C1_RX_DMA_CONFIG;
     i2c_config[I2C1_INDEX].dma_rx = &I2C1_dma_rx;
-#endif /* defined (BSP_I2C1_RX_USING_INT) */
+#endif /* defined (BSP_I2C1_RX_USING_DMA) */
 
 #endif /* defined(BSP_USING_HARD_I2C1) */
 
@@ -671,19 +673,21 @@ static void stm32_get_info(void)
 
 #if defined (BSP_I2C2_TX_USING_INT)
     i2c_objs[I2C2_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_INT_TX;
-#elif defined(BSP_I2C2_TX_USING_DMA)
+#endif /* defined (BSP_I2C2_TX_USING_INT) */
+#if defined(BSP_I2C2_TX_USING_DMA)
     i2c_objs[I2C2_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
     static struct dma_config I2C2_dma_tx = I2C2_TX_DMA_CONFIG;
     i2c_config[I2C2_INDEX].dma_tx = &I2C2_dma_tx;
-#endif /* defined (BSP_I2C2_TX_USING_INT) */
+#endif /* defined (BSP_I2C2_TX_USING_DMA) */
 
 #if defined (BSP_I2C2_RX_USING_INT)
     i2c_objs[I2C2_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_INT_RX;
-#elif defined(BSP_I2C2_RX_USING_DMA)
+#endif /* defined (BSP_I2C2_RX_USING_INT) */
+#if defined(BSP_I2C2_RX_USING_DMA)
     i2c_objs[I2C2_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
     static struct dma_config I2C2_dma_rx = I2C2_RX_DMA_CONFIG;
     i2c_config[I2C2_INDEX].dma_rx = &I2C2_dma_rx;
-#endif /* defined (BSP_I2C2_RX_USING_INT) */
+#endif /* defined (BSP_I2C2_RX_USING_DMA) */
 
 #endif /* defined(BSP_USING_HARD_I2C2) */
 
@@ -692,19 +696,21 @@ static void stm32_get_info(void)
 
 #if defined (BSP_I2C3_TX_USING_INT)
     i2c_objs[I2C3_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_INT_TX;
-#elif defined(BSP_I2C3_TX_USING_DMA)
+#endif /* defined (BSP_I2C3_TX_USING_INT) */
+#if defined(BSP_I2C3_TX_USING_DMA)
     i2c_objs[I2C3_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
     static struct dma_config I2C3_dma_tx = I2C3_TX_DMA_CONFIG;
     i2c_config[I2C3_INDEX].dma_tx = &I2C3_dma_tx;
-#endif /* defined (BSP_I2C3_TX_USING_INT) */
+#endif /* defined (BSP_I2C3_TX_USING_DMA) */
 
 #if defined (BSP_I2C3_RX_USING_INT)
     i2c_objs[I2C3_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_INT_RX;
-#elif defined(BSP_I2C3_RX_USING_DMA)
+#endif /* defined (BSP_I2C3_RX_USING_INT) */
+#if defined(BSP_I2C3_RX_USING_DMA)
     i2c_objs[I2C3_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
     static struct dma_config I2C3_dma_rx = I2C3_RX_DMA_CONFIG;
     i2c_config[I2C3_INDEX].dma_rx = &I2C3_dma_rx;
-#endif /* defined (BSP_I2C3_RX_USING_INT) */
+#endif /* defined (BSP_I2C3_RX_USING_DMA) */
 
 #endif /* defined(BSP_USING_HARD_I2C3) */
 
@@ -713,19 +719,21 @@ static void stm32_get_info(void)
 
 #if defined (BSP_I2C4_TX_USING_INT)
     i2c_objs[I2C4_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_INT_TX;
-#elif defined(BSP_I2C4_TX_USING_DMA)
+#endif /* defined (BSP_I2C4_TX_USING_INT) */
+#if defined(BSP_I2C4_TX_USING_DMA)
     i2c_objs[I2C4_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
     static struct dma_config I2C4_dma_tx = I2C4_TX_DMA_CONFIG;
     i2c_config[I2C4_INDEX].dma_tx = &I2C4_dma_tx;
-#endif /* defined (BSP_I2C4_TX_USING_INT) */
+#endif /* defined (BSP_I2C4_TX_USING_DMA) */
 
 #if defined (BSP_I2C4_RX_USING_INT)
     i2c_objs[I2C4_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_INT_RX;
-#elif defined(BSP_I2C4_RX_USING_DMA)
+#endif /* defined (BSP_I2C4_RX_USING_INT) */
+#if defined(BSP_I2C4_RX_USING_DMA)
     i2c_objs[I2C4_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
     static struct dma_config I2C4_dma_rx = I2C4_RX_DMA_CONFIG;
     i2c_config[I2C4_INDEX].dma_rx = &I2C4_dma_rx;
-#endif /* defined (BSP_I2C4_RX_USING_INT) */
+#endif /* defined (BSP_I2C4_RX_USING_DMA) */
 
 #endif /* defined(BSP_USING_HARD_I2C4) */
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

当前 `stm32_get_info()` 中 I2C1、I2C3 和 I2C4 的 TX/RX 宏配置仍使用 `INT` 与 `DMA` 的 `#elif` 互斥分支。启用 `BSP_I2C*_TX_USING_INT` 或 `BSP_I2C*_RX_USING_INT` 后，会屏蔽对应的 DMA 标志和 DMA 配置，导致一旦启用 INT 就无法继续使用 DMA。

#### 你的解决方案是什么 (what is your solution)

将 I2C1、I2C3 和 I2C4 的 TX/RX 配置改为与 I2C2 一致的独立 `#if` 判断，分别累计 `RT_DEVICE_FLAG_INT_*` 与 `RT_DEVICE_FLAG_DMA_*`，并在启用 DMA 时继续保留 `dma_tx` / `dma_rx` 配置。这样在同时打开 INT 和 DMA 宏时，运行时仍可按现有逻辑优先选择 DMA，在不满足 DMA 条件时回退到 IT 路径。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
  - 未提供，提交前建议补充本次验证所使用的 STM32 BSP 路径

- .config:
  - `CONFIG_BSP_USING_HARD_I2C`
  - `CONFIG_BSP_I2C_USING_IRQ`
  - 对应 I2C 实例同时开启 `BSP_I2C*_TX_USING_INT` 和 `BSP_I2C*_TX_USING_DMA`
  - 对应 I2C 实例同时开启 `BSP_I2C*_RX_USING_INT` 和 `BSP_I2C*_RX_USING_DMA`

- action:
  - 未提供，提交前建议补充 PR 分支对应 action 编译链接

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)