### PR TITLE
[HUST CSE][drivers][watchdog] validate i6300esb timeout bounds and null timeout args

### DIFF
--- a/components/drivers/watchdog/watchdog-i6300esb.c
+++ b/components/drivers/watchdog/watchdog-i6300esb.c
@@ -111,6 +111,11 @@ static rt_err_t i6300esb_timer_set_heartbeat(struct i6300esb_wdt *esb, rt_uint32
 {
     rt_uint32_t val;
 
+    if ((time < ESB_HEARTBEAT_MIN) || (time > ESB_HEARTBEAT_MAX))
+    {
+        return -RT_EINVAL;
+    }
+
     /*
      * We shift by 9, so if we are passed a value of 1 sec,
      * val will be 1 << 9 = 512, then write that to two
@@ -152,6 +157,11 @@ static rt_err_t i6300esb_wdt_control(rt_watchdog_t *wdt, int cmd, void *args)
         break;
 
     case RT_DEVICE_CTRL_WDT_SET_TIMEOUT:
+        if (args == RT_NULL)
+        {
+            err = -RT_EINVAL;
+            break;
+        }
         err = i6300esb_timer_set_heartbeat(esb, *(rt_uint32_t *)args);
         break;
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

当前 i6300esb watchdog 驱动在设置超时时间时缺少必要的运行时输入校验。旧实现直接解引用 `RT_DEVICE_CTRL_WDT_SET_TIMEOUT` 传入的 `args`，当调用方传入空指针时会触发空指针解引用；同时 `i6300esb_timer_set_heartbeat()` 对 `time` 没有做范围检查，非法超时时间会继续参与左移并写入硬件寄存器，导致 watchdog 配置失真。

#### 你的解决方案是什么 (what is your solution)

本 PR 在 `components/drivers/watchdog/watchdog-i6300esb.c` 中补上了两类运行时校验：

1. 对 `RT_DEVICE_CTRL_WDT_SET_TIMEOUT` 增加空指针检查：
   - 当 `args == RT_NULL` 时，直接返回 `-RT_EINVAL`；
   - 避免旧版本里对 `*(rt_uint32_t *)args` 的直接解引用。

2. 对 watchdog timeout 增加边界检查：
   - 在 `i6300esb_timer_set_heartbeat()` 中显式校验 `time` 是否位于 `ESB_HEARTBEAT_MIN` 和 `ESB_HEARTBEAT_MAX` 之间；
   - 对于 `0`、超过硬件允许范围的值以及其他异常输入，直接返回 `-RT_EINVAL`，不再继续写寄存器。

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: 暂无

- .config: 无（本次修改未新增 Kconfig 开关，也未改动现有配置项）

- action: 暂无

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
