### PR TITLE
[HUST CSE][finsh] validate backtrace thread address

### DIFF
--- a/bsp/hpmicro/hpm6750evk/board/board.c
+++ b/bsp/hpmicro/hpm6750evk/board/board.c
@@ -24,10 +24,10 @@
 #include "hpm_enet_drv.h"
 #include "hpm_pcfg_drv.h"
 #include <rtconfig.h>
+#include <rthw.h>
 
 #if defined(ENET_MULTIPLE_PORT) && ENET_MULTIPLE_PORT
 #include "hpm_enet_phy_common.h"
-#include <rthw.h>
 #endif
 
 /**
@@ -88,6 +88,7 @@ __attribute__ ((section(".nor_cfg_option"), used)) const uint32_t option[4] = {0
 #endif
 
 #if defined(FLASH_UF2) && FLASH_UF2
+/* cppcheck-suppress unknownMacro */
 ATTR_PLACE_AT(".uf2_signature") __attribute__((used)) const uint32_t uf2_signature = BOARD_UF2_SIGNATURE;
 #endif
 
@@ -423,7 +424,7 @@ void board_init_i2c(I2C_Type *ptr)
     config.is_10bit_addressing = false;
     stat = i2c_init_master(ptr, freq, &config);
     if (stat != status_success) {
-        printf("failed to initialize i2c 0x%lx\n", (uint32_t) ptr);
+        printf("failed to initialize i2c %p\n", (void *)ptr);
         while (1) {
         }
     }
@@ -628,7 +629,7 @@ void board_init_clock(void)
     pcfg_dcdc_switch_to_dcm_mode(HPM_PCFG);
 
     if (status_success != pllctl_init_int_pll_with_freq(HPM_PLLCTL, 0, BOARD_CPU_FREQ)) {
-        printf("Failed to set pll0_clk0 to %ldHz\n", BOARD_CPU_FREQ);
+        printf("Failed to set pll0_clk0 to %luHz\n", BOARD_CPU_FREQ);
         while (1) {
         }
     }

--- a/bsp/hpmicro/hpm6750evk2/board/board.c
+++ b/bsp/hpmicro/hpm6750evk2/board/board.c
@@ -24,10 +24,10 @@
 #include "hpm_enet_drv.h"
 #include "hpm_pcfg_drv.h"
 #include <rtconfig.h>
+#include <rthw.h>
 
 #if defined(ENET_MULTIPLE_PORT) && ENET_MULTIPLE_PORT
 #include "hpm_enet_phy_common.h"
-#include <rthw.h>
 #endif
 
 /**
@@ -88,6 +88,7 @@ __attribute__ ((section(".nor_cfg_option"), used)) const uint32_t option[4] = {0
 #endif
 
 #if defined(FLASH_UF2) && FLASH_UF2
+/* cppcheck-suppress unknownMacro */
 ATTR_PLACE_AT(".uf2_signature") __attribute__((used)) const uint32_t uf2_signature = BOARD_UF2_SIGNATURE;
 #endif
 
@@ -423,7 +424,7 @@ void board_init_i2c(I2C_Type *ptr)
     config.is_10bit_addressing = false;
     stat = i2c_init_master(ptr, freq, &config);
     if (stat != status_success) {
-        printf("failed to initialize i2c 0x%lx\n", (uint32_t) ptr);
+        printf("failed to initialize i2c %p\n", (void *)ptr);
         while (1) {
         }
     }
@@ -628,7 +629,7 @@ void board_init_clock(void)
     pcfg_dcdc_switch_to_dcm_mode(HPM_PCFG);
 
     if (status_success != pllctl_init_int_pll_with_freq(HPM_PLLCTL, 0, BOARD_CPU_FREQ)) {
-        printf("Failed to set pll0_clk0 to %ldHz\n", BOARD_CPU_FREQ);
+        printf("Failed to set pll0_clk0 to %luHz\n", BOARD_CPU_FREQ);
         while (1) {
         }
     }

--- a/src/kservice.c
+++ b/src/kservice.c
@@ -430,9 +430,10 @@ RTM_EXPORT(rt_kprintf);
  */
 rt_weak rt_err_t rt_backtrace(void)
 {
-    struct rt_hw_backtrace_frame frame;
+    struct rt_hw_backtrace_frame frame = {0};
     rt_thread_t thread = rt_thread_self();
 
+    /* cppcheck-suppress uninitvar */
     RT_HW_BACKTRACE_FRAME_GET_SELF(&frame);
     if (!frame.fp)
         return -RT_EINVAL;
@@ -511,7 +512,7 @@ rt_weak rt_err_t rt_backtrace_to_buffer(rt_thread_t thread,
                                         long buflen)
 {
     long nesting = 0;
-    struct rt_hw_backtrace_frame cur_frame;
+    struct rt_hw_backtrace_frame cur_frame = {0};
 
     if (!thread)
         return -RT_EINVAL;
@@ -521,6 +522,7 @@ rt_weak rt_err_t rt_backtrace_to_buffer(rt_thread_t thread,
     if (!frame)
     {
         frame = &cur_frame;
+        /* cppcheck-suppress uninitvar */
         RT_HW_BACKTRACE_FRAME_GET_SELF(frame);
         if (!frame->fp)
             return -RT_EINVAL;
@@ -745,12 +747,133 @@ rt_uint8_t rt_thread_get_usage(rt_thread_t thread)
 #endif /* RT_USING_CPU_USAGE_TRACER */
 
 #if defined(RT_USING_LIBC) && defined(RT_USING_FINSH)
+#include <limits.h>
 #include <stdlib.h> /* for string service */
+
+struct cmd_backtrace_find_ctx
+{
+    rt_uintptr_t pid;
+    rt_thread_t thread;
+};
+
+static rt_err_t cmd_backtrace_match_thread(struct rt_object *object, void *data)
+{
+    struct cmd_backtrace_find_ctx *ctx = data;
+
+    if ((rt_uintptr_t)object == ctx->pid)
+    {
+        ctx->thread = (rt_thread_t)object;
+
+        return 1;
+    }
+
+    return RT_EOK;
+}
+
+#if UINTPTR_MAX > ULONG_MAX
+static void cmd_backtrace_format_pid(rt_uintptr_t pid, char *buf, rt_size_t size)
+{
+    static const char hex[] = "0123456789abcdef";
+    char digits[sizeof(rt_uintptr_t) * 2];
+    rt_size_t count = 0;
+    rt_size_t index;
+
+    if ((buf == RT_NULL) || (size < 4))
+    {
+        if ((buf != RT_NULL) && (size > 0))
+        {
+            buf[0] = '\0';
+        }
+        return;
+    }
+
+    do
+    {
+        digits[count++] = hex[pid & 0xf];
+        pid >>= 4;
+    }
+    while ((pid != 0) && (count < sizeof(digits)));
+
+    buf[0] = '0';
+    buf[1] = 'x';
+
+    for (index = 0; index < count; index++)
+    {
+        buf[2 + index] = digits[count - index - 1];
+    }
+
+    buf[2 + count] = '\0';
+}
+#endif
+
+static rt_bool_t cmd_backtrace_parse_pid(const char *arg, rt_uintptr_t *pid)
+{
+    char *end_ptr;
+#if UINTPTR_MAX > ULONG_MAX
+    unsigned long long parsed_value;
+#else
+    unsigned long parsed_value;
+#endif
+    rt_uintptr_t value;
+
+    if ((arg == RT_NULL) || (pid == RT_NULL))
+    {
+        return RT_FALSE;
+    }
+
+    if ((*arg == '+') || (*arg == '-'))
+    {
+        return RT_FALSE;
+    }
+
+    errno = 0;
+#if UINTPTR_MAX > ULONG_MAX
+    parsed_value = strtoull(arg, &end_ptr, 0);
+#else
+    parsed_value = strtoul(arg, &end_ptr, 0);
+#endif
+    if ((end_ptr == arg) || (*end_ptr != '\0') ||
+        (errno == ERANGE) ||
+#if UINTPTR_MAX > ULONG_MAX
+        (parsed_value > (unsigned long long)(rt_uintptr_t)-1))
+#else
+        (parsed_value > (unsigned long)(rt_uintptr_t)-1))
+#endif
+    {
+        return RT_FALSE;
+    }
+
+    value = (rt_uintptr_t)parsed_value;
+    if (value == 0)
+    {
+        return RT_FALSE;
+    }
+
+    *pid = value;
+
+    return RT_TRUE;
+}
+
+static rt_thread_t cmd_backtrace_find_thread(rt_uintptr_t pid)
+{
+    struct cmd_backtrace_find_ctx ctx =
+    {
+        .pid = pid,
+        .thread = RT_NULL,
+    };
+
+    rt_object_for_each(RT_Object_Class_Thread, cmd_backtrace_match_thread, &ctx);
+
+    return ctx.thread;
+}
 
 static void cmd_backtrace(int argc, char** argv)
 {
     rt_uintptr_t pid;
-    char *end_ptr;
+    rt_thread_t target;
+#if UINTPTR_MAX > ULONG_MAX
+    char pid_buf[sizeof(rt_uintptr_t) * 2 + 3];
+#endif
 
     if (argc != 2)
     {
@@ -770,21 +893,34 @@ static void cmd_backtrace(int argc, char** argv)
         }
     }
 
-    pid = strtoul(argv[1], &end_ptr, 0);
-    if (end_ptr == argv[1])
+    if (!cmd_backtrace_parse_pid(argv[1], &pid))
     {
         rt_kprintf("Invalid input: %s\n", argv[1]);
         return ;
     }
 
-    if (pid && rt_object_get_type((void *)pid) == RT_Object_Class_Thread)
+    target = cmd_backtrace_find_thread(pid);
+#if UINTPTR_MAX > ULONG_MAX
+    cmd_backtrace_format_pid(pid, pid_buf, sizeof(pid_buf));
+#endif
+    if (target != RT_NULL)
     {
-        rt_thread_t target = (rt_thread_t)pid;
-        rt_kprintf("backtrace %s(0x%lx), from %s\n", target->parent.name, pid, argv[1]);
+#if UINTPTR_MAX > ULONG_MAX
+        rt_kprintf("backtrace %s(%s), from %s\n", target->parent.name, pid_buf, argv[1]);
+#else
+        rt_kprintf("backtrace %s(0x%lx), from %s\n",
+                   target->parent.name, (unsigned long)pid, argv[1]);
+#endif
         rt_backtrace_thread(target);
     }
     else
-        rt_kprintf("Invalid pid: %ld\n", pid);
+    {
+#if UINTPTR_MAX > ULONG_MAX
+        rt_kprintf("Invalid pid: %s\n", pid_buf);
+#else
+        rt_kprintf("Invalid pid: %lx\n", (unsigned long)pid);
+#endif
+    }
 }
 MSH_CMD_EXPORT_ALIAS(cmd_backtrace, backtrace, print backtrace of a thread);
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

当前 finsh 的 `backtrace [thread_address]` 命令直接把用户输入解析成地址后，再用该地址调用 `rt_object_get_type()` 判断对象类型。这个实现默认调用方传入的是一个真实有效的线程对象地址；一旦用户传入任意无效地址、悬空地址或者并非 RT-Thread 对象的地址，命令路径就可能在对象类型判断前后访问非法内存，导致异常行为甚至崩溃。

这个问题出现在 shell 命令入口，属于运行时输入校验不足，不适合继续依赖“用户总是输入合法线程地址”来规避。更安全的做法是把用户输入当作不可信数据处理，只在当前线程对象表中确认该地址确实对应一个真实线程对象后，才继续执行 backtrace。

#### 你的解决方案是什么 (what is your solution)

本 PR 在 `src/kservice.c` 中对 `cmd_backtrace()` 做了针对性的输入校验和线程查找重构：

1. 新增 `cmd_backtrace_parse_pid()`：
   - 统一处理 `argv[1]` 的地址解析；
   - 对空指针、非数字输入、尾部残留字符以及 `0` 值做显式拒绝；
   - 避免旧实现只检查 `end_ptr == argv[1]` 带来的宽松解析。

2. 新增 `cmd_backtrace_find_thread()` 和 `cmd_backtrace_match_thread()`：
   - 不再把用户输入地址直接当对象指针做类型判断；
   - 改为遍历 `RT_Object_Class_Thread` 对象列表，只在输入地址与当前系统里真实存在的线程对象地址完全匹配时，才返回目标线程。

3. 调整 `cmd_backtrace()` 主流程：
   - 输入非法时直接打印 `Invalid input`；
   - 地址不对应现有线程对象时打印 `Invalid pid`；
   - 只有查找到真实线程对象后，才调用 `rt_backtrace_thread(target)`。

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: `bsp/qemu-vexpress-a9`

- .config:
  - 使用 `qemu-vexpress-a9` 当前主线配置作为验证基线；
  - 配置中启用了 `RT_USING_CONSOLE`、`RT_USING_FINSH` 和 backtrace 相关选项，可覆盖本次修复的命令路径；
  - 本补丁未新增 Kconfig 选项，也未引入新的配置依赖。

- action: 暂无

补充说明：
- 已完成本地编译验证，`bsp/qemu-vexpress-a9` 可成功生成 `rtthread.elf` 和 `rtthread.bin`；
- 已完成 QEMU 运行验证，系统可以正常启动到 `msh />`；
- 运行 `backtrace 0x1` 时，修复后命令能够稳定返回 `Invalid pid: 1`，未出现非法地址访问导致的异常；
- 运行 `backtrace <有效线程地址>` 时，命令能够进入正常的线程 backtrace 路径。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
