### PR TITLE
[HUST CSE][components][finsh]reset shell line state on overflow

### DIFF
--- a/components/finsh/shell.c
+++ b/components/finsh/shell.c
@@ -457,6 +457,38 @@ static void shell_push_history(struct finsh_shell *shell)
 }
 #endif
 
+static void finsh_shell_reset_line(struct finsh_shell *shell)
+{
+    rt_memset(shell->line, 0, sizeof(shell->line));
+    shell->line_position = 0;
+    shell->line_curpos = 0;
+}
+
+static rt_bool_t finsh_shell_check_line(struct finsh_shell *shell)
+{
+    if ((shell->line_position > FINSH_CMD_SIZE) ||
+        (shell->line_curpos > shell->line_position))
+    {
+        finsh_shell_reset_line(shell);
+
+        return RT_FALSE;
+    }
+
+    shell->line[FINSH_CMD_SIZE] = '\0';
+
+    return RT_TRUE;
+}
+
+static void finsh_shell_update_line_length(struct finsh_shell *shell)
+{
+    rt_size_t length;
+
+    shell->line[FINSH_CMD_SIZE] = '\0';
+    length = rt_strnlen(shell->line, FINSH_CMD_SIZE);
+    shell->line[length] = '\0';
+    shell->line_curpos = shell->line_position = (rt_uint16_t)length;
+}
+
 #if defined(FINSH_USING_WORD_OPERATION)
 static int find_prev_word_start(const char *line, int curpos)
 {
@@ -683,6 +715,12 @@ static void finsh_thread_entry(void *parameter)
 #if defined(FINSH_USING_FUNC_EXT)
             else if (ch >= 0x31 && ch <= 0x34) /* home(0x31), insert(0x32), del(0x33), end(0x34) */
             {
+                if (shell->line_position >= FINSH_CMD_SIZE)
+                {
+                    finsh_shell_reset_line(shell);
+                    continue;
+                }
+
                 shell->stat                           = WAIT_EXT_KEY;
                 shell->line[shell->line_position + 1] = ch; /* store the key code */
                 continue;
@@ -714,7 +752,8 @@ static void finsh_thread_entry(void *parameter)
                 else if (key_code == 0x33) /* del key */
                 {
                     /* delete character at current cursor position */
-                    if (shell->line_curpos < shell->line_position)
+                    if (finsh_shell_check_line(shell) &&
+                        (shell->line_curpos < shell->line_position))
                     {
                         int i;
                         shell->line_position--;
@@ -745,6 +784,9 @@ static void finsh_thread_entry(void *parameter)
 #endif /*defined(FINSH_USING_FUNC_EXT) */
         }
 
+        if (!finsh_shell_check_line(shell))
+            continue;
+
         /* received null or error */
         if (ch == '\0' || ch == 0xFF) continue;
         /* handle tab key */
@@ -758,7 +800,7 @@ static void finsh_thread_entry(void *parameter)
             /* auto complete */
             shell_auto_complete(&shell->line[0]);
             /* re-calculate position */
-            shell->line_curpos = shell->line_position = (rt_uint16_t)rt_strlen(shell->line);
+            finsh_shell_update_line_length(shell);
 
             continue;
         }
@@ -843,14 +885,16 @@ static void finsh_thread_entry(void *parameter)
             msh_exec(shell->line, shell->line_position);
 
             rt_kprintf("%s", FINSH_PROMPT);
-            rt_memset(shell->line, 0, sizeof(shell->line));
-            shell->line_curpos = shell->line_position = 0;
+            finsh_shell_reset_line(shell);
             continue;
         }
 
         /* it's a large line, discard it */
         if (shell->line_position >= FINSH_CMD_SIZE)
-            shell->line_position = 0;
+        {
+            finsh_shell_reset_line(shell);
+            continue;
+        }
 
         /* normal character */
         if (shell->line_curpos < shell->line_position)
@@ -899,8 +943,7 @@ static void finsh_thread_entry(void *parameter)
         if (shell->line_position >= FINSH_CMD_SIZE)
         {
             /* clear command line */
-            shell->line_position = 0;
-            shell->line_curpos = 0;
+            finsh_shell_reset_line(shell);
         }
     } /* end of device read */
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

当前 finsh 行编辑状态在超长输入场景下缺少一致性保护。旧实现里，852行当命令行长度达到 `FINSH_CMD_SIZE` 上限后，部分路径只重置 `line_position`，没有同时清理 `line` 缓冲区和 `line_curpos`；同时，扩展按键、删除键和自动补全等路径也默认 `line_position`、`line_curpos` 与 `line[]` 内容始终保持一致。一旦超长输入把这几个状态拉偏，后续编辑流程就可能在错误位置继续读写命令行缓冲区，带来异常行为。虽然原代码在字符追加之后进行了再次检查，但是没有清楚原先line[]缓冲区里的字符，导致可以在清除过后通过自动补全让命令行进入坏状态，

#### 你的解决方案是什么 (what is your solution)

本 PR 在 `components/finsh/shell.c` 中补上了 line edit 状态复位与一致性检查：

1. 新增 `finsh_shell_reset_line()`：
   - 统一清空 `shell->line`；
   - 同时把 `line_position` 和 `line_curpos` 一起复位到 0；
   - 替代旧代码里多处只重置部分状态的分散实现。

2. 新增 `finsh_shell_check_line()`：
   - 在处理普通输入之前校验 `line_position <= FINSH_CMD_SIZE`；
   - 校验 `line_curpos <= line_position`；
   - 一旦状态不一致，立即调用 `finsh_shell_reset_line()` 并终止本轮处理；
   - 同时强制写入 `shell->line[FINSH_CMD_SIZE] = '\0'`，保证后续字符串操作有受控边界。

3. 新增 `finsh_shell_update_line_length()`：
   - 自动补全后不再直接用 `rt_strlen(shell->line)` 回填位置；
   - 改为使用 `rt_strnlen(shell->line, FINSH_CMD_SIZE)` 重新计算长度，避免对命令行缓冲区的越界扫描假设。

4. 调整 overflow 和扩展按键路径：
   - 在扩展按键进入 `WAIT_EXT_KEY` 之前，若命令行已满，直接复位整行状态；
   - 删除键路径在执行删除前先调用 `finsh_shell_check_line()`；
   - 回车执行后、普通字符输入后、以及“大行丢弃”路径里，都统一改为使用 `finsh_shell_reset_line()`，避免只重置一半状态。

这个修复没有改动 finsh 的外部命令接口，也没有改写整套行编辑逻辑，只是把原来“overflow 后状态可能残留不一致”的路径集中收敛成统一复位和显式边界检查，从而让后续编辑流程在异常输入后回到干净状态。

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: `bsp/qemu-vexpress-a9`

- .config:
  - 使用 `qemu-vexpress-a9` 当前主线配置作为验证基线；
  - 配置中启用了 `RT_USING_CONSOLE` 和 `RT_USING_FINSH`，可以覆盖本次修复的 shell 行编辑路径；
  - 本补丁未新增 Kconfig 选项，也未引入新的功能开关。

- action: 暂无

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
