### PR TITLE
[HUST CSE] dfs:fix uninitialized 9pfs protocol lookup

### DIFF
--- a/components/dfs/dfs_v1/filesystems/9pfs/dfs_9pfs.c
+++ b/components/dfs/dfs_v1/filesystems/9pfs/dfs_9pfs.c
@@ -31,9 +31,9 @@
 #define ORCLOSE 64      /* or'ed in, remove on close */
 #define OAPPEND 128     /* or'ed in, append */
 
-#define NOTAG   ((rt_uint16_t)~0)
-#define NOFID   ((rt_uint32_t)~0)
-#define TAG     1
+#define NOTAG ((rt_uint16_t)~0)
+#define NOFID ((rt_uint32_t)~0)
+#define TAG   1
 
 static rt_list_t _protocol_nodes = RT_LIST_OBJECT_INIT(_protocol_nodes);
 static struct rt_spinlock _protocol_lock = { 0 };
@@ -45,37 +45,37 @@ static struct rt_spinlock _protocol_lock = { 0 };
 #define rt_cpu_to_le8
 #endif
 
-#define P9_OF_OPS_GET(width, dir) \
-rt_inline rt_uint##width##_t get_##dir##_##value##width##_of(   \
-        struct p9_connection *conn, unsigned idx)               \
-{                                                               \
-    rt_uint##width##_t *vp = (void *)&conn->dir##_buffer[idx];  \
-    return rt_le##width##_to_cpu(*vp);                          \
-}
+#define P9_OF_OPS_GET(width, dir)                                  \
+    rt_inline rt_uint##width##_t get_##dir##_##value##width##_of(  \
+        struct p9_connection *conn, unsigned idx)                  \
+    {                                                              \
+        rt_uint##width##_t *vp = (void *)&conn->dir##_buffer[idx]; \
+        return rt_le##width##_to_cpu(*vp);                         \
+    }
 
-#define P9_OF_OPS_PUT(width, dir) \
-rt_inline void put_##dir##_##value##width##_of(                 \
-        struct p9_connection *conn, unsigned idx,               \
-        rt_uint##width##_t value)                               \
-{                                                               \
-    rt_uint##width##_t *vp = (void *)&conn->dir##_buffer[idx];  \
-    *vp = rt_cpu_to_le##width(value);                           \
-}
+#define P9_OF_OPS_PUT(width, dir)                                  \
+    rt_inline void put_##dir##_##value##width##_of(                \
+        struct p9_connection *conn, unsigned idx,                  \
+        rt_uint##width##_t value)                                  \
+    {                                                              \
+        rt_uint##width##_t *vp = (void *)&conn->dir##_buffer[idx]; \
+        *vp = rt_cpu_to_le##width(value);                          \
+    }
 
-#define P9_OPS_PUT(width) \
-rt_inline rt_off_t put_value##width(struct p9_connection *conn, \
-        rt_off_t off, rt_uint##width##_t value)                 \
-{                                                               \
-    ((rt_uint##width##_t *)(conn->tx_buffer + off))[0] =        \
-            rt_cpu_to_le##width(value);                         \
-    return off + sizeof(value);                                 \
-}
+#define P9_OPS_PUT(width)                                                       \
+    rt_inline rt_off_t put_value##width(struct p9_connection *conn,             \
+                                        rt_off_t off, rt_uint##width##_t value) \
+    {                                                                           \
+        ((rt_uint##width##_t *)(conn->tx_buffer + off))[0] =                    \
+            rt_cpu_to_le##width(value);                                         \
+        return off + sizeof(value);                                             \
+    }
 
-#define P9_OPS_GROUP(width)     \
-    P9_OF_OPS_GET(width, rx)    \
-    P9_OF_OPS_GET(width, tx)    \
-    P9_OF_OPS_PUT(width, rx)    \
-    P9_OF_OPS_PUT(width, tx)    \
+#define P9_OPS_GROUP(width)  \
+    P9_OF_OPS_GET(width, rx) \
+    P9_OF_OPS_GET(width, tx) \
+    P9_OF_OPS_PUT(width, rx) \
+    P9_OF_OPS_PUT(width, tx) \
     P9_OPS_PUT(width)
 
 P9_OPS_GROUP(8)
@@ -88,7 +88,7 @@ P9_OPS_GROUP(64)
 #undef P9_OPS_GROUP
 
 rt_inline rt_uint32_t put_header(struct p9_connection *conn,
-        rt_uint8_t hd, rt_uint16_t tag_flags)
+                                 rt_uint8_t hd, rt_uint16_t tag_flags)
 {
     rt_uint8_t *stack = conn->tx_buffer;
 
@@ -105,7 +105,7 @@ rt_inline rt_uint32_t put_header(struct p9_connection *conn,
 }
 
 rt_inline rt_off_t put_bytes(struct p9_connection *conn, rt_off_t off,
-        rt_uint8_t *bytes, rt_uint32_t count)
+                             rt_uint8_t *bytes, rt_uint32_t count)
 {
     rt_uint8_t *stack = conn->tx_buffer + off;
 
@@ -119,7 +119,7 @@ rt_inline rt_off_t put_bytes(struct p9_connection *conn, rt_off_t off,
 }
 
 rt_inline rt_off_t put_string(struct p9_connection *conn, rt_off_t off,
-        char *string)
+                              char *string)
 {
     rt_uint32_t len = rt_strlen(string);
     rt_uint8_t *stack = conn->tx_buffer + off;
@@ -134,7 +134,7 @@ rt_inline rt_off_t put_string(struct p9_connection *conn, rt_off_t off,
 }
 
 struct p9_connection *p9_connection_alloc(struct p9_protocol *p9p,
-        const char *aname, rt_uint32_t buffer_size)
+                                          const char *aname, rt_uint32_t buffer_size)
 {
     struct p9_connection *conn;
 
@@ -177,7 +177,7 @@ rt_err_t p9_connection_free(struct p9_connection *conn)
 }
 
 int p9_transaction(struct p9_connection *conn,
-        rt_uint32_t tx_size, rt_uint32_t *out_rx_size)
+                   rt_uint32_t tx_size, rt_uint32_t *out_rx_size)
 {
     rt_err_t err;
     rt_uint32_t rx_size;
@@ -187,7 +187,7 @@ int p9_transaction(struct p9_connection *conn,
 
     rx_size = conn->msg_size;
     if ((err = conn->protocol->transport(conn->protocol,
-            conn->tx_buffer, tx_size, conn->rx_buffer, &rx_size)))
+                                         conn->tx_buffer, tx_size, conn->rx_buffer, &rx_size)))
     {
         return P9_TRANSPORT_ERROR;
     }
@@ -201,7 +201,7 @@ int p9_transaction(struct p9_connection *conn,
     if (get_rx_value8_of(conn, P9_MSG_ID) == P9_MSG_ERR)
     {
         rt_uint32_t err_len = rt_min_t(rt_uint32_t, sizeof(conn->error) - 1,
-                get_rx_value16_of(conn, P9_MSG_ERR_STR_LEN));
+                                       get_rx_value16_of(conn, P9_MSG_ERR_STR_LEN));
 
         rt_strncpy(conn->error, (void *)&conn->rx_buffer[P9_MSG_ERR_STR], err_len);
 
@@ -367,8 +367,7 @@ rt_err_t dfs_9pfs_del_tag(struct p9_protocol *p9p)
 
 static int p9_to_fs_err(int rc)
 {
-    const int p9_err[] =
-    {
+    const int p9_err[] = {
         [0] = RT_EOK,
         [-P9_ERROR] = -EIO,
         [-P9_UNKNOWN_VERSION] = -ENOSYS,
@@ -428,10 +427,18 @@ static rt_uint8_t fs_to_p9_flags(rt_uint32_t raw_flags)
 
     switch (raw_flags & 3)
     {
-    case O_RDONLY: flags = OREAD; break;
-    case O_WRONLY: flags = OWRITE; break;
-    case O_RDWR: flags = ORDWR; break;
-    default: RT_ASSERT(0); break;
+    case O_RDONLY:
+        flags = OREAD;
+        break;
+    case O_WRONLY:
+        flags = OWRITE;
+        break;
+    case O_RDWR:
+        flags = ORDWR;
+        break;
+    default:
+        RT_ASSERT(0);
+        break;
     }
 
     if (raw_flags & O_TRUNC)
@@ -460,7 +467,7 @@ static char *p9_basename(const char *path)
 }
 
 static int p9_walk_path_raw(struct p9_connection *conn, const char *path,
-        rt_bool_t submode)
+                            rt_bool_t submode)
 {
     rt_uint32_t size;
     const char *split;
@@ -490,7 +497,8 @@ static int p9_walk_path_raw(struct p9_connection *conn, const char *path,
     size = put_value32(conn, size, new_fid);
     size = put_value16(conn, size, 0);  /* Fill later */
 
-    do {
+    do
+    {
         split = strchrnul(path, '/');
 
         len = split - path;
@@ -880,8 +888,8 @@ static int dfs_9pfs_getdents(struct dfs_file *fd, struct dirent *dirp, uint32_t 
             dirp->d_namlen = get_rx_value16_of(conn, off + P9_MSG_STAT_NAME_LEN);
             dirp->d_reclen = (rt_uint16_t)sizeof(struct dirent);
             rt_strncpy(dirp->d_name,
-                    (void *)conn->rx_buffer + off + P9_MSG_STAT_NAME,
-                    dirp->d_namlen);
+                       (void *)conn->rx_buffer + off + P9_MSG_STAT_NAME,
+                       dirp->d_namlen);
             dirp->d_name[dirp->d_namlen] = '\0';
 
             if (!rt_strcmp(dirp->d_name, ".") || !rt_strcmp(dirp->d_name, ".."))
@@ -908,19 +916,18 @@ static int dfs_9pfs_getdents(struct dfs_file *fd, struct dirent *dirp, uint32_t 
     return count;
 }
 
-static const struct dfs_file_ops _9pfs_fops =
-{
-    .open       = dfs_9pfs_open,
-    .close      = dfs_9pfs_close,
-    .read       = dfs_9pfs_read,
-    .write      = dfs_9pfs_write,
-    .flush      = dfs_9pfs_flush,
-    .lseek      = dfs_9pfs_lseek,
-    .getdents   = dfs_9pfs_getdents,
+static const struct dfs_file_ops _9pfs_fops = {
+    .open = dfs_9pfs_open,
+    .close = dfs_9pfs_close,
+    .read = dfs_9pfs_read,
+    .write = dfs_9pfs_write,
+    .flush = dfs_9pfs_flush,
+    .lseek = dfs_9pfs_lseek,
+    .getdents = dfs_9pfs_getdents,
 };
 
 static int dfs_9pfs_mount(struct dfs_filesystem *fs,
-        unsigned long rwflag, const void *data)
+                          unsigned long rwflag, const void *data)
 {
     rt_ubase_t level;
     struct p9_protocol *p9p = RT_NULL, *p9p_tmp;
@@ -1042,7 +1049,7 @@ static int dfs_9pfs_unlink(struct dfs_filesystem *fs, const char *pathname)
 }
 
 static int dfs_9pfs_stat(struct dfs_filesystem *fs,
-        const char *filename, struct stat *st)
+                         const char *filename, struct stat *st)
 {
     int rc = 0, fid;
     rt_uint32_t size, mode;
@@ -1133,7 +1140,7 @@ static int dfs_9pfs_stat(struct dfs_filesystem *fs,
 }
 
 static int dfs_9pfs_rename(struct dfs_filesystem *fs,
-        const char *oldpath, const char *newpath)
+                           const char *oldpath, const char *newpath)
 {
     int rc = 0, fid;
     rt_uint32_t size;
@@ -1162,20 +1169,19 @@ static int dfs_9pfs_rename(struct dfs_filesystem *fs,
     return p9_to_fs_err(rc);
 }
 
-static const struct dfs_filesystem_ops _9pfs =
-{
-    .name       = "9p",
-    .flags      = DFS_FS_FLAG_DEFAULT,
-    .fops       = &_9pfs_fops,
+static const struct dfs_filesystem_ops _9pfs = {
+    .name = "9p",
+    .flags = DFS_FS_FLAG_DEFAULT,
+    .fops = &_9pfs_fops,
 
-    .mount      = dfs_9pfs_mount,
-    .unmount    = dfs_9pfs_unmount,
+    .mount = dfs_9pfs_mount,
+    .unmount = dfs_9pfs_unmount,
 
-    .statfs     = dfs_9pfs_statfs,
+    .statfs = dfs_9pfs_statfs,
 
-    .unlink     = dfs_9pfs_unlink,
-    .stat       = dfs_9pfs_stat,
-    .rename     = dfs_9pfs_rename,
+    .unlink = dfs_9pfs_unlink,
+    .stat = dfs_9pfs_stat,
+    .rename = dfs_9pfs_rename,
 };
 
 int dfs_9pfs_init(void)

--- a/components/dfs/dfs_v1/filesystems/9pfs/dfs_9pfs.c
+++ b/components/dfs/dfs_v1/filesystems/9pfs/dfs_9pfs.c
@@ -923,7 +923,7 @@ static int dfs_9pfs_mount(struct dfs_filesystem *fs,
         unsigned long rwflag, const void *data)
 {
     rt_ubase_t level;
-    struct p9_protocol *p9p, *p9p_tmp;
+    struct p9_protocol *p9p = RT_NULL, *p9p_tmp;
     struct p9_connection *conn = RT_NULL;
 
     if (!data)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
`dfs_9pfs_mount()`在查找9pfs protocol tag前声明了未初始化的`p9p`指针。如果`_protocol_nodes`为空，或者没有找到匹配的 tag，后续`if (!p9p)`会读取未初始化的局部指针，导致mount失败路径依赖不确定的栈值，而不是稳定返回错误。

#### 你的解决方案是什么 (what is your solution)

将`p9p`初始化为`RT_NULL`,这样没有匹配protocol tag时,`dfs_9pfs_mount()`会稳定返回`-RT_EINVAL`。该修改只影响9pfs mount的错误路径，不改变成功路径行为。


#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:`bsp/k210`

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:本PR只修改9pfs mount错误路径中的局部变量初始化,无需修改`.config`


本地验证：
- `git diff --check -- components/dfs/dfs_v1/filesystems/9pfs/dfs_9pfs.c`
- `cppcheck --enable=warning,style,performance,portability --quiet components/dfs/dfs_v1/filesystems/9pfs/dfs_9pfs.c`

说明：本地尝试执行`scons -j2`验证`bsp/k210`，但本地环境缺少BSP配置的RISC-V工具链路径`/opt/gnu-mcu-eclipse/riscv-none-gcc/8.2.0-2.1-20190425-1021/bin`，因此未完成板级构建。

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:https://github.com/Aphlita/rt-thread/actions/runs/24945700242

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
