### PR TITLE
refactor[STM32][DMA]: unify DMA helpers and descriptors for HAL drivers

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/SConscript
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/SConscript
@@ -6,6 +6,9 @@ import os
 cwd = GetCurrentDir()
 group = []
 src = []
+# DMA-capable BSPs are expected to enable HAL_DMA_MODULE_ENABLED in the
+# STM32 HAL configuration, so keep the common DMA helper in the build.
+src += ['drv_dma.c']
 path = [cwd]
 
 if GetDepend(['RT_USING_PIN']):
@@ -35,7 +38,7 @@ if GetDepend('RT_USING_SOFT_SPI'):
 if GetDepend(['RT_USING_I2C', 'RT_USING_I2C_BITOPS']):
     if GetDepend('BSP_USING_I2C1') or GetDepend('BSP_USING_I2C2') or GetDepend('BSP_USING_I2C3') or GetDepend('BSP_USING_I2C4'):
         src += ['drv_soft_i2c.c']
-        
+
 if GetDepend(['RT_USING_I2C']):
     if GetDepend('BSP_USING_HARD_I2C1') or GetDepend('BSP_USING_HARD_I2C2') or GetDepend('BSP_USING_HARD_I2C3') or GetDepend('BSP_USING_HARD_I2C4'):
         src += ['drv_hard_i2c.c']

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f0/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f0/spi_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
  * 2019-01-05     SummerGift   modify DMA support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -20,67 +21,127 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI1,                           \
-        .bus_name = "spi1",                         \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_TX_DMA_RCC,                 \
-        .Instance = SPI1_TX_DMA_INSTANCE,           \
-        .dma_irq = SPI1_TX_DMA_IRQ,                 \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        SPI1_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_RX_DMA_RCC,                 \
-        .Instance = SPI1_RX_DMA_INSTANCE,           \
-        .dma_irq = SPI1_RX_DMA_IRQ,                 \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        SPI1_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI2,                           \
-        .bus_name = "spi2",                         \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc  = SPI2_TX_DMA_RCC,                \
-        .Instance = SPI2_TX_DMA_INSTANCE,           \
-        .dma_irq  = SPI2_TX_DMA_IRQ,                \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        SPI2_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc  = SPI2_RX_DMA_RCC,                \
-        .Instance = SPI2_RX_DMA_INSTANCE,           \
-        .dma_irq  = SPI2_RX_DMA_IRQ,                \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        SPI2_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f0/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f0/uart_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-10-30     zylx         first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -19,45 +20,77 @@ extern "C" {
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART1_RX_DMA_RCC,                               \
-        .dma_irq  = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART2_RX_DMA_RCC,                               \
-        .dma_irq  = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/dma_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/dma_config.h
@@ -120,6 +120,11 @@ extern "C" {
 #define SPI3_RX_DMA_RCC                 RCC_AHBENR_DMA2EN
 #define SPI3_RX_DMA_INSTANCE            DMA2_Channel1
 #define SPI3_RX_DMA_IRQ                 DMA2_Channel1_IRQn
+#elif defined(BSP_UART5_TX_USING_DMA) && !defined(UART5_TX_DMA_INSTANCE)
+#define UART5_DMA_TX_IRQHandler         DMA2_Channel1_IRQHandler
+#define UART5_TX_DMA_RCC                RCC_AHBENR_DMA2EN
+#define UART5_TX_DMA_INSTANCE           DMA2_Channel1
+#define UART5_TX_DMA_IRQ                DMA2_Channel1_IRQn
 #endif
 
 /* DMA2 channel2 */
@@ -149,6 +154,18 @@ extern "C" {
 #define SDIO_RX_DMA_RCC                 RCC_AHBENR_DMA2EN
 #define SDIO_RX_DMA_INSTANCE            DMA2_Channel4
 #define SDIO_RX_DMA_IRQ                 DMA2_Channel4_5_IRQn
+#elif defined(BSP_UART5_RX_USING_DMA) && !defined(UART5_RX_DMA_INSTANCE)
+#if defined(DMA2_Channel4_5_IRQHandler) && defined(DMA2_Channel4_5_IRQn)
+#define UART5_DMA_RX_IRQHandler         DMA2_Channel4_5_IRQHandler
+#define UART5_RX_DMA_IRQ                DMA2_Channel4_5_IRQn
+#elif defined(DMA2_Channel4_IRQHandler) && defined(DMA2_Channel4_IRQn)
+#define UART5_DMA_RX_IRQHandler         DMA2_Channel4_IRQHandler
+#define UART5_RX_DMA_IRQ                DMA2_Channel4_IRQn
+#else
+#error "Unsupported STM32F1 UART5 RX DMA IRQ mapping"
+#endif
+#define UART5_RX_DMA_RCC                RCC_AHBENR_DMA2EN
+#define UART5_RX_DMA_INSTANCE           DMA2_Channel4
 #endif
 
 /* DMA2 channel5 */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/i2c_hard_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/i2c_hard_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2024-02-06     Dyyt587   first version
  * 2024-04-23     Zeidan    Add I2Cx_xx_DMA_CONFIG
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 #ifndef __I2C_HARD_CONFIG_H__
 #define __I2C_HARD_CONFIG_H__
@@ -19,109 +20,199 @@ extern "C" {
 
 #ifdef BSP_USING_HARD_I2C1
 #ifndef I2C1_BUS_CONFIG
-#define I2C1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = I2C1,                           \
-        .timing = 100000,                           \
-        .timeout=0x1000,                            \
-        .name = "hwi2c1",                           \
-        .evirq_type = I2C1_EV_IRQn,                 \
-        .erirq_type = I2C1_ER_IRQn,                 \
+#define I2C1_BUS_CONFIG             \
+    {                               \
+        .Instance = I2C1,           \
+        .timing = 100000,           \
+        .timeout=0x1000,            \
+        .name = "hwi2c1",           \
+        .evirq_type = I2C1_EV_IRQn, \
+        .erirq_type = I2C1_ER_IRQn, \
     }
 #endif /* I2C1_BUS_CONFIG */
 #endif /* BSP_USING_HARD_I2C1 */
 
 #ifdef BSP_I2C1_TX_USING_DMA
+#ifndef I2C1_TX_DMA_PRIORITY
+#define I2C1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C1_TX_DMA_PRIORITY */
+
+#ifndef I2C1_TX_DMA_PREEMPT_PRIORITY
+#define I2C1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* I2C1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C1_TX_DMA_SUB_PRIORITY
+#define I2C1_TX_DMA_SUB_PRIORITY              0
+#endif /* I2C1_TX_DMA_SUB_PRIORITY */
 #ifndef I2C1_TX_DMA_CONFIG
-#define I2C1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C1_TX_DMA_RCC,                 \
-        .Instance = I2C1_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C1_TX_DMA_IRQ,                 \
-    }
+#define I2C1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        I2C1_TX_DMA_INSTANCE,         \
+        I2C1_TX_DMA_RCC,              \
+        I2C1_TX_DMA_IRQ,              \
+        0U,                           \
+        0U,                           \
+        I2C1_TX_DMA_PRIORITY,         \
+        I2C1_TX_DMA_PREEMPT_PRIORITY, \
+        I2C1_TX_DMA_SUB_PRIORITY)
 #endif /* I2C1_TX_DMA_CONFIG */
 #endif /* BSP_I2C1_TX_USING_DMA */
 
 #ifdef BSP_I2C1_RX_USING_DMA
+#ifndef I2C1_RX_DMA_PRIORITY
+#define I2C1_RX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C1_RX_DMA_PRIORITY */
+
+#ifndef I2C1_RX_DMA_PREEMPT_PRIORITY
+#define I2C1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* I2C1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C1_RX_DMA_SUB_PRIORITY
+#define I2C1_RX_DMA_SUB_PRIORITY              0
+#endif /* I2C1_RX_DMA_SUB_PRIORITY */
 #ifndef I2C1_RX_DMA_CONFIG
-#define I2C1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C1_RX_DMA_RCC,                 \
-        .Instance = I2C1_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C1_RX_DMA_IRQ,                 \
-    }
+#define I2C1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        I2C1_RX_DMA_INSTANCE,         \
+        I2C1_RX_DMA_RCC,              \
+        I2C1_RX_DMA_IRQ,              \
+        0U,                           \
+        0U,                           \
+        I2C1_RX_DMA_PRIORITY,         \
+        I2C1_RX_DMA_PREEMPT_PRIORITY, \
+        I2C1_RX_DMA_SUB_PRIORITY)
 #endif /* I2C1_RX_DMA_CONFIG */
 #endif /* BSP_I2C1_RX_USING_DMA */
 
 #ifdef BSP_USING_HARD_I2C2
 #ifndef I2C2_BUS_CONFIG
-#define I2C2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = I2C2,                           \
-        .timing = 100000,                           \
-        .timeout=0x1000,                            \
-        .name = "hwi2c2",                           \
-        .evirq_type = I2C2_EV_IRQn,                 \
-        .erirq_type = I2C2_ER_IRQn,                 \
+#define I2C2_BUS_CONFIG             \
+    {                               \
+        .Instance = I2C2,           \
+        .timing = 100000,           \
+        .timeout=0x1000,            \
+        .name = "hwi2c2",           \
+        .evirq_type = I2C2_EV_IRQn, \
+        .erirq_type = I2C2_ER_IRQn, \
     }
 #endif /* I2C2_BUS_CONFIG */
 #endif /* BSP_USING_HARD_I2C2 */
 
 #ifdef BSP_I2C2_TX_USING_DMA
+#ifndef I2C2_TX_DMA_PRIORITY
+#define I2C2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C2_TX_DMA_PRIORITY */
+
+#ifndef I2C2_TX_DMA_PREEMPT_PRIORITY
+#define I2C2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* I2C2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C2_TX_DMA_SUB_PRIORITY
+#define I2C2_TX_DMA_SUB_PRIORITY              0
+#endif /* I2C2_TX_DMA_SUB_PRIORITY */
 #ifndef I2C2_TX_DMA_CONFIG
-#define I2C2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C2_TX_DMA_RCC,                 \
-        .Instance = I2C2_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C2_TX_DMA_IRQ,                 \
-    }
+#define I2C2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        I2C2_TX_DMA_INSTANCE,         \
+        I2C2_TX_DMA_RCC,              \
+        I2C2_TX_DMA_IRQ,              \
+        0U,                           \
+        0U,                           \
+        I2C2_TX_DMA_PRIORITY,         \
+        I2C2_TX_DMA_PREEMPT_PRIORITY, \
+        I2C2_TX_DMA_SUB_PRIORITY)
 #endif /* I2C2_TX_DMA_CONFIG */
 #endif /* BSP_I2C2_TX_USING_DMA */
 
 #ifdef BSP_I2C2_RX_USING_DMA
+#ifndef I2C2_RX_DMA_PRIORITY
+#define I2C2_RX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C2_RX_DMA_PRIORITY */
+
+#ifndef I2C2_RX_DMA_PREEMPT_PRIORITY
+#define I2C2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* I2C2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C2_RX_DMA_SUB_PRIORITY
+#define I2C2_RX_DMA_SUB_PRIORITY              0
+#endif /* I2C2_RX_DMA_SUB_PRIORITY */
 #ifndef I2C2_RX_DMA_CONFIG
-#define I2C2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C2_RX_DMA_RCC,                 \
-        .Instance = I2C2_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C2_RX_DMA_IRQ,                 \
-    }
+#define I2C2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        I2C2_RX_DMA_INSTANCE,         \
+        I2C2_RX_DMA_RCC,              \
+        I2C2_RX_DMA_IRQ,              \
+        0U,                           \
+        0U,                           \
+        I2C2_RX_DMA_PRIORITY,         \
+        I2C2_RX_DMA_PREEMPT_PRIORITY, \
+        I2C2_RX_DMA_SUB_PRIORITY)
 #endif /* I2C2_RX_DMA_CONFIG */
 #endif /* BSP_I2C2_RX_USING_DMA */
 
 #ifdef BSP_USING_HARD_I2C3
 #ifndef I2C3_BUS_CONFIG
-#define I2C3_BUS_CONFIG                             \
-    {                                               \
-        .Instance = I2C3,                           \
-        .timing = 100000,                           \
-        .timeout=0x1000,                            \
-        .name = "hwi2c3",                           \
-        .evirq_type = I2C3_EV_IRQn,                 \
-        .erirq_type = I2C3_ER_IRQn,                 \
+#define I2C3_BUS_CONFIG             \
+    {                               \
+        .Instance = I2C3,           \
+        .timing = 100000,           \
+        .timeout=0x1000,            \
+        .name = "hwi2c3",           \
+        .evirq_type = I2C3_EV_IRQn, \
+        .erirq_type = I2C3_ER_IRQn, \
     }
 #endif /* I2C3_BUS_CONFIG */
 #endif /* BSP_USING_HARD_I2C3 */
 
 #ifdef BSP_I2C3_TX_USING_DMA
+#ifndef I2C3_TX_DMA_PRIORITY
+#define I2C3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C3_TX_DMA_PRIORITY */
+
+#ifndef I2C3_TX_DMA_PREEMPT_PRIORITY
+#define I2C3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* I2C3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C3_TX_DMA_SUB_PRIORITY
+#define I2C3_TX_DMA_SUB_PRIORITY              0
+#endif /* I2C3_TX_DMA_SUB_PRIORITY */
 #ifndef I2C3_TX_DMA_CONFIG
-#define I2C3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C3_TX_DMA_RCC,                 \
-        .Instance = I2C3_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C3_TX_DMA_IRQ,                 \
-    }
+#define I2C3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        I2C3_TX_DMA_INSTANCE,         \
+        I2C3_TX_DMA_RCC,              \
+        I2C3_TX_DMA_IRQ,              \
+        0U,                           \
+        0U,                           \
+        I2C3_TX_DMA_PRIORITY,         \
+        I2C3_TX_DMA_PREEMPT_PRIORITY, \
+        I2C3_TX_DMA_SUB_PRIORITY)
 #endif /* I2C3_TX_DMA_CONFIG */
 #endif /* BSP_I2C3_TX_USING_DMA */
 
 #ifdef BSP_I2C3_RX_USING_DMA
+#ifndef I2C3_RX_DMA_PRIORITY
+#define I2C3_RX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C3_RX_DMA_PRIORITY */
+
+#ifndef I2C3_RX_DMA_PREEMPT_PRIORITY
+#define I2C3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* I2C3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C3_RX_DMA_SUB_PRIORITY
+#define I2C3_RX_DMA_SUB_PRIORITY              0
+#endif /* I2C3_RX_DMA_SUB_PRIORITY */
 #ifndef I2C3_RX_DMA_CONFIG
-#define I2C3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C3_RX_DMA_RCC,                 \
-        .Instance = I2C3_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C3_RX_DMA_IRQ,                 \
-    }
+#define I2C3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        I2C3_RX_DMA_INSTANCE,         \
+        I2C3_RX_DMA_RCC,              \
+        I2C3_RX_DMA_IRQ,              \
+        0U,                           \
+        0U,                           \
+        I2C3_RX_DMA_PRIORITY,         \
+        I2C3_RX_DMA_PREEMPT_PRIORITY, \
+        I2C3_RX_DMA_SUB_PRIORITY)
 #endif /* I2C3_RX_DMA_CONFIG */
 #endif /* BSP_I2C3_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/sdio_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/sdio_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-13     BalanceTWK   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SDIO_CONFIG_H__
@@ -19,15 +20,59 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_SDIO
-#define SDIO_BUS_CONFIG                                  \
-    {                                                    \
-        .Instance = SDIO,                                \
-        .dma_rx.dma_rcc = RCC_AHBENR_DMA2EN,             \
-        .dma_tx.dma_rcc = RCC_AHBENR_DMA2EN,             \
-        .dma_rx.Instance = DMA2_Channel4,                \
-        .dma_rx.dma_irq = DMA2_Channel4_IRQn,            \
-        .dma_tx.Instance = DMA2_Channel4,                \
-        .dma_tx.dma_irq = DMA2_Channel4_IRQn,            \
+#if defined(DMA2_Channel4_5_IRQn)
+#define SDIO_DMA_IRQ_VALUE                      DMA2_Channel4_5_IRQn
+#elif defined(DMA2_Channel4_IRQn)
+#define SDIO_DMA_IRQ_VALUE                      DMA2_Channel4_IRQn
+#else
+#error "Unsupported STM32F1 SDIO DMA IRQ mapping"
+#endif
+
+#ifndef SDIO_RX_DMA_PRIORITY
+#define SDIO_RX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_RX_DMA_PRIORITY */
+
+#ifndef SDIO_RX_DMA_PREEMPT_PRIORITY
+#define SDIO_RX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_RX_DMA_SUB_PRIORITY
+#define SDIO_RX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_RX_DMA_SUB_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PRIORITY
+#define SDIO_TX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_TX_DMA_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PREEMPT_PRIORITY
+#define SDIO_TX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_TX_DMA_SUB_PRIORITY
+#define SDIO_TX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_TX_DMA_SUB_PRIORITY */
+
+#define SDIO_BUS_CONFIG                             \
+    {                                               \
+        .Instance = SDIO,                           \
+        .dma_rx = STM32_DMA_RX_WORD_CONFIG_INIT_EX( \
+            DMA2_Channel4,                          \
+            RCC_AHBENR_DMA2EN,                      \
+            SDIO_DMA_IRQ_VALUE,                     \
+            0U,                                     \
+            0U,                                     \
+            SDIO_RX_DMA_PRIORITY,                   \
+            SDIO_RX_DMA_PREEMPT_PRIORITY,           \
+            SDIO_RX_DMA_SUB_PRIORITY),              \
+        .dma_tx = STM32_DMA_TX_WORD_CONFIG_INIT_EX( \
+            DMA2_Channel4,                          \
+            RCC_AHBENR_DMA2EN,                      \
+            SDIO_DMA_IRQ_VALUE,                     \
+            0U,                                     \
+            0U,                                     \
+            SDIO_TX_DMA_PRIORITY,                   \
+            SDIO_TX_DMA_PREEMPT_PRIORITY,           \
+            SDIO_TX_DMA_SUB_PRIORITY),              \
     }
 
 #endif

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/spi_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
  * 2019-01-05     SummerGift   modify DMA support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -20,100 +21,190 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI1,                           \
-        .bus_name = "spi1",                         \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_TX_DMA_RCC,                 \
-        .Instance = SPI1_TX_DMA_INSTANCE,           \
-        .dma_irq = SPI1_TX_DMA_IRQ,                 \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        SPI1_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_RX_DMA_RCC,                 \
-        .Instance = SPI1_RX_DMA_INSTANCE,           \
-        .dma_irq = SPI1_RX_DMA_IRQ,                 \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        SPI1_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI2,                           \
-        .bus_name = "spi2",                         \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc  = SPI2_TX_DMA_RCC,                \
-        .Instance = SPI2_TX_DMA_INSTANCE,           \
-        .dma_irq  = SPI2_TX_DMA_IRQ,                \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        SPI2_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc  = SPI2_RX_DMA_RCC,                \
-        .Instance = SPI2_RX_DMA_INSTANCE,           \
-        .dma_irq  = SPI2_RX_DMA_IRQ,                \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        SPI2_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI3,                           \
-        .bus_name = "spi3",                         \
-        .irq_type = SPI3_IRQn,                      \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc  = SPI3_TX_DMA_RCC,                \
-        .Instance = SPI3_TX_DMA_INSTANCE,           \
-        .dma_irq  = SPI3_TX_DMA_IRQ,                \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        SPI3_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc  = SPI3_RX_DMA_RCC,                \
-        .Instance = SPI3_RX_DMA_INSTANCE,           \
-        .dma_irq  = SPI3_RX_DMA_IRQ,                \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        SPI3_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f1/uart_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-10-30     BalanceTWK   first version
  * 2019-01-05     SummerGift   modify DMA support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -15,161 +16,335 @@
 #include <rtthread.h>
 #include "dma_config.h"
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART1_RX_DMA_RCC,                               \
-        .dma_irq  = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART1_TX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART1_TX_DMA_RCC,                               \
-        .dma_irq  = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART1_TX_DMA_INSTANCE,         \
+        UART1_TX_DMA_RCC,              \
+        UART1_TX_DMA_IRQ,              \
+        0U,                            \
+        0U,                            \
+        UART1_TX_DMA_PRIORITY,         \
+        UART1_TX_DMA_PREEMPT_PRIORITY, \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART2_RX_DMA_RCC,                               \
-        .dma_irq  = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART2_TX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART2_TX_DMA_RCC,                               \
-        .dma_irq  = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        0U,                            \
+        0U,                            \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART3_RX_DMA_RCC,                               \
-        .dma_irq  = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART3_TX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART3_TX_DMA_RCC,                               \
-        .dma_irq  = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART3_TX_DMA_INSTANCE,         \
+        UART3_TX_DMA_RCC,              \
+        UART3_TX_DMA_IRQ,              \
+        0U,                            \
+        0U,                            \
+        UART3_TX_DMA_PRIORITY,         \
+        UART3_TX_DMA_PREEMPT_PRIORITY, \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_USING_UART4)
 #ifndef UART4_CONFIG
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = UART4,                                          \
-        .irq_type = UART4_IRQn,                                     \
+#define UART4_CONFIG            \
+    {                           \
+        .name = "uart4",        \
+        .Instance = UART4,      \
+        .irq_type = UART4_IRQn, \
     }
 #endif /* UART4_CONFIG */
 
 #if defined(BSP_UART4_RX_USING_DMA)
+#ifndef UART4_RX_DMA_PRIORITY
+#define UART4_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_RX_DMA_PRIORITY */
+
+#ifndef UART4_RX_DMA_PREEMPT_PRIORITY
+#define UART4_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_RX_DMA_SUB_PRIORITY
+#define UART4_RX_DMA_SUB_PRIORITY             0
+#endif /* UART4_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_RX_CONFIG
-#define UART4_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART4_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART4_RX_DMA_RCC,                               \
-        .dma_irq  = UART4_RX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART4_RX_DMA_INSTANCE,                 \
+        UART4_RX_DMA_RCC,                      \
+        UART4_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART4_RX_DMA_PRIORITY,                 \
+        UART4_RX_DMA_PREEMPT_PRIORITY,         \
+        UART4_RX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_RX_CONFIG */
 #endif /* BSP_UART4_RX_USING_DMA */
 
 #if defined(BSP_UART4_TX_USING_DMA)
+#ifndef UART4_TX_DMA_PRIORITY
+#define UART4_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_TX_DMA_PRIORITY */
+
+#ifndef UART4_TX_DMA_PREEMPT_PRIORITY
+#define UART4_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_TX_DMA_SUB_PRIORITY
+#define UART4_TX_DMA_SUB_PRIORITY             0
+#endif /* UART4_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_TX_CONFIG
-#define UART4_DMA_TX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART4_TX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART4_TX_DMA_RCC,                               \
-        .dma_irq  = UART4_TX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART4_TX_DMA_INSTANCE,         \
+        UART4_TX_DMA_RCC,              \
+        UART4_TX_DMA_IRQ,              \
+        0U,                            \
+        0U,                            \
+        UART4_TX_DMA_PRIORITY,         \
+        UART4_TX_DMA_PREEMPT_PRIORITY, \
+        UART4_TX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_TX_CONFIG */
 #endif /* BSP_UART4_TX_USING_DMA */
 #endif /* BSP_USING_UART4 */
 
 #if defined(BSP_USING_UART5)
 #ifndef UART5_CONFIG
-#define UART5_CONFIG                                                \
-    {                                                               \
-        .name = "uart5",                                            \
-        .Instance = UART5,                                          \
-        .irq_type = UART5_IRQn,                                     \
+#define UART5_CONFIG             \
+    {                            \
+        .name = "uart5",        \
+        .Instance = UART5,       \
+        .irq_type = UART5_IRQn,  \
     }
 #endif /* UART5_CONFIG */
 #endif /* BSP_USING_UART5 */
 
 #if defined(BSP_UART5_RX_USING_DMA)
+#ifndef UART5_RX_DMA_PRIORITY
+#define UART5_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_RX_DMA_PRIORITY */
+
+#ifndef UART5_RX_DMA_PREEMPT_PRIORITY
+#define UART5_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_RX_DMA_SUB_PRIORITY
+#define UART5_RX_DMA_SUB_PRIORITY             0
+#endif /* UART5_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_RX_CONFIG
-#define UART5_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = DMA_NOT_AVAILABLE,                              \
-    }
+#define UART5_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART5_RX_DMA_INSTANCE,                 \
+        UART5_RX_DMA_RCC,                      \
+        UART5_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART5_RX_DMA_PRIORITY,                 \
+        UART5_RX_DMA_PREEMPT_PRIORITY,         \
+        UART5_RX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_RX_CONFIG */
 #endif /* BSP_UART5_RX_USING_DMA */
+
+#if defined(BSP_UART5_TX_USING_DMA)
+#ifndef UART5_TX_DMA_PRIORITY
+#define UART5_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_TX_DMA_PRIORITY */
+
+#ifndef UART5_TX_DMA_PREEMPT_PRIORITY
+#define UART5_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_TX_DMA_SUB_PRIORITY
+#define UART5_TX_DMA_SUB_PRIORITY             0
+#endif /* UART5_TX_DMA_SUB_PRIORITY */
+
+#ifndef UART5_DMA_TX_CONFIG
+#define UART5_DMA_TX_CONFIG                    \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(          \
+        UART5_TX_DMA_INSTANCE,                 \
+        UART5_TX_DMA_RCC,                      \
+        UART5_TX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART5_TX_DMA_PRIORITY,                 \
+        UART5_TX_DMA_PREEMPT_PRIORITY,         \
+        UART5_TX_DMA_SUB_PRIORITY)
+#endif /* UART5_DMA_TX_CONFIG */
+#endif /* BSP_UART5_TX_USING_DMA */
 
 #ifdef __cplusplus
 }

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f2/sdio_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f2/sdio_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-13     BalanceTWK   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SDIO_CONFIG_H__
@@ -19,17 +20,71 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_SDIO
-#define SDIO_BUS_CONFIG                                  \
-    {                                                    \
-        .Instance = SDIO,                                \
-        .dma_rx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_tx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_rx.Instance = DMA2_Stream3,                 \
-        .dma_rx.channel = DMA_CHANNEL_4,                 \
-        .dma_rx.dma_irq = DMA2_Stream3_IRQn,             \
-        .dma_tx.Instance = DMA2_Stream6,                 \
-        .dma_tx.channel = DMA_CHANNEL_4,                 \
-        .dma_tx.dma_irq = DMA2_Stream6_IRQn,             \
+#ifndef SDIO_RX_DMA_PRIORITY
+#define SDIO_RX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_RX_DMA_PRIORITY */
+
+#ifndef SDIO_RX_DMA_PREEMPT_PRIORITY
+#define SDIO_RX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_RX_DMA_SUB_PRIORITY
+#define SDIO_RX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_RX_DMA_SUB_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PRIORITY
+#define SDIO_TX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_TX_DMA_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PREEMPT_PRIORITY
+#define SDIO_TX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_TX_DMA_SUB_PRIORITY
+#define SDIO_TX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_TX_DMA_SUB_PRIORITY */
+
+#define SDIO_BUS_CONFIG                          \
+    {                                            \
+        .Instance = SDIO,                        \
+        .dma_rx = STM32_DMA_CONFIG_INIT_FIFO_EX( \
+            DMA2_Stream3,                        \
+            RCC_AHB1ENR_DMA2EN,                  \
+            DMA2_Stream3_IRQn,                   \
+            DMA_CHANNEL_4,                       \
+            0U,                                  \
+            SDIO_RX_DMA_PRIORITY,                \
+            SDIO_RX_DMA_PREEMPT_PRIORITY,        \
+            SDIO_RX_DMA_SUB_PRIORITY,            \
+            DMA_PERIPH_TO_MEMORY,                \
+            DMA_PINC_DISABLE,                    \
+            DMA_MINC_ENABLE,                     \
+            DMA_PDATAALIGN_WORD,                 \
+            DMA_MDATAALIGN_WORD,                 \
+            DMA_PFCTRL,                          \
+            DMA_FIFOMODE_ENABLE,                 \
+            DMA_FIFO_THRESHOLD_FULL,             \
+            DMA_MBURST_INC4,                     \
+            DMA_PBURST_INC4),                    \
+        .dma_tx = STM32_DMA_CONFIG_INIT_FIFO_EX( \
+            DMA2_Stream6,                        \
+            RCC_AHB1ENR_DMA2EN,                  \
+            DMA2_Stream6_IRQn,                   \
+            DMA_CHANNEL_4,                       \
+            0U,                                  \
+            SDIO_TX_DMA_PRIORITY,                \
+            SDIO_TX_DMA_PREEMPT_PRIORITY,        \
+            SDIO_TX_DMA_SUB_PRIORITY,            \
+            DMA_MEMORY_TO_PERIPH,                \
+            DMA_PINC_DISABLE,                    \
+            DMA_MINC_ENABLE,                     \
+            DMA_PDATAALIGN_WORD,                 \
+            DMA_MDATAALIGN_WORD,                 \
+            DMA_PFCTRL,                          \
+            DMA_FIFOMODE_ENABLE,                 \
+            DMA_FIFO_THRESHOLD_FULL,             \
+            DMA_MBURST_INC4,                     \
+            DMA_PBURST_INC4),                    \
     }
 
 #endif

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f2/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f2/spi_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
  * 2019-01-05     SummerGift   modify DMA support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -20,106 +21,190 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI1,                           \
-        .bus_name = "spi1",                         \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_TX_DMA_RCC,                 \
-        .Instance = SPI1_TX_DMA_INSTANCE,           \
-        .channel = SPI1_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI1_TX_DMA_IRQ,                 \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        SPI1_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_RX_DMA_RCC,                 \
-        .Instance = SPI1_RX_DMA_INSTANCE,           \
-        .channel = SPI1_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI1_RX_DMA_IRQ,                 \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        SPI1_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI2,                           \
-        .bus_name = "spi2",                         \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_TX_DMA_RCC,                 \
-        .Instance = SPI2_TX_DMA_INSTANCE,           \
-        .channel = SPI2_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI2_TX_DMA_IRQ,                 \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        SPI2_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_RX_DMA_RCC,                 \
-        .Instance = SPI2_RX_DMA_INSTANCE,           \
-        .channel = SPI2_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI2_RX_DMA_IRQ,                 \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        SPI2_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI3,                           \
-        .bus_name = "spi3",                         \
-        .irq_type = SPI3_IRQn,                      \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_TX_DMA_RCC,                 \
-        .Instance = SPI3_TX_DMA_INSTANCE,           \
-        .channel = SPI3_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI3_TX_DMA_IRQ,                 \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        SPI3_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_RX_DMA_RCC,                 \
-        .Instance = SPI3_RX_DMA_INSTANCE,           \
-        .channel = SPI3_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI3_RX_DMA_IRQ,                 \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        SPI3_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f2/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f2/uart_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-10-30     SummerGift   first version
  * 2019-01-03     zylx         modify dma support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -20,210 +21,390 @@ extern "C" {
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART1_RX_DMA_INSTANCE,                         \
-        .channel = UART1_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_RX_DMA_RCC,                               \
-        .dma_irq = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        UART1_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART1_TX_DMA_INSTANCE,                         \
-        .channel = UART1_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_TX_DMA_RCC,                               \
-        .dma_irq = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART1_TX_DMA_INSTANCE,         \
+        UART1_TX_DMA_RCC,              \
+        UART1_TX_DMA_IRQ,              \
+        UART1_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART1_TX_DMA_PRIORITY,         \
+        UART1_TX_DMA_PREEMPT_PRIORITY, \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART2_RX_DMA_INSTANCE,                         \
-        .channel = UART2_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_RX_DMA_RCC,                               \
-        .dma_irq = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        UART2_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART2_TX_DMA_INSTANCE,                         \
-        .channel = UART2_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_TX_DMA_RCC,                               \
-        .dma_irq = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        UART2_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART3_RX_DMA_INSTANCE,                         \
-        .channel = UART3_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_RX_DMA_RCC,                               \
-        .dma_irq = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        UART3_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART3_TX_DMA_INSTANCE,                         \
-        .channel = UART3_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_TX_DMA_RCC,                               \
-        .dma_irq = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART3_TX_DMA_INSTANCE,         \
+        UART3_TX_DMA_RCC,              \
+        UART3_TX_DMA_IRQ,              \
+        UART3_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART3_TX_DMA_PRIORITY,         \
+        UART3_TX_DMA_PREEMPT_PRIORITY, \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_USING_UART4)
 #ifndef UART4_CONFIG
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = UART4,                                          \
-        .irq_type = UART4_IRQn,                                     \
+#define UART4_CONFIG            \
+    {                           \
+        .name = "uart4",        \
+        .Instance = UART4,      \
+        .irq_type = UART4_IRQn, \
     }
 #endif /* UART4_CONFIG */
 
 #if defined(BSP_UART4_RX_USING_DMA)
+#ifndef UART4_RX_DMA_PRIORITY
+#define UART4_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_RX_DMA_PRIORITY */
+
+#ifndef UART4_RX_DMA_PREEMPT_PRIORITY
+#define UART4_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_RX_DMA_SUB_PRIORITY
+#define UART4_RX_DMA_SUB_PRIORITY             0
+#endif /* UART4_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_RX_CONFIG
-#define UART4_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART4_RX_DMA_INSTANCE,                         \
-        .channel = UART4_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART4_RX_DMA_RCC,                               \
-        .dma_irq = UART4_RX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART4_RX_DMA_INSTANCE,                 \
+        UART4_RX_DMA_RCC,                      \
+        UART4_RX_DMA_IRQ,                      \
+        UART4_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART4_RX_DMA_PRIORITY,                 \
+        UART4_RX_DMA_PREEMPT_PRIORITY,         \
+        UART4_RX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_RX_CONFIG */
 #endif /* BSP_UART4_RX_USING_DMA */
 
 #if defined(BSP_UART4_TX_USING_DMA)
+#ifndef UART4_TX_DMA_PRIORITY
+#define UART4_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_TX_DMA_PRIORITY */
+
+#ifndef UART4_TX_DMA_PREEMPT_PRIORITY
+#define UART4_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_TX_DMA_SUB_PRIORITY
+#define UART4_TX_DMA_SUB_PRIORITY             0
+#endif /* UART4_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_TX_CONFIG
-#define UART4_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART4_TX_DMA_INSTANCE,                         \
-        .channel = UART4_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART4_TX_DMA_RCC,                               \
-        .dma_irq = UART4_TX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART4_TX_DMA_INSTANCE,         \
+        UART4_TX_DMA_RCC,              \
+        UART4_TX_DMA_IRQ,              \
+        UART4_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART4_TX_DMA_PRIORITY,         \
+        UART4_TX_DMA_PREEMPT_PRIORITY, \
+        UART4_TX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_TX_CONFIG */
-#endif /* BSP_UART4_RX_USING_DMA */
+#endif /* BSP_UART4_TX_USING_DMA */
 #endif /* BSP_USING_UART4 */
 
 #if defined(BSP_USING_UART5)
 #ifndef UART5_CONFIG
-#define UART5_CONFIG                                                \
-    {                                                               \
-        .name = "uart5",                                            \
-        .Instance = UART5,                                          \
-        .irq_type = UART5_IRQn,                                     \
+#define UART5_CONFIG            \
+    {                           \
+        .name = "uart5",        \
+        .Instance = UART5,      \
+        .irq_type = UART5_IRQn, \
     }
 #endif /* UART5_CONFIG */
 
 #if defined(BSP_UART5_RX_USING_DMA)
+#ifndef UART5_RX_DMA_PRIORITY
+#define UART5_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_RX_DMA_PRIORITY */
+
+#ifndef UART5_RX_DMA_PREEMPT_PRIORITY
+#define UART5_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_RX_DMA_SUB_PRIORITY
+#define UART5_RX_DMA_SUB_PRIORITY             0
+#endif /* UART5_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_RX_CONFIG
-#define UART5_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART5_RX_DMA_INSTANCE,                         \
-        .channel = UART5_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART5_RX_DMA_RCC,                               \
-        .dma_irq = UART5_RX_DMA_IRQ,                               \
-    }
+#define UART5_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART5_RX_DMA_INSTANCE,                 \
+        UART5_RX_DMA_RCC,                      \
+        UART5_RX_DMA_IRQ,                      \
+        UART5_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART5_RX_DMA_PRIORITY,                 \
+        UART5_RX_DMA_PREEMPT_PRIORITY,         \
+        UART5_RX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_RX_CONFIG */
 #endif /* BSP_UART5_RX_USING_DMA */
 
 #if defined(BSP_UART5_TX_USING_DMA)
+#ifndef UART5_TX_DMA_PRIORITY
+#define UART5_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_TX_DMA_PRIORITY */
+
+#ifndef UART5_TX_DMA_PREEMPT_PRIORITY
+#define UART5_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_TX_DMA_SUB_PRIORITY
+#define UART5_TX_DMA_SUB_PRIORITY             0
+#endif /* UART5_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_TX_CONFIG
-#define UART5_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART5_TX_DMA_INSTANCE,                         \
-        .channel = UART5_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART5_TX_DMA_RCC,                               \
-        .dma_irq = UART5_TX_DMA_IRQ,                               \
-    }
+#define UART5_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART5_TX_DMA_INSTANCE,         \
+        UART5_TX_DMA_RCC,              \
+        UART5_TX_DMA_IRQ,              \
+        UART5_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART5_TX_DMA_PRIORITY,         \
+        UART5_TX_DMA_PREEMPT_PRIORITY, \
+        UART5_TX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_TX_CONFIG */
 #endif /* BSP_UART5_TX_USING_DMA */
 #endif /* BSP_USING_UART5 */
 
 #if defined(BSP_USING_UART6)
 #ifndef UART6_CONFIG
-#define UART6_CONFIG                                                \
-    {                                                               \
-        .name = "uart6",                                            \
-        .Instance = USART6,                                         \
-        .irq_type = USART6_IRQn,                                    \
+#define UART6_CONFIG             \
+    {                            \
+        .name = "uart6",         \
+        .Instance = USART6,      \
+        .irq_type = USART6_IRQn, \
     }
 #endif /* UART6_CONFIG */
 
 #if defined(BSP_UART6_RX_USING_DMA)
+#ifndef UART6_RX_DMA_PRIORITY
+#define UART6_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART6_RX_DMA_PRIORITY */
+
+#ifndef UART6_RX_DMA_PREEMPT_PRIORITY
+#define UART6_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART6_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART6_RX_DMA_SUB_PRIORITY
+#define UART6_RX_DMA_SUB_PRIORITY             0
+#endif /* UART6_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART6_DMA_RX_CONFIG
-#define UART6_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART6_RX_DMA_INSTANCE,                         \
-        .channel = UART6_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART6_RX_DMA_RCC,                               \
-        .dma_irq = UART6_RX_DMA_IRQ,                               \
-    }
+#define UART6_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART6_RX_DMA_INSTANCE,                 \
+        UART6_RX_DMA_RCC,                      \
+        UART6_RX_DMA_IRQ,                      \
+        UART6_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART6_RX_DMA_PRIORITY,                 \
+        UART6_RX_DMA_PREEMPT_PRIORITY,         \
+        UART6_RX_DMA_SUB_PRIORITY)
 #endif /* UART6_DMA_RX_CONFIG */
 #endif /* BSP_UART6_RX_USING_DMA */
 
 #if defined(BSP_UART6_TX_USING_DMA)
+#ifndef UART6_TX_DMA_PRIORITY
+#define UART6_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART6_TX_DMA_PRIORITY */
+
+#ifndef UART6_TX_DMA_PREEMPT_PRIORITY
+#define UART6_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART6_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART6_TX_DMA_SUB_PRIORITY
+#define UART6_TX_DMA_SUB_PRIORITY             0
+#endif /* UART6_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART6_DMA_TX_CONFIG
-#define UART6_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART6_TX_DMA_INSTANCE,                         \
-        .channel = UART6_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART6_TX_DMA_RCC,                               \
-        .dma_irq = UART6_TX_DMA_IRQ,                               \
-    }
+#define UART6_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART6_TX_DMA_INSTANCE,         \
+        UART6_TX_DMA_RCC,              \
+        UART6_TX_DMA_IRQ,              \
+        UART6_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART6_TX_DMA_PRIORITY,         \
+        UART6_TX_DMA_PREEMPT_PRIORITY, \
+        UART6_TX_DMA_SUB_PRIORITY)
 #endif /* UART6_DMA_TX_CONFIG */
 #endif /* BSP_UART6_TX_USING_DMA */
 #endif /* BSP_USING_UART6 */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f3/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f3/uart_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-10-30     SummerGift   first version
  * 2019-01-03     zylx         modify dma support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -20,105 +21,195 @@ extern "C" {
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART1_RX_DMA_INSTANCE,                         \
-        .channel = UART1_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_RX_DMA_RCC,                               \
-        .dma_irq = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART1_TX_DMA_INSTANCE,                         \
-        .channel = UART1_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_TX_DMA_RCC,                               \
-        .dma_irq = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART1_TX_DMA_INSTANCE,         \
+        UART1_TX_DMA_RCC,              \
+        UART1_TX_DMA_IRQ,              \
+        0U,                            \
+        0U,                            \
+        UART1_TX_DMA_PRIORITY,         \
+        UART1_TX_DMA_PREEMPT_PRIORITY, \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART2_RX_DMA_INSTANCE,                         \
-        .channel = UART2_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_RX_DMA_RCC,                               \
-        .dma_irq = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART2_TX_DMA_INSTANCE,                         \
-        .channel = UART2_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_TX_DMA_RCC,                               \
-        .dma_irq = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        0U,                            \
+        0U,                            \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART3_RX_DMA_INSTANCE,                         \
-        .channel = UART3_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_RX_DMA_RCC,                               \
-        .dma_irq = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART3_TX_DMA_INSTANCE,                         \
-        .channel = UART3_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_TX_DMA_RCC,                               \
-        .dma_irq = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART3_TX_DMA_INSTANCE,         \
+        UART3_TX_DMA_RCC,              \
+        UART3_TX_DMA_IRQ,              \
+        0U,                            \
+        0U,                            \
+        UART3_TX_DMA_PRIORITY,         \
+        UART3_TX_DMA_PREEMPT_PRIORITY, \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 #endif /* BSP_USING_UART3 */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/dma_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/dma_config.h
@@ -454,6 +454,12 @@ extern "C" {
 #define MEMTOMEM7_DMA_INSTANCE           DMA2_Stream7
 #define MEMTOMEM7_DMA_CHANNEL            DMA_CHANNEL_6
 #define MEMTOMEM7_DMA_IRQ                DMA2_Stream7_IRQn
+#elif defined(BSP_QSPI_USING_DMA) && !defined(QSPI_DMA_INSTANCE)
+#define QSPI_DMA_IRQHandler              DMA2_Stream7_IRQHandler
+#define QSPI_DMA_RCC                     RCC_AHB1ENR_DMA2EN
+#define QSPI_DMA_INSTANCE                DMA2_Stream7
+#define QSPI_DMA_CHANNEL                 DMA_CHANNEL_3
+#define QSPI_DMA_IRQ                     DMA2_Stream7_IRQn
 #endif
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/i2c_hard_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/i2c_hard_config.h
@@ -8,6 +8,7 @@
  * 2024-02-06     Dyyt587   first version
  * 2024-04-23     Zeidan    Add I2Cx_xx_DMA_CONFIG
  * 2024-06-23     wdfk-prog Add I2C4 config entries
+ * 2026-04-13     wdfk-prog Unify DMA config descriptors
  */
 #ifndef __I2C_HARD_CONFIG_H__
 #define __I2C_HARD_CONFIG_H__
@@ -20,233 +21,273 @@ extern "C" {
 
 #ifdef BSP_USING_HARD_I2C1
 #ifndef I2C1_BUS_CONFIG
-#define I2C1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = I2C1,                           \
-        .timing = 100000,                           \
-        .timeout=0x1000,                            \
-        .name = "hwi2c1",                           \
-        .evirq_type = I2C1_EV_IRQn,                 \
-        .erirq_type = I2C1_ER_IRQn,                 \
+#define I2C1_BUS_CONFIG             \
+    {                               \
+        .Instance = I2C1,           \
+        .timing = 100000,           \
+        .timeout=0x1000,            \
+        .name = "hwi2c1",           \
+        .evirq_type = I2C1_EV_IRQn, \
+        .erirq_type = I2C1_ER_IRQn, \
     }
 #endif /* I2C1_BUS_CONFIG */
 #endif /* BSP_USING_HARD_I2C1 */
 
 #ifdef BSP_I2C1_TX_USING_DMA
+#ifndef I2C1_TX_DMA_PRIORITY
+#define I2C1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C1_TX_DMA_PRIORITY */
+
+#ifndef I2C1_TX_DMA_PREEMPT_PRIORITY
+#define I2C1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* I2C1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C1_TX_DMA_SUB_PRIORITY
+#define I2C1_TX_DMA_SUB_PRIORITY              0
+#endif /* I2C1_TX_DMA_SUB_PRIORITY */
+
 #ifndef I2C1_TX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C1_TX_DMA_RCC,                 \
-        .Instance = I2C1_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C1_TX_DMA_IRQ,                 \
-        .channel = I2C1_TX_DMA_CHANNEL              \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C1_TX_DMA_RCC,                 \
-        .Instance = I2C1_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C1_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C1_TX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        I2C1_TX_DMA_INSTANCE,         \
+        I2C1_TX_DMA_RCC,              \
+        I2C1_TX_DMA_IRQ,              \
+        I2C1_TX_DMA_CHANNEL,          \
+        0U,                           \
+        I2C1_TX_DMA_PRIORITY,         \
+        I2C1_TX_DMA_PREEMPT_PRIORITY, \
+        I2C1_TX_DMA_SUB_PRIORITY)
 #endif /* I2C1_TX_DMA_CONFIG */
 #endif /* BSP_I2C1_TX_USING_DMA */
 
 #ifdef BSP_I2C1_RX_USING_DMA
+#ifndef I2C1_RX_DMA_PRIORITY
+#define I2C1_RX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C1_RX_DMA_PRIORITY */
+
+#ifndef I2C1_RX_DMA_PREEMPT_PRIORITY
+#define I2C1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* I2C1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C1_RX_DMA_SUB_PRIORITY
+#define I2C1_RX_DMA_SUB_PRIORITY              0
+#endif /* I2C1_RX_DMA_SUB_PRIORITY */
+
 #ifndef I2C1_RX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C1_RX_DMA_RCC,                 \
-        .Instance = I2C1_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C1_RX_DMA_IRQ,                 \
-        .channel = I2C1_RX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C1_RX_DMA_RCC,                 \
-        .Instance = I2C1_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C1_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C1_RX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        I2C1_RX_DMA_INSTANCE,         \
+        I2C1_RX_DMA_RCC,              \
+        I2C1_RX_DMA_IRQ,              \
+        I2C1_RX_DMA_CHANNEL,          \
+        0U,                           \
+        I2C1_RX_DMA_PRIORITY,         \
+        I2C1_RX_DMA_PREEMPT_PRIORITY, \
+        I2C1_RX_DMA_SUB_PRIORITY)
 #endif /* I2C1_RX_DMA_CONFIG */
 #endif /* BSP_I2C1_RX_USING_DMA */
 
 #ifdef BSP_USING_HARD_I2C2
 #ifndef I2C2_BUS_CONFIG
-#define I2C2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = I2C2,                           \
-        .timing = 100000,                           \
-        .timeout=0x1000,                            \
-        .name = "hwi2c2",                           \
-        .evirq_type = I2C2_EV_IRQn,                 \
-        .erirq_type = I2C2_ER_IRQn,                 \
+#define I2C2_BUS_CONFIG             \
+    {                               \
+        .Instance = I2C2,           \
+        .timing = 100000,           \
+        .timeout=0x1000,            \
+        .name = "hwi2c2",           \
+        .evirq_type = I2C2_EV_IRQn, \
+        .erirq_type = I2C2_ER_IRQn, \
     }
 #endif /* I2C2_BUS_CONFIG */
 #endif /* BSP_USING_HARD_I2C2 */
 
 #ifdef BSP_I2C2_TX_USING_DMA
+#ifndef I2C2_TX_DMA_PRIORITY
+#define I2C2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C2_TX_DMA_PRIORITY */
+
+#ifndef I2C2_TX_DMA_PREEMPT_PRIORITY
+#define I2C2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* I2C2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C2_TX_DMA_SUB_PRIORITY
+#define I2C2_TX_DMA_SUB_PRIORITY              0
+#endif /* I2C2_TX_DMA_SUB_PRIORITY */
+
 #ifndef I2C2_TX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C2_TX_DMA_RCC,                 \
-        .Instance = I2C2_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C2_TX_DMA_IRQ,                 \
-        .channel = I2C2_TX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C2_TX_DMA_RCC,                 \
-        .Instance = I2C2_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C2_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C2_TX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        I2C2_TX_DMA_INSTANCE,         \
+        I2C2_TX_DMA_RCC,              \
+        I2C2_TX_DMA_IRQ,              \
+        I2C2_TX_DMA_CHANNEL,          \
+        0U,                           \
+        I2C2_TX_DMA_PRIORITY,         \
+        I2C2_TX_DMA_PREEMPT_PRIORITY, \
+        I2C2_TX_DMA_SUB_PRIORITY)
 #endif /* I2C2_TX_DMA_CONFIG */
 #endif /* BSP_I2C2_TX_USING_DMA */
 
 #ifdef BSP_I2C2_RX_USING_DMA
+#ifndef I2C2_RX_DMA_PRIORITY
+#define I2C2_RX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C2_RX_DMA_PRIORITY */
+
+#ifndef I2C2_RX_DMA_PREEMPT_PRIORITY
+#define I2C2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* I2C2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C2_RX_DMA_SUB_PRIORITY
+#define I2C2_RX_DMA_SUB_PRIORITY              0
+#endif /* I2C2_RX_DMA_SUB_PRIORITY */
+
 #ifndef I2C2_RX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C2_RX_DMA_RCC,                 \
-        .Instance = I2C2_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C2_RX_DMA_IRQ,                 \
-        .channel = I2C2_RX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C2_RX_DMA_RCC,                 \
-        .Instance = I2C2_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C2_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C2_RX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        I2C2_RX_DMA_INSTANCE,         \
+        I2C2_RX_DMA_RCC,              \
+        I2C2_RX_DMA_IRQ,              \
+        I2C2_RX_DMA_CHANNEL,          \
+        0U,                           \
+        I2C2_RX_DMA_PRIORITY,         \
+        I2C2_RX_DMA_PREEMPT_PRIORITY, \
+        I2C2_RX_DMA_SUB_PRIORITY)
 #endif /* I2C2_RX_DMA_CONFIG */
 #endif /* BSP_I2C2_RX_USING_DMA */
 
 #ifdef BSP_USING_HARD_I2C3
 #ifndef I2C3_BUS_CONFIG
-#define I2C3_BUS_CONFIG                             \
-    {                                               \
-        .Instance = I2C3,                           \
-        .timing = 100000,                           \
-        .timeout=0x1000,                            \
-        .name = "hwi2c3",                           \
-        .evirq_type = I2C3_EV_IRQn,                 \
-        .erirq_type = I2C3_ER_IRQn,                 \
+#define I2C3_BUS_CONFIG             \
+    {                               \
+        .Instance = I2C3,           \
+        .timing = 100000,           \
+        .timeout=0x1000,            \
+        .name = "hwi2c3",           \
+        .evirq_type = I2C3_EV_IRQn, \
+        .erirq_type = I2C3_ER_IRQn, \
     }
 #endif /* I2C3_BUS_CONFIG */
 #endif /* BSP_USING_HARD_I2C3 */
 
 #ifdef BSP_I2C3_TX_USING_DMA
+#ifndef I2C3_TX_DMA_PRIORITY
+#define I2C3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C3_TX_DMA_PRIORITY */
+
+#ifndef I2C3_TX_DMA_PREEMPT_PRIORITY
+#define I2C3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* I2C3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C3_TX_DMA_SUB_PRIORITY
+#define I2C3_TX_DMA_SUB_PRIORITY              0
+#endif /* I2C3_TX_DMA_SUB_PRIORITY */
+
 #ifndef I2C3_TX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C3_TX_DMA_RCC,                 \
-        .Instance = I2C3_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C3_TX_DMA_IRQ,                 \
-        .channel = I2C3_TX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C3_TX_DMA_RCC,                 \
-        .Instance = I2C3_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C3_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C3_TX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        I2C3_TX_DMA_INSTANCE,         \
+        I2C3_TX_DMA_RCC,              \
+        I2C3_TX_DMA_IRQ,              \
+        I2C3_TX_DMA_CHANNEL,          \
+        0U,                           \
+        I2C3_TX_DMA_PRIORITY,         \
+        I2C3_TX_DMA_PREEMPT_PRIORITY, \
+        I2C3_TX_DMA_SUB_PRIORITY)
 #endif /* I2C3_TX_DMA_CONFIG */
 #endif /* BSP_I2C3_TX_USING_DMA */
 
 #ifdef BSP_I2C3_RX_USING_DMA
+#ifndef I2C3_RX_DMA_PRIORITY
+#define I2C3_RX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C3_RX_DMA_PRIORITY */
+
+#ifndef I2C3_RX_DMA_PREEMPT_PRIORITY
+#define I2C3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* I2C3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C3_RX_DMA_SUB_PRIORITY
+#define I2C3_RX_DMA_SUB_PRIORITY              0
+#endif /* I2C3_RX_DMA_SUB_PRIORITY */
+
 #ifndef I2C3_RX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C3_RX_DMA_RCC,                 \
-        .Instance = I2C3_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C3_RX_DMA_IRQ,                 \
-        .channel = I2C3_RX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C3_RX_DMA_RCC,                 \
-        .Instance = I2C3_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C3_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C3_RX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        I2C3_RX_DMA_INSTANCE,         \
+        I2C3_RX_DMA_RCC,              \
+        I2C3_RX_DMA_IRQ,              \
+        I2C3_RX_DMA_CHANNEL,          \
+        0U,                           \
+        I2C3_RX_DMA_PRIORITY,         \
+        I2C3_RX_DMA_PREEMPT_PRIORITY, \
+        I2C3_RX_DMA_SUB_PRIORITY)
 #endif /* I2C3_RX_DMA_CONFIG */
 #endif /* BSP_I2C3_RX_USING_DMA */
 
 #ifdef BSP_USING_HARD_I2C4
 #ifndef I2C4_BUS_CONFIG
-#define I2C4_BUS_CONFIG                             \
-    {                                               \
-        .Instance = I2C4,                           \
-        .timing = 100000,                           \
-        .timeout = 0x1000,                          \
-        .name = "hwi2c4",                           \
-        .evirq_type = I2C4_EV_IRQn,                 \
-        .erirq_type = I2C4_ER_IRQn,                 \
+#define I2C4_BUS_CONFIG             \
+    {                               \
+        .Instance = I2C4,           \
+        .timing = 100000,           \
+        .timeout=0x1000,            \
+        .name = "hwi2c4",           \
+        .evirq_type = I2C4_EV_IRQn, \
+        .erirq_type = I2C4_ER_IRQn, \
     }
 #endif /* I2C4_BUS_CONFIG */
 #endif /* BSP_USING_HARD_I2C4 */
 
 #ifdef BSP_I2C4_TX_USING_DMA
+#ifndef I2C4_TX_DMA_PRIORITY
+#define I2C4_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C4_TX_DMA_PRIORITY */
+
+#ifndef I2C4_TX_DMA_PREEMPT_PRIORITY
+#define I2C4_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* I2C4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C4_TX_DMA_SUB_PRIORITY
+#define I2C4_TX_DMA_SUB_PRIORITY              0
+#endif /* I2C4_TX_DMA_SUB_PRIORITY */
+
 #ifndef I2C4_TX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C4_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C4_TX_DMA_RCC,                 \
-        .Instance = I2C4_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C4_TX_DMA_IRQ,                 \
-        .channel = I2C4_TX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C4_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C4_TX_DMA_RCC,                 \
-        .Instance = I2C4_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C4_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C4_TX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C4_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        I2C4_TX_DMA_INSTANCE,         \
+        I2C4_TX_DMA_RCC,              \
+        I2C4_TX_DMA_IRQ,              \
+        I2C4_TX_DMA_CHANNEL,          \
+        0U,                           \
+        I2C4_TX_DMA_PRIORITY,         \
+        I2C4_TX_DMA_PREEMPT_PRIORITY, \
+        I2C4_TX_DMA_SUB_PRIORITY)
 #endif /* I2C4_TX_DMA_CONFIG */
 #endif /* BSP_I2C4_TX_USING_DMA */
 
 #ifdef BSP_I2C4_RX_USING_DMA
+#ifndef I2C4_RX_DMA_PRIORITY
+#define I2C4_RX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C4_RX_DMA_PRIORITY */
+
+#ifndef I2C4_RX_DMA_PREEMPT_PRIORITY
+#define I2C4_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* I2C4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C4_RX_DMA_SUB_PRIORITY
+#define I2C4_RX_DMA_SUB_PRIORITY              0
+#endif /* I2C4_RX_DMA_SUB_PRIORITY */
+
 #ifndef I2C4_RX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C4_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C4_RX_DMA_RCC,                 \
-        .Instance = I2C4_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C4_RX_DMA_IRQ,                 \
-        .channel = I2C4_RX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C4_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C4_RX_DMA_RCC,                 \
-        .Instance = I2C4_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C4_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C4_RX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C4_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        I2C4_RX_DMA_INSTANCE,         \
+        I2C4_RX_DMA_RCC,              \
+        I2C4_RX_DMA_IRQ,              \
+        I2C4_RX_DMA_CHANNEL,          \
+        0U,                           \
+        I2C4_RX_DMA_PRIORITY,         \
+        I2C4_RX_DMA_PREEMPT_PRIORITY, \
+        I2C4_RX_DMA_SUB_PRIORITY)
 #endif /* I2C4_RX_DMA_CONFIG */
 #endif /* BSP_I2C4_RX_USING_DMA */
 
@@ -254,4 +295,4 @@ extern "C" {
 }
 #endif
 
-#endif /*__I2C_CONFIG_H__ */
+#endif /* __I2C_HARD_CONFIG_H__ */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/qspi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/qspi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-22     zylx         first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __QSPI_CONFIG_H__
@@ -30,19 +31,29 @@ extern "C" {
 #endif /* BSP_USING_QSPI */
 
 #ifdef BSP_QSPI_USING_DMA
+#ifndef QSPI_DMA_PRIORITY
+#define QSPI_DMA_PRIORITY                         DMA_PRIORITY_LOW
+#endif /* QSPI_DMA_PRIORITY */
+
+#ifndef QSPI_DMA_PREEMPT_PRIORITY
+#define QSPI_DMA_PREEMPT_PRIORITY                 0
+#endif /* QSPI_DMA_PREEMPT_PRIORITY */
+
+#ifndef QSPI_DMA_SUB_PRIORITY
+#define QSPI_DMA_SUB_PRIORITY                     0
+#endif /* QSPI_DMA_SUB_PRIORITY */
+
 #ifndef QSPI_DMA_CONFIG
-#define QSPI_DMA_CONFIG                                        \
-    {                                                          \
-        .Instance = QSPI_DMA_INSTANCE,                         \
-        .Init.Channel  = QSPI_DMA_CHANNEL,                     \
-        .Init.Direction = DMA_PERIPH_TO_MEMORY,                \
-        .Init.PeriphInc = DMA_PINC_DISABLE,                    \
-        .Init.MemInc = DMA_MINC_ENABLE,                        \
-        .Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE,       \
-        .Init.MemDataAlignment = DMA_MDATAALIGN_BYTE,          \
-        .Init.Mode = DMA_NORMAL,                               \
-        .Init.Priority = DMA_PRIORITY_LOW                      \
-    }
+#define QSPI_DMA_CONFIG                 \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX(   \
+        QSPI_DMA_INSTANCE,              \
+        QSPI_DMA_RCC,                   \
+        QSPI_DMA_IRQ,                   \
+        QSPI_DMA_CHANNEL,               \
+        0U,                             \
+        QSPI_DMA_PRIORITY,              \
+        QSPI_DMA_PREEMPT_PRIORITY,      \
+        QSPI_DMA_SUB_PRIORITY)
 #endif /* QSPI_DMA_CONFIG */
 #endif /* BSP_QSPI_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/sdio_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/sdio_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-13     BalanceTWK   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SDIO_CONFIG_H__
@@ -19,17 +20,71 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_SDIO
-#define SDIO_BUS_CONFIG                                  \
-    {                                                    \
-        .Instance = SDIO,                                \
-        .dma_rx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_tx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_rx.Instance = DMA2_Stream3,                 \
-        .dma_rx.channel = DMA_CHANNEL_4,                 \
-        .dma_rx.dma_irq = DMA2_Stream3_IRQn,             \
-        .dma_tx.Instance = DMA2_Stream6,                 \
-        .dma_tx.channel = DMA_CHANNEL_4,                 \
-        .dma_tx.dma_irq = DMA2_Stream6_IRQn,             \
+#ifndef SDIO_RX_DMA_PRIORITY
+#define SDIO_RX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_RX_DMA_PRIORITY */
+
+#ifndef SDIO_RX_DMA_PREEMPT_PRIORITY
+#define SDIO_RX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_RX_DMA_SUB_PRIORITY
+#define SDIO_RX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_RX_DMA_SUB_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PRIORITY
+#define SDIO_TX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_TX_DMA_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PREEMPT_PRIORITY
+#define SDIO_TX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_TX_DMA_SUB_PRIORITY
+#define SDIO_TX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_TX_DMA_SUB_PRIORITY */
+
+#define SDIO_BUS_CONFIG                          \
+    {                                            \
+        .Instance = SDIO,                        \
+        .dma_rx = STM32_DMA_CONFIG_INIT_FIFO_EX( \
+            DMA2_Stream3,                        \
+            RCC_AHB1ENR_DMA2EN,                  \
+            DMA2_Stream3_IRQn,                   \
+            DMA_CHANNEL_4,                       \
+            0U,                                  \
+            SDIO_RX_DMA_PRIORITY,                \
+            SDIO_RX_DMA_PREEMPT_PRIORITY,        \
+            SDIO_RX_DMA_SUB_PRIORITY,            \
+            DMA_PERIPH_TO_MEMORY,                \
+            DMA_PINC_DISABLE,                    \
+            DMA_MINC_ENABLE,                     \
+            DMA_PDATAALIGN_WORD,                 \
+            DMA_MDATAALIGN_WORD,                 \
+            DMA_PFCTRL,                          \
+            DMA_FIFOMODE_ENABLE,                 \
+            DMA_FIFO_THRESHOLD_FULL,             \
+            DMA_MBURST_INC4,                     \
+            DMA_PBURST_INC4),                    \
+        .dma_tx = STM32_DMA_CONFIG_INIT_FIFO_EX( \
+            DMA2_Stream6,                        \
+            RCC_AHB1ENR_DMA2EN,                  \
+            DMA2_Stream6_IRQn,                   \
+            DMA_CHANNEL_4,                       \
+            0U,                                  \
+            SDIO_TX_DMA_PRIORITY,                \
+            SDIO_TX_DMA_PREEMPT_PRIORITY,        \
+            SDIO_TX_DMA_SUB_PRIORITY,            \
+            DMA_MEMORY_TO_PERIPH,                \
+            DMA_PINC_DISABLE,                    \
+            DMA_MINC_ENABLE,                     \
+            DMA_PDATAALIGN_WORD,                 \
+            DMA_MDATAALIGN_WORD,                 \
+            DMA_PFCTRL,                          \
+            DMA_FIFOMODE_ENABLE,                 \
+            DMA_FIFO_THRESHOLD_FULL,             \
+            DMA_MBURST_INC4,                     \
+            DMA_PBURST_INC4),                    \
     }
 
 #endif
@@ -39,6 +94,3 @@ extern "C" {
 #endif
 
 #endif /*__SDIO_CONFIG_H__ */
-
-
-

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/spi_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
  * 2019-01-03     zylx         modify DMA support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -20,178 +21,393 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI1,                           \
-        .bus_name = "spi1",                         \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
+
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_TX_DMA_RCC,                 \
-        .Instance = SPI1_TX_DMA_INSTANCE,           \
-        .channel = SPI1_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI1_TX_DMA_IRQ,                 \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        SPI1_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
+
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_RX_DMA_RCC,                 \
-        .Instance = SPI1_RX_DMA_INSTANCE,           \
-        .channel = SPI1_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI1_RX_DMA_IRQ,                 \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        SPI1_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI2,                           \
-        .bus_name = "spi2",                         \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
+
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_TX_DMA_RCC,                 \
-        .Instance = SPI2_TX_DMA_INSTANCE,           \
-        .channel = SPI2_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI2_TX_DMA_IRQ,                 \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        SPI2_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
+
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_RX_DMA_RCC,                 \
-        .Instance = SPI2_RX_DMA_INSTANCE,           \
-        .channel = SPI2_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI2_RX_DMA_IRQ,                 \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        SPI2_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI3,                           \
-        .bus_name = "spi3",                         \
-        .irq_type = SPI3_IRQn,                      \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
+
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_TX_DMA_RCC,                 \
-        .Instance = SPI3_TX_DMA_INSTANCE,           \
-        .channel = SPI3_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI3_TX_DMA_IRQ,                 \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        SPI3_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
+
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_RX_DMA_RCC,                 \
-        .Instance = SPI3_RX_DMA_INSTANCE,           \
-        .channel = SPI3_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI3_RX_DMA_IRQ,                 \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        SPI3_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI4
 #ifndef SPI4_BUS_CONFIG
-#define SPI4_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI4,                           \
-        .bus_name = "spi4",                         \
-        .irq_type = SPI4_IRQn,                      \
+#define SPI4_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI4,      \
+        .bus_name = "spi4",    \
+        .irq_type = SPI4_IRQn, \
     }
 #endif /* SPI4_BUS_CONFIG */
 #endif /* BSP_USING_SPI4 */
 
 #ifdef BSP_SPI4_TX_USING_DMA
+#ifndef SPI4_TX_DMA_PRIORITY
+#define SPI4_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI4_TX_DMA_PRIORITY */
+
+#ifndef SPI4_TX_DMA_PREEMPT_PRIORITY
+#define SPI4_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI4_TX_DMA_SUB_PRIORITY
+#define SPI4_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI4_TX_DMA_SUB_PRIORITY */
+
 #ifndef SPI4_TX_DMA_CONFIG
-#define SPI4_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI4_TX_DMA_RCC,                 \
-        .Instance = SPI4_TX_DMA_INSTANCE,           \
-        .channel = SPI4_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI4_TX_DMA_IRQ,                 \
-    }
+#define SPI4_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI4_TX_DMA_INSTANCE,         \
+        SPI4_TX_DMA_RCC,              \
+        SPI4_TX_DMA_IRQ,              \
+        SPI4_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI4_TX_DMA_PRIORITY,         \
+        SPI4_TX_DMA_PREEMPT_PRIORITY, \
+        SPI4_TX_DMA_SUB_PRIORITY)
 #endif /* SPI4_TX_DMA_CONFIG */
 #endif /* BSP_SPI4_TX_USING_DMA */
 
 #ifdef BSP_SPI4_RX_USING_DMA
+#ifndef SPI4_RX_DMA_PRIORITY
+#define SPI4_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI4_RX_DMA_PRIORITY */
+
+#ifndef SPI4_RX_DMA_PREEMPT_PRIORITY
+#define SPI4_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI4_RX_DMA_SUB_PRIORITY
+#define SPI4_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI4_RX_DMA_SUB_PRIORITY */
+
 #ifndef SPI4_RX_DMA_CONFIG
-#define SPI4_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI4_RX_DMA_RCC,                 \
-        .Instance = SPI4_RX_DMA_INSTANCE,           \
-        .channel = SPI4_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI4_RX_DMA_IRQ,                 \
-    }
+#define SPI4_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI4_RX_DMA_INSTANCE,         \
+        SPI4_RX_DMA_RCC,              \
+        SPI4_RX_DMA_IRQ,              \
+        SPI4_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI4_RX_DMA_PRIORITY,         \
+        SPI4_RX_DMA_PREEMPT_PRIORITY, \
+        SPI4_RX_DMA_SUB_PRIORITY)
 #endif /* SPI4_RX_DMA_CONFIG */
 #endif /* BSP_SPI4_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI5
 #ifndef SPI5_BUS_CONFIG
-#define SPI5_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI5,                           \
-        .bus_name = "spi5",                         \
-        .irq_type = SPI5_IRQn,                      \
+#define SPI5_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI5,      \
+        .bus_name = "spi5",    \
+        .irq_type = SPI5_IRQn, \
     }
 #endif /* SPI5_BUS_CONFIG */
 #endif /* BSP_USING_SPI5 */
 
 #ifdef BSP_SPI5_TX_USING_DMA
+#ifndef SPI5_TX_DMA_PRIORITY
+#define SPI5_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI5_TX_DMA_PRIORITY */
+
+#ifndef SPI5_TX_DMA_PREEMPT_PRIORITY
+#define SPI5_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI5_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI5_TX_DMA_SUB_PRIORITY
+#define SPI5_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI5_TX_DMA_SUB_PRIORITY */
+
 #ifndef SPI5_TX_DMA_CONFIG
-#define SPI5_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI5_TX_DMA_RCC,                 \
-        .Instance = SPI5_TX_DMA_INSTANCE,           \
-        .channel = SPI5_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI5_TX_DMA_IRQ,                 \
-    }
+#define SPI5_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI5_TX_DMA_INSTANCE,         \
+        SPI5_TX_DMA_RCC,              \
+        SPI5_TX_DMA_IRQ,              \
+        SPI5_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI5_TX_DMA_PRIORITY,         \
+        SPI5_TX_DMA_PREEMPT_PRIORITY, \
+        SPI5_TX_DMA_SUB_PRIORITY)
 #endif /* SPI5_TX_DMA_CONFIG */
 #endif /* BSP_SPI5_TX_USING_DMA */
 
 #ifdef BSP_SPI5_RX_USING_DMA
+#ifndef SPI5_RX_DMA_PRIORITY
+#define SPI5_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI5_RX_DMA_PRIORITY */
+
+#ifndef SPI5_RX_DMA_PREEMPT_PRIORITY
+#define SPI5_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI5_RX_DMA_SUB_PRIORITY
+#define SPI5_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI5_RX_DMA_SUB_PRIORITY */
+
 #ifndef SPI5_RX_DMA_CONFIG
-#define SPI5_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI5_RX_DMA_RCC,                 \
-        .Instance = SPI5_RX_DMA_INSTANCE,           \
-        .channel = SPI5_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI5_RX_DMA_IRQ,                 \
-    }
+#define SPI5_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI5_RX_DMA_INSTANCE,         \
+        SPI5_RX_DMA_RCC,              \
+        SPI5_RX_DMA_IRQ,              \
+        SPI5_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI5_RX_DMA_PRIORITY,         \
+        SPI5_RX_DMA_PREEMPT_PRIORITY, \
+        SPI5_RX_DMA_SUB_PRIORITY)
 #endif /* SPI5_RX_DMA_CONFIG */
 #endif /* BSP_SPI5_RX_USING_DMA */
+
+#ifdef BSP_USING_SPI6
+#ifndef SPI6_BUS_CONFIG
+#define SPI6_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI6,      \
+        .bus_name = "spi6",    \
+        .irq_type = SPI6_IRQn, \
+    }
+#endif /* SPI6_BUS_CONFIG */
+#endif /* BSP_USING_SPI6 */
+
+#ifdef BSP_SPI6_TX_USING_DMA
+#ifndef SPI6_TX_DMA_PRIORITY
+#define SPI6_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI6_TX_DMA_PRIORITY */
+
+#ifndef SPI6_TX_DMA_PREEMPT_PRIORITY
+#define SPI6_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI6_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI6_TX_DMA_SUB_PRIORITY
+#define SPI6_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI6_TX_DMA_SUB_PRIORITY */
+
+#ifndef SPI6_TX_DMA_CONFIG
+#define SPI6_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI6_TX_DMA_INSTANCE,         \
+        SPI6_TX_DMA_RCC,              \
+        SPI6_TX_DMA_IRQ,              \
+        SPI6_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI6_TX_DMA_PRIORITY,         \
+        SPI6_TX_DMA_PREEMPT_PRIORITY, \
+        SPI6_TX_DMA_SUB_PRIORITY)
+#endif /* SPI6_TX_DMA_CONFIG */
+#endif /* BSP_SPI6_TX_USING_DMA */
+
+#ifdef BSP_SPI6_RX_USING_DMA
+#ifndef SPI6_RX_DMA_PRIORITY
+#define SPI6_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI6_RX_DMA_PRIORITY */
+
+#ifndef SPI6_RX_DMA_PREEMPT_PRIORITY
+#define SPI6_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI6_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI6_RX_DMA_SUB_PRIORITY
+#define SPI6_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI6_RX_DMA_SUB_PRIORITY */
+
+#ifndef SPI6_RX_DMA_CONFIG
+#define SPI6_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI6_RX_DMA_INSTANCE,         \
+        SPI6_RX_DMA_RCC,              \
+        SPI6_RX_DMA_IRQ,              \
+        SPI6_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI6_RX_DMA_PRIORITY,         \
+        SPI6_RX_DMA_PREEMPT_PRIORITY, \
+        SPI6_RX_DMA_SUB_PRIORITY)
+#endif /* SPI6_RX_DMA_CONFIG */
+#endif /* BSP_SPI6_RX_USING_DMA */
 
 #ifdef __cplusplus
 }

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f4/uart_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-10-30     SummerGift   first version
  * 2019-01-03     zylx         modify dma support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -20,280 +21,520 @@ extern "C" {
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART1_RX_DMA_INSTANCE,                         \
-        .channel = UART1_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_RX_DMA_RCC,                               \
-        .dma_irq = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        UART1_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART1_TX_DMA_INSTANCE,                         \
-        .channel = UART1_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_TX_DMA_RCC,                               \
-        .dma_irq = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART1_TX_DMA_INSTANCE,         \
+        UART1_TX_DMA_RCC,              \
+        UART1_TX_DMA_IRQ,              \
+        UART1_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART1_TX_DMA_PRIORITY,         \
+        UART1_TX_DMA_PREEMPT_PRIORITY, \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART2_RX_DMA_INSTANCE,                         \
-        .channel = UART2_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_RX_DMA_RCC,                               \
-        .dma_irq = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        UART2_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART2_TX_DMA_INSTANCE,                         \
-        .channel = UART2_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_TX_DMA_RCC,                               \
-        .dma_irq = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        UART2_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART3_RX_DMA_INSTANCE,                         \
-        .channel = UART3_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_RX_DMA_RCC,                               \
-        .dma_irq = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        UART3_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART3_TX_DMA_INSTANCE,                         \
-        .channel = UART3_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_TX_DMA_RCC,                               \
-        .dma_irq = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART3_TX_DMA_INSTANCE,         \
+        UART3_TX_DMA_RCC,              \
+        UART3_TX_DMA_IRQ,              \
+        UART3_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART3_TX_DMA_PRIORITY,         \
+        UART3_TX_DMA_PREEMPT_PRIORITY, \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_USING_UART4)
 #ifndef UART4_CONFIG
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = UART4,                                          \
-        .irq_type = UART4_IRQn,                                     \
+#define UART4_CONFIG            \
+    {                           \
+        .name = "uart4",        \
+        .Instance = UART4,      \
+        .irq_type = UART4_IRQn, \
     }
 #endif /* UART4_CONFIG */
 
 #if defined(BSP_UART4_RX_USING_DMA)
+#ifndef UART4_RX_DMA_PRIORITY
+#define UART4_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_RX_DMA_PRIORITY */
+
+#ifndef UART4_RX_DMA_PREEMPT_PRIORITY
+#define UART4_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_RX_DMA_SUB_PRIORITY
+#define UART4_RX_DMA_SUB_PRIORITY             0
+#endif /* UART4_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_RX_CONFIG
-#define UART4_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART4_RX_DMA_INSTANCE,                         \
-        .channel = UART4_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART4_RX_DMA_RCC,                               \
-        .dma_irq = UART4_RX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART4_RX_DMA_INSTANCE,                 \
+        UART4_RX_DMA_RCC,                      \
+        UART4_RX_DMA_IRQ,                      \
+        UART4_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART4_RX_DMA_PRIORITY,                 \
+        UART4_RX_DMA_PREEMPT_PRIORITY,         \
+        UART4_RX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_RX_CONFIG */
 #endif /* BSP_UART4_RX_USING_DMA */
 
 #if defined(BSP_UART4_TX_USING_DMA)
+#ifndef UART4_TX_DMA_PRIORITY
+#define UART4_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_TX_DMA_PRIORITY */
+
+#ifndef UART4_TX_DMA_PREEMPT_PRIORITY
+#define UART4_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_TX_DMA_SUB_PRIORITY
+#define UART4_TX_DMA_SUB_PRIORITY             0
+#endif /* UART4_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_TX_CONFIG
-#define UART4_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART4_TX_DMA_INSTANCE,                         \
-        .channel = UART4_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART4_TX_DMA_RCC,                               \
-        .dma_irq = UART4_TX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART4_TX_DMA_INSTANCE,         \
+        UART4_TX_DMA_RCC,              \
+        UART4_TX_DMA_IRQ,              \
+        UART4_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART4_TX_DMA_PRIORITY,         \
+        UART4_TX_DMA_PREEMPT_PRIORITY, \
+        UART4_TX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_TX_CONFIG */
-#endif /* BSP_UART4_RX_USING_DMA */
+#endif /* BSP_UART4_TX_USING_DMA */
 #endif /* BSP_USING_UART4 */
 
 #if defined(BSP_USING_UART5)
 #ifndef UART5_CONFIG
-#define UART5_CONFIG                                                \
-    {                                                               \
-        .name = "uart5",                                            \
-        .Instance = UART5,                                          \
-        .irq_type = UART5_IRQn,                                     \
+#define UART5_CONFIG            \
+    {                           \
+        .name = "uart5",        \
+        .Instance = UART5,      \
+        .irq_type = UART5_IRQn, \
     }
 #endif /* UART5_CONFIG */
 
 #if defined(BSP_UART5_RX_USING_DMA)
+#ifndef UART5_RX_DMA_PRIORITY
+#define UART5_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_RX_DMA_PRIORITY */
+
+#ifndef UART5_RX_DMA_PREEMPT_PRIORITY
+#define UART5_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_RX_DMA_SUB_PRIORITY
+#define UART5_RX_DMA_SUB_PRIORITY             0
+#endif /* UART5_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_RX_CONFIG
-#define UART5_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART5_RX_DMA_INSTANCE,                         \
-        .channel = UART5_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART5_RX_DMA_RCC,                               \
-        .dma_irq = UART5_RX_DMA_IRQ,                               \
-    }
+#define UART5_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART5_RX_DMA_INSTANCE,                 \
+        UART5_RX_DMA_RCC,                      \
+        UART5_RX_DMA_IRQ,                      \
+        UART5_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART5_RX_DMA_PRIORITY,                 \
+        UART5_RX_DMA_PREEMPT_PRIORITY,         \
+        UART5_RX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_RX_CONFIG */
 #endif /* BSP_UART5_RX_USING_DMA */
 
 #if defined(BSP_UART5_TX_USING_DMA)
+#ifndef UART5_TX_DMA_PRIORITY
+#define UART5_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_TX_DMA_PRIORITY */
+
+#ifndef UART5_TX_DMA_PREEMPT_PRIORITY
+#define UART5_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_TX_DMA_SUB_PRIORITY
+#define UART5_TX_DMA_SUB_PRIORITY             0
+#endif /* UART5_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_TX_CONFIG
-#define UART5_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART5_TX_DMA_INSTANCE,                         \
-        .channel = UART5_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART5_TX_DMA_RCC,                               \
-        .dma_irq = UART5_TX_DMA_IRQ,                               \
-    }
+#define UART5_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART5_TX_DMA_INSTANCE,         \
+        UART5_TX_DMA_RCC,              \
+        UART5_TX_DMA_IRQ,              \
+        UART5_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART5_TX_DMA_PRIORITY,         \
+        UART5_TX_DMA_PREEMPT_PRIORITY, \
+        UART5_TX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_TX_CONFIG */
 #endif /* BSP_UART5_TX_USING_DMA */
 #endif /* BSP_USING_UART5 */
 
 #if defined(BSP_USING_UART6)
 #ifndef UART6_CONFIG
-#define UART6_CONFIG                                                \
-    {                                                               \
-        .name = "uart6",                                            \
-        .Instance = USART6,                                         \
-        .irq_type = USART6_IRQn,                                    \
+#define UART6_CONFIG             \
+    {                            \
+        .name = "uart6",         \
+        .Instance = USART6,      \
+        .irq_type = USART6_IRQn, \
     }
 #endif /* UART6_CONFIG */
 
 #if defined(BSP_UART6_RX_USING_DMA)
+#ifndef UART6_RX_DMA_PRIORITY
+#define UART6_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART6_RX_DMA_PRIORITY */
+
+#ifndef UART6_RX_DMA_PREEMPT_PRIORITY
+#define UART6_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART6_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART6_RX_DMA_SUB_PRIORITY
+#define UART6_RX_DMA_SUB_PRIORITY             0
+#endif /* UART6_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART6_DMA_RX_CONFIG
-#define UART6_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART6_RX_DMA_INSTANCE,                         \
-        .channel = UART6_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART6_RX_DMA_RCC,                               \
-        .dma_irq = UART6_RX_DMA_IRQ,                               \
-    }
+#define UART6_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART6_RX_DMA_INSTANCE,                 \
+        UART6_RX_DMA_RCC,                      \
+        UART6_RX_DMA_IRQ,                      \
+        UART6_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART6_RX_DMA_PRIORITY,                 \
+        UART6_RX_DMA_PREEMPT_PRIORITY,         \
+        UART6_RX_DMA_SUB_PRIORITY)
 #endif /* UART6_DMA_RX_CONFIG */
 #endif /* BSP_UART6_RX_USING_DMA */
 
 #if defined(BSP_UART6_TX_USING_DMA)
+#ifndef UART6_TX_DMA_PRIORITY
+#define UART6_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART6_TX_DMA_PRIORITY */
+
+#ifndef UART6_TX_DMA_PREEMPT_PRIORITY
+#define UART6_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART6_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART6_TX_DMA_SUB_PRIORITY
+#define UART6_TX_DMA_SUB_PRIORITY             0
+#endif /* UART6_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART6_DMA_TX_CONFIG
-#define UART6_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART6_TX_DMA_INSTANCE,                         \
-        .channel = UART6_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART6_TX_DMA_RCC,                               \
-        .dma_irq = UART6_TX_DMA_IRQ,                               \
-    }
+#define UART6_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART6_TX_DMA_INSTANCE,         \
+        UART6_TX_DMA_RCC,              \
+        UART6_TX_DMA_IRQ,              \
+        UART6_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART6_TX_DMA_PRIORITY,         \
+        UART6_TX_DMA_PREEMPT_PRIORITY, \
+        UART6_TX_DMA_SUB_PRIORITY)
 #endif /* UART6_DMA_TX_CONFIG */
 #endif /* BSP_UART6_TX_USING_DMA */
 #endif /* BSP_USING_UART6 */
 
 #if defined(BSP_USING_UART7)
 #ifndef UART7_CONFIG
-#define UART7_CONFIG                                                \
-    {                                                               \
-        .name = "uart7",                                            \
-        .Instance = UART7,                                         \
-        .irq_type = UART7_IRQn,                                    \
+#define UART7_CONFIG            \
+    {                           \
+        .name = "uart7",        \
+        .Instance = UART7,      \
+        .irq_type = UART7_IRQn, \
     }
 #endif /* UART7_CONFIG */
 
 #if defined(BSP_UART7_RX_USING_DMA)
+#ifndef UART7_RX_DMA_PRIORITY
+#define UART7_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART7_RX_DMA_PRIORITY */
+
+#ifndef UART7_RX_DMA_PREEMPT_PRIORITY
+#define UART7_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART7_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART7_RX_DMA_SUB_PRIORITY
+#define UART7_RX_DMA_SUB_PRIORITY             0
+#endif /* UART7_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART7_DMA_RX_CONFIG
-#define UART7_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART7_RX_DMA_INSTANCE,                         \
-        .channel = UART7_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART7_RX_DMA_RCC,                               \
-        .dma_irq = UART7_RX_DMA_IRQ,                               \
-    }
+#define UART7_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART7_RX_DMA_INSTANCE,                 \
+        UART7_RX_DMA_RCC,                      \
+        UART7_RX_DMA_IRQ,                      \
+        UART7_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART7_RX_DMA_PRIORITY,                 \
+        UART7_RX_DMA_PREEMPT_PRIORITY,         \
+        UART7_RX_DMA_SUB_PRIORITY)
 #endif /* UART7_DMA_RX_CONFIG */
 #endif /* BSP_UART7_RX_USING_DMA */
 
 #if defined(BSP_UART7_TX_USING_DMA)
+#ifndef UART7_TX_DMA_PRIORITY
+#define UART7_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART7_TX_DMA_PRIORITY */
+
+#ifndef UART7_TX_DMA_PREEMPT_PRIORITY
+#define UART7_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART7_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART7_TX_DMA_SUB_PRIORITY
+#define UART7_TX_DMA_SUB_PRIORITY             0
+#endif /* UART7_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART7_DMA_TX_CONFIG
-#define UART7_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART7_TX_DMA_INSTANCE,                         \
-        .channel = UART7_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART7_TX_DMA_RCC,                               \
-        .dma_irq = UART7_TX_DMA_IRQ,                               \
-    }
+#define UART7_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART7_TX_DMA_INSTANCE,         \
+        UART7_TX_DMA_RCC,              \
+        UART7_TX_DMA_IRQ,              \
+        UART7_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART7_TX_DMA_PRIORITY,         \
+        UART7_TX_DMA_PREEMPT_PRIORITY, \
+        UART7_TX_DMA_SUB_PRIORITY)
 #endif /* UART7_DMA_TX_CONFIG */
 #endif /* BSP_UART7_TX_USING_DMA */
 #endif /* BSP_USING_UART7 */
 
 #if defined(BSP_USING_UART8)
 #ifndef UART8_CONFIG
-#define UART8_CONFIG                                                \
-    {                                                               \
-        .name = "uart8",                                            \
-        .Instance = UART8,                                         \
-        .irq_type = UART8_IRQn,                                    \
+#define UART8_CONFIG            \
+    {                           \
+        .name = "uart8",        \
+        .Instance = UART8,      \
+        .irq_type = UART8_IRQn, \
     }
 #endif /* UART8_CONFIG */
 
 #if defined(BSP_UART8_RX_USING_DMA)
+#ifndef UART8_RX_DMA_PRIORITY
+#define UART8_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART8_RX_DMA_PRIORITY */
+
+#ifndef UART8_RX_DMA_PREEMPT_PRIORITY
+#define UART8_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART8_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART8_RX_DMA_SUB_PRIORITY
+#define UART8_RX_DMA_SUB_PRIORITY             0
+#endif /* UART8_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART8_DMA_RX_CONFIG
-#define UART8_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART8_RX_DMA_INSTANCE,                         \
-        .channel = UART8_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART8_RX_DMA_RCC,                               \
-        .dma_irq = UART8_RX_DMA_IRQ,                               \
-    }
+#define UART8_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART8_RX_DMA_INSTANCE,                 \
+        UART8_RX_DMA_RCC,                      \
+        UART8_RX_DMA_IRQ,                      \
+        UART8_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART8_RX_DMA_PRIORITY,                 \
+        UART8_RX_DMA_PREEMPT_PRIORITY,         \
+        UART8_RX_DMA_SUB_PRIORITY)
 #endif /* UART8_DMA_RX_CONFIG */
 #endif /* BSP_UART8_RX_USING_DMA */
 
 #if defined(BSP_UART8_TX_USING_DMA)
+#ifndef UART8_TX_DMA_PRIORITY
+#define UART8_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART8_TX_DMA_PRIORITY */
+
+#ifndef UART8_TX_DMA_PREEMPT_PRIORITY
+#define UART8_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART8_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART8_TX_DMA_SUB_PRIORITY
+#define UART8_TX_DMA_SUB_PRIORITY             0
+#endif /* UART8_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART8_DMA_TX_CONFIG
-#define UART8_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART8_TX_DMA_INSTANCE,                         \
-        .channel = UART8_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART8_TX_DMA_RCC,                               \
-        .dma_irq = UART8_TX_DMA_IRQ,                               \
-    }
+#define UART8_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART8_TX_DMA_INSTANCE,         \
+        UART8_TX_DMA_RCC,              \
+        UART8_TX_DMA_IRQ,              \
+        UART8_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART8_TX_DMA_PRIORITY,         \
+        UART8_TX_DMA_PREEMPT_PRIORITY, \
+        UART8_TX_DMA_SUB_PRIORITY)
 #endif /* UART8_DMA_TX_CONFIG */
 #endif /* BSP_UART8_TX_USING_DMA */
 #endif /* BSP_USING_UART8 */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f7/qspi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f7/qspi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-22     zylx         first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __QSPI_CONFIG_H__
@@ -30,19 +31,29 @@ extern "C" {
 #endif /* BSP_USING_QSPI */
 
 #ifdef BSP_QSPI_USING_DMA
+#ifndef QSPI_DMA_PRIORITY
+#define QSPI_DMA_PRIORITY                         DMA_PRIORITY_LOW
+#endif /* QSPI_DMA_PRIORITY */
+
+#ifndef QSPI_DMA_PREEMPT_PRIORITY
+#define QSPI_DMA_PREEMPT_PRIORITY                 0
+#endif /* QSPI_DMA_PREEMPT_PRIORITY */
+
+#ifndef QSPI_DMA_SUB_PRIORITY
+#define QSPI_DMA_SUB_PRIORITY                     0
+#endif /* QSPI_DMA_SUB_PRIORITY */
+
 #ifndef QSPI_DMA_CONFIG
-#define QSPI_DMA_CONFIG                                        \
-    {                                                          \
-        .Instance = QSPI_DMA_INSTANCE,                         \
-        .Init.Channel  = QSPI_DMA_CHANNEL,                     \
-        .Init.Direction = DMA_PERIPH_TO_MEMORY,                \
-        .Init.PeriphInc = DMA_PINC_DISABLE,                    \
-        .Init.MemInc = DMA_MINC_ENABLE,                        \
-        .Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE,       \
-        .Init.MemDataAlignment = DMA_MDATAALIGN_BYTE,          \
-        .Init.Mode = DMA_NORMAL,                               \
-        .Init.Priority = DMA_PRIORITY_LOW                      \
-    }
+#define QSPI_DMA_CONFIG               \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        QSPI_DMA_INSTANCE,            \
+        QSPI_DMA_RCC,                 \
+        QSPI_DMA_IRQ,                 \
+        QSPI_DMA_CHANNEL,             \
+        0U,                           \
+        QSPI_DMA_PRIORITY,            \
+        QSPI_DMA_PREEMPT_PRIORITY,    \
+        QSPI_DMA_SUB_PRIORITY)
 #endif /* QSPI_DMA_CONFIG */
 #endif /* BSP_QSPI_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f7/sdio_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f7/sdio_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-13     BalanceTWK   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SDIO_CONFIG_H__
@@ -19,17 +20,71 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_SDIO
-#define SDIO_BUS_CONFIG                                  \
-    {                                                    \
-        .Instance = SDMMC1,                              \
-        .dma_rx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_tx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_rx.Instance = DMA2_Stream3,                 \
-        .dma_rx.channel = DMA_CHANNEL_4,                 \
-        .dma_rx.dma_irq = DMA2_Stream3_IRQn,             \
-        .dma_tx.Instance = DMA2_Stream6,                 \
-        .dma_tx.channel = DMA_CHANNEL_4,                 \
-        .dma_tx.dma_irq = DMA2_Stream6_IRQn,             \
+#ifndef SDIO_RX_DMA_PRIORITY
+#define SDIO_RX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_RX_DMA_PRIORITY */
+
+#ifndef SDIO_RX_DMA_PREEMPT_PRIORITY
+#define SDIO_RX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_RX_DMA_SUB_PRIORITY
+#define SDIO_RX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_RX_DMA_SUB_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PRIORITY
+#define SDIO_TX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_TX_DMA_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PREEMPT_PRIORITY
+#define SDIO_TX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_TX_DMA_SUB_PRIORITY
+#define SDIO_TX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_TX_DMA_SUB_PRIORITY */
+
+#define SDIO_BUS_CONFIG                          \
+    {                                            \
+        .Instance = SDMMC1,                      \
+        .dma_rx = STM32_DMA_CONFIG_INIT_FIFO_EX( \
+            DMA2_Stream3,                        \
+            RCC_AHB1ENR_DMA2EN,                  \
+            DMA2_Stream3_IRQn,                   \
+            DMA_CHANNEL_4,                       \
+            0U,                                  \
+            SDIO_RX_DMA_PRIORITY,                \
+            SDIO_RX_DMA_PREEMPT_PRIORITY,        \
+            SDIO_RX_DMA_SUB_PRIORITY,            \
+            DMA_PERIPH_TO_MEMORY,                \
+            DMA_PINC_DISABLE,                    \
+            DMA_MINC_ENABLE,                     \
+            DMA_PDATAALIGN_WORD,                 \
+            DMA_MDATAALIGN_WORD,                 \
+            DMA_PFCTRL,                          \
+            DMA_FIFOMODE_ENABLE,                 \
+            DMA_FIFO_THRESHOLD_FULL,             \
+            DMA_MBURST_INC4,                     \
+            DMA_PBURST_INC4),                    \
+        .dma_tx = STM32_DMA_CONFIG_INIT_FIFO_EX( \
+            DMA2_Stream6,                        \
+            RCC_AHB1ENR_DMA2EN,                  \
+            DMA2_Stream6_IRQn,                   \
+            DMA_CHANNEL_4,                       \
+            0U,                                  \
+            SDIO_TX_DMA_PRIORITY,                \
+            SDIO_TX_DMA_PREEMPT_PRIORITY,        \
+            SDIO_TX_DMA_SUB_PRIORITY,            \
+            DMA_MEMORY_TO_PERIPH,                \
+            DMA_PINC_DISABLE,                    \
+            DMA_MINC_ENABLE,                     \
+            DMA_PDATAALIGN_WORD,                 \
+            DMA_MDATAALIGN_WORD,                 \
+            DMA_PFCTRL,                          \
+            DMA_FIFOMODE_ENABLE,                 \
+            DMA_FIFO_THRESHOLD_FULL,             \
+            DMA_MBURST_INC4,                     \
+            DMA_PBURST_INC4),                    \
     }
 
 #endif

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f7/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f7/spi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -19,176 +20,316 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI1,                           \
-        .bus_name = "spi1",                         \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_TX_DMA_RCC,                 \
-        .Instance = SPI1_TX_DMA_INSTANCE,           \
-        .channel = SPI1_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI1_TX_DMA_IRQ,                 \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        SPI1_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_RX_DMA_RCC,                 \
-        .Instance = SPI1_RX_DMA_INSTANCE,           \
-        .channel = SPI1_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI1_RX_DMA_IRQ,                 \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        SPI1_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI2,                           \
-        .bus_name = "spi2",                         \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_TX_DMA_RCC,                 \
-        .Instance = SPI2_TX_DMA_INSTANCE,           \
-        .channel = SPI2_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI2_TX_DMA_IRQ,                 \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        SPI2_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_RX_DMA_RCC,                 \
-        .Instance = SPI2_RX_DMA_INSTANCE,           \
-        .channel = SPI2_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI2_RX_DMA_IRQ,                 \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        SPI2_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI3,                           \
-        .bus_name = "spi3",                         \
-        .irq_type = SPI3_IRQn,                      \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_TX_DMA_RCC,                 \
-        .Instance = SPI3_TX_DMA_INSTANCE,           \
-        .channel = SPI3_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI3_TX_DMA_IRQ,                 \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        SPI3_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_RX_DMA_RCC,                 \
-        .Instance = SPI3_RX_DMA_INSTANCE,           \
-        .channel = SPI3_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI3_RX_DMA_IRQ,                 \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        SPI3_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI4
 #ifndef SPI4_BUS_CONFIG
-#define SPI4_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI4,                           \
-        .bus_name = "spi4",                         \
-        .irq_type = SPI4_IRQn,                      \
+#define SPI4_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI4,      \
+        .bus_name = "spi4",    \
+        .irq_type = SPI4_IRQn, \
     }
 #endif /* SPI4_BUS_CONFIG */
 #endif /* BSP_USING_SPI4 */
 
 #ifdef BSP_SPI4_TX_USING_DMA
+#ifndef SPI4_TX_DMA_PRIORITY
+#define SPI4_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI4_TX_DMA_PRIORITY */
+
+#ifndef SPI4_TX_DMA_PREEMPT_PRIORITY
+#define SPI4_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI4_TX_DMA_SUB_PRIORITY
+#define SPI4_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI4_TX_DMA_SUB_PRIORITY */
 #ifndef SPI4_TX_DMA_CONFIG
-#define SPI4_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI4_TX_DMA_RCC,                 \
-        .Instance = SPI4_TX_DMA_INSTANCE,           \
-        .channel = SPI4_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI4_TX_DMA_IRQ,                 \
-    }
+#define SPI4_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI4_TX_DMA_INSTANCE,         \
+        SPI4_TX_DMA_RCC,              \
+        SPI4_TX_DMA_IRQ,              \
+        SPI4_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI4_TX_DMA_PRIORITY,         \
+        SPI4_TX_DMA_PREEMPT_PRIORITY, \
+        SPI4_TX_DMA_SUB_PRIORITY)
 #endif /* SPI4_TX_DMA_CONFIG */
 #endif /* BSP_SPI4_TX_USING_DMA */
 
 #ifdef BSP_SPI4_RX_USING_DMA
+#ifndef SPI4_RX_DMA_PRIORITY
+#define SPI4_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI4_RX_DMA_PRIORITY */
+
+#ifndef SPI4_RX_DMA_PREEMPT_PRIORITY
+#define SPI4_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI4_RX_DMA_SUB_PRIORITY
+#define SPI4_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI4_RX_DMA_SUB_PRIORITY */
 #ifndef SPI4_RX_DMA_CONFIG
-#define SPI4_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI4_RX_DMA_RCC,                 \
-        .Instance = SPI4_RX_DMA_INSTANCE,           \
-        .channel = SPI4_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI4_RX_DMA_IRQ,                 \
-    }
+#define SPI4_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI4_RX_DMA_INSTANCE,         \
+        SPI4_RX_DMA_RCC,              \
+        SPI4_RX_DMA_IRQ,              \
+        SPI4_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI4_RX_DMA_PRIORITY,         \
+        SPI4_RX_DMA_PREEMPT_PRIORITY, \
+        SPI4_RX_DMA_SUB_PRIORITY)
 #endif /* SPI4_RX_DMA_CONFIG */
 #endif /* BSP_SPI4_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI5
 #ifndef SPI5_BUS_CONFIG
-#define SPI5_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI5,                           \
-        .bus_name = "spi5",                         \
-        .irq_type = SPI5_IRQn,                      \
+#define SPI5_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI5,      \
+        .bus_name = "spi5",    \
+        .irq_type = SPI5_IRQn, \
     }
 #endif /* SPI5_BUS_CONFIG */
 #endif /* BSP_USING_SPI5 */
 
 #ifdef BSP_SPI5_TX_USING_DMA
+#ifndef SPI5_TX_DMA_PRIORITY
+#define SPI5_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI5_TX_DMA_PRIORITY */
+
+#ifndef SPI5_TX_DMA_PREEMPT_PRIORITY
+#define SPI5_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI5_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI5_TX_DMA_SUB_PRIORITY
+#define SPI5_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI5_TX_DMA_SUB_PRIORITY */
 #ifndef SPI5_TX_DMA_CONFIG
-#define SPI5_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI5_TX_DMA_RCC,                 \
-        .Instance = SPI5_TX_DMA_INSTANCE,           \
-        .channel = SPI5_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI5_TX_DMA_IRQ,                 \
-    }
+#define SPI5_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI5_TX_DMA_INSTANCE,         \
+        SPI5_TX_DMA_RCC,              \
+        SPI5_TX_DMA_IRQ,              \
+        SPI5_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI5_TX_DMA_PRIORITY,         \
+        SPI5_TX_DMA_PREEMPT_PRIORITY, \
+        SPI5_TX_DMA_SUB_PRIORITY)
 #endif /* SPI5_TX_DMA_CONFIG */
 #endif /* BSP_SPI5_TX_USING_DMA */
 
 #ifdef BSP_SPI5_RX_USING_DMA
+#ifndef SPI5_RX_DMA_PRIORITY
+#define SPI5_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI5_RX_DMA_PRIORITY */
+
+#ifndef SPI5_RX_DMA_PREEMPT_PRIORITY
+#define SPI5_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI5_RX_DMA_SUB_PRIORITY
+#define SPI5_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI5_RX_DMA_SUB_PRIORITY */
 #ifndef SPI5_RX_DMA_CONFIG
-#define SPI5_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI5_RX_DMA_RCC,                 \
-        .Instance = SPI5_RX_DMA_INSTANCE,           \
-        .channel = SPI5_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI5_RX_DMA_IRQ,                 \
-    }
+#define SPI5_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI5_RX_DMA_INSTANCE,         \
+        SPI5_RX_DMA_RCC,              \
+        SPI5_RX_DMA_IRQ,              \
+        SPI5_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI5_RX_DMA_PRIORITY,         \
+        SPI5_RX_DMA_PREEMPT_PRIORITY, \
+        SPI5_RX_DMA_SUB_PRIORITY)
 #endif /* SPI5_RX_DMA_CONFIG */
 #endif /* BSP_SPI5_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/f7/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/f7/uart_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-10-30     SummerGift   first version
  * 2019-01-05     zylx         modify dma support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -20,139 +21,229 @@ extern "C" {
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                         \
-        .channel = UART1_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_RX_DMA_RCC,                               \
-        .dma_irq = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        UART1_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                         \
-        .channel = UART2_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_RX_DMA_RCC,                               \
-        .dma_irq = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        UART2_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                         \
-        .channel = UART3_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_RX_DMA_RCC,                               \
-        .dma_irq = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        UART3_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_USING_UART4)
 #ifndef UART4_CONFIG
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = UART4,                                          \
-        .irq_type = UART4_IRQn,                                     \
+#define UART4_CONFIG            \
+    {                           \
+        .name = "uart4",        \
+        .Instance = UART4,      \
+        .irq_type = UART4_IRQn, \
     }
 #endif /* UART4_CONFIG */
 #endif /* BSP_USING_UART4 */
 
 #if defined(BSP_UART4_RX_USING_DMA)
+#ifndef UART4_RX_DMA_PRIORITY
+#define UART4_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_RX_DMA_PRIORITY */
+
+#ifndef UART4_RX_DMA_PREEMPT_PRIORITY
+#define UART4_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_RX_DMA_SUB_PRIORITY
+#define UART4_RX_DMA_SUB_PRIORITY             0
+#endif /* UART4_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_RX_CONFIG
-#define UART4_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART4_RX_DMA_INSTANCE,                         \
-        .channel = UART4_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART4_RX_DMA_RCC,                               \
-        .dma_irq = UART4_RX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART4_RX_DMA_INSTANCE,                 \
+        UART4_RX_DMA_RCC,                      \
+        UART4_RX_DMA_IRQ,                      \
+        UART4_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART4_RX_DMA_PRIORITY,                 \
+        UART4_RX_DMA_PREEMPT_PRIORITY,         \
+        UART4_RX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_RX_CONFIG */
 #endif /* BSP_UART4_RX_USING_DMA */
 
 #if defined(BSP_USING_UART5)
 #ifndef UART5_CONFIG
-#define UART5_CONFIG                                                \
-    {                                                               \
-        .name = "uart5",                                            \
-        .Instance = UART5,                                          \
-        .irq_type = UART5_IRQn,                                     \
+#define UART5_CONFIG            \
+    {                           \
+        .name = "uart5",        \
+        .Instance = UART5,      \
+        .irq_type = UART5_IRQn, \
     }
 #endif /* UART5_CONFIG */
 #endif /* BSP_USING_UART5 */
 
 #if defined(BSP_UART5_RX_USING_DMA)
+#ifndef UART5_RX_DMA_PRIORITY
+#define UART5_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_RX_DMA_PRIORITY */
+
+#ifndef UART5_RX_DMA_PREEMPT_PRIORITY
+#define UART5_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_RX_DMA_SUB_PRIORITY
+#define UART5_RX_DMA_SUB_PRIORITY             0
+#endif /* UART5_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_RX_CONFIG
-#define UART5_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART5_RX_DMA_INSTANCE,                         \
-        .channel = UART5_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART5_RX_DMA_RCC,                               \
-        .dma_irq = UART5_RX_DMA_IRQ,                               \
-    }
+#define UART5_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART5_RX_DMA_INSTANCE,                 \
+        UART5_RX_DMA_RCC,                      \
+        UART5_RX_DMA_IRQ,                      \
+        UART5_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART5_RX_DMA_PRIORITY,                 \
+        UART5_RX_DMA_PREEMPT_PRIORITY,         \
+        UART5_RX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_RX_CONFIG */
 #endif /* BSP_UART5_RX_USING_DMA */
 
 #if defined(BSP_USING_UART6)
 #ifndef UART6_CONFIG
-#define UART6_CONFIG                                                \
-    {                                                               \
-        .name = "uart6",                                            \
-        .Instance = USART6,                                          \
-        .irq_type = USART6_IRQn,                                     \
+#define UART6_CONFIG             \
+    {                            \
+        .name = "uart6",         \
+        .Instance = USART6,      \
+        .irq_type = USART6_IRQn, \
     }
 #endif /* UART6_CONFIG */
 #endif /* BSP_USING_UART6 */
 
 #if defined(BSP_UART6_RX_USING_DMA)
+#ifndef UART6_RX_DMA_PRIORITY
+#define UART6_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART6_RX_DMA_PRIORITY */
+
+#ifndef UART6_RX_DMA_PREEMPT_PRIORITY
+#define UART6_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART6_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART6_RX_DMA_SUB_PRIORITY
+#define UART6_RX_DMA_SUB_PRIORITY             0
+#endif /* UART6_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART6_DMA_RX_CONFIG
-#define UART6_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART6_RX_DMA_INSTANCE,                         \
-        .channel = UART6_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART6_RX_DMA_RCC,                               \
-        .dma_irq = UART6_RX_DMA_IRQ,                               \
-    }
+#define UART6_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART6_RX_DMA_INSTANCE,                 \
+        UART6_RX_DMA_RCC,                      \
+        UART6_RX_DMA_IRQ,                      \
+        UART6_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART6_RX_DMA_PRIORITY,                 \
+        UART6_RX_DMA_PREEMPT_PRIORITY,         \
+        UART6_RX_DMA_SUB_PRIORITY)
 #endif /* UART6_DMA_RX_CONFIG */
 #endif /* BSP_UART6_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/g0/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/g0/spi_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-01-05     zylx         first version
  * 2019-01-08     SummerGift   clean up the code
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -20,80 +21,136 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI1,                           \
-        .bus_name = "spi1",                         \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_TX_DMA_RCC,                 \
-        .Instance = SPI1_TX_DMA_INSTANCE,           \
-        .request = SPI1_TX_DMA_REQUEST,             \
-        .dma_irq = SPI1_TX_DMA_IRQ,                 \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI1_TX_DMA_REQUEST,          \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_RX_DMA_RCC,                 \
-        .Instance = SPI1_RX_DMA_INSTANCE,           \
-        .request = SPI1_RX_DMA_REQUEST,             \
-        .dma_irq = SPI1_RX_DMA_IRQ,                 \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI1_RX_DMA_REQUEST,          \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
 #if defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined(STM32G0C1xx)
-#define SPI2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI2,                           \
-        .bus_name = "spi2",                         \
-        .irq_type = SPI2_3_IRQn,                    \
+#define SPI2_BUS_CONFIG          \
+    {                            \
+        .Instance = SPI2,        \
+        .bus_name = "spi2",      \
+        .irq_type = SPI2_3_IRQn, \
     }
 #else
-#define SPI2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI2,                           \
-        .bus_name = "spi2",                         \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* defined(STM32G0B0xx) || defined(STM32G0B1xx) || defined(STM32G0C1xx) */
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_TX_DMA_RCC,                 \
-        .Instance = SPI2_TX_DMA_INSTANCE,           \
-        .request = SPI2_TX_DMA_REQUEST,             \
-        .dma_irq = SPI2_TX_DMA_IRQ,                 \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI2_TX_DMA_REQUEST,          \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_RX_DMA_RCC,                 \
-        .Instance = SPI2_RX_DMA_INSTANCE,           \
-        .request = SPI2_RX_DMA_REQUEST,             \
-        .dma_irq = SPI2_RX_DMA_IRQ,                 \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI2_RX_DMA_REQUEST,          \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/g0/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/g0/uart_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-10-30     zylx         first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -20,252 +21,375 @@ extern "C" {
 #if defined(BSP_USING_LPUART1)
 #ifndef LPUART1_CONFIG
 #if defined(STM32G071xx) || defined(STM32G081xx)
-#define LPUART1_CONFIG                                              \
-    {                                                               \
-        .name = "lpuart1",                                          \
-        .Instance = LPUART1,                                        \
-        .irq_type = USART3_4_LPUART1_IRQn,                          \
+#define LPUART1_CONFIG                     \
+    {                                      \
+        .name = "lpuart1",                 \
+        .Instance = LPUART1,               \
+        .irq_type = USART3_4_LPUART1_IRQn, \
     }
 #elif defined(STM32G0B1xx) || defined(STM32G0C1xx)
-#define LPUART1_CONFIG                                              \
-    {                                                               \
-        .name = "lpuart1",                                          \
-        .Instance = LPUART1,                                        \
-        .irq_type = USART3_4_5_6_LPUART1_IRQn,                      \
+#define LPUART1_CONFIG                         \
+    {                                          \
+        .name = "lpuart1",                     \
+        .Instance = LPUART1,                   \
+        .irq_type = USART3_4_5_6_LPUART1_IRQn, \
     }
 #endif /* defined(STM32G071xx) || defined(STM32G081xx) */
 #endif /* LPUART1_CONFIG */
 #if defined(BSP_LPUART1_RX_USING_DMA)
+#ifndef LPUART1_DMA_PRIORITY
+#define LPUART1_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* LPUART1_DMA_PRIORITY */
+
+#ifndef LPUART1_DMA_PREEMPT_PRIORITY
+#define LPUART1_DMA_PREEMPT_PRIORITY         0
+#endif /* LPUART1_DMA_PREEMPT_PRIORITY */
+
+#ifndef LPUART1_DMA_SUB_PRIORITY
+#define LPUART1_DMA_SUB_PRIORITY             0
+#endif /* LPUART1_DMA_SUB_PRIORITY */
+
 #ifndef LPUART1_DMA_CONFIG
-#define LPUART1_DMA_CONFIG                                          \
-    {                                                               \
-        .Instance = LPUART1_RX_DMA_INSTANCE,                        \
-        .request =  LPUART1_RX_DMA_REQUEST,                         \
-        .dma_rcc  = LPUART1_RX_DMA_RCC,                             \
-        .dma_irq  = LPUART1_RX_DMA_IRQ,                             \
-    }
+#define LPUART1_DMA_CONFIG                     \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        LPUART1_RX_DMA_INSTANCE,               \
+        LPUART1_RX_DMA_RCC,                    \
+        LPUART1_RX_DMA_IRQ,                    \
+        0U,                                    \
+        LPUART1_RX_DMA_REQUEST,                \
+        LPUART1_DMA_PRIORITY,                  \
+        LPUART1_DMA_PREEMPT_PRIORITY,          \
+        LPUART1_DMA_SUB_PRIORITY)
 #endif /* LPUART1_DMA_CONFIG */
 #endif /* BSP_LPUART1_RX_USING_DMA */
 #endif /* BSP_USING_LPUART1 */
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .request =  UART1_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_RX_DMA_RCC,                               \
-        .dma_irq  = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART1_RX_DMA_REQUEST,                  \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART1_TX_DMA_INSTANCE,                          \
-        .request =  UART1_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_TX_DMA_RCC,                               \
-        .dma_irq  = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART1_TX_DMA_INSTANCE,         \
+        UART1_TX_DMA_RCC,              \
+        UART1_TX_DMA_IRQ,              \
+        0U,                            \
+        UART1_TX_DMA_REQUEST,          \
+        UART1_TX_DMA_PRIORITY,         \
+        UART1_TX_DMA_PREEMPT_PRIORITY, \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
 #if defined(STM32G0B1xx) || defined(STM32G0C1xx)
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_LPUART2_IRQn ,                           \
+#define UART2_CONFIG                      \
+    {                                     \
+        .name = "uart2",                  \
+        .Instance = USART2,               \
+        .irq_type = USART2_LPUART2_IRQn , \
     }
 #else
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* defined(STM32G0B1xx) || defined(STM32G0C1xx) */
 #endif /* UART2_CONFIG */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .request =  UART2_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_RX_DMA_RCC,                               \
-        .dma_irq  = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART2_RX_DMA_REQUEST,                  \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART2_TX_DMA_INSTANCE,                          \
-        .request =  UART2_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_TX_DMA_RCC,                               \
-        .dma_irq  = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        0U,                            \
+        UART2_TX_DMA_REQUEST,          \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
 #if defined(STM32G0B1xx) || defined(STM32G0C1xx)
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_4_5_6_LPUART1_IRQn,                      \
+#define UART3_CONFIG                           \
+    {                                          \
+        .name = "uart3",                       \
+        .Instance = USART3,                    \
+        .irq_type = USART3_4_5_6_LPUART1_IRQn, \
     }
 #elif defined(STM32G070xx)
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_4_IRQn,                                  \
+#define UART3_CONFIG               \
+    {                              \
+        .name = "uart3",           \
+        .Instance = USART3,        \
+        .irq_type = USART3_4_IRQn, \
     }
 #elif defined(STM32G071xx) || defined(STM32G081xx)
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_4_LPUART1_IRQn,                          \
+#define UART3_CONFIG                       \
+    {                                      \
+        .name = "uart3",                   \
+        .Instance = USART3,                \
+        .irq_type = USART3_4_LPUART1_IRQn, \
     }
 #elif defined(STM32G0B0xx)
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_4_5_6_IRQn,                              \
+#define UART3_CONFIG                   \
+    {                                  \
+        .name = "uart3",               \
+        .Instance = USART3,            \
+        .irq_type = USART3_4_5_6_IRQn, \
     }
 #else
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* defined(STM32G0B1xx) || defined(STM32G0C1xx) */
 #endif /* UART3_CONFIG */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                          \
-        .request =  UART3_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_RX_DMA_RCC,                               \
-        .dma_irq  = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART3_RX_DMA_REQUEST,                  \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_USING_UART4)
 #ifndef UART4_CONFIG
 #if defined(STM32G0B1xx) || defined(STM32G0C1xx)
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = USART4,                                         \
-        .irq_type = USART3_4_5_6_LPUART1_IRQn,                      \
+#define UART4_CONFIG                           \
+    {                                          \
+        .name = "uart4",                       \
+        .Instance = USART4,                    \
+        .irq_type = USART3_4_5_6_LPUART1_IRQn, \
     }
 #elif defined(STM32G070xx)
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = USART4,                                         \
-        .irq_type = USART3_4_IRQn,                                  \
+#define UART4_CONFIG               \
+    {                              \
+        .name = "uart4",           \
+        .Instance = USART4,        \
+        .irq_type = USART3_4_IRQn, \
     }
 #elif defined(STM32G071xx) || defined(STM32G081xx)
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = USART4,                                         \
-        .irq_type = USART3_4_LPUART1_IRQn,                          \
+#define UART4_CONFIG                       \
+    {                                      \
+        .name = "uart4",                   \
+        .Instance = USART4,                \
+        .irq_type = USART3_4_LPUART1_IRQn, \
     }
 #elif defined(STM32G0B0xx)
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = USART4,                                         \
-        .irq_type = USART3_4_5_6_IRQn,                              \
+#define UART4_CONFIG                   \
+    {                                  \
+        .name = "uart4",               \
+        .Instance = USART4,            \
+        .irq_type = USART3_4_5_6_IRQn, \
     }
 #else
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = USART4,                                         \
-        .irq_type = USART4_IRQn,                                    \
+#define UART4_CONFIG             \
+    {                            \
+        .name = "uart4",         \
+        .Instance = USART4,      \
+        .irq_type = USART4_IRQn, \
     }
 #endif /* defined(STM32G0B1xx) || defined(STM32G0C1xx) */
 #endif /* UART4_CONFIG */
 #endif /* BSP_USING_UART4 */
 
 #if defined(BSP_UART4_RX_USING_DMA)
+#ifndef UART4_RX_DMA_PRIORITY
+#define UART4_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_RX_DMA_PRIORITY */
+
+#ifndef UART4_RX_DMA_PREEMPT_PRIORITY
+#define UART4_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_RX_DMA_SUB_PRIORITY
+#define UART4_RX_DMA_SUB_PRIORITY             0
+#endif /* UART4_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_RX_CONFIG
-#define UART4_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART4_RX_DMA_INSTANCE,                          \
-        .request =  UART4_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART4_RX_DMA_RCC,                               \
-        .dma_irq  = UART4_RX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART4_RX_DMA_INSTANCE,                 \
+        UART4_RX_DMA_RCC,                      \
+        UART4_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART4_RX_DMA_REQUEST,                  \
+        UART4_RX_DMA_PRIORITY,                 \
+        UART4_RX_DMA_PREEMPT_PRIORITY,         \
+        UART4_RX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_RX_CONFIG */
 #endif /* BSP_UART4_RX_USING_DMA */
 
 #if defined(BSP_USING_UART5)
 #ifndef UART5_CONFIG
 #if defined(STM32G0B1xx) || defined(STM32G0C1xx)
-#define UART5_CONFIG                                                \
-    {                                                               \
-        .name = "uart5",                                            \
-        .Instance = UART5,                                          \
-        .irq_type = USART3_4_5_6_LPUART1_IRQn,                      \
+#define UART5_CONFIG                           \
+    {                                          \
+        .name = "uart5",                       \
+        .Instance = UART5,                     \
+        .irq_type = USART3_4_5_6_LPUART1_IRQn, \
     }
 #elif defined(STM32G0B0xx)
-#define UART5_CONFIG                                                \
-    {                                                               \
-        .name = "uart5",                                            \
-        .Instance = UART5,                                          \
-        .irq_type = USART3_4_5_6_IRQn,                              \
+#define UART5_CONFIG                   \
+    {                                  \
+        .name = "uart5",               \
+        .Instance = UART5,             \
+        .irq_type = USART3_4_5_6_IRQn, \
     }
 #else
-#define UART5_CONFIG                                                \
-    {                                                               \
-        .name = "uart5",                                            \
-        .Instance = UART5,                                          \
-        .irq_type = UART5_IRQn,                                     \
+#define UART5_CONFIG            \
+    {                           \
+        .name = "uart5",        \
+        .Instance = UART5,      \
+        .irq_type = UART5_IRQn, \
     }
 #endif /* defined(STM32G0B1xx) || defined(STM32G0C1xx) */
 #endif /* UART5_CONFIG */
 #endif /* BSP_USING_UART5 */
 
 #if defined(BSP_UART5_RX_USING_DMA)
+#ifndef UART5_RX_DMA_PRIORITY
+#define UART5_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_RX_DMA_PRIORITY */
+
+#ifndef UART5_RX_DMA_PREEMPT_PRIORITY
+#define UART5_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_RX_DMA_SUB_PRIORITY
+#define UART5_RX_DMA_SUB_PRIORITY             0
+#endif /* UART5_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_RX_CONFIG
-#define UART5_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = DMA_NOT_AVAILABLE,                              \
-    }
+#define UART5_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART5_RX_DMA_INSTANCE,                 \
+        UART5_RX_DMA_RCC,                      \
+        UART5_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART5_RX_DMA_REQUEST,                  \
+        UART5_RX_DMA_PRIORITY,                 \
+        UART5_RX_DMA_PREEMPT_PRIORITY,         \
+        UART5_RX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_RX_CONFIG */
 #endif /* BSP_UART5_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/g4/dma_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/g4/dma_config.h
@@ -193,6 +193,12 @@ extern "C" {
 #define UART1_RX_DMA_INSTANCE           DMA2_Stream2
 #define UART1_RX_DMA_CHANNEL            DMA_CHANNEL_4
 #define UART1_RX_DMA_IRQ                DMA2_Stream2_IRQn
+#elif defined(BSP_QSPI_USING_DMA) && !defined(QSPI_DMA_INSTANCE)
+#define QSPI_DMA_IRQHandler             DMA2_Stream2_IRQHandler
+#define QSPI_DMA_RCC                    RCC_AHB1ENR_DMA2EN
+#define QSPI_DMA_INSTANCE               DMA2_Stream2
+#define QSPI_DMA_CHANNEL                DMA_CHANNEL_11
+#define QSPI_DMA_IRQ                    DMA2_Stream2_IRQn
 #endif
 
 /* DMA2 stream3 */
@@ -274,6 +280,12 @@ extern "C" {
 #define UART1_TX_DMA_INSTANCE           DMA2_Stream7
 #define UART1_TX_DMA_CHANNEL            DMA_CHANNEL_4
 #define UART1_TX_DMA_IRQ                DMA2_Stream7_IRQn
+#elif defined(BSP_QSPI_USING_DMA) && !defined(QSPI_DMA_INSTANCE)
+#define QSPI_DMA_IRQHandler             DMA2_Stream7_IRQHandler
+#define QSPI_DMA_RCC                    RCC_AHB1ENR_DMA2EN
+#define QSPI_DMA_INSTANCE               DMA2_Stream7
+#define QSPI_DMA_CHANNEL                DMA_CHANNEL_3
+#define QSPI_DMA_IRQ                    DMA2_Stream7_IRQn
 #endif
 
 #ifdef __cplusplus

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/g4/qspi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/g4/qspi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-22     zylx         first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __QSPI_CONFIG_H__
@@ -30,19 +31,29 @@ extern "C" {
 #endif /* BSP_USING_QSPI */
 
 #ifdef BSP_QSPI_USING_DMA
+#ifndef QSPI_DMA_PRIORITY
+#define QSPI_DMA_PRIORITY                         DMA_PRIORITY_LOW
+#endif /* QSPI_DMA_PRIORITY */
+
+#ifndef QSPI_DMA_PREEMPT_PRIORITY
+#define QSPI_DMA_PREEMPT_PRIORITY                 0
+#endif /* QSPI_DMA_PREEMPT_PRIORITY */
+
+#ifndef QSPI_DMA_SUB_PRIORITY
+#define QSPI_DMA_SUB_PRIORITY                     0
+#endif /* QSPI_DMA_SUB_PRIORITY */
+
 #ifndef QSPI_DMA_CONFIG
-#define QSPI_DMA_CONFIG                                        \
-    {                                                          \
-        .Instance = QSPI_DMA_INSTANCE,                         \
-        .Init.Channel  = QSPI_DMA_CHANNEL,                     \
-        .Init.Direction = DMA_PERIPH_TO_MEMORY,                \
-        .Init.PeriphInc = DMA_PINC_DISABLE,                    \
-        .Init.MemInc = DMA_MINC_ENABLE,                        \
-        .Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE,       \
-        .Init.MemDataAlignment = DMA_MDATAALIGN_BYTE,          \
-        .Init.Mode = DMA_NORMAL,                               \
-        .Init.Priority = DMA_PRIORITY_LOW                      \
-    }
+#define QSPI_DMA_CONFIG                 \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX(   \
+        QSPI_DMA_INSTANCE,              \
+        QSPI_DMA_RCC,                   \
+        QSPI_DMA_IRQ,                   \
+        QSPI_DMA_CHANNEL,               \
+        0U,                             \
+        QSPI_DMA_PRIORITY,              \
+        QSPI_DMA_PREEMPT_PRIORITY,      \
+        QSPI_DMA_SUB_PRIORITY)
 #endif /* QSPI_DMA_CONFIG */
 #endif /* BSP_QSPI_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/g4/sdio_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/g4/sdio_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-13     BalanceTWK   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SDIO_CONFIG_H__
@@ -19,17 +20,71 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_SDIO
-#define SDIO_BUS_CONFIG                                  \
-    {                                                    \
-        .Instance = SDIO,                                \
-        .dma_rx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_tx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_rx.Instance = DMA2_Stream3,                 \
-        .dma_rx.channel = DMA_CHANNEL_4,                 \
-        .dma_rx.dma_irq = DMA2_Stream3_IRQn,             \
-        .dma_tx.Instance = DMA2_Stream6,                 \
-        .dma_tx.channel = DMA_CHANNEL_4,                 \
-        .dma_tx.dma_irq = DMA2_Stream6_IRQn,             \
+#ifndef SDIO_RX_DMA_PRIORITY
+#define SDIO_RX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_RX_DMA_PRIORITY */
+
+#ifndef SDIO_RX_DMA_PREEMPT_PRIORITY
+#define SDIO_RX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_RX_DMA_SUB_PRIORITY
+#define SDIO_RX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_RX_DMA_SUB_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PRIORITY
+#define SDIO_TX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_TX_DMA_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PREEMPT_PRIORITY
+#define SDIO_TX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_TX_DMA_SUB_PRIORITY
+#define SDIO_TX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_TX_DMA_SUB_PRIORITY */
+
+#define SDIO_BUS_CONFIG                          \
+    {                                            \
+        .Instance = SDIO,                        \
+        .dma_rx = STM32_DMA_CONFIG_INIT_FIFO_EX( \
+            DMA2_Stream3,                        \
+            RCC_AHB1ENR_DMA2EN,                  \
+            DMA2_Stream3_IRQn,                   \
+            DMA_CHANNEL_4,                       \
+            0U,                                  \
+            SDIO_RX_DMA_PRIORITY,                \
+            SDIO_RX_DMA_PREEMPT_PRIORITY,        \
+            SDIO_RX_DMA_SUB_PRIORITY,            \
+            DMA_PERIPH_TO_MEMORY,                \
+            DMA_PINC_DISABLE,                    \
+            DMA_MINC_ENABLE,                     \
+            DMA_PDATAALIGN_WORD,                 \
+            DMA_MDATAALIGN_WORD,                 \
+            DMA_PFCTRL,                          \
+            DMA_FIFOMODE_ENABLE,                 \
+            DMA_FIFO_THRESHOLD_FULL,             \
+            DMA_MBURST_INC4,                     \
+            DMA_PBURST_INC4),                    \
+        .dma_tx = STM32_DMA_CONFIG_INIT_FIFO_EX( \
+            DMA2_Stream6,                        \
+            RCC_AHB1ENR_DMA2EN,                  \
+            DMA2_Stream6_IRQn,                   \
+            DMA_CHANNEL_4,                       \
+            0U,                                  \
+            SDIO_TX_DMA_PRIORITY,                \
+            SDIO_TX_DMA_PREEMPT_PRIORITY,        \
+            SDIO_TX_DMA_SUB_PRIORITY,            \
+            DMA_MEMORY_TO_PERIPH,                \
+            DMA_PINC_DISABLE,                    \
+            DMA_MINC_ENABLE,                     \
+            DMA_PDATAALIGN_WORD,                 \
+            DMA_MDATAALIGN_WORD,                 \
+            DMA_PFCTRL,                          \
+            DMA_FIFOMODE_ENABLE,                 \
+            DMA_FIFO_THRESHOLD_FULL,             \
+            DMA_MBURST_INC4,                     \
+            DMA_PBURST_INC4),                    \
     }
 
 #endif

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/g4/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/g4/spi_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
  * 2019-01-03     zylx         modify DMA support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -20,176 +21,316 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI1,                           \
-        .bus_name = "spi1",                         \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_TX_DMA_RCC,                 \
-        .Instance = SPI1_TX_DMA_INSTANCE,           \
-        .channel = SPI1_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI1_TX_DMA_IRQ,                 \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        SPI1_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_RX_DMA_RCC,                 \
-        .Instance = SPI1_RX_DMA_INSTANCE,           \
-        .channel = SPI1_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI1_RX_DMA_IRQ,                 \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        SPI1_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI2,                           \
-        .bus_name = "spi2",                         \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_TX_DMA_RCC,                 \
-        .Instance = SPI2_TX_DMA_INSTANCE,           \
-        .channel = SPI2_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI2_TX_DMA_IRQ,                 \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        SPI2_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_RX_DMA_RCC,                 \
-        .Instance = SPI2_RX_DMA_INSTANCE,           \
-        .channel = SPI2_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI2_RX_DMA_IRQ,                 \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        SPI2_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI3,                           \
-        .bus_name = "spi3",                         \
-        .irq_type = SPI3_IRQn,                      \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_TX_DMA_RCC,                 \
-        .Instance = SPI3_TX_DMA_INSTANCE,           \
-        .channel = SPI3_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI3_TX_DMA_IRQ,                 \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        SPI3_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_RX_DMA_RCC,                 \
-        .Instance = SPI3_RX_DMA_INSTANCE,           \
-        .channel = SPI3_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI3_RX_DMA_IRQ,                 \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        SPI3_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI4
 #ifndef SPI4_BUS_CONFIG
-#define SPI4_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI4,                           \
-        .bus_name = "spi4",                         \
-        .irq_type = SPI4_IRQn,                      \
+#define SPI4_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI4,      \
+        .bus_name = "spi4",    \
+        .irq_type = SPI4_IRQn, \
     }
 #endif /* SPI4_BUS_CONFIG */
 #endif /* BSP_USING_SPI4 */
 
 #ifdef BSP_SPI4_TX_USING_DMA
+#ifndef SPI4_TX_DMA_PRIORITY
+#define SPI4_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI4_TX_DMA_PRIORITY */
+
+#ifndef SPI4_TX_DMA_PREEMPT_PRIORITY
+#define SPI4_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI4_TX_DMA_SUB_PRIORITY
+#define SPI4_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI4_TX_DMA_SUB_PRIORITY */
 #ifndef SPI4_TX_DMA_CONFIG
-#define SPI4_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI4_TX_DMA_RCC,                 \
-        .Instance = SPI4_TX_DMA_INSTANCE,           \
-        .channel = SPI4_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI4_TX_DMA_IRQ,                 \
-    }
+#define SPI4_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI4_TX_DMA_INSTANCE,         \
+        SPI4_TX_DMA_RCC,              \
+        SPI4_TX_DMA_IRQ,              \
+        SPI4_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI4_TX_DMA_PRIORITY,         \
+        SPI4_TX_DMA_PREEMPT_PRIORITY, \
+        SPI4_TX_DMA_SUB_PRIORITY)
 #endif /* SPI4_TX_DMA_CONFIG */
 #endif /* BSP_SPI4_TX_USING_DMA */
 
 #ifdef BSP_SPI4_RX_USING_DMA
+#ifndef SPI4_RX_DMA_PRIORITY
+#define SPI4_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI4_RX_DMA_PRIORITY */
+
+#ifndef SPI4_RX_DMA_PREEMPT_PRIORITY
+#define SPI4_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI4_RX_DMA_SUB_PRIORITY
+#define SPI4_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI4_RX_DMA_SUB_PRIORITY */
 #ifndef SPI4_RX_DMA_CONFIG
-#define SPI4_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI4_RX_DMA_RCC,                 \
-        .Instance = SPI4_RX_DMA_INSTANCE,           \
-        .channel = SPI4_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI4_RX_DMA_IRQ,                 \
-    }
+#define SPI4_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI4_RX_DMA_INSTANCE,         \
+        SPI4_RX_DMA_RCC,              \
+        SPI4_RX_DMA_IRQ,              \
+        SPI4_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI4_RX_DMA_PRIORITY,         \
+        SPI4_RX_DMA_PREEMPT_PRIORITY, \
+        SPI4_RX_DMA_SUB_PRIORITY)
 #endif /* SPI4_RX_DMA_CONFIG */
 #endif /* BSP_SPI4_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI5
 #ifndef SPI5_BUS_CONFIG
-#define SPI5_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI5,                           \
-        .bus_name = "spi5",                         \
-        .irq_type = SPI5_IRQn,                      \
+#define SPI5_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI5,      \
+        .bus_name = "spi5",    \
+        .irq_type = SPI5_IRQn, \
     }
 #endif /* SPI5_BUS_CONFIG */
 #endif /* BSP_USING_SPI5 */
 
 #ifdef BSP_SPI5_TX_USING_DMA
+#ifndef SPI5_TX_DMA_PRIORITY
+#define SPI5_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI5_TX_DMA_PRIORITY */
+
+#ifndef SPI5_TX_DMA_PREEMPT_PRIORITY
+#define SPI5_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI5_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI5_TX_DMA_SUB_PRIORITY
+#define SPI5_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI5_TX_DMA_SUB_PRIORITY */
 #ifndef SPI5_TX_DMA_CONFIG
-#define SPI5_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI5_TX_DMA_RCC,                 \
-        .Instance = SPI5_TX_DMA_INSTANCE,           \
-        .channel = SPI5_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI5_TX_DMA_IRQ,                 \
-    }
+#define SPI5_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI5_TX_DMA_INSTANCE,         \
+        SPI5_TX_DMA_RCC,              \
+        SPI5_TX_DMA_IRQ,              \
+        SPI5_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI5_TX_DMA_PRIORITY,         \
+        SPI5_TX_DMA_PREEMPT_PRIORITY, \
+        SPI5_TX_DMA_SUB_PRIORITY)
 #endif /* SPI5_TX_DMA_CONFIG */
 #endif /* BSP_SPI5_TX_USING_DMA */
 
 #ifdef BSP_SPI5_RX_USING_DMA
+#ifndef SPI5_RX_DMA_PRIORITY
+#define SPI5_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI5_RX_DMA_PRIORITY */
+
+#ifndef SPI5_RX_DMA_PREEMPT_PRIORITY
+#define SPI5_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI5_RX_DMA_SUB_PRIORITY
+#define SPI5_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI5_RX_DMA_SUB_PRIORITY */
 #ifndef SPI5_RX_DMA_CONFIG
-#define SPI5_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI5_RX_DMA_RCC,                 \
-        .Instance = SPI5_RX_DMA_INSTANCE,           \
-        .channel = SPI5_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI5_RX_DMA_IRQ,                 \
-    }
+#define SPI5_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI5_RX_DMA_INSTANCE,         \
+        SPI5_RX_DMA_RCC,              \
+        SPI5_RX_DMA_IRQ,              \
+        SPI5_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI5_RX_DMA_PRIORITY,         \
+        SPI5_RX_DMA_PREEMPT_PRIORITY, \
+        SPI5_RX_DMA_SUB_PRIORITY)
 #endif /* SPI5_RX_DMA_CONFIG */
 #endif /* BSP_SPI5_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/g4/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/g4/uart_config.h
@@ -8,6 +8,7 @@
  * 2018-10-30     SummerGift   first version
  * 2019-01-03     zylx         modify dma support
  * 2019-10-03     xuzhuoyi     modify for STM32G4
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -21,197 +22,362 @@ extern "C" {
 
 #if defined(BSP_USING_LPUART1)
 #ifndef LPUART1_CONFIG
-#define LPUART1_CONFIG                                              \
-    {                                                               \
-        .name = "lpuart1",                                          \
-        .Instance = LPUART1,                                        \
-        .irq_type = LPUART1_IRQn,                                   \
+#define LPUART1_CONFIG            \
+    {                             \
+        .name = "lpuart1",        \
+        .Instance = LPUART1,      \
+        .irq_type = LPUART1_IRQn, \
     }
 #endif /* LPUART1_CONFIG */
 #if defined(BSP_LPUART1_RX_USING_DMA)
+#ifndef LPUART1_DMA_PRIORITY
+#define LPUART1_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* LPUART1_DMA_PRIORITY */
+
+#ifndef LPUART1_DMA_PREEMPT_PRIORITY
+#define LPUART1_DMA_PREEMPT_PRIORITY         0
+#endif /* LPUART1_DMA_PREEMPT_PRIORITY */
+
+#ifndef LPUART1_DMA_SUB_PRIORITY
+#define LPUART1_DMA_SUB_PRIORITY             0
+#endif /* LPUART1_DMA_SUB_PRIORITY */
+
 #ifndef LPUART1_DMA_CONFIG
-#define LPUART1_DMA_CONFIG                                          \
-    {                                                               \
-        .Instance = LPUART1_RX_DMA_INSTANCE,                        \
-        .request  = LPUART1_RX_DMA_REQUEST,                         \
-        .dma_rcc  = LPUART1_RX_DMA_RCC,                             \
-        .dma_irq  = LPUART1_RX_DMA_IRQ,                             \
-    }
+#define LPUART1_DMA_CONFIG                     \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        LPUART1_RX_DMA_INSTANCE,               \
+        LPUART1_RX_DMA_RCC,                    \
+        LPUART1_RX_DMA_IRQ,                    \
+        LPUART1_RX_DMA_CHANNEL,                \
+        0U,                                    \
+        LPUART1_DMA_PRIORITY,                  \
+        LPUART1_DMA_PREEMPT_PRIORITY,          \
+        LPUART1_DMA_SUB_PRIORITY)
 #endif /* LPUART1_DMA_CONFIG */
 #endif /* BSP_LPUART1_RX_USING_DMA */
 #endif /* BSP_USING_LPUART1 */
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART1_RX_DMA_INSTANCE,                         \
-        .channel = UART1_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_RX_DMA_RCC,                               \
-        .dma_irq = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        UART1_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART1_TX_DMA_INSTANCE,                         \
-        .channel = UART1_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_TX_DMA_RCC,                               \
-        .dma_irq = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART1_TX_DMA_INSTANCE,         \
+        UART1_TX_DMA_RCC,              \
+        UART1_TX_DMA_IRQ,              \
+        UART1_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART1_TX_DMA_PRIORITY,         \
+        UART1_TX_DMA_PREEMPT_PRIORITY, \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART2_RX_DMA_INSTANCE,                         \
-        .channel = UART2_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_RX_DMA_RCC,                               \
-        .dma_irq = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        UART2_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART2_TX_DMA_INSTANCE,                         \
-        .channel = UART2_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_TX_DMA_RCC,                               \
-        .dma_irq = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        UART2_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART3_RX_DMA_INSTANCE,                         \
-        .channel = UART3_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_RX_DMA_RCC,                               \
-        .dma_irq = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        UART3_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART3_TX_DMA_INSTANCE,                         \
-        .channel = UART3_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_TX_DMA_RCC,                               \
-        .dma_irq = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART3_TX_DMA_INSTANCE,         \
+        UART3_TX_DMA_RCC,              \
+        UART3_TX_DMA_IRQ,              \
+        UART3_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART3_TX_DMA_PRIORITY,         \
+        UART3_TX_DMA_PREEMPT_PRIORITY, \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_USING_UART4)
 #ifndef UART4_CONFIG
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = UART4,                                          \
-        .irq_type = UART4_IRQn,                                     \
+#define UART4_CONFIG            \
+    {                           \
+        .name = "uart4",        \
+        .Instance = UART4,      \
+        .irq_type = UART4_IRQn, \
     }
 #endif /* UART4_CONFIG */
 
 #if defined(BSP_UART4_RX_USING_DMA)
+#ifndef UART4_RX_DMA_PRIORITY
+#define UART4_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_RX_DMA_PRIORITY */
+
+#ifndef UART4_RX_DMA_PREEMPT_PRIORITY
+#define UART4_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_RX_DMA_SUB_PRIORITY
+#define UART4_RX_DMA_SUB_PRIORITY             0
+#endif /* UART4_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_RX_CONFIG
-#define UART4_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART4_RX_DMA_INSTANCE,                         \
-        .channel = UART4_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART4_RX_DMA_RCC,                               \
-        .dma_irq = UART4_RX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART4_RX_DMA_INSTANCE,                 \
+        UART4_RX_DMA_RCC,                      \
+        UART4_RX_DMA_IRQ,                      \
+        UART4_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART4_RX_DMA_PRIORITY,                 \
+        UART4_RX_DMA_PREEMPT_PRIORITY,         \
+        UART4_RX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_RX_CONFIG */
 #endif /* BSP_UART4_RX_USING_DMA */
 
 #if defined(BSP_UART4_TX_USING_DMA)
+#ifndef UART4_TX_DMA_PRIORITY
+#define UART4_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_TX_DMA_PRIORITY */
+
+#ifndef UART4_TX_DMA_PREEMPT_PRIORITY
+#define UART4_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_TX_DMA_SUB_PRIORITY
+#define UART4_TX_DMA_SUB_PRIORITY             0
+#endif /* UART4_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_TX_CONFIG
-#define UART4_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART4_TX_DMA_INSTANCE,                         \
-        .channel = UART4_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART4_TX_DMA_RCC,                               \
-        .dma_irq = UART4_TX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART4_TX_DMA_INSTANCE,         \
+        UART4_TX_DMA_RCC,              \
+        UART4_TX_DMA_IRQ,              \
+        UART4_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART4_TX_DMA_PRIORITY,         \
+        UART4_TX_DMA_PREEMPT_PRIORITY, \
+        UART4_TX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_TX_CONFIG */
-#endif /* BSP_UART4_RX_USING_DMA */
+#endif /* BSP_UART4_TX_USING_DMA */
 #endif /* BSP_USING_UART4 */
 
 #if defined(BSP_USING_UART5)
 #ifndef UART5_CONFIG
-#define UART5_CONFIG                                                \
-    {                                                               \
-        .name = "uart5",                                            \
-        .Instance = UART5,                                          \
-        .irq_type = UART5_IRQn,                                     \
+#define UART5_CONFIG            \
+    {                           \
+        .name = "uart5",        \
+        .Instance = UART5,      \
+        .irq_type = UART5_IRQn, \
     }
 #endif /* UART5_CONFIG */
 
 #if defined(BSP_UART5_RX_USING_DMA)
+#ifndef UART5_RX_DMA_PRIORITY
+#define UART5_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_RX_DMA_PRIORITY */
+
+#ifndef UART5_RX_DMA_PREEMPT_PRIORITY
+#define UART5_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_RX_DMA_SUB_PRIORITY
+#define UART5_RX_DMA_SUB_PRIORITY             0
+#endif /* UART5_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_RX_CONFIG
-#define UART5_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART5_RX_DMA_INSTANCE,                         \
-        .channel = UART5_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART5_RX_DMA_RCC,                               \
-        .dma_irq = UART5_RX_DMA_IRQ,                               \
-    }
+#define UART5_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART5_RX_DMA_INSTANCE,                 \
+        UART5_RX_DMA_RCC,                      \
+        UART5_RX_DMA_IRQ,                      \
+        UART5_RX_DMA_CHANNEL,                  \
+        0U,                                    \
+        UART5_RX_DMA_PRIORITY,                 \
+        UART5_RX_DMA_PREEMPT_PRIORITY,         \
+        UART5_RX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_RX_CONFIG */
 #endif /* BSP_UART5_RX_USING_DMA */
 
 #if defined(BSP_UART5_TX_USING_DMA)
+#ifndef UART5_TX_DMA_PRIORITY
+#define UART5_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_TX_DMA_PRIORITY */
+
+#ifndef UART5_TX_DMA_PREEMPT_PRIORITY
+#define UART5_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_TX_DMA_SUB_PRIORITY
+#define UART5_TX_DMA_SUB_PRIORITY             0
+#endif /* UART5_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_TX_CONFIG
-#define UART5_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART5_TX_DMA_INSTANCE,                         \
-        .channel = UART5_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART5_TX_DMA_RCC,                               \
-        .dma_irq = UART5_TX_DMA_IRQ,                               \
-    }
+#define UART5_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART5_TX_DMA_INSTANCE,         \
+        UART5_TX_DMA_RCC,              \
+        UART5_TX_DMA_IRQ,              \
+        UART5_TX_DMA_CHANNEL,          \
+        0U,                            \
+        UART5_TX_DMA_PRIORITY,         \
+        UART5_TX_DMA_PREEMPT_PRIORITY, \
+        UART5_TX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_TX_CONFIG */
 #endif /* BSP_UART5_TX_USING_DMA */
 #endif /* BSP_USING_UART5 */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/h5/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/h5/uart_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -19,128 +20,226 @@ extern "C" {
 
 #if defined(BSP_USING_LPUART1)
 #ifndef LPUART1_CONFIG
-#define LPUART1_CONFIG                                              \
-    {                                                               \
-        .name = "lpuart1",                                          \
-        .Instance = LPUART1,                                        \
-        .irq_type = LPUART1_IRQn,                                   \
+#define LPUART1_CONFIG            \
+    {                             \
+        .name = "lpuart1",        \
+        .Instance = LPUART1,      \
+        .irq_type = LPUART1_IRQn, \
     }
 #endif /* LPUART1_CONFIG */
 #if defined(BSP_LPUART1_RX_USING_DMA)
+#ifndef LPUART1_DMA_PRIORITY
+#define LPUART1_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* LPUART1_DMA_PRIORITY */
+
+#ifndef LPUART1_DMA_PREEMPT_PRIORITY
+#define LPUART1_DMA_PREEMPT_PRIORITY         0
+#endif /* LPUART1_DMA_PREEMPT_PRIORITY */
+
+#ifndef LPUART1_DMA_SUB_PRIORITY
+#define LPUART1_DMA_SUB_PRIORITY             0
+#endif /* LPUART1_DMA_SUB_PRIORITY */
+
 #ifndef LPUART1_DMA_CONFIG
-#define LPUART1_DMA_CONFIG                                          \
-    {                                                               \
-        .Instance = LPUART1_RX_DMA_INSTANCE,                        \
-        .request  = LPUART1_RX_DMA_REQUEST,                         \
-        .dma_rcc  = LPUART1_RX_DMA_RCC,                             \
-        .dma_irq  = LPUART1_RX_DMA_IRQ,                             \
-    }
+#define LPUART1_DMA_CONFIG                       \
+    STM32_GPDMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        LPUART1_RX_DMA_INSTANCE,                 \
+        LPUART1_RX_DMA_RCC,                      \
+        LPUART1_RX_DMA_IRQ,                      \
+        LPUART1_RX_DMA_REQUEST,                  \
+        LPUART1_DMA_PRIORITY,                    \
+        LPUART1_DMA_PREEMPT_PRIORITY,            \
+        LPUART1_DMA_SUB_PRIORITY)
 #endif /* LPUART1_DMA_CONFIG */
 #endif /* BSP_LPUART1_RX_USING_DMA */
 #endif /* BSP_USING_LPUART1 */
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .request  = UART1_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_RX_DMA_RCC,                               \
-        .dma_irq  = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                      \
+    STM32_GPDMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                   \
+        UART1_RX_DMA_RCC,                        \
+        UART1_RX_DMA_IRQ,                        \
+        UART1_RX_DMA_REQUEST,                    \
+        UART1_RX_DMA_PRIORITY,                   \
+        UART1_RX_DMA_PREEMPT_PRIORITY,           \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_TX_DMA_INSTANCE,                          \
-        .request  = UART1_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_TX_DMA_RCC,                               \
-        .dma_irq  = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG             \
+    STM32_GPDMA_TX_BYTE_CONFIG_INIT_EX( \
+        UART1_TX_DMA_INSTANCE,          \
+        UART1_TX_DMA_RCC,               \
+        UART1_TX_DMA_IRQ,               \
+        UART1_TX_DMA_REQUEST,           \
+        UART1_TX_DMA_PRIORITY,          \
+        UART1_TX_DMA_PREEMPT_PRIORITY,  \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .request  = UART2_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_RX_DMA_RCC,                               \
-        .dma_irq  = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                      \
+    STM32_GPDMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                   \
+        UART2_RX_DMA_RCC,                        \
+        UART2_RX_DMA_IRQ,                        \
+        UART2_RX_DMA_REQUEST,                    \
+        UART2_RX_DMA_PRIORITY,                   \
+        UART2_RX_DMA_PREEMPT_PRIORITY,           \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_TX_DMA_INSTANCE,                          \
-        .request  = UART2_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_TX_DMA_RCC,                               \
-        .dma_irq  = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG             \
+    STM32_GPDMA_TX_BYTE_CONFIG_INIT_EX( \
+        UART2_TX_DMA_INSTANCE,          \
+        UART2_TX_DMA_RCC,               \
+        UART2_TX_DMA_IRQ,               \
+        UART2_TX_DMA_REQUEST,           \
+        UART2_TX_DMA_PRIORITY,          \
+        UART2_TX_DMA_PREEMPT_PRIORITY,  \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                          \
-        .request  = UART3_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_RX_DMA_RCC,                               \
-        .dma_irq  = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                      \
+    STM32_GPDMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                   \
+        UART3_RX_DMA_RCC,                        \
+        UART3_RX_DMA_IRQ,                        \
+        UART3_RX_DMA_REQUEST,                    \
+        UART3_RX_DMA_PRIORITY,                   \
+        UART3_RX_DMA_PREEMPT_PRIORITY,           \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_TX_DMA_INSTANCE,                          \
-        .request  = UART3_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_TX_DMA_RCC,                               \
-        .dma_irq  = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG             \
+    STM32_GPDMA_TX_BYTE_CONFIG_INIT_EX( \
+        UART3_TX_DMA_INSTANCE,          \
+        UART3_TX_DMA_RCC,               \
+        UART3_TX_DMA_IRQ,               \
+        UART3_TX_DMA_REQUEST,           \
+        UART3_TX_DMA_PRIORITY,          \
+        UART3_TX_DMA_PREEMPT_PRIORITY,  \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/dma_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/dma_config.h
@@ -141,6 +141,11 @@ extern "C" {
 #define QSPI_DMA_IRQHandler              DMA2_Stream7_IRQHandler
 #define QSPI_DMA_RCC                     RCC_AHB1ENR_DMA2EN
 #define QSPI_DMA_INSTANCE                DMA2_Stream7
+#if defined(DMA_REQUEST_QUADSPI)
+#define QSPI_DMA_REQUEST                 DMA_REQUEST_QUADSPI
+#elif defined(DMA_REQUEST_QUADSPI1)
+#define QSPI_DMA_REQUEST                 DMA_REQUEST_QUADSPI1
+#endif
 #define QSPI_DMA_IRQ                     DMA2_Stream7_IRQn
 #endif
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/i2c_hard_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/i2c_hard_config.h
@@ -8,6 +8,7 @@
  * 2024-02-06     Dyyt587   first version
  * 2024-04-23     Zeidan    Add I2Cx_xx_DMA_CONFIG
  * 2024-06-23     wdfk-prog Add H7 hard I2C config
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 #ifndef __I2C_HARD_CONFIG_H__
 #define __I2C_HARD_CONFIG_H__
@@ -20,233 +21,265 @@ extern "C" {
 
 #ifdef BSP_USING_HARD_I2C1
 #ifndef I2C1_BUS_CONFIG
-#define I2C1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = I2C1,                           \
-        .timing = 0x307075B1,                       \
-        .timeout = 1000,                            \
-        .name = "hwi2c1",                           \
-        .evirq_type = I2C1_EV_IRQn,                 \
-        .erirq_type = I2C1_ER_IRQn,                 \
+#define I2C1_BUS_CONFIG             \
+    {                               \
+        .Instance = I2C1,           \
+        .timing = 0x307075B1,       \
+        .timeout = 1000,            \
+        .name = "hwi2c1",           \
+        .evirq_type = I2C1_EV_IRQn, \
+        .erirq_type = I2C1_ER_IRQn, \
     }
 #endif /* I2C1_BUS_CONFIG */
 #endif /* BSP_USING_HARD_I2C1 */
 
 #ifdef BSP_I2C1_TX_USING_DMA
+#ifndef I2C1_TX_DMA_PRIORITY
+#define I2C1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C1_TX_DMA_PRIORITY */
+
+#ifndef I2C1_TX_DMA_PREEMPT_PRIORITY
+#define I2C1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* I2C1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C1_TX_DMA_SUB_PRIORITY
+#define I2C1_TX_DMA_SUB_PRIORITY              0
+#endif /* I2C1_TX_DMA_SUB_PRIORITY */
 #ifndef I2C1_TX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C1_TX_DMA_RCC,                 \
-        .Instance = I2C1_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C1_TX_DMA_IRQ,                 \
-        .channel = I2C1_TX_DMA_CHANNEL              \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C1_TX_DMA_RCC,                 \
-        .Instance = I2C1_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C1_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C1_TX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        I2C1_TX_DMA_INSTANCE,         \
+        I2C1_TX_DMA_RCC,              \
+        I2C1_TX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_I2C1_TX,          \
+        I2C1_TX_DMA_PRIORITY,         \
+        I2C1_TX_DMA_PREEMPT_PRIORITY, \
+        I2C1_TX_DMA_SUB_PRIORITY)
 #endif /* I2C1_TX_DMA_CONFIG */
 #endif /* BSP_I2C1_TX_USING_DMA */
 
 #ifdef BSP_I2C1_RX_USING_DMA
+#ifndef I2C1_RX_DMA_PRIORITY
+#define I2C1_RX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C1_RX_DMA_PRIORITY */
+
+#ifndef I2C1_RX_DMA_PREEMPT_PRIORITY
+#define I2C1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* I2C1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C1_RX_DMA_SUB_PRIORITY
+#define I2C1_RX_DMA_SUB_PRIORITY              0
+#endif /* I2C1_RX_DMA_SUB_PRIORITY */
 #ifndef I2C1_RX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C1_RX_DMA_RCC,                 \
-        .Instance = I2C1_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C1_RX_DMA_IRQ,                 \
-        .channel = I2C1_RX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C1_RX_DMA_RCC,                 \
-        .Instance = I2C1_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C1_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C1_RX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        I2C1_RX_DMA_INSTANCE,         \
+        I2C1_RX_DMA_RCC,              \
+        I2C1_RX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_I2C1_RX,          \
+        I2C1_RX_DMA_PRIORITY,         \
+        I2C1_RX_DMA_PREEMPT_PRIORITY, \
+        I2C1_RX_DMA_SUB_PRIORITY)
 #endif /* I2C1_RX_DMA_CONFIG */
 #endif /* BSP_I2C1_RX_USING_DMA */
 
 #ifdef BSP_USING_HARD_I2C2
 #ifndef I2C2_BUS_CONFIG
-#define I2C2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = I2C2,                           \
-        .timing = 0x307075B1,                       \
-        .timeout = 1000,                            \
-        .name = "hwi2c2",                           \
-        .evirq_type = I2C2_EV_IRQn,                 \
-        .erirq_type = I2C2_ER_IRQn,                 \
+#define I2C2_BUS_CONFIG             \
+    {                               \
+        .Instance = I2C2,           \
+        .timing = 0x307075B1,       \
+        .timeout = 1000,            \
+        .name = "hwi2c2",           \
+        .evirq_type = I2C2_EV_IRQn, \
+        .erirq_type = I2C2_ER_IRQn, \
     }
 #endif /* I2C2_BUS_CONFIG */
 #endif /* BSP_USING_HARD_I2C2 */
 
 #ifdef BSP_I2C2_TX_USING_DMA
+#ifndef I2C2_TX_DMA_PRIORITY
+#define I2C2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C2_TX_DMA_PRIORITY */
+
+#ifndef I2C2_TX_DMA_PREEMPT_PRIORITY
+#define I2C2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* I2C2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C2_TX_DMA_SUB_PRIORITY
+#define I2C2_TX_DMA_SUB_PRIORITY              0
+#endif /* I2C2_TX_DMA_SUB_PRIORITY */
 #ifndef I2C2_TX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C2_TX_DMA_RCC,                 \
-        .Instance = I2C2_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C2_TX_DMA_IRQ,                 \
-        .channel = I2C2_TX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C2_TX_DMA_RCC,                 \
-        .Instance = I2C2_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C2_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C2_TX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        I2C2_TX_DMA_INSTANCE,         \
+        I2C2_TX_DMA_RCC,              \
+        I2C2_TX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_I2C2_TX,          \
+        I2C2_TX_DMA_PRIORITY,         \
+        I2C2_TX_DMA_PREEMPT_PRIORITY, \
+        I2C2_TX_DMA_SUB_PRIORITY)
 #endif /* I2C2_TX_DMA_CONFIG */
 #endif /* BSP_I2C2_TX_USING_DMA */
 
 #ifdef BSP_I2C2_RX_USING_DMA
+#ifndef I2C2_RX_DMA_PRIORITY
+#define I2C2_RX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C2_RX_DMA_PRIORITY */
+
+#ifndef I2C2_RX_DMA_PREEMPT_PRIORITY
+#define I2C2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* I2C2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C2_RX_DMA_SUB_PRIORITY
+#define I2C2_RX_DMA_SUB_PRIORITY              0
+#endif /* I2C2_RX_DMA_SUB_PRIORITY */
 #ifndef I2C2_RX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C2_RX_DMA_RCC,                 \
-        .Instance = I2C2_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C2_RX_DMA_IRQ,                 \
-        .channel = I2C2_RX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C2_RX_DMA_RCC,                 \
-        .Instance = I2C2_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C2_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C2_RX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        I2C2_RX_DMA_INSTANCE,         \
+        I2C2_RX_DMA_RCC,              \
+        I2C2_RX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_I2C2_RX,          \
+        I2C2_RX_DMA_PRIORITY,         \
+        I2C2_RX_DMA_PREEMPT_PRIORITY, \
+        I2C2_RX_DMA_SUB_PRIORITY)
 #endif /* I2C2_RX_DMA_CONFIG */
 #endif /* BSP_I2C2_RX_USING_DMA */
 
 #ifdef BSP_USING_HARD_I2C3
 #ifndef I2C3_BUS_CONFIG
-#define I2C3_BUS_CONFIG                             \
-    {                                               \
-        .Instance = I2C3,                           \
-        .timing = 0x307075B1,                       \
-        .timeout = 1000,                            \
-        .name = "hwi2c3",                           \
-        .evirq_type = I2C3_EV_IRQn,                 \
-        .erirq_type = I2C3_ER_IRQn,                 \
+#define I2C3_BUS_CONFIG             \
+    {                               \
+        .Instance = I2C3,           \
+        .timing = 0x307075B1,       \
+        .timeout = 1000,            \
+        .name = "hwi2c3",           \
+        .evirq_type = I2C3_EV_IRQn, \
+        .erirq_type = I2C3_ER_IRQn, \
     }
 #endif /* I2C3_BUS_CONFIG */
 #endif /* BSP_USING_HARD_I2C3 */
 
 #ifdef BSP_I2C3_TX_USING_DMA
+#ifndef I2C3_TX_DMA_PRIORITY
+#define I2C3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C3_TX_DMA_PRIORITY */
+
+#ifndef I2C3_TX_DMA_PREEMPT_PRIORITY
+#define I2C3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* I2C3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C3_TX_DMA_SUB_PRIORITY
+#define I2C3_TX_DMA_SUB_PRIORITY              0
+#endif /* I2C3_TX_DMA_SUB_PRIORITY */
 #ifndef I2C3_TX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C3_TX_DMA_RCC,                 \
-        .Instance = I2C3_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C3_TX_DMA_IRQ,                 \
-        .channel = I2C3_TX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C3_TX_DMA_RCC,                 \
-        .Instance = I2C3_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C3_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C3_TX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        I2C3_TX_DMA_INSTANCE,         \
+        I2C3_TX_DMA_RCC,              \
+        I2C3_TX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_I2C3_TX,          \
+        I2C3_TX_DMA_PRIORITY,         \
+        I2C3_TX_DMA_PREEMPT_PRIORITY, \
+        I2C3_TX_DMA_SUB_PRIORITY)
 #endif /* I2C3_TX_DMA_CONFIG */
 #endif /* BSP_I2C3_TX_USING_DMA */
 
 #ifdef BSP_I2C3_RX_USING_DMA
+#ifndef I2C3_RX_DMA_PRIORITY
+#define I2C3_RX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C3_RX_DMA_PRIORITY */
+
+#ifndef I2C3_RX_DMA_PREEMPT_PRIORITY
+#define I2C3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* I2C3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C3_RX_DMA_SUB_PRIORITY
+#define I2C3_RX_DMA_SUB_PRIORITY              0
+#endif /* I2C3_RX_DMA_SUB_PRIORITY */
 #ifndef I2C3_RX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C3_RX_DMA_RCC,                 \
-        .Instance = I2C3_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C3_RX_DMA_IRQ,                 \
-        .channel = I2C3_RX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C3_RX_DMA_RCC,                 \
-        .Instance = I2C3_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C3_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C3_RX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        I2C3_RX_DMA_INSTANCE,         \
+        I2C3_RX_DMA_RCC,              \
+        I2C3_RX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_I2C3_RX,          \
+        I2C3_RX_DMA_PRIORITY,         \
+        I2C3_RX_DMA_PREEMPT_PRIORITY, \
+        I2C3_RX_DMA_SUB_PRIORITY)
 #endif /* I2C3_RX_DMA_CONFIG */
 #endif /* BSP_I2C3_RX_USING_DMA */
 
 #ifdef BSP_USING_HARD_I2C4
 #ifndef I2C4_BUS_CONFIG
-#define I2C4_BUS_CONFIG                             \
-    {                                               \
-        .Instance = I2C4,                           \
-        .timing = 0x307075B1,                       \
-        .timeout = 1000,                            \
-        .name = "hwi2c4",                           \
-        .evirq_type = I2C4_EV_IRQn,                 \
-        .erirq_type = I2C4_ER_IRQn,                 \
+#define I2C4_BUS_CONFIG             \
+    {                               \
+        .Instance = I2C4,           \
+        .timing = 0x307075B1,       \
+        .timeout = 1000,            \
+        .name = "hwi2c4",           \
+        .evirq_type = I2C4_EV_IRQn, \
+        .erirq_type = I2C4_ER_IRQn, \
     }
 #endif /* I2C4_BUS_CONFIG */
 #endif /* BSP_USING_HARD_I2C4 */
 
 #ifdef BSP_I2C4_TX_USING_DMA
+#ifndef I2C4_TX_DMA_PRIORITY
+#define I2C4_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C4_TX_DMA_PRIORITY */
+
+#ifndef I2C4_TX_DMA_PREEMPT_PRIORITY
+#define I2C4_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* I2C4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C4_TX_DMA_SUB_PRIORITY
+#define I2C4_TX_DMA_SUB_PRIORITY              0
+#endif /* I2C4_TX_DMA_SUB_PRIORITY */
 #ifndef I2C4_TX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C4_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C4_TX_DMA_RCC,                 \
-        .Instance = I2C4_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C4_TX_DMA_IRQ,                 \
-        .channel = I2C4_TX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C4_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C4_TX_DMA_RCC,                 \
-        .Instance = I2C4_TX_DMA_INSTANCE,           \
-        .dma_irq = I2C4_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C4_TX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C4_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        I2C4_TX_DMA_INSTANCE,         \
+        I2C4_TX_DMA_RCC,              \
+        I2C4_TX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_I2C4_TX,          \
+        I2C4_TX_DMA_PRIORITY,         \
+        I2C4_TX_DMA_PREEMPT_PRIORITY, \
+        I2C4_TX_DMA_SUB_PRIORITY)
 #endif /* I2C4_TX_DMA_CONFIG */
 #endif /* BSP_I2C4_TX_USING_DMA */
 
 #ifdef BSP_I2C4_RX_USING_DMA
+#ifndef I2C4_RX_DMA_PRIORITY
+#define I2C4_RX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* I2C4_RX_DMA_PRIORITY */
+
+#ifndef I2C4_RX_DMA_PREEMPT_PRIORITY
+#define I2C4_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* I2C4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef I2C4_RX_DMA_SUB_PRIORITY
+#define I2C4_RX_DMA_SUB_PRIORITY              0
+#endif /* I2C4_RX_DMA_SUB_PRIORITY */
 #ifndef I2C4_RX_DMA_CONFIG
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-#define I2C4_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C4_RX_DMA_RCC,                 \
-        .Instance = I2C4_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C4_RX_DMA_IRQ,                 \
-        .channel = I2C4_RX_DMA_CHANNEL,             \
-    }
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-#define I2C4_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = I2C4_RX_DMA_RCC,                 \
-        .Instance = I2C4_RX_DMA_INSTANCE,           \
-        .dma_irq = I2C4_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_I2C4_RX              \
-    }
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
+#define I2C4_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        I2C4_RX_DMA_INSTANCE,         \
+        I2C4_RX_DMA_RCC,              \
+        I2C4_RX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_I2C4_RX,          \
+        I2C4_RX_DMA_PRIORITY,         \
+        I2C4_RX_DMA_PREEMPT_PRIORITY, \
+        I2C4_RX_DMA_SUB_PRIORITY)
 #endif /* I2C4_RX_DMA_CONFIG */
 #endif /* BSP_I2C4_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/qspi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/qspi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-22     zylx         first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __QSPI_CONFIG_H__
@@ -30,19 +31,29 @@ extern "C" {
 #endif /* BSP_USING_QSPI */
 
 #ifdef BSP_QSPI_USING_DMA
+#ifndef QSPI_DMA_PRIORITY
+#define QSPI_DMA_PRIORITY                         DMA_PRIORITY_LOW
+#endif /* QSPI_DMA_PRIORITY */
+
+#ifndef QSPI_DMA_PREEMPT_PRIORITY
+#define QSPI_DMA_PREEMPT_PRIORITY                 0
+#endif /* QSPI_DMA_PREEMPT_PRIORITY */
+
+#ifndef QSPI_DMA_SUB_PRIORITY
+#define QSPI_DMA_SUB_PRIORITY                     0
+#endif /* QSPI_DMA_SUB_PRIORITY */
+
 #ifndef QSPI_DMA_CONFIG
-#define QSPI_DMA_CONFIG                                        \
-    {                                                          \
-        .Instance = QSPI_DMA_INSTANCE,                         \
-        .Init.Channel  = QSPI_DMA_CHANNEL,                     \
-        .Init.Direction = DMA_PERIPH_TO_MEMORY,                \
-        .Init.PeriphInc = DMA_PINC_DISABLE,                    \
-        .Init.MemInc = DMA_MINC_ENABLE,                        \
-        .Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE,       \
-        .Init.MemDataAlignment = DMA_MDATAALIGN_BYTE,          \
-        .Init.Mode = DMA_NORMAL,                               \
-        .Init.Priority = DMA_PRIORITY_LOW                      \
-    }
+#define QSPI_DMA_CONFIG               \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        QSPI_DMA_INSTANCE,            \
+        QSPI_DMA_RCC,                 \
+        QSPI_DMA_IRQ,                 \
+        0U,                           \
+        QSPI_DMA_REQUEST,             \
+        QSPI_DMA_PRIORITY,            \
+        QSPI_DMA_PREEMPT_PRIORITY,    \
+        QSPI_DMA_SUB_PRIORITY)
 #endif /* QSPI_DMA_CONFIG */
 #endif /* BSP_QSPI_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/sdio_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/sdio_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-13     BalanceTWK   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SDIO_CONFIG_H__
@@ -19,17 +20,71 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_SDIO
-#define SDIO_BUS_CONFIG                                  \
-    {                                                    \
-        .Instance = SDMMC1,                              \
-        .dma_rx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_tx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_rx.Instance = DMA2_Stream3,                 \
-        .dma_rx.channel = DMA_CHANNEL_4,                 \
-        .dma_rx.dma_irq = DMA2_Stream3_IRQn,             \
-        .dma_tx.Instance = DMA2_Stream6,                 \
-        .dma_tx.channel = DMA_CHANNEL_4,                 \
-        .dma_tx.dma_irq = DMA2_Stream6_IRQn,             \
+#ifndef SDIO_RX_DMA_PRIORITY
+#define SDIO_RX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_RX_DMA_PRIORITY */
+
+#ifndef SDIO_RX_DMA_PREEMPT_PRIORITY
+#define SDIO_RX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_RX_DMA_SUB_PRIORITY
+#define SDIO_RX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_RX_DMA_SUB_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PRIORITY
+#define SDIO_TX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_TX_DMA_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PREEMPT_PRIORITY
+#define SDIO_TX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_TX_DMA_SUB_PRIORITY
+#define SDIO_TX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_TX_DMA_SUB_PRIORITY */
+
+#define SDIO_BUS_CONFIG                          \
+    {                                            \
+        .Instance = SDMMC1,                      \
+        .dma_rx = STM32_DMA_CONFIG_INIT_FIFO_EX( \
+            DMA2_Stream3,                        \
+            RCC_AHB1ENR_DMA2EN,                  \
+            DMA2_Stream3_IRQn,                   \
+            DMA_CHANNEL_4,                       \
+            0U,                                  \
+            SDIO_RX_DMA_PRIORITY,                \
+            SDIO_RX_DMA_PREEMPT_PRIORITY,        \
+            SDIO_RX_DMA_SUB_PRIORITY,            \
+            DMA_PERIPH_TO_MEMORY,                \
+            DMA_PINC_DISABLE,                    \
+            DMA_MINC_ENABLE,                     \
+            DMA_PDATAALIGN_WORD,                 \
+            DMA_MDATAALIGN_WORD,                 \
+            DMA_PFCTRL,                          \
+            DMA_FIFOMODE_ENABLE,                 \
+            DMA_FIFO_THRESHOLD_FULL,             \
+            DMA_MBURST_INC4,                     \
+            DMA_PBURST_INC4),                    \
+        .dma_tx = STM32_DMA_CONFIG_INIT_FIFO_EX( \
+            DMA2_Stream6,                        \
+            RCC_AHB1ENR_DMA2EN,                  \
+            DMA2_Stream6_IRQn,                   \
+            DMA_CHANNEL_4,                       \
+            0U,                                  \
+            SDIO_TX_DMA_PRIORITY,                \
+            SDIO_TX_DMA_PREEMPT_PRIORITY,        \
+            SDIO_TX_DMA_SUB_PRIORITY,            \
+            DMA_MEMORY_TO_PERIPH,                \
+            DMA_PINC_DISABLE,                    \
+            DMA_MINC_ENABLE,                     \
+            DMA_PDATAALIGN_WORD,                 \
+            DMA_MDATAALIGN_WORD,                 \
+            DMA_PFCTRL,                          \
+            DMA_FIFOMODE_ENABLE,                 \
+            DMA_FIFO_THRESHOLD_FULL,             \
+            DMA_MBURST_INC4,                     \
+            DMA_PBURST_INC4),                    \
     }
 
 #endif

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/spi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -19,176 +20,316 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI1,                           \
-        .bus_name = "spi1",                         \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_TX_DMA_RCC,                 \
-        .Instance = SPI1_TX_DMA_INSTANCE,           \
-        .dma_irq = SPI1_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_SPI1_TX              \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_SPI1_TX,          \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_RX_DMA_RCC,                 \
-        .Instance = SPI1_RX_DMA_INSTANCE,           \
-        .dma_irq = SPI1_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_SPI1_RX              \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_SPI1_RX,          \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI2,                           \
-        .bus_name = "spi2",                         \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_TX_DMA_RCC,                 \
-        .Instance = SPI2_TX_DMA_INSTANCE,           \
-        .dma_irq = SPI2_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_SPI2_TX              \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_SPI2_TX,          \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_RX_DMA_RCC,                 \
-        .Instance = SPI2_RX_DMA_INSTANCE,           \
-        .dma_irq = SPI2_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_SPI2_RX              \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_SPI2_RX,          \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI3,                           \
-        .bus_name = "spi3",                         \
-        .irq_type = SPI3_IRQn,                      \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_TX_DMA_RCC,                 \
-        .Instance = SPI3_TX_DMA_INSTANCE,           \
-        .dma_irq = SPI3_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_SPI3_TX              \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_SPI3_TX,          \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_RX_DMA_RCC,                 \
-        .Instance = SPI3_RX_DMA_INSTANCE,           \
-        .dma_irq = SPI3_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_SPI3_RX              \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_SPI3_RX,          \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI4
 #ifndef SPI4_BUS_CONFIG
-#define SPI4_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI4,                           \
-        .bus_name = "spi4",                         \
-        .irq_type = SPI4_IRQn,                      \
+#define SPI4_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI4,      \
+        .bus_name = "spi4",    \
+        .irq_type = SPI4_IRQn, \
     }
 #endif /* SPI4_BUS_CONFIG */
 #endif /* BSP_USING_SPI4 */
 
 #ifdef BSP_SPI4_TX_USING_DMA
+#ifndef SPI4_TX_DMA_PRIORITY
+#define SPI4_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI4_TX_DMA_PRIORITY */
+
+#ifndef SPI4_TX_DMA_PREEMPT_PRIORITY
+#define SPI4_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI4_TX_DMA_SUB_PRIORITY
+#define SPI4_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI4_TX_DMA_SUB_PRIORITY */
 #ifndef SPI4_TX_DMA_CONFIG
-#define SPI4_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI4_TX_DMA_RCC,                 \
-        .Instance = SPI4_TX_DMA_INSTANCE,           \
-        .dma_irq = SPI4_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_SPI4_TX              \
-    }
+#define SPI4_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI4_TX_DMA_INSTANCE,         \
+        SPI4_TX_DMA_RCC,              \
+        SPI4_TX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_SPI4_TX,          \
+        SPI4_TX_DMA_PRIORITY,         \
+        SPI4_TX_DMA_PREEMPT_PRIORITY, \
+        SPI4_TX_DMA_SUB_PRIORITY)
 #endif /* SPI4_TX_DMA_CONFIG */
 #endif /* BSP_SPI4_TX_USING_DMA */
 
 #ifdef BSP_SPI4_RX_USING_DMA
+#ifndef SPI4_RX_DMA_PRIORITY
+#define SPI4_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI4_RX_DMA_PRIORITY */
+
+#ifndef SPI4_RX_DMA_PREEMPT_PRIORITY
+#define SPI4_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI4_RX_DMA_SUB_PRIORITY
+#define SPI4_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI4_RX_DMA_SUB_PRIORITY */
 #ifndef SPI4_RX_DMA_CONFIG
-#define SPI4_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI4_RX_DMA_RCC,                 \
-        .Instance = SPI4_RX_DMA_INSTANCE,           \
-        .dma_irq = SPI4_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_SPI4_RX              \
-    }
+#define SPI4_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI4_RX_DMA_INSTANCE,         \
+        SPI4_RX_DMA_RCC,              \
+        SPI4_RX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_SPI4_RX,          \
+        SPI4_RX_DMA_PRIORITY,         \
+        SPI4_RX_DMA_PREEMPT_PRIORITY, \
+        SPI4_RX_DMA_SUB_PRIORITY)
 #endif /* SPI4_RX_DMA_CONFIG */
 #endif /* BSP_SPI4_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI5
 #ifndef SPI5_BUS_CONFIG
-#define SPI5_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI5,                           \
-        .bus_name = "spi5",                         \
-        .irq_type = SPI5_IRQn,                      \
+#define SPI5_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI5,      \
+        .bus_name = "spi5",    \
+        .irq_type = SPI5_IRQn, \
     }
 #endif /* SPI5_BUS_CONFIG */
 #endif /* BSP_USING_SPI5 */
 
 #ifdef BSP_SPI5_TX_USING_DMA
+#ifndef SPI5_TX_DMA_PRIORITY
+#define SPI5_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI5_TX_DMA_PRIORITY */
+
+#ifndef SPI5_TX_DMA_PREEMPT_PRIORITY
+#define SPI5_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI5_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI5_TX_DMA_SUB_PRIORITY
+#define SPI5_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI5_TX_DMA_SUB_PRIORITY */
 #ifndef SPI5_TX_DMA_CONFIG
-#define SPI5_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI5_TX_DMA_RCC,                 \
-        .Instance = SPI5_TX_DMA_INSTANCE,           \
-        .dma_irq = SPI5_TX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_SPI5_TX              \
-    }
+#define SPI5_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI5_TX_DMA_INSTANCE,         \
+        SPI5_TX_DMA_RCC,              \
+        SPI5_TX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_SPI5_TX,          \
+        SPI5_TX_DMA_PRIORITY,         \
+        SPI5_TX_DMA_PREEMPT_PRIORITY, \
+        SPI5_TX_DMA_SUB_PRIORITY)
 #endif /* SPI5_TX_DMA_CONFIG */
 #endif /* BSP_SPI5_TX_USING_DMA */
 
 #ifdef BSP_SPI5_RX_USING_DMA
+#ifndef SPI5_RX_DMA_PRIORITY
+#define SPI5_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI5_RX_DMA_PRIORITY */
+
+#ifndef SPI5_RX_DMA_PREEMPT_PRIORITY
+#define SPI5_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI5_RX_DMA_SUB_PRIORITY
+#define SPI5_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI5_RX_DMA_SUB_PRIORITY */
 #ifndef SPI5_RX_DMA_CONFIG
-#define SPI5_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI5_RX_DMA_RCC,                 \
-        .Instance = SPI5_RX_DMA_INSTANCE,           \
-        .dma_irq = SPI5_RX_DMA_IRQ,                 \
-        .request = DMA_REQUEST_SPI5_RX              \
-    }
+#define SPI5_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI5_RX_DMA_INSTANCE,         \
+        SPI5_RX_DMA_RCC,              \
+        SPI5_RX_DMA_IRQ,              \
+        0U,                           \
+        DMA_REQUEST_SPI5_RX,          \
+        SPI5_RX_DMA_PRIORITY,         \
+        SPI5_RX_DMA_PREEMPT_PRIORITY, \
+        SPI5_RX_DMA_SUB_PRIORITY)
 #endif /* SPI5_RX_DMA_CONFIG */
 #endif /* BSP_SPI5_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/h7/uart_config.h
@@ -8,6 +8,7 @@
  * 2018-10-30     SummerGift   first version
  * 2019-01-05     zylx         modify dma support
  * 2020-05-02     whj4674672   support stm32h7 uart dma
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -21,137 +22,227 @@ extern "C" {
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .request = UART1_RX_DMA_REQUEST,                            \
-        .dma_rcc = UART1_RX_DMA_RCC,                                \
-        .dma_irq = UART1_RX_DMA_IRQ,                                \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART1_RX_DMA_REQUEST,                  \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .request = UART2_RX_DMA_REQUEST,                            \
-        .dma_rcc = UART2_RX_DMA_RCC,                                \
-        .dma_irq = UART2_RX_DMA_IRQ,                                \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART2_RX_DMA_REQUEST,                  \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART2_TX_DMA_INSTANCE,                          \
-        .request = UART2_TX_DMA_REQUEST,                            \
-        .dma_rcc = UART2_TX_DMA_RCC,                                \
-        .dma_irq = UART2_TX_DMA_IRQ,                                \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        0U,                            \
+        UART2_TX_DMA_REQUEST,          \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                          \
-        .request = UART3_RX_DMA_REQUEST,                            \
-        .dma_rcc = UART3_RX_DMA_RCC,                                \
-        .dma_irq = UART3_RX_DMA_IRQ,                                \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART3_RX_DMA_REQUEST,                  \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_USING_UART4)
 #ifndef UART4_CONFIG
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = UART4,                                          \
-        .irq_type = UART4_IRQn,                                     \
+#define UART4_CONFIG            \
+    {                           \
+        .name = "uart4",        \
+        .Instance = UART4,      \
+        .irq_type = UART4_IRQn, \
     }
 #endif /* UART4_CONFIG */
 #endif /* BSP_USING_UART4 */
 
 #if defined(BSP_UART4_RX_USING_DMA)
+#ifndef UART4_RX_DMA_PRIORITY
+#define UART4_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_RX_DMA_PRIORITY */
+
+#ifndef UART4_RX_DMA_PREEMPT_PRIORITY
+#define UART4_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_RX_DMA_SUB_PRIORITY
+#define UART4_RX_DMA_SUB_PRIORITY             0
+#endif /* UART4_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_RX_CONFIG
-#define UART4_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART4_RX_DMA_INSTANCE,                          \
-        .request = UART4_RX_DMA_REQUEST,                            \
-        .dma_rcc = UART4_RX_DMA_RCC,                                \
-        .dma_irq = UART4_RX_DMA_IRQ,                                \
-    }
+#define UART4_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART4_RX_DMA_INSTANCE,                 \
+        UART4_RX_DMA_RCC,                      \
+        UART4_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART4_RX_DMA_REQUEST,                  \
+        UART4_RX_DMA_PRIORITY,                 \
+        UART4_RX_DMA_PREEMPT_PRIORITY,         \
+        UART4_RX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_RX_CONFIG */
 #endif /* BSP_UART4_RX_USING_DMA */
 
 #if defined(BSP_USING_UART5)
 #ifndef UART5_CONFIG
-#define UART5_CONFIG                                                \
-    {                                                               \
-        .name = "uart5",                                            \
-        .Instance = UART5,                                          \
-        .irq_type = UART5_IRQn,                                     \
+#define UART5_CONFIG            \
+    {                           \
+        .name = "uart5",        \
+        .Instance = UART5,      \
+        .irq_type = UART5_IRQn, \
     }
 #endif /* UART5_CONFIG */
 #endif /* BSP_USING_UART5 */
 
 #if defined(BSP_UART5_RX_USING_DMA)
+#ifndef UART5_RX_DMA_PRIORITY
+#define UART5_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_RX_DMA_PRIORITY */
+
+#ifndef UART5_RX_DMA_PREEMPT_PRIORITY
+#define UART5_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_RX_DMA_SUB_PRIORITY
+#define UART5_RX_DMA_SUB_PRIORITY             0
+#endif /* UART5_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_RX_CONFIG
-#define UART5_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART5_RX_DMA_INSTANCE,                          \
-        .request = UART5_RX_DMA_REQUEST,                            \
-        .dma_rcc = UART5_RX_DMA_RCC,                                \
-        .dma_irq = UART5_RX_DMA_IRQ,                                \
-    }
+#define UART5_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART5_RX_DMA_INSTANCE,                 \
+        UART5_RX_DMA_RCC,                      \
+        UART5_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART5_RX_DMA_REQUEST,                  \
+        UART5_RX_DMA_PRIORITY,                 \
+        UART5_RX_DMA_PREEMPT_PRIORITY,         \
+        UART5_RX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_RX_CONFIG */
 #endif /* BSP_UART5_RX_USING_DMA */
 
 #if defined(BSP_USING_LPUART1)
 #ifndef LPUART1_CONFIG
-#define LPUART1_CONFIG                                              \
-    {                                                               \
-        .name = "hlpuart1",                                          \
-        .Instance = LPUART1,                                        \
-        .irq_type = LPUART1_IRQn,                                   \
+#define LPUART1_CONFIG            \
+    {                             \
+        .name = "hlpuart1",       \
+        .Instance = LPUART1,      \
+        .irq_type = LPUART1_IRQn, \
     }
 #endif /* LPUART1_CONFIG */
 #endif /* BSP_USING_LPUART1 */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l0/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l0/uart_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-10-30     zylx         first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -19,45 +20,77 @@ extern "C" {
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART1_RX_DMA_RCC,                               \
-        .dma_irq  = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART2_RX_DMA_RCC,                               \
-        .dma_irq  = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l1/sdio_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l1/sdio_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-13     BalanceTWK   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SDIO_CONFIG_H__
@@ -19,15 +20,51 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_SDIO
-#define SDIO_BUS_CONFIG                                  \
-    {                                                    \
-        .Instance = SDIO,                                \
-        .dma_rx.dma_rcc = RCC_AHBENR_DMA2EN,             \
-        .dma_tx.dma_rcc = RCC_AHBENR_DMA2EN,             \
-        .dma_rx.Instance = DMA2_Channel4,                \
-        .dma_rx.dma_irq = DMA2_Channel4_IRQn,            \
-        .dma_tx.Instance = DMA2_Channel4,                \
-        .dma_tx.dma_irq = DMA2_Channel4_IRQn,            \
+#ifndef SDIO_RX_DMA_PRIORITY
+#define SDIO_RX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_RX_DMA_PRIORITY */
+
+#ifndef SDIO_RX_DMA_PREEMPT_PRIORITY
+#define SDIO_RX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_RX_DMA_SUB_PRIORITY
+#define SDIO_RX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_RX_DMA_SUB_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PRIORITY
+#define SDIO_TX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_TX_DMA_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PREEMPT_PRIORITY
+#define SDIO_TX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_TX_DMA_SUB_PRIORITY
+#define SDIO_TX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_TX_DMA_SUB_PRIORITY */
+
+#define SDIO_BUS_CONFIG                             \
+    {                                               \
+        .Instance = SDIO,                           \
+        .dma_rx = STM32_DMA_RX_WORD_CONFIG_INIT_EX( \
+            DMA2_Channel4,                          \
+            RCC_AHBENR_DMA2EN,                      \
+            DMA2_Channel4_IRQn,                     \
+            0U,                                     \
+            0U,                                     \
+            SDIO_RX_DMA_PRIORITY,                   \
+            SDIO_RX_DMA_PREEMPT_PRIORITY,           \
+            SDIO_RX_DMA_SUB_PRIORITY),              \
+        .dma_tx = STM32_DMA_TX_WORD_CONFIG_INIT_EX( \
+            DMA2_Channel4,                          \
+            RCC_AHBENR_DMA2EN,                      \
+            DMA2_Channel4_IRQn,                     \
+            0U,                                     \
+            0U,                                     \
+            SDIO_TX_DMA_PRIORITY,                   \
+            SDIO_TX_DMA_PREEMPT_PRIORITY,           \
+            SDIO_TX_DMA_SUB_PRIORITY),              \
     }
 
 #endif

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l1/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l1/spi_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
  * 2019-01-05     SummerGift   modify DMA support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -20,100 +21,190 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI1,                           \
-        .bus_name = "spi1",                         \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_TX_DMA_RCC,                 \
-        .Instance = SPI1_TX_DMA_INSTANCE,           \
-        .dma_irq = SPI1_TX_DMA_IRQ,                 \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        SPI1_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_RX_DMA_RCC,                 \
-        .Instance = SPI1_RX_DMA_INSTANCE,           \
-        .dma_irq = SPI1_RX_DMA_IRQ,                 \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        SPI1_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI2,                           \
-        .bus_name = "spi2",                         \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc  = SPI2_TX_DMA_RCC,                \
-        .Instance = SPI2_TX_DMA_INSTANCE,           \
-        .dma_irq  = SPI2_TX_DMA_IRQ,                \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        SPI2_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc  = SPI2_RX_DMA_RCC,                \
-        .Instance = SPI2_RX_DMA_INSTANCE,           \
-        .dma_irq  = SPI2_RX_DMA_IRQ,                \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        SPI2_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI3,                           \
-        .bus_name = "spi3",                         \
-        .irq_type = SPI3_IRQn,                      \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc  = SPI3_TX_DMA_RCC,                \
-        .Instance = SPI3_TX_DMA_INSTANCE,           \
-        .dma_irq  = SPI3_TX_DMA_IRQ,                \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        SPI3_TX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc  = SPI3_RX_DMA_RCC,                \
-        .Instance = SPI3_RX_DMA_INSTANCE,           \
-        .dma_irq  = SPI3_RX_DMA_IRQ,                \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        SPI3_RX_DMA_CHANNEL,          \
+        0U,                           \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l1/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l1/uart_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-10-30     BalanceTWK   first version
  * 2019-01-05     SummerGift   modify DMA support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -21,153 +22,299 @@ extern "C" {
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART1_RX_DMA_RCC,                               \
-        .dma_irq  = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART1_TX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART1_TX_DMA_RCC,                               \
-        .dma_irq  = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART1_TX_DMA_INSTANCE,         \
+        UART1_TX_DMA_RCC,              \
+        UART1_TX_DMA_IRQ,              \
+        0U,                            \
+        0U,                            \
+        UART1_TX_DMA_PRIORITY,         \
+        UART1_TX_DMA_PREEMPT_PRIORITY, \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART2_RX_DMA_RCC,                               \
-        .dma_irq  = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART2_TX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART2_TX_DMA_RCC,                               \
-        .dma_irq  = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        0U,                            \
+        0U,                            \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART3_RX_DMA_RCC,                               \
-        .dma_irq  = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART3_TX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART3_TX_DMA_RCC,                               \
-        .dma_irq  = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART3_TX_DMA_INSTANCE,         \
+        UART3_TX_DMA_RCC,              \
+        UART3_TX_DMA_IRQ,              \
+        0U,                            \
+        0U,                            \
+        UART3_TX_DMA_PRIORITY,         \
+        UART3_TX_DMA_PREEMPT_PRIORITY, \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_USING_UART4)
 #ifndef UART4_CONFIG
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = UART4,                                          \
-        .irq_type = UART4_IRQn,                                     \
+#define UART4_CONFIG            \
+    {                           \
+        .name = "uart4",        \
+        .Instance = UART4,      \
+        .irq_type = UART4_IRQn, \
     }
 #endif /* UART4_CONFIG */
 
 #if defined(BSP_UART4_RX_USING_DMA)
+#ifndef UART4_RX_DMA_PRIORITY
+#define UART4_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_RX_DMA_PRIORITY */
+
+#ifndef UART4_RX_DMA_PREEMPT_PRIORITY
+#define UART4_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_RX_DMA_SUB_PRIORITY
+#define UART4_RX_DMA_SUB_PRIORITY             0
+#endif /* UART4_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_RX_CONFIG
-#define UART4_DMA_RX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART4_RX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART4_RX_DMA_RCC,                               \
-        .dma_irq  = UART4_RX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART4_RX_DMA_INSTANCE,                 \
+        UART4_RX_DMA_RCC,                      \
+        UART4_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART4_RX_DMA_PRIORITY,                 \
+        UART4_RX_DMA_PREEMPT_PRIORITY,         \
+        UART4_RX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_RX_CONFIG */
 #endif /* BSP_UART4_RX_USING_DMA */
 
 #if defined(BSP_UART4_TX_USING_DMA)
+#ifndef UART4_TX_DMA_PRIORITY
+#define UART4_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_TX_DMA_PRIORITY */
+
+#ifndef UART4_TX_DMA_PREEMPT_PRIORITY
+#define UART4_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_TX_DMA_SUB_PRIORITY
+#define UART4_TX_DMA_SUB_PRIORITY             0
+#endif /* UART4_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_TX_CONFIG
-#define UART4_DMA_TX_CONFIG                                         \
-    {                                                               \
-        .Instance = UART4_TX_DMA_INSTANCE,                          \
-        .dma_rcc  = UART4_TX_DMA_RCC,                               \
-        .dma_irq  = UART4_TX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART4_TX_DMA_INSTANCE,         \
+        UART4_TX_DMA_RCC,              \
+        UART4_TX_DMA_IRQ,              \
+        0U,                            \
+        0U,                            \
+        UART4_TX_DMA_PRIORITY,         \
+        UART4_TX_DMA_PREEMPT_PRIORITY, \
+        UART4_TX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_TX_CONFIG */
 #endif /* BSP_UART4_TX_USING_DMA */
 #endif /* BSP_USING_UART4 */
 
 #if defined(BSP_USING_UART5)
 #ifndef UART5_CONFIG
-#define UART5_CONFIG                                                \
-    {                                                               \
-        .name = "uart5",                                            \
-        .Instance = UART5,                                          \
-        .irq_type = UART5_IRQn,                                     \
+#define UART5_CONFIG            \
+    {                           \
+        .name = "uart5",        \
+        .Instance = UART5,      \
+        .irq_type = UART5_IRQn, \
     }
 #endif /* UART5_CONFIG */
 #endif /* BSP_USING_UART5 */
 
 #if defined(BSP_UART5_RX_USING_DMA)
+#ifndef UART5_RX_DMA_PRIORITY
+#define UART5_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_RX_DMA_PRIORITY */
+
+#ifndef UART5_RX_DMA_PREEMPT_PRIORITY
+#define UART5_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_RX_DMA_SUB_PRIORITY
+#define UART5_RX_DMA_SUB_PRIORITY             0
+#endif /* UART5_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_RX_CONFIG
-#define UART5_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = DMA_NOT_AVAILABLE,                              \
-    }
+#define UART5_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART5_RX_DMA_INSTANCE,                 \
+        UART5_RX_DMA_RCC,                      \
+        UART5_RX_DMA_IRQ,                      \
+        0U,                                    \
+        0U,                                    \
+        UART5_RX_DMA_PRIORITY,                 \
+        UART5_RX_DMA_PREEMPT_PRIORITY,         \
+        UART5_RX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_RX_CONFIG */
 #endif /* BSP_UART5_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l4/qspi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l4/qspi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-22     zylx         first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __QSPI_CONFIG_H__
@@ -30,19 +31,29 @@ extern "C" {
 #endif /* BSP_USING_QSPI */
 
 #ifdef BSP_QSPI_USING_DMA
+#ifndef QSPI_DMA_PRIORITY
+#define QSPI_DMA_PRIORITY                         DMA_PRIORITY_LOW
+#endif /* QSPI_DMA_PRIORITY */
+
+#ifndef QSPI_DMA_PREEMPT_PRIORITY
+#define QSPI_DMA_PREEMPT_PRIORITY                 0
+#endif /* QSPI_DMA_PREEMPT_PRIORITY */
+
+#ifndef QSPI_DMA_SUB_PRIORITY
+#define QSPI_DMA_SUB_PRIORITY                     0
+#endif /* QSPI_DMA_SUB_PRIORITY */
+
 #ifndef QSPI_DMA_CONFIG
-#define QSPI_DMA_CONFIG                                        \
-    {                                                          \
-        .Instance = QSPI_DMA_INSTANCE,                         \
-        .Init.Request = QSPI_DMA_REQUEST,                      \
-        .Init.Direction = DMA_PERIPH_TO_MEMORY,                \
-        .Init.PeriphInc = DMA_PINC_DISABLE,                    \
-        .Init.MemInc = DMA_MINC_ENABLE,                        \
-        .Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE,       \
-        .Init.MemDataAlignment = DMA_MDATAALIGN_BYTE,          \
-        .Init.Mode = DMA_NORMAL,                               \
-        .Init.Priority = DMA_PRIORITY_LOW                      \
-    }
+#define QSPI_DMA_CONFIG               \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        QSPI_DMA_INSTANCE,            \
+        QSPI_DMA_RCC,                 \
+        QSPI_DMA_IRQ,                 \
+        0U,                           \
+        QSPI_DMA_REQUEST,             \
+        QSPI_DMA_PRIORITY,            \
+        QSPI_DMA_PREEMPT_PRIORITY,    \
+        QSPI_DMA_SUB_PRIORITY)
 #endif /* QSPI_DMA_CONFIG */
 #endif /* BSP_QSPI_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l4/sdio_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l4/sdio_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-13     BalanceTWK   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SDIO_CONFIG_H__
@@ -19,17 +20,51 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_SDIO
-#define SDIO_BUS_CONFIG                                  \
-    {                                                    \
-        .Instance = SDMMC1,                              \
-        .dma_rx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_tx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_rx.Instance = DMA2_Channel4,                \
-        .dma_rx.request = DMA_REQUEST_7,                 \
-        .dma_rx.dma_irq = DMA2_Channel4_IRQn,            \
-        .dma_tx.Instance = DMA2_Channel5,                \
-        .dma_tx.request = DMA_REQUEST_7,                 \
-        .dma_tx.dma_irq = DMA2_Channel5_IRQn,            \
+#ifndef SDIO_RX_DMA_PRIORITY
+#define SDIO_RX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_RX_DMA_PRIORITY */
+
+#ifndef SDIO_RX_DMA_PREEMPT_PRIORITY
+#define SDIO_RX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_RX_DMA_SUB_PRIORITY
+#define SDIO_RX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_RX_DMA_SUB_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PRIORITY
+#define SDIO_TX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_TX_DMA_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PREEMPT_PRIORITY
+#define SDIO_TX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_TX_DMA_SUB_PRIORITY
+#define SDIO_TX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_TX_DMA_SUB_PRIORITY */
+
+#define SDIO_BUS_CONFIG                             \
+    {                                               \
+        .Instance = SDMMC1,                         \
+        .dma_rx = STM32_DMA_RX_WORD_CONFIG_INIT_EX( \
+            DMA2_Channel4,                          \
+            RCC_AHB1ENR_DMA2EN,                     \
+            DMA2_Channel4_IRQn,                     \
+            0U,                                     \
+            DMA_REQUEST_7,                          \
+            SDIO_RX_DMA_PRIORITY,                   \
+            SDIO_RX_DMA_PREEMPT_PRIORITY,           \
+            SDIO_RX_DMA_SUB_PRIORITY),              \
+        .dma_tx = STM32_DMA_TX_WORD_CONFIG_INIT_EX( \
+            DMA2_Channel5,                          \
+            RCC_AHB1ENR_DMA2EN,                     \
+            DMA2_Channel5_IRQn,                     \
+            0U,                                     \
+            DMA_REQUEST_7,                          \
+            SDIO_TX_DMA_PRIORITY,                   \
+            SDIO_TX_DMA_PREEMPT_PRIORITY,           \
+            SDIO_TX_DMA_SUB_PRIORITY),              \
     }
 
 #endif

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l4/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l4/spi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -19,106 +20,190 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI1,                                   \
-        .bus_name = "spi1",                                 \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI1_TX_DMA_RCC,                         \
-        .Instance = SPI1_TX_DMA_INSTANCE,                   \
-        .request = SPI1_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI1_TX_DMA_IRQ,                         \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI1_TX_DMA_REQUEST,          \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI1_RX_DMA_RCC,                         \
-        .Instance = SPI1_RX_DMA_INSTANCE,                   \
-        .request = SPI1_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI1_RX_DMA_IRQ,                         \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI1_RX_DMA_REQUEST,          \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI2,                                   \
-        .bus_name = "spi2",                                 \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI2_TX_DMA_RCC,                         \
-        .Instance = SPI2_TX_DMA_INSTANCE,                   \
-        .request = SPI2_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI2_TX_DMA_IRQ,                         \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI2_TX_DMA_REQUEST,          \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI2_RX_DMA_RCC,                         \
-        .Instance = SPI2_RX_DMA_INSTANCE,                   \
-        .request = SPI2_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI2_RX_DMA_IRQ,                         \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI2_RX_DMA_REQUEST,          \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI3,                                   \
-        .bus_name = "spi3",                                 \
-        .irq_type = SPI3_IRQn,                      \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI3_TX_DMA_RCC,                         \
-        .Instance = SPI3_TX_DMA_INSTANCE,                   \
-        .request = SPI3_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI3_TX_DMA_IRQ,                         \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI3_TX_DMA_REQUEST,          \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI3_RX_DMA_RCC,                         \
-        .Instance = SPI3_RX_DMA_INSTANCE,                   \
-        .request = SPI3_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI3_RX_DMA_IRQ,                         \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI3_RX_DMA_REQUEST,          \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l4/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l4/uart_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -19,128 +20,233 @@ extern "C" {
 
 #if defined(BSP_USING_LPUART1)
 #ifndef LPUART1_CONFIG
-#define LPUART1_CONFIG                                              \
-    {                                                               \
-        .name = "lpuart1",                                          \
-        .Instance = LPUART1,                                        \
-        .irq_type = LPUART1_IRQn,                                   \
+#define LPUART1_CONFIG            \
+    {                             \
+        .name = "lpuart1",        \
+        .Instance = LPUART1,      \
+        .irq_type = LPUART1_IRQn, \
     }
 #endif /* LPUART1_CONFIG */
 #if defined(BSP_LPUART1_RX_USING_DMA)
+#ifndef LPUART1_DMA_PRIORITY
+#define LPUART1_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* LPUART1_DMA_PRIORITY */
+
+#ifndef LPUART1_DMA_PREEMPT_PRIORITY
+#define LPUART1_DMA_PREEMPT_PRIORITY         0
+#endif /* LPUART1_DMA_PREEMPT_PRIORITY */
+
+#ifndef LPUART1_DMA_SUB_PRIORITY
+#define LPUART1_DMA_SUB_PRIORITY             0
+#endif /* LPUART1_DMA_SUB_PRIORITY */
+
 #ifndef LPUART1_DMA_CONFIG
-#define LPUART1_DMA_CONFIG                                          \
-    {                                                               \
-        .Instance = LPUART1_RX_DMA_INSTANCE,                        \
-        .request  = LPUART1_RX_DMA_REQUEST,                         \
-        .dma_rcc  = LPUART1_RX_DMA_RCC,                             \
-        .dma_irq  = LPUART1_RX_DMA_IRQ,                             \
-    }
+#define LPUART1_DMA_CONFIG                     \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        LPUART1_RX_DMA_INSTANCE,               \
+        LPUART1_RX_DMA_RCC,                    \
+        LPUART1_RX_DMA_IRQ,                    \
+        0U,                                    \
+        LPUART1_RX_DMA_REQUEST,                \
+        LPUART1_DMA_PRIORITY,                  \
+        LPUART1_DMA_PREEMPT_PRIORITY,          \
+        LPUART1_DMA_SUB_PRIORITY)
 #endif /* LPUART1_DMA_CONFIG */
 #endif /* BSP_LPUART1_RX_USING_DMA */
 #endif /* BSP_USING_LPUART1 */
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .request  = UART1_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_RX_DMA_RCC,                               \
-        .dma_irq  = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART1_RX_DMA_REQUEST,                  \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_TX_DMA_INSTANCE,                          \
-        .request  = UART1_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_TX_DMA_RCC,                               \
-        .dma_irq  = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART1_TX_DMA_INSTANCE,         \
+        UART1_TX_DMA_RCC,              \
+        UART1_TX_DMA_IRQ,              \
+        0U,                            \
+        UART1_TX_DMA_REQUEST,          \
+        UART1_TX_DMA_PRIORITY,         \
+        UART1_TX_DMA_PREEMPT_PRIORITY, \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .request  = UART2_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_RX_DMA_RCC,                               \
-        .dma_irq  = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART2_RX_DMA_REQUEST,                  \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_TX_DMA_INSTANCE,                          \
-        .request  = UART2_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_TX_DMA_RCC,                               \
-        .dma_irq  = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        0U,                            \
+        UART2_TX_DMA_REQUEST,          \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                          \
-        .request  = UART3_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_RX_DMA_RCC,                               \
-        .dma_irq  = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART3_RX_DMA_REQUEST,                  \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_TX_DMA_INSTANCE,                          \
-        .request  = UART3_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_TX_DMA_RCC,                               \
-        .dma_irq  = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART3_TX_DMA_INSTANCE,         \
+        UART3_TX_DMA_RCC,              \
+        UART3_TX_DMA_IRQ,              \
+        0U,                            \
+        UART3_TX_DMA_REQUEST,          \
+        UART3_TX_DMA_PRIORITY,         \
+        UART3_TX_DMA_PREEMPT_PRIORITY, \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l5/qspi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l5/qspi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-22     zylx         first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __QSPI_CONFIG_H__
@@ -30,19 +31,29 @@ extern "C" {
 #endif /* BSP_USING_QSPI */
 
 #ifdef BSP_QSPI_USING_DMA
+#ifndef QSPI_DMA_PRIORITY
+#define QSPI_DMA_PRIORITY                         DMA_PRIORITY_LOW
+#endif /* QSPI_DMA_PRIORITY */
+
+#ifndef QSPI_DMA_PREEMPT_PRIORITY
+#define QSPI_DMA_PREEMPT_PRIORITY                 0
+#endif /* QSPI_DMA_PREEMPT_PRIORITY */
+
+#ifndef QSPI_DMA_SUB_PRIORITY
+#define QSPI_DMA_SUB_PRIORITY                     0
+#endif /* QSPI_DMA_SUB_PRIORITY */
+
 #ifndef QSPI_DMA_CONFIG
-#define QSPI_DMA_CONFIG                                        \
-    {                                                          \
-        .Instance = QSPI_DMA_INSTANCE,                         \
-        .Init.Request = QSPI_DMA_REQUEST,                      \
-        .Init.Direction = DMA_PERIPH_TO_MEMORY,                \
-        .Init.PeriphInc = DMA_PINC_DISABLE,                    \
-        .Init.MemInc = DMA_MINC_ENABLE,                        \
-        .Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE,       \
-        .Init.MemDataAlignment = DMA_MDATAALIGN_BYTE,          \
-        .Init.Mode = DMA_NORMAL,                               \
-        .Init.Priority = DMA_PRIORITY_LOW                      \
-    }
+#define QSPI_DMA_CONFIG               \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        QSPI_DMA_INSTANCE,            \
+        QSPI_DMA_RCC,                 \
+        QSPI_DMA_IRQ,                 \
+        0U,                           \
+        QSPI_DMA_REQUEST,             \
+        QSPI_DMA_PRIORITY,            \
+        QSPI_DMA_PREEMPT_PRIORITY,    \
+        QSPI_DMA_SUB_PRIORITY)
 #endif /* QSPI_DMA_CONFIG */
 #endif /* BSP_QSPI_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l5/sdio_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l5/sdio_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-13     BalanceTWK   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SDIO_CONFIG_H__
@@ -19,17 +20,51 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_SDIO
-#define SDIO_BUS_CONFIG                                  \
-    {                                                    \
-        .Instance = SDMMC1,                              \
-        .dma_rx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_tx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_rx.Instance = DMA2_Channel4,                \
-        .dma_rx.request = DMA_REQUEST_7,                 \
-        .dma_rx.dma_irq = DMA2_Channel4_IRQn,            \
-        .dma_tx.Instance = DMA2_Channel5,                \
-        .dma_tx.request = DMA_REQUEST_7,                 \
-        .dma_tx.dma_irq = DMA2_Channel5_IRQn,            \
+#ifndef SDIO_RX_DMA_PRIORITY
+#define SDIO_RX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_RX_DMA_PRIORITY */
+
+#ifndef SDIO_RX_DMA_PREEMPT_PRIORITY
+#define SDIO_RX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_RX_DMA_SUB_PRIORITY
+#define SDIO_RX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_RX_DMA_SUB_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PRIORITY
+#define SDIO_TX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_TX_DMA_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PREEMPT_PRIORITY
+#define SDIO_TX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_TX_DMA_SUB_PRIORITY
+#define SDIO_TX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_TX_DMA_SUB_PRIORITY */
+
+#define SDIO_BUS_CONFIG                             \
+    {                                               \
+        .Instance = SDMMC1,                         \
+        .dma_rx = STM32_DMA_RX_WORD_CONFIG_INIT_EX( \
+            DMA2_Channel4,                          \
+            RCC_AHB1ENR_DMA2EN,                     \
+            DMA2_Channel4_IRQn,                     \
+            0U,                                     \
+            DMA_REQUEST_7,                          \
+            SDIO_RX_DMA_PRIORITY,                   \
+            SDIO_RX_DMA_PREEMPT_PRIORITY,           \
+            SDIO_RX_DMA_SUB_PRIORITY),              \
+        .dma_tx = STM32_DMA_TX_WORD_CONFIG_INIT_EX( \
+            DMA2_Channel5,                          \
+            RCC_AHB1ENR_DMA2EN,                     \
+            DMA2_Channel5_IRQn,                     \
+            0U,                                     \
+            DMA_REQUEST_7,                          \
+            SDIO_TX_DMA_PRIORITY,                   \
+            SDIO_TX_DMA_PREEMPT_PRIORITY,           \
+            SDIO_TX_DMA_SUB_PRIORITY),              \
     }
 
 #endif

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l5/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l5/spi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -19,106 +20,190 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI1,                                   \
-        .bus_name = "spi1",                                 \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI1_TX_DMA_RCC,                         \
-        .Instance = SPI1_TX_DMA_INSTANCE,                   \
-        .request = SPI1_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI1_TX_DMA_IRQ,                         \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI1_TX_DMA_REQUEST,          \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI1_RX_DMA_RCC,                         \
-        .Instance = SPI1_RX_DMA_INSTANCE,                   \
-        .request = SPI1_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI1_RX_DMA_IRQ,                         \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        0U,                             \
+        SPI1_RX_DMA_REQUEST,          \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI2,                                   \
-        .bus_name = "spi2",                                 \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI2_TX_DMA_RCC,                         \
-        .Instance = SPI2_TX_DMA_INSTANCE,                   \
-        .request = SPI2_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI2_TX_DMA_IRQ,                         \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        0U,                             \
+        SPI2_TX_DMA_REQUEST,          \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI2_RX_DMA_RCC,                         \
-        .Instance = SPI2_RX_DMA_INSTANCE,                   \
-        .request = SPI2_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI2_RX_DMA_IRQ,                         \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        0U,                             \
+        SPI2_RX_DMA_REQUEST,          \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI3,                                   \
-        .bus_name = "spi3",                                 \
-        .irq_type = SPI3_IRQn,                      \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI3_TX_DMA_RCC,                         \
-        .Instance = SPI3_TX_DMA_INSTANCE,                   \
-        .request = SPI3_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI3_TX_DMA_IRQ,                         \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        0U,                             \
+        SPI3_TX_DMA_REQUEST,          \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI3_RX_DMA_RCC,                         \
-        .Instance = SPI3_RX_DMA_INSTANCE,                   \
-        .request = SPI3_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI3_RX_DMA_IRQ,                         \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        0U,                             \
+        SPI3_RX_DMA_REQUEST,          \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/l5/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/l5/uart_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -19,128 +20,233 @@ extern "C" {
 
 #if defined(BSP_USING_LPUART1)
 #ifndef LPUART1_CONFIG
-#define LPUART1_CONFIG                                              \
-    {                                                               \
-        .name = "lpuart1",                                          \
-        .Instance = LPUART1,                                        \
-        .irq_type = LPUART1_IRQn,                                   \
+#define LPUART1_CONFIG            \
+    {                             \
+        .name = "lpuart1",        \
+        .Instance = LPUART1,      \
+        .irq_type = LPUART1_IRQn, \
     }
 #endif /* LPUART1_CONFIG */
 #if defined(BSP_LPUART1_RX_USING_DMA)
+#ifndef LPUART1_DMA_PRIORITY
+#define LPUART1_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* LPUART1_DMA_PRIORITY */
+
+#ifndef LPUART1_DMA_PREEMPT_PRIORITY
+#define LPUART1_DMA_PREEMPT_PRIORITY         0
+#endif /* LPUART1_DMA_PREEMPT_PRIORITY */
+
+#ifndef LPUART1_DMA_SUB_PRIORITY
+#define LPUART1_DMA_SUB_PRIORITY             0
+#endif /* LPUART1_DMA_SUB_PRIORITY */
+
 #ifndef LPUART1_DMA_CONFIG
-#define LPUART1_DMA_CONFIG                                          \
-    {                                                               \
-        .Instance = LPUART1_RX_DMA_INSTANCE,                        \
-        .request  = LPUART1_RX_DMA_REQUEST,                         \
-        .dma_rcc  = LPUART1_RX_DMA_RCC,                             \
-        .dma_irq  = LPUART1_RX_DMA_IRQ,                             \
-    }
+#define LPUART1_DMA_CONFIG                     \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        LPUART1_RX_DMA_INSTANCE,               \
+        LPUART1_RX_DMA_RCC,                    \
+        LPUART1_RX_DMA_IRQ,                    \
+        0U,                                    \
+        LPUART1_RX_DMA_REQUEST,                \
+        LPUART1_DMA_PRIORITY,                  \
+        LPUART1_DMA_PREEMPT_PRIORITY,          \
+        LPUART1_DMA_SUB_PRIORITY)
 #endif /* LPUART1_DMA_CONFIG */
 #endif /* BSP_LPUART1_RX_USING_DMA */
 #endif /* BSP_USING_LPUART1 */
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .request  = UART1_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_RX_DMA_RCC,                               \
-        .dma_irq  = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART1_RX_DMA_REQUEST,                  \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_TX_DMA_INSTANCE,                          \
-        .request  = UART1_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_TX_DMA_RCC,                               \
-        .dma_irq  = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART1_TX_DMA_INSTANCE,         \
+        UART1_TX_DMA_RCC,              \
+        UART1_TX_DMA_IRQ,              \
+        0U,                            \
+        UART1_TX_DMA_REQUEST,          \
+        UART1_TX_DMA_PRIORITY,         \
+        UART1_TX_DMA_PREEMPT_PRIORITY, \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .request  = UART2_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_RX_DMA_RCC,                               \
-        .dma_irq  = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART2_RX_DMA_REQUEST,                  \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_TX_DMA_INSTANCE,                          \
-        .request  = UART2_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_TX_DMA_RCC,                               \
-        .dma_irq  = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        0U,                            \
+        UART2_TX_DMA_REQUEST,          \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                          \
-        .request  = UART3_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_RX_DMA_RCC,                               \
-        .dma_irq  = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART3_RX_DMA_REQUEST,                  \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_TX_DMA_INSTANCE,                          \
-        .request  = UART3_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_TX_DMA_RCC,                               \
-        .dma_irq  = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART3_TX_DMA_INSTANCE,         \
+        UART3_TX_DMA_RCC,              \
+        UART3_TX_DMA_IRQ,              \
+        0U,                            \
+        UART3_TX_DMA_REQUEST,          \
+        UART3_TX_DMA_PRIORITY,         \
+        UART3_TX_DMA_PREEMPT_PRIORITY, \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/mp1/dma_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/mp1/dma_config.h
@@ -68,6 +68,11 @@ extern "C" {
 #define QSPI_DMA_IRQHandler              DMA2_Stream2_IRQHandler
 #define QSPI_DMA_RCC                     RCC_MC_AHB2ENSETR_DMA2EN
 #define QSPI_DMA_INSTANCE                DMA2_Stream2
+#if defined(DMA_REQUEST_QUADSPI)
+#define QSPI_DMA_REQUEST                 DMA_REQUEST_QUADSPI
+#elif defined(DMA_REQUEST_QUADSPI1)
+#define QSPI_DMA_REQUEST                 DMA_REQUEST_QUADSPI1
+#endif
 #define QSPI_DMA_CHANNEL                 DMA_CHANNEL_11
 #define QSPI_DMA_IRQ                     DMA2_Stream2_IRQn
 #endif

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/mp1/qspi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/mp1/qspi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-22     zylx         first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __QSPI_CONFIG_H__
@@ -30,19 +31,29 @@ extern "C" {
 #endif /* BSP_USING_QSPI */
 
 #ifdef BSP_QSPI_USING_DMA
+#ifndef QSPI_DMA_PRIORITY
+#define QSPI_DMA_PRIORITY                         DMA_PRIORITY_LOW
+#endif /* QSPI_DMA_PRIORITY */
+
+#ifndef QSPI_DMA_PREEMPT_PRIORITY
+#define QSPI_DMA_PREEMPT_PRIORITY                 0
+#endif /* QSPI_DMA_PREEMPT_PRIORITY */
+
+#ifndef QSPI_DMA_SUB_PRIORITY
+#define QSPI_DMA_SUB_PRIORITY                     0
+#endif /* QSPI_DMA_SUB_PRIORITY */
+
 #ifndef QSPI_DMA_CONFIG
-#define QSPI_DMA_CONFIG                                        \
-    {                                                          \
-        .Instance = QSPI_DMA_INSTANCE,                         \
-        .Init.Channel  = QSPI_DMA_CHANNEL,                     \
-        .Init.Direction = DMA_PERIPH_TO_MEMORY,                \
-        .Init.PeriphInc = DMA_PINC_DISABLE,                    \
-        .Init.MemInc = DMA_MINC_ENABLE,                        \
-        .Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE,       \
-        .Init.MemDataAlignment = DMA_MDATAALIGN_BYTE,          \
-        .Init.Mode = DMA_NORMAL,                               \
-        .Init.Priority = DMA_PRIORITY_LOW                      \
-    }
+#define QSPI_DMA_CONFIG               \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        QSPI_DMA_INSTANCE,            \
+        QSPI_DMA_RCC,                 \
+        QSPI_DMA_IRQ,                 \
+        0U,                           \
+        QSPI_DMA_REQUEST,             \
+        QSPI_DMA_PRIORITY,            \
+        QSPI_DMA_PREEMPT_PRIORITY,    \
+        QSPI_DMA_SUB_PRIORITY)
 #endif /* QSPI_DMA_CONFIG */
 #endif /* BSP_QSPI_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/mp1/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/mp1/spi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -19,176 +20,316 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI1,                           \
-        .bus_name = "spi1",                         \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_TX_DMA_RCC,                 \
-        .Instance = SPI1_TX_DMA_INSTANCE,           \
-        .request = SPI1_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI1_TX_DMA_IRQ,                 \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI1_TX_DMA_CHANNEL,          \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI1_RX_DMA_RCC,                 \
-        .Instance = SPI1_RX_DMA_INSTANCE,           \
-        .request = SPI1_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI1_RX_DMA_IRQ,                 \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI1_RX_DMA_CHANNEL,          \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI2,                           \
-        .bus_name = "spi2",                         \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_TX_DMA_RCC,                 \
-        .Instance = SPI2_TX_DMA_INSTANCE,           \
-        .request = SPI2_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI2_TX_DMA_IRQ,                 \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI2_TX_DMA_CHANNEL,          \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI2_RX_DMA_RCC,                 \
-        .Instance = SPI2_RX_DMA_INSTANCE,           \
-        .request = SPI2_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI2_RX_DMA_IRQ,                 \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI2_RX_DMA_CHANNEL,          \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI3,                           \
-        .bus_name = "spi3",                         \
-        .irq_type = SPI3_IRQn,                      \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_TX_DMA_RCC,                 \
-        .Instance = SPI3_TX_DMA_INSTANCE,           \
-        .request = SPI3_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI3_TX_DMA_IRQ,                 \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI3_TX_DMA_CHANNEL,          \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI3_RX_DMA_RCC,                 \
-        .Instance = SPI3_RX_DMA_INSTANCE,           \
-        .request = SPI3_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI3_RX_DMA_IRQ,                 \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI3_RX_DMA_CHANNEL,          \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI4
 #ifndef SPI4_BUS_CONFIG
-#define SPI4_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI4,                           \
-        .bus_name = "spi4",                         \
-        .irq_type = SPI4_IRQn,                      \
+#define SPI4_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI4,      \
+        .bus_name = "spi4",    \
+        .irq_type = SPI4_IRQn, \
     }
 #endif /* SPI4_BUS_CONFIG */
 #endif /* BSP_USING_SPI4 */
 
 #ifdef BSP_SPI4_TX_USING_DMA
+#ifndef SPI4_TX_DMA_PRIORITY
+#define SPI4_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI4_TX_DMA_PRIORITY */
+
+#ifndef SPI4_TX_DMA_PREEMPT_PRIORITY
+#define SPI4_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI4_TX_DMA_SUB_PRIORITY
+#define SPI4_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI4_TX_DMA_SUB_PRIORITY */
 #ifndef SPI4_TX_DMA_CONFIG
-#define SPI4_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI4_TX_DMA_RCC,                 \
-        .Instance = SPI4_TX_DMA_INSTANCE,           \
-        .request = SPI4_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI4_TX_DMA_IRQ,                 \
-    }
+#define SPI4_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI4_TX_DMA_INSTANCE,         \
+        SPI4_TX_DMA_RCC,              \
+        SPI4_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI4_TX_DMA_CHANNEL,          \
+        SPI4_TX_DMA_PRIORITY,         \
+        SPI4_TX_DMA_PREEMPT_PRIORITY, \
+        SPI4_TX_DMA_SUB_PRIORITY)
 #endif /* SPI4_TX_DMA_CONFIG */
 #endif /* BSP_SPI4_TX_USING_DMA */
 
 #ifdef BSP_SPI4_RX_USING_DMA
+#ifndef SPI4_RX_DMA_PRIORITY
+#define SPI4_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI4_RX_DMA_PRIORITY */
+
+#ifndef SPI4_RX_DMA_PREEMPT_PRIORITY
+#define SPI4_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI4_RX_DMA_SUB_PRIORITY
+#define SPI4_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI4_RX_DMA_SUB_PRIORITY */
 #ifndef SPI4_RX_DMA_CONFIG
-#define SPI4_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI4_RX_DMA_RCC,                 \
-        .Instance = SPI4_RX_DMA_INSTANCE,           \
-        .request = SPI4_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI4_RX_DMA_IRQ,                 \
-    }
+#define SPI4_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI4_RX_DMA_INSTANCE,         \
+        SPI4_RX_DMA_RCC,              \
+        SPI4_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI4_RX_DMA_CHANNEL,          \
+        SPI4_RX_DMA_PRIORITY,         \
+        SPI4_RX_DMA_PREEMPT_PRIORITY, \
+        SPI4_RX_DMA_SUB_PRIORITY)
 #endif /* SPI4_RX_DMA_CONFIG */
 #endif /* BSP_SPI4_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI5
 #ifndef SPI5_BUS_CONFIG
-#define SPI5_BUS_CONFIG                             \
-    {                                               \
-        .Instance = SPI5,                           \
-        .bus_name = "spi5",                         \
-        .irq_type = SPI5_IRQn,                      \
+#define SPI5_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI5,      \
+        .bus_name = "spi5",    \
+        .irq_type = SPI5_IRQn, \
     }
 #endif /* SPI5_BUS_CONFIG */
 #endif /* BSP_USING_SPI5 */
 
 #ifdef BSP_SPI5_TX_USING_DMA
+#ifndef SPI5_TX_DMA_PRIORITY
+#define SPI5_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI5_TX_DMA_PRIORITY */
+
+#ifndef SPI5_TX_DMA_PREEMPT_PRIORITY
+#define SPI5_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI5_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI5_TX_DMA_SUB_PRIORITY
+#define SPI5_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI5_TX_DMA_SUB_PRIORITY */
 #ifndef SPI5_TX_DMA_CONFIG
-#define SPI5_TX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI5_TX_DMA_RCC,                 \
-        .Instance = SPI5_TX_DMA_INSTANCE,           \
-        .request = SPI5_TX_DMA_CHANNEL,             \
-        .dma_irq = SPI5_TX_DMA_IRQ,                 \
-    }
+#define SPI5_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI5_TX_DMA_INSTANCE,         \
+        SPI5_TX_DMA_RCC,              \
+        SPI5_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI5_TX_DMA_CHANNEL,          \
+        SPI5_TX_DMA_PRIORITY,         \
+        SPI5_TX_DMA_PREEMPT_PRIORITY, \
+        SPI5_TX_DMA_SUB_PRIORITY)
 #endif /* SPI5_TX_DMA_CONFIG */
 #endif /* BSP_SPI5_TX_USING_DMA */
 
 #ifdef BSP_SPI5_RX_USING_DMA
+#ifndef SPI5_RX_DMA_PRIORITY
+#define SPI5_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI5_RX_DMA_PRIORITY */
+
+#ifndef SPI5_RX_DMA_PREEMPT_PRIORITY
+#define SPI5_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI5_RX_DMA_SUB_PRIORITY
+#define SPI5_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI5_RX_DMA_SUB_PRIORITY */
 #ifndef SPI5_RX_DMA_CONFIG
-#define SPI5_RX_DMA_CONFIG                          \
-    {                                               \
-        .dma_rcc = SPI5_RX_DMA_RCC,                 \
-        .Instance = SPI5_RX_DMA_INSTANCE,           \
-        .request = SPI5_RX_DMA_CHANNEL,             \
-        .dma_irq = SPI5_RX_DMA_IRQ,                 \
-    }
+#define SPI5_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI5_RX_DMA_INSTANCE,         \
+        SPI5_RX_DMA_RCC,              \
+        SPI5_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI5_RX_DMA_CHANNEL,          \
+        SPI5_RX_DMA_PRIORITY,         \
+        SPI5_RX_DMA_PREEMPT_PRIORITY, \
+        SPI5_RX_DMA_SUB_PRIORITY)
 #endif /* SPI5_RX_DMA_CONFIG */
 #endif /* BSP_SPI5_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/mp1/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/mp1/uart_config.h
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-10-30     SummerGift   first version
  * 2019-01-03     zylx         modify dma support
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -20,210 +21,390 @@ extern "C" {
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART1_RX_DMA_INSTANCE,                         \
-        .request = UART1_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_RX_DMA_RCC,                               \
-        .dma_irq = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART1_RX_DMA_CHANNEL,                  \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART1_TX_DMA_INSTANCE,                         \
-        .request = UART1_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART1_TX_DMA_RCC,                               \
-        .dma_irq = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART1_TX_DMA_INSTANCE,         \
+        UART1_TX_DMA_RCC,              \
+        UART1_TX_DMA_IRQ,              \
+        0U,                            \
+        UART1_TX_DMA_CHANNEL,          \
+        UART1_TX_DMA_PRIORITY,         \
+        UART1_TX_DMA_PREEMPT_PRIORITY, \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART2_RX_DMA_INSTANCE,                         \
-        .request = UART2_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_RX_DMA_RCC,                               \
-        .dma_irq = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART2_RX_DMA_CHANNEL,                  \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART2_TX_DMA_INSTANCE,                         \
-        .request = UART2_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART2_TX_DMA_RCC,                               \
-        .dma_irq = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        0U,                            \
+        UART2_TX_DMA_CHANNEL,          \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART3_RX_DMA_INSTANCE,                         \
-        .request = UART3_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_RX_DMA_RCC,                               \
-        .dma_irq = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART3_RX_DMA_CHANNEL,                  \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART3_TX_DMA_INSTANCE,                         \
-        .request = UART3_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART3_TX_DMA_RCC,                               \
-        .dma_irq = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART3_TX_DMA_INSTANCE,         \
+        UART3_TX_DMA_RCC,              \
+        UART3_TX_DMA_IRQ,              \
+        0U,                            \
+        UART3_TX_DMA_CHANNEL,          \
+        UART3_TX_DMA_PRIORITY,         \
+        UART3_TX_DMA_PREEMPT_PRIORITY, \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_USING_UART4)
 #ifndef UART4_CONFIG
-#define UART4_CONFIG                                                \
-    {                                                               \
-        .name = "uart4",                                            \
-        .Instance = UART4,                                          \
-        .irq_type = UART4_IRQn,                                     \
+#define UART4_CONFIG            \
+    {                           \
+        .name = "uart4",        \
+        .Instance = UART4,      \
+        .irq_type = UART4_IRQn, \
     }
 #endif /* UART4_CONFIG */
 
 #if defined(BSP_UART4_RX_USING_DMA)
+#ifndef UART4_RX_DMA_PRIORITY
+#define UART4_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_RX_DMA_PRIORITY */
+
+#ifndef UART4_RX_DMA_PREEMPT_PRIORITY
+#define UART4_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_RX_DMA_SUB_PRIORITY
+#define UART4_RX_DMA_SUB_PRIORITY             0
+#endif /* UART4_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_RX_CONFIG
-#define UART4_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART4_RX_DMA_INSTANCE,                         \
-        .request = UART4_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART4_RX_DMA_RCC,                               \
-        .dma_irq = UART4_RX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART4_RX_DMA_INSTANCE,                 \
+        UART4_RX_DMA_RCC,                      \
+        UART4_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART4_RX_DMA_CHANNEL,                  \
+        UART4_RX_DMA_PRIORITY,                 \
+        UART4_RX_DMA_PREEMPT_PRIORITY,         \
+        UART4_RX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_RX_CONFIG */
 #endif /* BSP_UART4_RX_USING_DMA */
 
 #if defined(BSP_UART4_TX_USING_DMA)
+#ifndef UART4_TX_DMA_PRIORITY
+#define UART4_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART4_TX_DMA_PRIORITY */
+
+#ifndef UART4_TX_DMA_PREEMPT_PRIORITY
+#define UART4_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART4_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART4_TX_DMA_SUB_PRIORITY
+#define UART4_TX_DMA_SUB_PRIORITY             0
+#endif /* UART4_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART4_DMA_TX_CONFIG
-#define UART4_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART4_TX_DMA_INSTANCE,                         \
-        .request = UART4_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART4_TX_DMA_RCC,                               \
-        .dma_irq = UART4_TX_DMA_IRQ,                               \
-    }
+#define UART4_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART4_TX_DMA_INSTANCE,         \
+        UART4_TX_DMA_RCC,              \
+        UART4_TX_DMA_IRQ,              \
+        0U,                            \
+        UART4_TX_DMA_CHANNEL,          \
+        UART4_TX_DMA_PRIORITY,         \
+        UART4_TX_DMA_PREEMPT_PRIORITY, \
+        UART4_TX_DMA_SUB_PRIORITY)
 #endif /* UART4_DMA_TX_CONFIG */
-#endif /* BSP_UART4_RX_USING_DMA */
+#endif /* BSP_UART4_TX_USING_DMA */
 #endif /* BSP_USING_UART4 */
 
 #if defined(BSP_USING_UART5)
 #ifndef UART5_CONFIG
-#define UART5_CONFIG                                                \
-    {                                                               \
-        .name = "uart5",                                            \
-        .Instance = UART5,                                          \
-        .irq_type = UART5_IRQn,                                     \
+#define UART5_CONFIG            \
+    {                           \
+        .name = "uart5",        \
+        .Instance = UART5,      \
+        .irq_type = UART5_IRQn, \
     }
 #endif /* UART5_CONFIG */
 
 #if defined(BSP_UART5_RX_USING_DMA)
+#ifndef UART5_RX_DMA_PRIORITY
+#define UART5_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_RX_DMA_PRIORITY */
+
+#ifndef UART5_RX_DMA_PREEMPT_PRIORITY
+#define UART5_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_RX_DMA_SUB_PRIORITY
+#define UART5_RX_DMA_SUB_PRIORITY             0
+#endif /* UART5_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_RX_CONFIG
-#define UART5_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART5_RX_DMA_INSTANCE,                         \
-        .request = UART5_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART5_RX_DMA_RCC,                               \
-        .dma_irq = UART5_RX_DMA_IRQ,                               \
-    }
+#define UART5_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART5_RX_DMA_INSTANCE,                 \
+        UART5_RX_DMA_RCC,                      \
+        UART5_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART5_RX_DMA_CHANNEL,                  \
+        UART5_RX_DMA_PRIORITY,                 \
+        UART5_RX_DMA_PREEMPT_PRIORITY,         \
+        UART5_RX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_RX_CONFIG */
 #endif /* BSP_UART5_RX_USING_DMA */
 
 #if defined(BSP_UART5_TX_USING_DMA)
+#ifndef UART5_TX_DMA_PRIORITY
+#define UART5_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART5_TX_DMA_PRIORITY */
+
+#ifndef UART5_TX_DMA_PREEMPT_PRIORITY
+#define UART5_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART5_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART5_TX_DMA_SUB_PRIORITY
+#define UART5_TX_DMA_SUB_PRIORITY             0
+#endif /* UART5_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART5_DMA_TX_CONFIG
-#define UART5_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART5_TX_DMA_INSTANCE,                         \
-        .request = UART5_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART5_TX_DMA_RCC,                               \
-        .dma_irq = UART5_TX_DMA_IRQ,                               \
-    }
+#define UART5_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART5_TX_DMA_INSTANCE,         \
+        UART5_TX_DMA_RCC,              \
+        UART5_TX_DMA_IRQ,              \
+        0U,                            \
+        UART5_TX_DMA_CHANNEL,          \
+        UART5_TX_DMA_PRIORITY,         \
+        UART5_TX_DMA_PREEMPT_PRIORITY, \
+        UART5_TX_DMA_SUB_PRIORITY)
 #endif /* UART5_DMA_TX_CONFIG */
 #endif /* BSP_UART5_TX_USING_DMA */
 #endif /* BSP_USING_UART5 */
 
 #if defined(BSP_USING_UART6)
 #ifndef UART6_CONFIG
-#define UART6_CONFIG                                                \
-    {                                                               \
-        .name = "uart6",                                            \
-        .Instance = USART6,                                         \
-        .irq_type = USART6_IRQn,                                    \
+#define UART6_CONFIG             \
+    {                            \
+        .name = "uart6",         \
+        .Instance = USART6,      \
+        .irq_type = USART6_IRQn, \
     }
 #endif /* UART6_CONFIG */
 
 #if defined(BSP_UART6_RX_USING_DMA)
+#ifndef UART6_RX_DMA_PRIORITY
+#define UART6_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART6_RX_DMA_PRIORITY */
+
+#ifndef UART6_RX_DMA_PREEMPT_PRIORITY
+#define UART6_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART6_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART6_RX_DMA_SUB_PRIORITY
+#define UART6_RX_DMA_SUB_PRIORITY             0
+#endif /* UART6_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART6_DMA_RX_CONFIG
-#define UART6_DMA_RX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART6_RX_DMA_INSTANCE,                         \
-        .request = UART6_RX_DMA_CHANNEL,                           \
-        .dma_rcc = UART6_RX_DMA_RCC,                               \
-        .dma_irq = UART6_RX_DMA_IRQ,                               \
-    }
+#define UART6_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART6_RX_DMA_INSTANCE,                 \
+        UART6_RX_DMA_RCC,                      \
+        UART6_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART6_RX_DMA_CHANNEL,                  \
+        UART6_RX_DMA_PRIORITY,                 \
+        UART6_RX_DMA_PREEMPT_PRIORITY,         \
+        UART6_RX_DMA_SUB_PRIORITY)
 #endif /* UART6_DMA_RX_CONFIG */
 #endif /* BSP_UART6_RX_USING_DMA */
 
 #if defined(BSP_UART6_TX_USING_DMA)
+#ifndef UART6_TX_DMA_PRIORITY
+#define UART6_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART6_TX_DMA_PRIORITY */
+
+#ifndef UART6_TX_DMA_PREEMPT_PRIORITY
+#define UART6_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART6_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART6_TX_DMA_SUB_PRIORITY
+#define UART6_TX_DMA_SUB_PRIORITY             0
+#endif /* UART6_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART6_DMA_TX_CONFIG
-#define UART6_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = UART6_TX_DMA_INSTANCE,                         \
-        .request = UART6_TX_DMA_CHANNEL,                           \
-        .dma_rcc = UART6_TX_DMA_RCC,                               \
-        .dma_irq = UART6_TX_DMA_IRQ,                               \
-    }
+#define UART6_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART6_TX_DMA_INSTANCE,         \
+        UART6_TX_DMA_RCC,              \
+        UART6_TX_DMA_IRQ,              \
+        0U,                            \
+        UART6_TX_DMA_CHANNEL,          \
+        UART6_TX_DMA_PRIORITY,         \
+        UART6_TX_DMA_PREEMPT_PRIORITY, \
+        UART6_TX_DMA_SUB_PRIORITY)
 #endif /* UART6_DMA_TX_CONFIG */
 #endif /* BSP_UART6_TX_USING_DMA */
 #endif /* BSP_USING_UART6 */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/u5/qspi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/u5/qspi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-22     zylx         first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __QSPI_CONFIG_H__
@@ -30,19 +31,28 @@ extern "C" {
 #endif /* BSP_USING_QSPI */
 
 #ifdef BSP_QSPI_USING_DMA
+#ifndef QSPI_DMA_PRIORITY
+#define QSPI_DMA_PRIORITY                         DMA_PRIORITY_LOW
+#endif /* QSPI_DMA_PRIORITY */
+
+#ifndef QSPI_DMA_PREEMPT_PRIORITY
+#define QSPI_DMA_PREEMPT_PRIORITY                 0
+#endif /* QSPI_DMA_PREEMPT_PRIORITY */
+
+#ifndef QSPI_DMA_SUB_PRIORITY
+#define QSPI_DMA_SUB_PRIORITY                     0
+#endif /* QSPI_DMA_SUB_PRIORITY */
+
 #ifndef QSPI_DMA_CONFIG
-#define QSPI_DMA_CONFIG                                        \
-    {                                                          \
-        .Instance = QSPI_DMA_INSTANCE,                         \
-        .Init.Request = QSPI_DMA_REQUEST,                      \
-        .Init.Direction = DMA_PERIPH_TO_MEMORY,                \
-        .Init.PeriphInc = DMA_PINC_DISABLE,                    \
-        .Init.MemInc = DMA_MINC_ENABLE,                        \
-        .Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE,       \
-        .Init.MemDataAlignment = DMA_MDATAALIGN_BYTE,          \
-        .Init.Mode = DMA_NORMAL,                               \
-        .Init.Priority = DMA_PRIORITY_LOW                      \
-    }
+#define QSPI_DMA_CONFIG                 \
+    STM32_GPDMA_RX_BYTE_CONFIG_INIT_EX( \
+        QSPI_DMA_INSTANCE,              \
+        QSPI_DMA_RCC,                   \
+        QSPI_DMA_IRQ,                   \
+        QSPI_DMA_REQUEST,               \
+        QSPI_DMA_PRIORITY,              \
+        QSPI_DMA_PREEMPT_PRIORITY,      \
+        QSPI_DMA_SUB_PRIORITY)
 #endif /* QSPI_DMA_CONFIG */
 #endif /* BSP_QSPI_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/u5/sdio_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/u5/sdio_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-12-13     BalanceTWK   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SDIO_CONFIG_H__
@@ -19,17 +20,49 @@ extern "C" {
 #endif
 
 #ifdef BSP_USING_SDIO
-#define SDIO_BUS_CONFIG                                  \
-    {                                                    \
-        .Instance = SDMMC1,                              \
-        .dma_rx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_tx.dma_rcc = RCC_AHB1ENR_DMA2EN,            \
-        .dma_rx.Instance = DMA2_Channel4,                \
-        .dma_rx.request = DMA_REQUEST_7,                 \
-        .dma_rx.dma_irq = DMA2_Channel4_IRQn,            \
-        .dma_tx.Instance = DMA2_Channel5,                \
-        .dma_tx.request = DMA_REQUEST_7,                 \
-        .dma_tx.dma_irq = DMA2_Channel5_IRQn,            \
+#ifndef SDIO_RX_DMA_PRIORITY
+#define SDIO_RX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_RX_DMA_PRIORITY */
+
+#ifndef SDIO_RX_DMA_PREEMPT_PRIORITY
+#define SDIO_RX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_RX_DMA_SUB_PRIORITY
+#define SDIO_RX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_RX_DMA_SUB_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PRIORITY
+#define SDIO_TX_DMA_PRIORITY                      DMA_PRIORITY_MEDIUM
+#endif /* SDIO_TX_DMA_PRIORITY */
+
+#ifndef SDIO_TX_DMA_PREEMPT_PRIORITY
+#define SDIO_TX_DMA_PREEMPT_PRIORITY              0
+#endif /* SDIO_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SDIO_TX_DMA_SUB_PRIORITY
+#define SDIO_TX_DMA_SUB_PRIORITY                  0
+#endif /* SDIO_TX_DMA_SUB_PRIORITY */
+
+#define SDIO_BUS_CONFIG                               \
+    {                                                 \
+        .Instance = SDMMC1,                           \
+        .dma_rx = STM32_GPDMA_RX_WORD_CONFIG_INIT_EX( \
+            DMA2_Channel4,                            \
+            RCC_AHB1ENR_DMA2EN,                       \
+            DMA2_Channel4_IRQn,                       \
+            DMA_REQUEST_7,                            \
+            SDIO_RX_DMA_PRIORITY,                     \
+            SDIO_RX_DMA_PREEMPT_PRIORITY,             \
+            SDIO_RX_DMA_SUB_PRIORITY),                \
+        .dma_tx = STM32_GPDMA_TX_WORD_CONFIG_INIT_EX( \
+            DMA2_Channel5,                            \
+            RCC_AHB1ENR_DMA2EN,                       \
+            DMA2_Channel5_IRQn,                       \
+            DMA_REQUEST_7,                            \
+            SDIO_TX_DMA_PRIORITY,                     \
+            SDIO_TX_DMA_PREEMPT_PRIORITY,             \
+            SDIO_TX_DMA_SUB_PRIORITY),                \
     }
 
 #endif

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/u5/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/u5/spi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -19,106 +20,184 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI1,                                   \
-        .bus_name = "spi1",                                 \
-        .irq_type = SPI1_IRQn,                      \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI1_TX_DMA_RCC,                         \
-        .Instance = SPI1_TX_DMA_INSTANCE,                   \
-        .request = SPI1_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI1_TX_DMA_IRQ,                         \
-    }
+#define SPI1_TX_DMA_CONFIG              \
+    STM32_GPDMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,           \
+        SPI1_TX_DMA_RCC,                \
+        SPI1_TX_DMA_IRQ,                \
+        SPI1_TX_DMA_REQUEST,            \
+        SPI1_TX_DMA_PRIORITY,           \
+        SPI1_TX_DMA_PREEMPT_PRIORITY,   \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI1_RX_DMA_RCC,                         \
-        .Instance = SPI1_RX_DMA_INSTANCE,                   \
-        .request = SPI1_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI1_RX_DMA_IRQ,                         \
-    }
+#define SPI1_RX_DMA_CONFIG              \
+    STM32_GPDMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,           \
+        SPI1_RX_DMA_RCC,                \
+        SPI1_RX_DMA_IRQ,                \
+        SPI1_RX_DMA_REQUEST,            \
+        SPI1_RX_DMA_PRIORITY,           \
+        SPI1_RX_DMA_PREEMPT_PRIORITY,   \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI2,                                   \
-        .bus_name = "spi2",                                 \
-        .irq_type = SPI2_IRQn,                      \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI2_TX_DMA_RCC,                         \
-        .Instance = SPI2_TX_DMA_INSTANCE,                   \
-        .request = SPI2_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI2_TX_DMA_IRQ,                         \
-    }
+#define SPI2_TX_DMA_CONFIG              \
+    STM32_GPDMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,           \
+        SPI2_TX_DMA_RCC,                \
+        SPI2_TX_DMA_IRQ,                \
+        SPI2_TX_DMA_REQUEST,            \
+        SPI2_TX_DMA_PRIORITY,           \
+        SPI2_TX_DMA_PREEMPT_PRIORITY,   \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI2_RX_DMA_RCC,                         \
-        .Instance = SPI2_RX_DMA_INSTANCE,                   \
-        .request = SPI2_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI2_RX_DMA_IRQ,                         \
-    }
+#define SPI2_RX_DMA_CONFIG              \
+    STM32_GPDMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,           \
+        SPI2_RX_DMA_RCC,                \
+        SPI2_RX_DMA_IRQ,                \
+        SPI2_RX_DMA_REQUEST,            \
+        SPI2_RX_DMA_PRIORITY,           \
+        SPI2_RX_DMA_PREEMPT_PRIORITY,   \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI3,                                   \
-        .bus_name = "spi3",                                 \
-        .irq_type = SPI3_IRQn,                      \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI3_TX_DMA_RCC,                         \
-        .Instance = SPI3_TX_DMA_INSTANCE,                   \
-        .request = SPI3_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI3_TX_DMA_IRQ,                         \
-    }
+#define SPI3_TX_DMA_CONFIG              \
+    STM32_GPDMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,           \
+        SPI3_TX_DMA_RCC,                \
+        SPI3_TX_DMA_IRQ,                \
+        SPI3_TX_DMA_REQUEST,            \
+        SPI3_TX_DMA_PRIORITY,           \
+        SPI3_TX_DMA_PREEMPT_PRIORITY,   \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI3_RX_DMA_RCC,                         \
-        .Instance = SPI3_RX_DMA_INSTANCE,                   \
-        .request = SPI3_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI3_RX_DMA_IRQ,                         \
-    }
+#define SPI3_RX_DMA_CONFIG              \
+    STM32_GPDMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,           \
+        SPI3_RX_DMA_RCC,                \
+        SPI3_RX_DMA_IRQ,                \
+        SPI3_RX_DMA_REQUEST,            \
+        SPI3_RX_DMA_PRIORITY,           \
+        SPI3_RX_DMA_PREEMPT_PRIORITY,   \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/u5/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/u5/uart_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -19,128 +20,226 @@ extern "C" {
 
 #if defined(BSP_USING_LPUART1)
 #ifndef LPUART1_CONFIG
-#define LPUART1_CONFIG                                              \
-    {                                                               \
-        .name = "lpuart1",                                          \
-        .Instance = LPUART1,                                        \
-        .irq_type = LPUART1_IRQn,                                   \
+#define LPUART1_CONFIG            \
+    {                             \
+        .name = "lpuart1",        \
+        .Instance = LPUART1,      \
+        .irq_type = LPUART1_IRQn, \
     }
 #endif /* LPUART1_CONFIG */
 #if defined(BSP_LPUART1_RX_USING_DMA)
+#ifndef LPUART1_DMA_PRIORITY
+#define LPUART1_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* LPUART1_DMA_PRIORITY */
+
+#ifndef LPUART1_DMA_PREEMPT_PRIORITY
+#define LPUART1_DMA_PREEMPT_PRIORITY         0
+#endif /* LPUART1_DMA_PREEMPT_PRIORITY */
+
+#ifndef LPUART1_DMA_SUB_PRIORITY
+#define LPUART1_DMA_SUB_PRIORITY             0
+#endif /* LPUART1_DMA_SUB_PRIORITY */
+
 #ifndef LPUART1_DMA_CONFIG
-#define LPUART1_DMA_CONFIG                                          \
-    {                                                               \
-        .Instance = LPUART1_RX_DMA_INSTANCE,                        \
-        .request  = LPUART1_RX_DMA_REQUEST,                         \
-        .dma_rcc  = LPUART1_RX_DMA_RCC,                             \
-        .dma_irq  = LPUART1_RX_DMA_IRQ,                             \
-    }
+#define LPUART1_DMA_CONFIG                       \
+    STM32_GPDMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        LPUART1_RX_DMA_INSTANCE,                 \
+        LPUART1_RX_DMA_RCC,                      \
+        LPUART1_RX_DMA_IRQ,                      \
+        LPUART1_RX_DMA_REQUEST,                  \
+        LPUART1_DMA_PRIORITY,                    \
+        LPUART1_DMA_PREEMPT_PRIORITY,            \
+        LPUART1_DMA_SUB_PRIORITY)
 #endif /* LPUART1_DMA_CONFIG */
 #endif /* BSP_LPUART1_RX_USING_DMA */
 #endif /* BSP_USING_LPUART1 */
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .request  = UART1_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_RX_DMA_RCC,                               \
-        .dma_irq  = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                      \
+    STM32_GPDMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                   \
+        UART1_RX_DMA_RCC,                        \
+        UART1_RX_DMA_IRQ,                        \
+        UART1_RX_DMA_REQUEST,                    \
+        UART1_RX_DMA_PRIORITY,                   \
+        UART1_RX_DMA_PREEMPT_PRIORITY,           \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_TX_DMA_INSTANCE,                          \
-        .request  = UART1_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_TX_DMA_RCC,                               \
-        .dma_irq  = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG             \
+    STM32_GPDMA_TX_BYTE_CONFIG_INIT_EX( \
+        UART1_TX_DMA_INSTANCE,          \
+        UART1_TX_DMA_RCC,               \
+        UART1_TX_DMA_IRQ,               \
+        UART1_TX_DMA_REQUEST,           \
+        UART1_TX_DMA_PRIORITY,          \
+        UART1_TX_DMA_PREEMPT_PRIORITY,  \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .request  = UART2_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_RX_DMA_RCC,                               \
-        .dma_irq  = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                      \
+    STM32_GPDMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                   \
+        UART2_RX_DMA_RCC,                        \
+        UART2_RX_DMA_IRQ,                        \
+        UART2_RX_DMA_REQUEST,                    \
+        UART2_RX_DMA_PRIORITY,                   \
+        UART2_RX_DMA_PREEMPT_PRIORITY,           \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_TX_DMA_INSTANCE,                          \
-        .request  = UART2_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_TX_DMA_RCC,                               \
-        .dma_irq  = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG             \
+    STM32_GPDMA_TX_BYTE_CONFIG_INIT_EX( \
+        UART2_TX_DMA_INSTANCE,          \
+        UART2_TX_DMA_RCC,               \
+        UART2_TX_DMA_IRQ,               \
+        UART2_TX_DMA_REQUEST,           \
+        UART2_TX_DMA_PRIORITY,          \
+        UART2_TX_DMA_PREEMPT_PRIORITY,  \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                          \
-        .request  = UART3_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_RX_DMA_RCC,                               \
-        .dma_irq  = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                      \
+    STM32_GPDMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                   \
+        UART3_RX_DMA_RCC,                        \
+        UART3_RX_DMA_IRQ,                        \
+        UART3_RX_DMA_REQUEST,                    \
+        UART3_RX_DMA_PRIORITY,                   \
+        UART3_RX_DMA_PREEMPT_PRIORITY,           \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_TX_DMA_INSTANCE,                          \
-        .request  = UART3_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_TX_DMA_RCC,                               \
-        .dma_irq  = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG             \
+    STM32_GPDMA_TX_BYTE_CONFIG_INIT_EX( \
+        UART3_TX_DMA_INSTANCE,          \
+        UART3_TX_DMA_RCC,               \
+        UART3_TX_DMA_IRQ,               \
+        UART3_TX_DMA_REQUEST,           \
+        UART3_TX_DMA_PRIORITY,          \
+        UART3_TX_DMA_PREEMPT_PRIORITY,  \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/wb/qspi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/wb/qspi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author            Notes
  * 2020-10-14     PeakRacing   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __QSPI_CONFIG_H__
@@ -30,19 +31,29 @@ extern "C" {
 #endif /* BSP_USING_QSPI */
 
 #ifdef BSP_QSPI_USING_DMA
+#ifndef QSPI_DMA_PRIORITY
+#define QSPI_DMA_PRIORITY                         DMA_PRIORITY_LOW
+#endif /* QSPI_DMA_PRIORITY */
+
+#ifndef QSPI_DMA_PREEMPT_PRIORITY
+#define QSPI_DMA_PREEMPT_PRIORITY                 0
+#endif /* QSPI_DMA_PREEMPT_PRIORITY */
+
+#ifndef QSPI_DMA_SUB_PRIORITY
+#define QSPI_DMA_SUB_PRIORITY                     0
+#endif /* QSPI_DMA_SUB_PRIORITY */
+
 #ifndef QSPI_DMA_CONFIG
-#define QSPI_DMA_CONFIG                                        \
-    {                                                          \
-        .Instance = QSPI_DMA_INSTANCE,                         \
-        .Init.Request = QSPI_DMA_REQUEST,                      \
-        .Init.Direction = DMA_PERIPH_TO_MEMORY,                \
-        .Init.PeriphInc = DMA_PINC_DISABLE,                    \
-        .Init.MemInc = DMA_MINC_ENABLE,                        \
-        .Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE,       \
-        .Init.MemDataAlignment = DMA_MDATAALIGN_BYTE,          \
-        .Init.Mode = DMA_NORMAL,                               \
-        .Init.Priority = DMA_PRIORITY_LOW                      \
-    }
+#define QSPI_DMA_CONFIG               \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        QSPI_DMA_INSTANCE,            \
+        QSPI_DMA_RCC,                 \
+        QSPI_DMA_IRQ,                 \
+        0U,                           \
+        QSPI_DMA_REQUEST,             \
+        QSPI_DMA_PRIORITY,            \
+        QSPI_DMA_PREEMPT_PRIORITY,    \
+        QSPI_DMA_SUB_PRIORITY)
 #endif /* QSPI_DMA_CONFIG */
 #endif /* BSP_QSPI_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/wb/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/wb/spi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author            Notes
  * 2020-10-14     PeakRacing   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -19,106 +20,190 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI1,                                   \
-        .bus_name = "spi1",                                 \
-        .irq_type = SPI1_IRQn,                              \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI1_TX_DMA_RCC,                         \
-        .Instance = SPI1_TX_DMA_INSTANCE,                   \
-        .request = SPI1_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI1_TX_DMA_IRQ,                         \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI1_TX_DMA_REQUEST,          \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI1_RX_DMA_RCC,                         \
-        .Instance = SPI1_RX_DMA_INSTANCE,                   \
-        .request = SPI1_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI1_RX_DMA_IRQ,                         \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI1_RX_DMA_REQUEST,          \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI2,                                   \
-        .bus_name = "spi2",                                 \
-        .irq_type = SPI2_IRQn,                              \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI2_TX_DMA_RCC,                         \
-        .Instance = SPI2_TX_DMA_INSTANCE,                   \
-        .request = SPI2_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI2_TX_DMA_IRQ,                         \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI2_TX_DMA_REQUEST,          \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI2_RX_DMA_RCC,                         \
-        .Instance = SPI2_RX_DMA_INSTANCE,                   \
-        .request = SPI2_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI2_RX_DMA_IRQ,                         \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI2_RX_DMA_REQUEST,          \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI3,                                   \
-        .bus_name = "spi3",                                 \
-        .irq_type = SPI3_IRQn,                              \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI3_TX_DMA_RCC,                         \
-        .Instance = SPI3_TX_DMA_INSTANCE,                   \
-        .request = SPI3_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI3_TX_DMA_IRQ,                         \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI3_TX_DMA_REQUEST,          \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI3_RX_DMA_RCC,                         \
-        .Instance = SPI3_RX_DMA_INSTANCE,                   \
-        .request = SPI3_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI3_RX_DMA_IRQ,                         \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI3_RX_DMA_REQUEST,          \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/wb/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/wb/uart_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author            Notes
  * 2020-10-14     PeakRacing   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -19,128 +20,233 @@ extern "C" {
 
 #if defined(BSP_USING_LPUART1)
 #ifndef LPUART1_CONFIG
-#define LPUART1_CONFIG                                              \
-    {                                                               \
-        .name = "lpuart1",                                          \
-        .Instance = LPUART1,                                        \
-        .irq_type = LPUART1_IRQn,                                   \
+#define LPUART1_CONFIG            \
+    {                             \
+        .name = "lpuart1",        \
+        .Instance = LPUART1,      \
+        .irq_type = LPUART1_IRQn, \
     }
 #endif /* LPUART1_CONFIG */
 #if defined(BSP_LPUART1_RX_USING_DMA)
+#ifndef LPUART1_DMA_PRIORITY
+#define LPUART1_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* LPUART1_DMA_PRIORITY */
+
+#ifndef LPUART1_DMA_PREEMPT_PRIORITY
+#define LPUART1_DMA_PREEMPT_PRIORITY         0
+#endif /* LPUART1_DMA_PREEMPT_PRIORITY */
+
+#ifndef LPUART1_DMA_SUB_PRIORITY
+#define LPUART1_DMA_SUB_PRIORITY             0
+#endif /* LPUART1_DMA_SUB_PRIORITY */
+
 #ifndef LPUART1_DMA_CONFIG
-#define LPUART1_DMA_CONFIG                                          \
-    {                                                               \
-        .Instance = LPUART1_RX_DMA_INSTANCE,                        \
-        .request  = LPUART1_RX_DMA_REQUEST,                         \
-        .dma_rcc  = LPUART1_RX_DMA_RCC,                             \
-        .dma_irq  = LPUART1_RX_DMA_IRQ,                             \
-    }
+#define LPUART1_DMA_CONFIG                     \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        LPUART1_RX_DMA_INSTANCE,               \
+        LPUART1_RX_DMA_RCC,                    \
+        LPUART1_RX_DMA_IRQ,                    \
+        0U,                                    \
+        LPUART1_RX_DMA_REQUEST,                \
+        LPUART1_DMA_PRIORITY,                  \
+        LPUART1_DMA_PREEMPT_PRIORITY,          \
+        LPUART1_DMA_SUB_PRIORITY)
 #endif /* LPUART1_DMA_CONFIG */
 #endif /* BSP_LPUART1_RX_USING_DMA */
 #endif /* BSP_USING_LPUART1 */
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .request  = UART1_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_RX_DMA_RCC,                               \
-        .dma_irq  = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART1_RX_DMA_REQUEST,                  \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_UART1_TX_USING_DMA)
+#ifndef UART1_TX_DMA_PRIORITY
+#define UART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_TX_DMA_PRIORITY */
+
+#ifndef UART1_TX_DMA_PREEMPT_PRIORITY
+#define UART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_TX_DMA_SUB_PRIORITY
+#define UART1_TX_DMA_SUB_PRIORITY             0
+#endif /* UART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_TX_CONFIG
-#define UART1_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_TX_DMA_INSTANCE,                          \
-        .request  = UART1_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_TX_DMA_RCC,                               \
-        .dma_irq  = UART1_TX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART1_TX_DMA_INSTANCE,         \
+        UART1_TX_DMA_RCC,              \
+        UART1_TX_DMA_IRQ,              \
+        0U,                            \
+        UART1_TX_DMA_REQUEST,          \
+        UART1_TX_DMA_PRIORITY,         \
+        UART1_TX_DMA_PREEMPT_PRIORITY, \
+        UART1_TX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_TX_CONFIG */
 #endif /* BSP_UART1_TX_USING_DMA */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .request  = UART2_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_RX_DMA_RCC,                               \
-        .dma_irq  = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART2_RX_DMA_REQUEST,                  \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_UART2_TX_USING_DMA)
+#ifndef UART2_TX_DMA_PRIORITY
+#define UART2_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_TX_DMA_PRIORITY */
+
+#ifndef UART2_TX_DMA_PREEMPT_PRIORITY
+#define UART2_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_TX_DMA_SUB_PRIORITY
+#define UART2_TX_DMA_SUB_PRIORITY             0
+#endif /* UART2_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_TX_CONFIG
-#define UART2_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_TX_DMA_INSTANCE,                          \
-        .request  = UART2_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_TX_DMA_RCC,                               \
-        .dma_irq  = UART2_TX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART2_TX_DMA_INSTANCE,         \
+        UART2_TX_DMA_RCC,              \
+        UART2_TX_DMA_IRQ,              \
+        0U,                            \
+        UART2_TX_DMA_REQUEST,          \
+        UART2_TX_DMA_PRIORITY,         \
+        UART2_TX_DMA_PREEMPT_PRIORITY, \
+        UART2_TX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_TX_CONFIG */
 #endif /* BSP_UART2_TX_USING_DMA */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                          \
-        .request  = UART3_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_RX_DMA_RCC,                               \
-        .dma_irq  = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART3_RX_DMA_REQUEST,                  \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 
 #if defined(BSP_UART3_TX_USING_DMA)
+#ifndef UART3_TX_DMA_PRIORITY
+#define UART3_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_TX_DMA_PRIORITY */
+
+#ifndef UART3_TX_DMA_PREEMPT_PRIORITY
+#define UART3_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_TX_DMA_SUB_PRIORITY
+#define UART3_TX_DMA_SUB_PRIORITY             0
+#endif /* UART3_TX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_TX_CONFIG
-#define UART3_DMA_TX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_TX_DMA_INSTANCE,                          \
-        .request  = UART3_TX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_TX_DMA_RCC,                               \
-        .dma_irq  = UART3_TX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(  \
+        UART3_TX_DMA_INSTANCE,         \
+        UART3_TX_DMA_RCC,              \
+        UART3_TX_DMA_IRQ,              \
+        0U,                            \
+        UART3_TX_DMA_REQUEST,          \
+        UART3_TX_DMA_PRIORITY,         \
+        UART3_TX_DMA_PREEMPT_PRIORITY, \
+        UART3_TX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_TX_CONFIG */
 #endif /* BSP_UART3_TX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/wl/spi_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/wl/spi_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __SPI_CONFIG_H__
@@ -19,106 +20,190 @@ extern "C" {
 
 #ifdef BSP_USING_SPI1
 #ifndef SPI1_BUS_CONFIG
-#define SPI1_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI1,                                   \
-        .bus_name = "spi1",                                 \
-        .irq_type = SPI1_IRQn,                              \
+#define SPI1_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI1,      \
+        .bus_name = "spi1",    \
+        .irq_type = SPI1_IRQn, \
     }
 #endif /* SPI1_BUS_CONFIG */
 #endif /* BSP_USING_SPI1 */
 
 #ifdef BSP_SPI1_TX_USING_DMA
+#ifndef SPI1_TX_DMA_PRIORITY
+#define SPI1_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI1_TX_DMA_PRIORITY */
+
+#ifndef SPI1_TX_DMA_PREEMPT_PRIORITY
+#define SPI1_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_TX_DMA_SUB_PRIORITY
+#define SPI1_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_TX_DMA_SUB_PRIORITY */
 #ifndef SPI1_TX_DMA_CONFIG
-#define SPI1_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI1_TX_DMA_RCC,                         \
-        .Instance = SPI1_TX_DMA_INSTANCE,                   \
-        .request = SPI1_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI1_TX_DMA_IRQ,                         \
-    }
+#define SPI1_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI1_TX_DMA_INSTANCE,         \
+        SPI1_TX_DMA_RCC,              \
+        SPI1_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI1_TX_DMA_REQUEST,          \
+        SPI1_TX_DMA_PRIORITY,         \
+        SPI1_TX_DMA_PREEMPT_PRIORITY, \
+        SPI1_TX_DMA_SUB_PRIORITY)
 #endif /* SPI1_TX_DMA_CONFIG */
 #endif /* BSP_SPI1_TX_USING_DMA */
 
 #ifdef BSP_SPI1_RX_USING_DMA
+#ifndef SPI1_RX_DMA_PRIORITY
+#define SPI1_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI1_RX_DMA_PRIORITY */
+
+#ifndef SPI1_RX_DMA_PREEMPT_PRIORITY
+#define SPI1_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI1_RX_DMA_SUB_PRIORITY
+#define SPI1_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI1_RX_DMA_SUB_PRIORITY */
 #ifndef SPI1_RX_DMA_CONFIG
-#define SPI1_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI1_RX_DMA_RCC,                         \
-        .Instance = SPI1_RX_DMA_INSTANCE,                   \
-        .request = SPI1_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI1_RX_DMA_IRQ,                         \
-    }
+#define SPI1_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI1_RX_DMA_INSTANCE,         \
+        SPI1_RX_DMA_RCC,              \
+        SPI1_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI1_RX_DMA_REQUEST,          \
+        SPI1_RX_DMA_PRIORITY,         \
+        SPI1_RX_DMA_PREEMPT_PRIORITY, \
+        SPI1_RX_DMA_SUB_PRIORITY)
 #endif /* SPI1_RX_DMA_CONFIG */
 #endif /* BSP_SPI1_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI2
 #ifndef SPI2_BUS_CONFIG
-#define SPI2_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI2,                                   \
-        .bus_name = "spi2",                                 \
-        .irq_type = SPI2_IRQn,                              \
+#define SPI2_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI2,      \
+        .bus_name = "spi2",    \
+        .irq_type = SPI2_IRQn, \
     }
 #endif /* SPI2_BUS_CONFIG */
 #endif /* BSP_USING_SPI2 */
 
 #ifdef BSP_SPI2_TX_USING_DMA
+#ifndef SPI2_TX_DMA_PRIORITY
+#define SPI2_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI2_TX_DMA_PRIORITY */
+
+#ifndef SPI2_TX_DMA_PREEMPT_PRIORITY
+#define SPI2_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI2_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_TX_DMA_SUB_PRIORITY
+#define SPI2_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_TX_DMA_SUB_PRIORITY */
 #ifndef SPI2_TX_DMA_CONFIG
-#define SPI2_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI2_TX_DMA_RCC,                         \
-        .Instance = SPI2_TX_DMA_INSTANCE,                   \
-        .request = SPI2_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI2_TX_DMA_IRQ,                         \
-    }
+#define SPI2_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI2_TX_DMA_INSTANCE,         \
+        SPI2_TX_DMA_RCC,              \
+        SPI2_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI2_TX_DMA_REQUEST,          \
+        SPI2_TX_DMA_PRIORITY,         \
+        SPI2_TX_DMA_PREEMPT_PRIORITY, \
+        SPI2_TX_DMA_SUB_PRIORITY)
 #endif /* SPI2_TX_DMA_CONFIG */
 #endif /* BSP_SPI2_TX_USING_DMA */
 
 #ifdef BSP_SPI2_RX_USING_DMA
+#ifndef SPI2_RX_DMA_PRIORITY
+#define SPI2_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI2_RX_DMA_PRIORITY */
+
+#ifndef SPI2_RX_DMA_PREEMPT_PRIORITY
+#define SPI2_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI2_RX_DMA_SUB_PRIORITY
+#define SPI2_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI2_RX_DMA_SUB_PRIORITY */
 #ifndef SPI2_RX_DMA_CONFIG
-#define SPI2_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI2_RX_DMA_RCC,                         \
-        .Instance = SPI2_RX_DMA_INSTANCE,                   \
-        .request = SPI2_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI2_RX_DMA_IRQ,                         \
-    }
+#define SPI2_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI2_RX_DMA_INSTANCE,         \
+        SPI2_RX_DMA_RCC,              \
+        SPI2_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI2_RX_DMA_REQUEST,          \
+        SPI2_RX_DMA_PRIORITY,         \
+        SPI2_RX_DMA_PREEMPT_PRIORITY, \
+        SPI2_RX_DMA_SUB_PRIORITY)
 #endif /* SPI2_RX_DMA_CONFIG */
 #endif /* BSP_SPI2_RX_USING_DMA */
 
 #ifdef BSP_USING_SPI3
 #ifndef SPI3_BUS_CONFIG
-#define SPI3_BUS_CONFIG                                     \
-    {                                                       \
-        .Instance = SPI3,                                   \
-        .bus_name = "spi3",                                 \
-        .irq_type = SPI3_IRQn,                              \
+#define SPI3_BUS_CONFIG        \
+    {                          \
+        .Instance = SPI3,      \
+        .bus_name = "spi3",    \
+        .irq_type = SPI3_IRQn, \
     }
 #endif /* SPI3_BUS_CONFIG */
 #endif /* BSP_USING_SPI3 */
 
 #ifdef BSP_SPI3_TX_USING_DMA
+#ifndef SPI3_TX_DMA_PRIORITY
+#define SPI3_TX_DMA_PRIORITY                  DMA_PRIORITY_LOW
+#endif /* SPI3_TX_DMA_PRIORITY */
+
+#ifndef SPI3_TX_DMA_PREEMPT_PRIORITY
+#define SPI3_TX_DMA_PREEMPT_PRIORITY          1
+#endif /* SPI3_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_TX_DMA_SUB_PRIORITY
+#define SPI3_TX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_TX_DMA_SUB_PRIORITY */
 #ifndef SPI3_TX_DMA_CONFIG
-#define SPI3_TX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI3_TX_DMA_RCC,                         \
-        .Instance = SPI3_TX_DMA_INSTANCE,                   \
-        .request = SPI3_TX_DMA_REQUEST,                     \
-        .dma_irq = SPI3_TX_DMA_IRQ,                         \
-    }
+#define SPI3_TX_DMA_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX( \
+        SPI3_TX_DMA_INSTANCE,         \
+        SPI3_TX_DMA_RCC,              \
+        SPI3_TX_DMA_IRQ,              \
+        0U,                           \
+        SPI3_TX_DMA_REQUEST,          \
+        SPI3_TX_DMA_PRIORITY,         \
+        SPI3_TX_DMA_PREEMPT_PRIORITY, \
+        SPI3_TX_DMA_SUB_PRIORITY)
 #endif /* SPI3_TX_DMA_CONFIG */
 #endif /* BSP_SPI3_TX_USING_DMA */
 
 #ifdef BSP_SPI3_RX_USING_DMA
+#ifndef SPI3_RX_DMA_PRIORITY
+#define SPI3_RX_DMA_PRIORITY                  DMA_PRIORITY_HIGH
+#endif /* SPI3_RX_DMA_PRIORITY */
+
+#ifndef SPI3_RX_DMA_PREEMPT_PRIORITY
+#define SPI3_RX_DMA_PREEMPT_PRIORITY          0
+#endif /* SPI3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef SPI3_RX_DMA_SUB_PRIORITY
+#define SPI3_RX_DMA_SUB_PRIORITY              0
+#endif /* SPI3_RX_DMA_SUB_PRIORITY */
 #ifndef SPI3_RX_DMA_CONFIG
-#define SPI3_RX_DMA_CONFIG                                  \
-    {                                                       \
-        .dma_rcc = SPI3_RX_DMA_RCC,                         \
-        .Instance = SPI3_RX_DMA_INSTANCE,                   \
-        .request = SPI3_RX_DMA_REQUEST,                     \
-        .dma_irq = SPI3_RX_DMA_IRQ,                         \
-    }
+#define SPI3_RX_DMA_CONFIG            \
+    STM32_DMA_RX_BYTE_CONFIG_INIT_EX( \
+        SPI3_RX_DMA_INSTANCE,         \
+        SPI3_RX_DMA_RCC,              \
+        SPI3_RX_DMA_IRQ,              \
+        0U,                           \
+        SPI3_RX_DMA_REQUEST,          \
+        SPI3_RX_DMA_PRIORITY,         \
+        SPI3_RX_DMA_PREEMPT_PRIORITY, \
+        SPI3_RX_DMA_SUB_PRIORITY)
 #endif /* SPI3_RX_DMA_CONFIG */
 #endif /* BSP_SPI3_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/config/wl/uart_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/config/wl/uart_config.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2018-11-06     SummerGift   first version
+ * 2026-04-13     wdfk-prog    Unify DMA config descriptors
  */
 
 #ifndef __UART_CONFIG_H__
@@ -19,104 +20,180 @@ extern "C" {
 
 #if defined(BSP_USING_LPUART1)
 #ifndef LPUART1_CONFIG
-#define LPUART1_CONFIG                                              \
-    {                                                               \
-        .name = "lpuart1",                                          \
-        .Instance = LPUART1,                                        \
-        .irq_type = LPUART1_IRQn,                                   \
+#define LPUART1_CONFIG            \
+    {                             \
+        .name = "lpuart1",        \
+        .Instance = LPUART1,      \
+        .irq_type = LPUART1_IRQn, \
     }
 #endif /* LPUART1_CONFIG */
 #if defined(BSP_LPUART1_RX_USING_DMA)
-#ifndef LPUART1_DMA_RX_CONFIG
-#define LPUART1_DMA_RX_CONFIG                                          \
-    {                                                               \
-        .Instance = LPUART1_RX_DMA_INSTANCE,                        \
-        .request  = LPUART1_RX_DMA_REQUEST,                         \
-        .dma_rcc  = LPUART1_RX_DMA_RCC,                             \
-        .dma_irq  = LPUART1_RX_DMA_IRQ,                             \
-    }
+#ifndef LPUART1_DMA_PRIORITY
+#define LPUART1_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* LPUART1_DMA_PRIORITY */
+
+#ifndef LPUART1_DMA_PREEMPT_PRIORITY
+#define LPUART1_DMA_PREEMPT_PRIORITY         0
+#endif /* LPUART1_DMA_PREEMPT_PRIORITY */
+
+#ifndef LPUART1_DMA_SUB_PRIORITY
+#define LPUART1_DMA_SUB_PRIORITY             0
+#endif /* LPUART1_DMA_SUB_PRIORITY */
+
+#ifndef LPUART1_DMA_CONFIG
+#define LPUART1_DMA_CONFIG                     \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        LPUART1_RX_DMA_INSTANCE,               \
+        LPUART1_RX_DMA_RCC,                    \
+        LPUART1_RX_DMA_IRQ,                    \
+        0U,                                    \
+        LPUART1_RX_DMA_REQUEST,                \
+        LPUART1_DMA_PRIORITY,                  \
+        LPUART1_DMA_PREEMPT_PRIORITY,          \
+        LPUART1_DMA_SUB_PRIORITY)
 #endif /* LPUART1_DMA_CONFIG */
 #endif /* BSP_LPUART1_RX_USING_DMA */
 
 
 #if defined(BSP_LPUART1_TX_USING_DMA)
+#ifndef LPUART1_TX_DMA_PRIORITY
+#define LPUART1_TX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* LPUART1_TX_DMA_PRIORITY */
+
+#ifndef LPUART1_TX_DMA_PREEMPT_PRIORITY
+#define LPUART1_TX_DMA_PREEMPT_PRIORITY         0
+#endif /* LPUART1_TX_DMA_PREEMPT_PRIORITY */
+
+#ifndef LPUART1_TX_DMA_SUB_PRIORITY
+#define LPUART1_TX_DMA_SUB_PRIORITY             0
+#endif /* LPUART1_TX_DMA_SUB_PRIORITY */
+
 #ifndef LPUART1_DMA_TX_CONFIG
-#define LPUART1_DMA_TX_CONFIG                                        \
-    {                                                              \
-        .Instance = LPUART1_TX_DMA_INSTANCE,                         \
-        .dma_rcc = LPUART1_TX_DMA_RCC,                               \
-        .dma_irq = LPUART1_TX_DMA_IRQ,                               \
-    }
-#endif /* UART1_DMA_TX_CONFIG */
-#endif /* BSP_UART1_TX_USING_DMA */
-#endif /* BSP_USING_UART1 */
+#define LPUART1_DMA_TX_CONFIG            \
+    STM32_DMA_TX_BYTE_CONFIG_INIT_EX(    \
+        LPUART1_TX_DMA_INSTANCE,         \
+        LPUART1_TX_DMA_RCC,              \
+        LPUART1_TX_DMA_IRQ,              \
+        0U,                              \
+        LPUART1_TX_DMA_REQUEST,          \
+        LPUART1_TX_DMA_PRIORITY,         \
+        LPUART1_TX_DMA_PREEMPT_PRIORITY, \
+        LPUART1_TX_DMA_SUB_PRIORITY)
+#endif /* LPUART1_DMA_TX_CONFIG */
+#endif /* BSP_LPUART1_TX_USING_DMA */
+#endif /* BSP_USING_LPUART1 */
 
 #if defined(BSP_USING_UART1)
 #ifndef UART1_CONFIG
-#define UART1_CONFIG                                                \
-    {                                                               \
-        .name = "uart1",                                            \
-        .Instance = USART1,                                         \
-        .irq_type = USART1_IRQn,                                    \
+#define UART1_CONFIG             \
+    {                            \
+        .name = "uart1",         \
+        .Instance = USART1,      \
+        .irq_type = USART1_IRQn, \
     }
 #endif /* UART1_CONFIG */
 #endif /* BSP_USING_UART1 */
 
 #if defined(BSP_UART1_RX_USING_DMA)
+#ifndef UART1_RX_DMA_PRIORITY
+#define UART1_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART1_RX_DMA_PRIORITY */
+
+#ifndef UART1_RX_DMA_PREEMPT_PRIORITY
+#define UART1_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART1_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART1_RX_DMA_SUB_PRIORITY
+#define UART1_RX_DMA_SUB_PRIORITY             0
+#endif /* UART1_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART1_DMA_RX_CONFIG
-#define UART1_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART1_RX_DMA_INSTANCE,                          \
-        .request  = UART1_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART1_RX_DMA_RCC,                               \
-        .dma_irq  = UART1_RX_DMA_IRQ,                               \
-    }
+#define UART1_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART1_RX_DMA_INSTANCE,                 \
+        UART1_RX_DMA_RCC,                      \
+        UART1_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART1_RX_DMA_REQUEST,                  \
+        UART1_RX_DMA_PRIORITY,                 \
+        UART1_RX_DMA_PREEMPT_PRIORITY,         \
+        UART1_RX_DMA_SUB_PRIORITY)
 #endif /* UART1_DMA_RX_CONFIG */
 #endif /* BSP_UART1_RX_USING_DMA */
 
 #if defined(BSP_USING_UART2)
 #ifndef UART2_CONFIG
-#define UART2_CONFIG                                                \
-    {                                                               \
-        .name = "uart2",                                            \
-        .Instance = USART2,                                         \
-        .irq_type = USART2_IRQn,                                    \
+#define UART2_CONFIG             \
+    {                            \
+        .name = "uart2",         \
+        .Instance = USART2,      \
+        .irq_type = USART2_IRQn, \
     }
 #endif /* UART2_CONFIG */
 #endif /* BSP_USING_UART2 */
 
 #if defined(BSP_UART2_RX_USING_DMA)
+#ifndef UART2_RX_DMA_PRIORITY
+#define UART2_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART2_RX_DMA_PRIORITY */
+
+#ifndef UART2_RX_DMA_PREEMPT_PRIORITY
+#define UART2_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART2_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART2_RX_DMA_SUB_PRIORITY
+#define UART2_RX_DMA_SUB_PRIORITY             0
+#endif /* UART2_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART2_DMA_RX_CONFIG
-#define UART2_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART2_RX_DMA_INSTANCE,                          \
-        .request  = UART2_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART2_RX_DMA_RCC,                               \
-        .dma_irq  = UART2_RX_DMA_IRQ,                               \
-    }
+#define UART2_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART2_RX_DMA_INSTANCE,                 \
+        UART2_RX_DMA_RCC,                      \
+        UART2_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART2_RX_DMA_REQUEST,                  \
+        UART2_RX_DMA_PRIORITY,                 \
+        UART2_RX_DMA_PREEMPT_PRIORITY,         \
+        UART2_RX_DMA_SUB_PRIORITY)
 #endif /* UART2_DMA_RX_CONFIG */
 #endif /* BSP_UART2_RX_USING_DMA */
 
 #if defined(BSP_USING_UART3)
 #ifndef UART3_CONFIG
-#define UART3_CONFIG                                                \
-    {                                                               \
-        .name = "uart3",                                            \
-        .Instance = USART3,                                         \
-        .irq_type = USART3_IRQn,                                    \
+#define UART3_CONFIG             \
+    {                            \
+        .name = "uart3",         \
+        .Instance = USART3,      \
+        .irq_type = USART3_IRQn, \
     }
 #endif /* UART3_CONFIG */
 #endif /* BSP_USING_UART3 */
 
 #if defined(BSP_UART3_RX_USING_DMA)
+#ifndef UART3_RX_DMA_PRIORITY
+#define UART3_RX_DMA_PRIORITY                 DMA_PRIORITY_MEDIUM
+#endif /* UART3_RX_DMA_PRIORITY */
+
+#ifndef UART3_RX_DMA_PREEMPT_PRIORITY
+#define UART3_RX_DMA_PREEMPT_PRIORITY         0
+#endif /* UART3_RX_DMA_PREEMPT_PRIORITY */
+
+#ifndef UART3_RX_DMA_SUB_PRIORITY
+#define UART3_RX_DMA_SUB_PRIORITY             0
+#endif /* UART3_RX_DMA_SUB_PRIORITY */
+
 #ifndef UART3_DMA_RX_CONFIG
-#define UART3_DMA_RX_CONFIG                                            \
-    {                                                               \
-        .Instance = UART3_RX_DMA_INSTANCE,                          \
-        .request  = UART3_RX_DMA_REQUEST,                           \
-        .dma_rcc  = UART3_RX_DMA_RCC,                               \
-        .dma_irq  = UART3_RX_DMA_IRQ,                               \
-    }
+#define UART3_DMA_RX_CONFIG                    \
+    STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX( \
+        UART3_RX_DMA_INSTANCE,                 \
+        UART3_RX_DMA_RCC,                      \
+        UART3_RX_DMA_IRQ,                      \
+        0U,                                    \
+        UART3_RX_DMA_REQUEST,                  \
+        UART3_RX_DMA_PRIORITY,                 \
+        UART3_RX_DMA_PREEMPT_PRIORITY,         \
+        UART3_RX_DMA_SUB_PRIORITY)
 #endif /* UART3_DMA_RX_CONFIG */
 #endif /* BSP_UART3_RX_USING_DMA */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_config.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_config.h
@@ -14,6 +14,7 @@
 
 #include <board.h>
 #include <rtdevice.h>
+#include "drv_dma.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_dma.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_dma.c
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2006-2026, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2026-04-13     wdfk-prog    Add STM32 DMA common helpers
+ */
+
+/**
+ * @file drv_dma.c
+ * @brief STM32 DMA common helper layer for peripheral drivers.
+ */
+
+#include "drv_dma.h"
+
+// #define DRV_DEBUG
+#define LOG_TAG             "drv.dma"
+#include <drv_log.h>
+/*
+ * DMA-capable BSPs are expected to enable HAL_DMA_MODULE_ENABLED in the
+ * STM32 HAL configuration, so keep the common DMA helper in the build.
+ */
+#ifdef HAL_DMA_MODULE_ENABLED
+
+#if defined(STM32_DMA_USES_REQUEST)
+/**
+ * @brief Enable the DMAMUX clock when the current STM32 DMA path needs it.
+ */
+static void stm32_dma_enable_dmamux_clock(void)
+{
+#if defined(DMAMUX1) && defined(__HAL_RCC_DMAMUX1_CLK_ENABLE)
+    __HAL_RCC_DMAMUX1_CLK_ENABLE();
+#elif defined(DMAMUX) && defined(__HAL_RCC_DMAMUX_CLK_ENABLE)
+    __HAL_RCC_DMAMUX_CLK_ENABLE();
+#endif /* defined(DMAMUX1) && defined(__HAL_RCC_DMAMUX1_CLK_ENABLE) */
+}
+#endif /* defined(STM32_DMA_USES_REQUEST) */
+
+/**
+ * @brief Enable the clock of one DMA controller and wait for the write to complete.
+ * @param dma_rcc RCC enable bit of the DMA controller.
+ */
+static void stm32_dma_enable_clock(rt_uint32_t dma_rcc)
+{
+    rt_uint32_t tmpreg = 0x00U;
+
+#if defined(STM32_DMA_USES_RCC_AHBENR)
+    SET_BIT(RCC->AHBENR, dma_rcc);
+    tmpreg = READ_BIT(RCC->AHBENR, dma_rcc);
+#elif defined(STM32_DMA_USES_RCC_MP_AHB2ENSETR)
+    SET_BIT(RCC->MP_AHB2ENSETR, dma_rcc);
+    tmpreg = READ_BIT(RCC->MP_AHB2ENSETR, dma_rcc);
+#elif defined(STM32_DMA_USES_RCC_AHB1ENR)
+    SET_BIT(RCC->AHB1ENR, dma_rcc);
+    tmpreg = READ_BIT(RCC->AHB1ENR, dma_rcc);
+#endif /* defined(STM32_DMA_USES_RCC_AHBENR) || defined(STM32_DMA_USES_RCC_MP_AHB2ENSETR) || defined(STM32_DMA_USES_RCC_AHB1ENR) */
+
+#if defined(STM32_DMA_USES_REQUEST)
+    stm32_dma_enable_dmamux_clock();
+#endif /* defined(STM32_DMA_USES_REQUEST) */
+
+    UNUSED(tmpreg);
+}
+
+/* Only a few STM32 families expose DMA requests on shared NVIC lines.
+ * Use reference counting only for those known shared IRQ numbers so one
+ * DMA client does not disable a line still used by another active client.
+ * All other DMA IRQs keep the direct enable/disable behavior.
+ */
+#if (defined(SOC_SERIES_STM32F1) && defined(DMA2_Channel4_5_IRQn)) \
+ || (defined(SOC_SERIES_STM32L0) && defined(DMA1_Channel4_5_6_7_IRQn)) \
+ || (defined(SOC_SERIES_STM32G0) && defined(DMA1_Channel2_3_IRQn)) \
+ || (defined(SOC_SERIES_STM32F0) && (defined(DMA1_Channel2_3_IRQn) || defined(DMA1_Channel4_5_IRQn) || defined(DMA1_Channel4_5_6_7_IRQn)))
+#define STM32_DMA_HAS_SHARED_IRQ_REFCNT
+#define STM32_DMA_IRQ_SLOT_COUNT    ((rt_uint32_t)(sizeof(NVIC->ISER) / sizeof(NVIC->ISER[0]) * 32U))
+
+/**
+ * @brief Reference count for each shared DMA IRQ line.
+ */
+static rt_uint16_t stm32_dma_irq_ref_count[STM32_DMA_IRQ_SLOT_COUNT];
+
+/**
+ * @brief Check whether one DMA IRQ number can index the local reference table.
+ * @param dma_irq DMA IRQ number to validate.
+ * @retval RT_TRUE The IRQ number maps to one valid table slot.
+ * @retval RT_FALSE The IRQ number is negative or outside the table range.
+ */
+static rt_bool_t stm32_dma_irq_is_valid(IRQn_Type dma_irq)
+{
+    return ((int32_t)dma_irq >= 0) && ((rt_uint32_t)dma_irq < STM32_DMA_IRQ_SLOT_COUNT);
+}
+
+/**
+ * @brief Check whether one DMA IRQ line is shared and needs reference counting.
+ * @param dma_irq DMA IRQ number to inspect.
+ * @retval RT_TRUE The IRQ line is shared by multiple DMA endpoints.
+ * @retval RT_FALSE The IRQ line can use direct enable and disable handling.
+ */
+static rt_bool_t stm32_dma_irq_needs_refcount(IRQn_Type dma_irq)
+{
+#if defined(SOC_SERIES_STM32F1) && defined(DMA2_Channel4_5_IRQn)
+    if (dma_irq == DMA2_Channel4_5_IRQn)
+    {
+        return RT_TRUE;
+    }
+#endif /* defined(SOC_SERIES_STM32F1) && defined(DMA2_Channel4_5_IRQn) */
+
+#if defined(SOC_SERIES_STM32L0) && defined(DMA1_Channel4_5_6_7_IRQn)
+    if (dma_irq == DMA1_Channel4_5_6_7_IRQn)
+    {
+        return RT_TRUE;
+    }
+#endif /* defined(SOC_SERIES_STM32L0) && defined(DMA1_Channel4_5_6_7_IRQn) */
+
+#if defined(SOC_SERIES_STM32G0) && defined(DMA1_Channel2_3_IRQn)
+    if (dma_irq == DMA1_Channel2_3_IRQn)
+    {
+        return RT_TRUE;
+    }
+#endif /* defined(SOC_SERIES_STM32G0) && defined(DMA1_Channel2_3_IRQn) */
+
+#if defined(SOC_SERIES_STM32F0)
+# if defined(DMA1_Channel2_3_IRQn)
+    if (dma_irq == DMA1_Channel2_3_IRQn)
+    {
+        return RT_TRUE;
+    }
+# endif /* defined(DMA1_Channel2_3_IRQn) */
+# if defined(DMA1_Channel4_5_IRQn)
+    if (dma_irq == DMA1_Channel4_5_IRQn)
+    {
+        return RT_TRUE;
+    }
+# endif /* defined(DMA1_Channel4_5_IRQn) */
+# if defined(DMA1_Channel4_5_6_7_IRQn)
+    if (dma_irq == DMA1_Channel4_5_6_7_IRQn)
+    {
+        return RT_TRUE;
+    }
+# endif /* defined(DMA1_Channel4_5_6_7_IRQn) */
+#endif /* defined(SOC_SERIES_STM32F0) */
+
+    return RT_FALSE;
+}
+#endif /* shared DMA IRQ families */
+
+/**
+ * @brief Enable one DMA IRQ line and apply the requested NVIC priority.
+ * @param dma_irq DMA IRQ number to enable.
+ * @param preempt_priority NVIC preempt priority for the DMA IRQ.
+ * @param sub_priority NVIC subpriority for the DMA IRQ.
+ */
+static void stm32_dma_irq_get(IRQn_Type dma_irq,
+                              rt_uint8_t preempt_priority,
+                              rt_uint8_t sub_priority)
+{
+#if defined(STM32_DMA_HAS_SHARED_IRQ_REFCNT)
+    rt_base_t level;
+
+    if (stm32_dma_irq_needs_refcount(dma_irq) && stm32_dma_irq_is_valid(dma_irq))
+    {
+        level = rt_hw_interrupt_disable();
+        if (stm32_dma_irq_ref_count[(rt_uint32_t)dma_irq] == 0U)
+        {
+            HAL_NVIC_SetPriority(dma_irq, preempt_priority, sub_priority);
+            HAL_NVIC_EnableIRQ(dma_irq);
+        }
+        stm32_dma_irq_ref_count[(rt_uint32_t)dma_irq]++;
+        rt_hw_interrupt_enable(level);
+        return;
+    }
+#endif /* defined(STM32_DMA_HAS_SHARED_IRQ_REFCNT) */
+
+    HAL_NVIC_SetPriority(dma_irq, preempt_priority, sub_priority);
+    HAL_NVIC_EnableIRQ(dma_irq);
+}
+
+/**
+ * @brief Release one DMA IRQ line and disable it when no user remains.
+ * @param dma_irq DMA IRQ number to release.
+ */
+static void stm32_dma_irq_put(IRQn_Type dma_irq)
+{
+#if defined(STM32_DMA_HAS_SHARED_IRQ_REFCNT)
+    rt_base_t level;
+
+    if (stm32_dma_irq_needs_refcount(dma_irq) && stm32_dma_irq_is_valid(dma_irq))
+    {
+        level = rt_hw_interrupt_disable();
+        if (stm32_dma_irq_ref_count[(rt_uint32_t)dma_irq] > 0U)
+        {
+            stm32_dma_irq_ref_count[(rt_uint32_t)dma_irq]--;
+            if (stm32_dma_irq_ref_count[(rt_uint32_t)dma_irq] == 0U)
+            {
+                HAL_NVIC_DisableIRQ(dma_irq);
+            }
+        }
+        rt_hw_interrupt_enable(level);
+        return;
+    }
+#endif /* defined(STM32_DMA_HAS_SHARED_IRQ_REFCNT) */
+
+    HAL_NVIC_DisableIRQ(dma_irq);
+}
+
+/**
+ * @brief Copy one static DMA descriptor into one HAL DMA handle.
+ * @param dma_handle DMA handle to update.
+ * @param dma_config Static DMA endpoint description.
+ */
+static void stm32_dma_apply_config(DMA_HandleTypeDef *dma_handle,
+                                   const struct stm32_dma_config *dma_config)
+{
+    dma_handle->Instance = dma_config->Instance;
+#if defined(STM32_DMA_USES_GPDMA)
+    dma_handle->Init.Request = dma_config->request;
+    dma_handle->Init.BlkHWRequest = dma_config->blk_hw_request;
+    dma_handle->Init.Direction = dma_config->direction;
+    dma_handle->Init.SrcInc = dma_config->src_inc;
+    dma_handle->Init.DestInc = dma_config->dest_inc;
+    dma_handle->Init.SrcDataWidth = dma_config->src_data_width;
+    dma_handle->Init.DestDataWidth = dma_config->dest_data_width;
+    dma_handle->Init.Priority = dma_config->priority;
+    dma_handle->Init.SrcBurstLength = dma_config->src_burst_length;
+    dma_handle->Init.DestBurstLength = dma_config->dest_burst_length;
+    dma_handle->Init.TransferAllocatedPort = dma_config->transfer_allocated_port;
+    dma_handle->Init.TransferEventMode = dma_config->transfer_event_mode;
+    dma_handle->Init.Mode = dma_config->mode;
+#else
+#if defined(STM32_DMA_USES_CHANNEL)
+    dma_handle->Init.Channel = dma_config->channel;
+#endif /* defined(STM32_DMA_USES_CHANNEL) */
+#if defined(STM32_DMA_USES_REQUEST)
+    dma_handle->Init.Request = dma_config->request;
+#endif /* defined(STM32_DMA_USES_REQUEST) */
+    dma_handle->Init.Direction = dma_config->direction;
+    dma_handle->Init.PeriphInc = dma_config->periph_inc;
+    dma_handle->Init.MemInc = dma_config->mem_inc;
+    dma_handle->Init.PeriphDataAlignment = dma_config->periph_data_alignment;
+    dma_handle->Init.MemDataAlignment = dma_config->mem_data_alignment;
+    dma_handle->Init.Mode = dma_config->mode;
+    dma_handle->Init.Priority = dma_config->priority;
+#if defined(STM32_DMA_SUPPORTS_FIFO)
+    dma_handle->Init.FIFOMode = dma_config->fifo_mode;
+    dma_handle->Init.FIFOThreshold = dma_config->fifo_threshold;
+    dma_handle->Init.MemBurst = dma_config->mem_burst;
+    dma_handle->Init.PeriphBurst = dma_config->periph_burst;
+#endif /* defined(STM32_DMA_SUPPORTS_FIFO) */
+#endif /* defined(STM32_DMA_USES_GPDMA) */
+}
+
+/**
+ * @brief Enable one DMA controller, apply the static descriptor and initialize HAL state.
+ * @param dma_handle DMA handle owned by one peripheral driver.
+ * @param dma_config Board-level DMA endpoint description.
+ * @retval RT_EOK Initialization succeeded.
+ * @retval -RT_ERROR HAL initialization failed.
+ */
+rt_err_t stm32_dma_init(DMA_HandleTypeDef *dma_handle,
+                        const struct stm32_dma_config *dma_config)
+{
+    RT_ASSERT(dma_handle != RT_NULL);
+    RT_ASSERT(dma_config != RT_NULL);
+
+    stm32_dma_enable_clock(dma_config->dma_rcc);
+    stm32_dma_apply_config(dma_handle, dma_config);
+
+    LOG_D("dma init, dma=%p, irq=%d", dma_handle->Instance, dma_config->dma_irq);
+
+    if (HAL_DMA_DeInit(dma_handle) != HAL_OK)
+    {
+        LOG_E("dma deinit failed, dma=%p, irq=%d", dma_handle->Instance, dma_config->dma_irq);
+        return -RT_ERROR;
+    }
+
+    if (HAL_DMA_Init(dma_handle) != HAL_OK)
+    {
+        LOG_E("dma init failed, dma=%p, irq=%d", dma_handle->Instance, dma_config->dma_irq);
+        return -RT_ERROR;
+    }
+
+    return RT_EOK;
+}
+
+/**
+ * @brief Initialize one DMA handle, attach it to the parent HAL handle and enable the DMA IRQ.
+ * @param dma_handle DMA handle owned by one peripheral driver.
+ * @param parent_handle Parent HAL handle, such as UART_HandleTypeDef or SPI_HandleTypeDef.
+ * @param dma_slot Address of the parent handle DMA slot, such as &huart->hdmarx.
+ * @param dma_config Board-level DMA endpoint description.
+ * @retval RT_EOK Initialization succeeded.
+ * @retval -RT_ERROR HAL initialization failed.
+ */
+rt_err_t stm32_dma_setup(DMA_HandleTypeDef *dma_handle,
+                         void *parent_handle,
+                         DMA_HandleTypeDef **dma_slot,
+                         const struct stm32_dma_config *dma_config)
+{
+    rt_err_t result;
+
+    result = stm32_dma_init(dma_handle, dma_config);
+    if (result != RT_EOK)
+    {
+        return result;
+    }
+
+    if ((parent_handle != RT_NULL) && (dma_slot != RT_NULL))
+    {
+        *dma_slot = dma_handle;
+        dma_handle->Parent = parent_handle;
+    }
+
+    stm32_dma_irq_get(dma_config->dma_irq, dma_config->preempt_priority, dma_config->sub_priority);
+
+    LOG_D("dma setup, dma=%p, irq=%d", dma_handle->Instance, dma_config->dma_irq);
+
+    return RT_EOK;
+}
+
+/**
+ * @brief Disable one DMA IRQ, optionally abort the current transfer and de-initialize HAL state.
+ * @param dma_handle DMA handle owned by one peripheral driver.
+ * @param dma_config Board-level DMA endpoint description.
+ * @param abort_first RT_TRUE aborts the ongoing transfer before HAL_DMA_DeInit().
+ * @retval RT_EOK De-initialization succeeded.
+ * @retval -RT_ERROR HAL de-initialization failed.
+ */
+rt_err_t stm32_dma_deinit(DMA_HandleTypeDef *dma_handle,
+                          const struct stm32_dma_config *dma_config,
+                          rt_bool_t abort_first)
+{
+    RT_ASSERT(dma_handle != RT_NULL);
+    RT_ASSERT(dma_config != RT_NULL);
+
+    stm32_dma_irq_put(dma_config->dma_irq);
+
+    LOG_D("dma deinit, dma=%p, irq=%d", dma_handle->Instance, dma_config->dma_irq);
+
+    if (abort_first)
+    {
+        if (HAL_DMA_Abort(dma_handle) != HAL_OK)
+        {
+            LOG_W("dma abort failed, continue deinit, dma=%p, irq=%d", dma_handle->Instance, dma_config->dma_irq);
+        }
+    }
+
+    if (HAL_DMA_DeInit(dma_handle) != HAL_OK)
+    {
+        LOG_E("dma deinit failed, dma=%p, irq=%d", dma_handle->Instance, dma_config->dma_irq);
+        return -RT_ERROR;
+    }
+
+    return RT_EOK;
+}
+#endif /* HAL_DMA_MODULE_ENABLED */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_dma.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_dma.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2023, RT-Thread Development Team
+ * Copyright (c) 2006-2026, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -7,6 +7,12 @@
  * Date           Author       Notes
  * 2018-11-10     SummerGift   first version
  * 2020-10-14     PeakRacing   Porting for stm32wbxx
+ * 2026-04-13     wdfk-prog    Add STM32 DMA common helpers
+ */
+
+/**
+ * @file drv_dma.h
+ * @brief STM32 DMA common descriptors and helper interfaces.
  */
 
 #ifndef __DRV_DMA_H_
@@ -19,33 +25,334 @@
 extern "C" {
 #endif
 
-#if defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32L0) || defined(SOC_SERIES_STM32L5)\
+/*
+ * DMA-capable BSPs are expected to enable HAL_DMA_MODULE_ENABLED in the
+ * STM32 HAL configuration, so keep the common DMA helper in the build.
+ */
+#ifdef HAL_DMA_MODULE_ENABLED
+
+/**
+ * @brief DMA capability classification for STM32 series supported by this BSP.
+ */
+#if defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32L0) || defined(SOC_SERIES_STM32L5) \
     || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) || defined(SOC_SERIES_STM32G0) \
-    || defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32WB)|| defined(SOC_SERIES_STM32F3) \
-    || defined(SOC_SERIES_STM32U5) || defined(SOC_SERIES_STM32H5) || defined(SOC_SERIES_STM32H7RS)
+    || defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32F3) \
+    || defined(SOC_SERIES_STM32U5) || defined(SOC_SERIES_STM32H5) || defined(SOC_SERIES_STM32H7RS) || defined(SOC_SERIES_STM32L1)
 #define DMA_INSTANCE_TYPE              DMA_Channel_TypeDef
-#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)\
+#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) \
     || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32MP1)
 #define DMA_INSTANCE_TYPE              DMA_Stream_TypeDef
-#endif /*  defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL)  */
+#endif /* defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32L0) || defined(SOC_SERIES_STM32L5)
+|| defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) || defined(SOC_SERIES_STM32G0)
+|| defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32F3)
+|| defined(SOC_SERIES_STM32U5) || defined(SOC_SERIES_STM32H5) || defined(SOC_SERIES_STM32H7RS) || defined(SOC_SERIES_STM32L1)*/
 
-struct dma_config {
-    DMA_INSTANCE_TYPE *Instance;
-    rt_uint32_t dma_rcc;
-    IRQn_Type dma_irq;
+#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
+#define STM32_DMA_USES_CHANNEL
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
 
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)|| defined(SOC_SERIES_STM32F3)
-    rt_uint32_t channel;
-#endif
+#if defined(SOC_SERIES_STM32U5) || defined(SOC_SERIES_STM32H5) || defined(SOC_SERIES_STM32H7RS)
+#define STM32_DMA_USES_GPDMA
+#endif /* defined(SOC_SERIES_STM32U5) || defined(SOC_SERIES_STM32H5) || defined(SOC_SERIES_STM32H7RS) */
 
-#if defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL)  || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32G4)\
-    || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32L5)
-    rt_uint32_t request;
-#endif
+#if defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) || defined(SOC_SERIES_STM32G0) \
+    || defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32MP1) \
+    || defined(SOC_SERIES_STM32L5) || defined(SOC_SERIES_STM32U5) || defined(SOC_SERIES_STM32H5) || defined(SOC_SERIES_STM32H7RS)
+#define STM32_DMA_USES_REQUEST
+#endif /* defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) || defined(SOC_SERIES_STM32G0)
+|| defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32MP1)
+|| defined(SOC_SERIES_STM32L5) || defined(SOC_SERIES_STM32U5) || defined(SOC_SERIES_STM32H5) || defined(SOC_SERIES_STM32H7RS) */
+
+#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) \
+    || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32MP1)
+#define STM32_DMA_SUPPORTS_FIFO
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32MP1) */
+
+#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32G0) \
+    || defined(SOC_SERIES_STM32L0) || defined(SOC_SERIES_STM32F3) || defined(SOC_SERIES_STM32L1)
+#define STM32_DMA_USES_RCC_AHBENR
+#endif /* defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32L0) || defined(SOC_SERIES_STM32F3) || defined(SOC_SERIES_STM32L1) */
+
+#if defined(SOC_SERIES_STM32MP1)
+#define STM32_DMA_USES_RCC_MP_AHB2ENSETR
+#endif /* defined(SOC_SERIES_STM32MP1) */
+
+#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)    \
+    || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) || defined(SOC_SERIES_STM32G4) \
+    || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32L5) \
+    || defined(SOC_SERIES_STM32U5) || defined(SOC_SERIES_STM32H5) || defined(SOC_SERIES_STM32H7RS)
+#define STM32_DMA_USES_RCC_AHB1ENR
+#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
+|| defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) || defined(SOC_SERIES_STM32G4)
+|| defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32L5)
+|| defined(SOC_SERIES_STM32U5) || defined(SOC_SERIES_STM32H5) || defined(SOC_SERIES_STM32H7RS) */
+
+#ifndef STM32_DMA_DEFAULT_PRIORITY
+#define STM32_DMA_DEFAULT_PRIORITY              DMA_PRIORITY_LOW
+#endif /* STM32_DMA_DEFAULT_PRIORITY */
+
+#ifndef STM32_DMA_DEFAULT_PREEMPT_PRIORITY
+#define STM32_DMA_DEFAULT_PREEMPT_PRIORITY      0
+#endif /* STM32_DMA_DEFAULT_PREEMPT_PRIORITY */
+
+#ifndef STM32_DMA_DEFAULT_SUB_PRIORITY
+#define STM32_DMA_DEFAULT_SUB_PRIORITY          0
+#endif /* STM32_DMA_DEFAULT_SUB_PRIORITY */
+
+#if defined(STM32_DMA_USES_GPDMA)
+#ifndef STM32_GPDMA_DEFAULT_BLOCK_HW_REQUEST
+#define STM32_GPDMA_DEFAULT_BLOCK_HW_REQUEST        DMA_BREQ_SINGLE_BURST
+#endif /* STM32_GPDMA_DEFAULT_BLOCK_HW_REQUEST */
+
+#ifndef STM32_GPDMA_DEFAULT_SRC_BURST_LENGTH
+#define STM32_GPDMA_DEFAULT_SRC_BURST_LENGTH        1U
+#endif /* STM32_GPDMA_DEFAULT_SRC_BURST_LENGTH */
+
+#ifndef STM32_GPDMA_DEFAULT_DEST_BURST_LENGTH
+#define STM32_GPDMA_DEFAULT_DEST_BURST_LENGTH       1U
+#endif /* STM32_GPDMA_DEFAULT_DEST_BURST_LENGTH */
+
+#ifndef STM32_GPDMA_DEFAULT_TRANSFER_ALLOCATED_PORT
+#define STM32_GPDMA_DEFAULT_TRANSFER_ALLOCATED_PORT 0U
+#endif /* STM32_GPDMA_DEFAULT_TRANSFER_ALLOCATED_PORT */
+
+#ifndef STM32_GPDMA_DEFAULT_TRANSFER_EVENT_MODE
+#define STM32_GPDMA_DEFAULT_TRANSFER_EVENT_MODE     DMA_TCEM_BLOCK_TRANSFER
+#endif /* STM32_GPDMA_DEFAULT_TRANSFER_EVENT_MODE */
+#endif /* defined(STM32_DMA_USES_GPDMA) */
+
+/**
+ * @brief Static DMA endpoint description used by board-level config headers.
+ *
+ * This descriptor stores one complete DMA endpoint configuration so peripheral
+ * drivers can initialize DMA directly from the board-level config tables.
+ */
+struct stm32_dma_config
+{
+    DMA_INSTANCE_TYPE *Instance;        /**< DMA controller instance pointer. */
+    rt_uint32_t dma_rcc;                /**< RCC enable bit for the DMA controller. */
+    IRQn_Type dma_irq;                  /**< DMA global IRQ number. */
+    rt_uint32_t priority;               /**< DMA transfer priority. */
+    rt_uint8_t preempt_priority;        /**< NVIC preempt priority for the DMA IRQ. */
+    rt_uint8_t sub_priority;            /**< NVIC sub priority for the DMA IRQ. */
+
+#if defined(STM32_DMA_USES_GPDMA)
+    rt_uint32_t request;                /**< DMA request selector for the GPDMA channel. */
+    rt_uint32_t blk_hw_request;         /**< GPDMA block hardware request mode. */
+    rt_uint32_t direction;              /**< DMA transfer direction. */
+    rt_uint32_t src_inc;                /**< GPDMA source increment mode. */
+    rt_uint32_t dest_inc;               /**< GPDMA destination increment mode. */
+    rt_uint32_t src_data_width;         /**< GPDMA source data width. */
+    rt_uint32_t dest_data_width;        /**< GPDMA destination data width. */
+    rt_uint32_t src_burst_length;       /**< GPDMA source burst length. */
+    rt_uint32_t dest_burst_length;      /**< GPDMA destination burst length. */
+    rt_uint32_t transfer_allocated_port;/**< GPDMA allocated port selection. */
+    rt_uint32_t transfer_event_mode;    /**< GPDMA transfer event mode. */
+    rt_uint32_t mode;                   /**< DMA transfer mode. */
+#else
+#ifdef STM32_DMA_USES_CHANNEL
+    rt_uint32_t channel;                /**< DMA channel selector for stream-based DMA. */
+#endif /* STM32_DMA_USES_CHANNEL */
+
+#ifdef STM32_DMA_USES_REQUEST
+    rt_uint32_t request;                /**< DMA request selector for DMAMUX/request-based DMA. */
+#endif /* STM32_DMA_USES_REQUEST */
+
+    rt_uint32_t direction;              /**< DMA transfer direction. */
+    rt_uint32_t periph_inc;             /**< Peripheral address increment mode. */
+    rt_uint32_t mem_inc;                /**< Memory address increment mode. */
+    rt_uint32_t periph_data_alignment;  /**< Peripheral data alignment. */
+    rt_uint32_t mem_data_alignment;     /**< Memory data alignment. */
+    rt_uint32_t mode;                   /**< DMA transfer mode. */
+
+#if defined(STM32_DMA_SUPPORTS_FIFO)
+    rt_uint32_t fifo_mode;              /**< FIFO enable state. */
+    rt_uint32_t fifo_threshold;         /**< FIFO threshold selection. */
+    rt_uint32_t mem_burst;              /**< Memory burst transfer mode. */
+    rt_uint32_t periph_burst;           /**< Peripheral burst transfer mode. */
+#endif /* defined(STM32_DMA_SUPPORTS_FIFO) */
+#endif /* defined(STM32_DMA_USES_GPDMA) */
 };
+
+/**
+ * @brief Optional selector fields kept in the descriptor for board-level readability.
+ */
+#if defined(STM32_DMA_USES_CHANNEL)
+#define STM32_DMA_CHANNEL_FIELD(_channel)          .channel = (_channel),
+#else
+#define STM32_DMA_CHANNEL_FIELD(_channel)
+#endif /* defined(STM32_DMA_USES_CHANNEL) */
+
+#if defined(STM32_DMA_USES_REQUEST)
+#define STM32_DMA_REQUEST_FIELD(_request)          .request = (_request),
+#else
+#define STM32_DMA_REQUEST_FIELD(_request)
+#endif /* defined(STM32_DMA_USES_REQUEST) */
+
+#if defined(STM32_DMA_SUPPORTS_FIFO)
+#define STM32_DMA_FIFO_FIELD_DEFAULTS              \
+        .fifo_mode = DMA_FIFOMODE_DISABLE,         \
+        .fifo_threshold = DMA_FIFO_THRESHOLD_FULL, \
+        .mem_burst = DMA_MBURST_SINGLE,            \
+        .periph_burst = DMA_PBURST_SINGLE,
+
+#define STM32_DMA_FIFO_FIELD_VALUES(_fifo_mode, _fifo_threshold, _mem_burst, _periph_burst) \
+        .fifo_mode = (_fifo_mode),                                                          \
+        .fifo_threshold = (_fifo_threshold),                                                \
+        .mem_burst = (_mem_burst),                                                          \
+        .periph_burst = (_periph_burst),
+#else
+#define STM32_DMA_FIFO_FIELD_DEFAULTS
+#define STM32_DMA_FIFO_FIELD_VALUES(_fifo_mode, _fifo_threshold, _mem_burst, _periph_burst)
+#endif /* defined(STM32_DMA_SUPPORTS_FIFO) */
+
+/**
+ * @brief Generic descriptor initializer with explicit DMA direction and data layout.
+ */
+#define STM32_DMA_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _channel, _request, _priority, _preempt_priority, _sub_priority, _direction, _periph_inc, _mem_inc, _periph_data_alignment, _mem_data_alignment, _mode) \
+    {                                                                                                                                                                                                                   \
+        .Instance = (_instance),                                                                                                                                                                                        \
+        .dma_rcc = (_dma_rcc),                                                                                                                                                                                          \
+        .dma_irq = (_dma_irq),                                                                                                                                                                                          \
+        .priority = (_priority),                                                                                                                                                                                        \
+        .preempt_priority = (_preempt_priority),                                                                                                                                                                        \
+        .sub_priority = (_sub_priority),                                                                                                                                                                                \
+        STM32_DMA_CHANNEL_FIELD(_channel)                                                                                                                                                                               \
+        STM32_DMA_REQUEST_FIELD(_request)                                                                                                                                                                               \
+        .direction = (_direction),                                                                                                                                                                                      \
+        .periph_inc = (_periph_inc),                                                                                                                                                                                    \
+        .mem_inc = (_mem_inc),                                                                                                                                                                                          \
+        .periph_data_alignment = (_periph_data_alignment),                                                                                                                                                              \
+        .mem_data_alignment = (_mem_data_alignment),                                                                                                                                                                    \
+        .mode = (_mode),                                                                                                                                                                                                \
+        STM32_DMA_FIFO_FIELD_DEFAULTS                                                                                                                                                                                   \
+    }
+
+/**
+ * @brief Generic descriptor initializer for controllers that expose FIFO and burst fields.
+ */
+#define STM32_DMA_CONFIG_INIT_FIFO_EX(_instance, _dma_rcc, _dma_irq, _channel, _request, _priority, _preempt_priority, _sub_priority, _direction, _periph_inc, _mem_inc, _periph_data_alignment, _mem_data_alignment, _mode, _fifo_mode, _fifo_threshold, _mem_burst, _periph_burst) \
+    {                                                                                                                                                                                                                                                                                \
+        .Instance = (_instance),                                                                                                                                                                                                                                                     \
+        .dma_rcc = (_dma_rcc),                                                                                                                                                                                                                                                       \
+        .dma_irq = (_dma_irq),                                                                                                                                                                                                                                                       \
+        .priority = (_priority),                                                                                                                                                                                                                                                     \
+        .preempt_priority = (_preempt_priority),                                                                                                                                                                                                                                     \
+        .sub_priority = (_sub_priority),                                                                                                                                                                                                                                             \
+        STM32_DMA_CHANNEL_FIELD(_channel)                                                                                                                                                                                                                                            \
+        STM32_DMA_REQUEST_FIELD(_request)                                                                                                                                                                                                                                            \
+        .direction = (_direction),                                                                                                                                                                                                                                                   \
+        .periph_inc = (_periph_inc),                                                                                                                                                                                                                                                 \
+        .mem_inc = (_mem_inc),                                                                                                                                                                                                                                                       \
+        .periph_data_alignment = (_periph_data_alignment),                                                                                                                                                                                                                           \
+        .mem_data_alignment = (_mem_data_alignment),                                                                                                                                                                                                                                 \
+        .mode = (_mode),                                                                                                                                                                                                                                                             \
+        STM32_DMA_FIFO_FIELD_VALUES(_fifo_mode, _fifo_threshold, _mem_burst, _periph_burst)                                                                                                                                                                                          \
+    }
+
+/**
+ * @brief Common byte/word transfer descriptor helpers used by board-level config headers.
+ */
+#define STM32_DMA_RX_BYTE_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _channel, _request, _priority, _preempt_priority, _sub_priority) \
+    STM32_DMA_CONFIG_INIT_EX((_instance), (_dma_rcc), (_dma_irq), (_channel), (_request), (_priority), (_preempt_priority), (_sub_priority), DMA_PERIPH_TO_MEMORY, DMA_PINC_DISABLE, DMA_MINC_ENABLE, DMA_PDATAALIGN_BYTE, DMA_MDATAALIGN_BYTE, DMA_NORMAL)
+
+#define STM32_DMA_TX_BYTE_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _channel, _request, _priority, _preempt_priority, _sub_priority) \
+    STM32_DMA_CONFIG_INIT_EX((_instance), (_dma_rcc), (_dma_irq), (_channel), (_request), (_priority), (_preempt_priority), (_sub_priority), DMA_MEMORY_TO_PERIPH, DMA_PINC_DISABLE, DMA_MINC_ENABLE, DMA_PDATAALIGN_BYTE, DMA_MDATAALIGN_BYTE, DMA_NORMAL)
+
+#define STM32_DMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _channel, _request, _priority, _preempt_priority, _sub_priority) \
+    STM32_DMA_CONFIG_INIT_EX((_instance), (_dma_rcc), (_dma_irq), (_channel), (_request), (_priority), (_preempt_priority), (_sub_priority), DMA_PERIPH_TO_MEMORY, DMA_PINC_DISABLE, DMA_MINC_ENABLE, DMA_PDATAALIGN_BYTE, DMA_MDATAALIGN_BYTE, DMA_CIRCULAR)
+
+#define STM32_DMA_RX_WORD_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _channel, _request, _priority, _preempt_priority, _sub_priority) \
+    STM32_DMA_CONFIG_INIT_EX((_instance), (_dma_rcc), (_dma_irq), (_channel), (_request), (_priority), (_preempt_priority), (_sub_priority), DMA_PERIPH_TO_MEMORY, DMA_PINC_DISABLE, DMA_MINC_ENABLE, DMA_PDATAALIGN_WORD, DMA_MDATAALIGN_WORD, DMA_NORMAL)
+
+#define STM32_DMA_TX_WORD_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _channel, _request, _priority, _preempt_priority, _sub_priority) \
+    STM32_DMA_CONFIG_INIT_EX((_instance), (_dma_rcc), (_dma_irq), (_channel), (_request), (_priority), (_preempt_priority), (_sub_priority), DMA_MEMORY_TO_PERIPH, DMA_PINC_DISABLE, DMA_MINC_ENABLE, DMA_PDATAALIGN_WORD, DMA_MDATAALIGN_WORD, DMA_NORMAL)
+
+/**
+ * @brief GPDMA descriptor initializer with explicit source and destination attributes.
+ */
+#define STM32_GPDMA_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _request, _priority, _preempt_priority, _sub_priority, _direction, _src_inc, _dest_inc, _src_data_width, _dest_data_width, _mode) \
+    {                                                                                                                                                                                               \
+        .Instance = (_instance),                                                                                                                                                                    \
+        .dma_rcc = (_dma_rcc),                                                                                                                                                                      \
+        .dma_irq = (_dma_irq),                                                                                                                                                                      \
+        .priority = (_priority),                                                                                                                                                                    \
+        .preempt_priority = (_preempt_priority),                                                                                                                                                    \
+        .sub_priority = (_sub_priority),                                                                                                                                                            \
+        .request = (_request),                                                                                                                                                                      \
+        .blk_hw_request = STM32_GPDMA_DEFAULT_BLOCK_HW_REQUEST,                                                                                                                                     \
+        .direction = (_direction),                                                                                                                                                                  \
+        .src_inc = (_src_inc),                                                                                                                                                                      \
+        .dest_inc = (_dest_inc),                                                                                                                                                                    \
+        .src_data_width = (_src_data_width),                                                                                                                                                        \
+        .dest_data_width = (_dest_data_width),                                                                                                                                                      \
+        .src_burst_length = STM32_GPDMA_DEFAULT_SRC_BURST_LENGTH,                                                                                                                                   \
+        .dest_burst_length = STM32_GPDMA_DEFAULT_DEST_BURST_LENGTH,                                                                                                                                 \
+        .transfer_allocated_port = STM32_GPDMA_DEFAULT_TRANSFER_ALLOCATED_PORT,                                                                                                                     \
+        .transfer_event_mode = STM32_GPDMA_DEFAULT_TRANSFER_EVENT_MODE,                                                                                                                             \
+        .mode = (_mode),                                                                                                                                                                            \
+    }
+
+#define STM32_GPDMA_RX_BYTE_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _request, _priority, _preempt_priority, _sub_priority) \
+    STM32_GPDMA_CONFIG_INIT_EX((_instance), (_dma_rcc), (_dma_irq), (_request), (_priority), (_preempt_priority), (_sub_priority), DMA_PERIPH_TO_MEMORY, DMA_SINC_FIXED, DMA_DINC_INCREMENTED, DMA_SRC_DATAWIDTH_BYTE, DMA_DEST_DATAWIDTH_BYTE, DMA_NORMAL)
+
+#define STM32_GPDMA_TX_BYTE_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _request, _priority, _preempt_priority, _sub_priority) \
+    STM32_GPDMA_CONFIG_INIT_EX((_instance), (_dma_rcc), (_dma_irq), (_request), (_priority), (_preempt_priority), (_sub_priority), DMA_MEMORY_TO_PERIPH, DMA_SINC_INCREMENTED, DMA_DINC_FIXED, DMA_SRC_DATAWIDTH_BYTE, DMA_DEST_DATAWIDTH_BYTE, DMA_NORMAL)
+
+#define STM32_GPDMA_RX_BYTE_CIRCULAR_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _request, _priority, _preempt_priority, _sub_priority) \
+    STM32_GPDMA_CONFIG_INIT_EX((_instance), (_dma_rcc), (_dma_irq), (_request), (_priority), (_preempt_priority), (_sub_priority), DMA_PERIPH_TO_MEMORY, DMA_SINC_FIXED, DMA_DINC_INCREMENTED, DMA_SRC_DATAWIDTH_BYTE, DMA_DEST_DATAWIDTH_BYTE, DMA_CIRCULAR)
+
+#define STM32_GPDMA_RX_WORD_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _request, _priority, _preempt_priority, _sub_priority) \
+    STM32_GPDMA_CONFIG_INIT_EX((_instance), (_dma_rcc), (_dma_irq), (_request), (_priority), (_preempt_priority), (_sub_priority), DMA_PERIPH_TO_MEMORY, DMA_SINC_FIXED, DMA_DINC_INCREMENTED, DMA_SRC_DATAWIDTH_WORD, DMA_DEST_DATAWIDTH_WORD, DMA_NORMAL)
+
+#define STM32_GPDMA_TX_WORD_CONFIG_INIT_EX(_instance, _dma_rcc, _dma_irq, _request, _priority, _preempt_priority, _sub_priority) \
+    STM32_GPDMA_CONFIG_INIT_EX((_instance), (_dma_rcc), (_dma_irq), (_request), (_priority), (_preempt_priority), (_sub_priority), DMA_MEMORY_TO_PERIPH, DMA_SINC_INCREMENTED, DMA_DINC_FIXED, DMA_SRC_DATAWIDTH_WORD, DMA_DEST_DATAWIDTH_WORD, DMA_NORMAL)
+
+/**
+ * @brief Apply one static DMA descriptor and initialize the HAL DMA handle.
+ * @param dma_handle DMA handle to initialize.
+ * @param dma_config Static DMA endpoint description.
+ * @retval RT_EOK Success.
+ * @retval -RT_ERROR HAL initialization failed.
+ */
+rt_err_t stm32_dma_init(DMA_HandleTypeDef *dma_handle,
+                        const struct stm32_dma_config *dma_config);
+
+/**
+ * @brief Initialize one DMA handle, link it to the parent peripheral and enable its IRQ.
+ * @param dma_handle DMA handle to initialize.
+ * @param parent_handle Parent peripheral HAL handle.
+ * @param dma_slot Parent peripheral DMA slot address, such as &huart->hdmarx.
+ * @param dma_config Static DMA endpoint description.
+ * @retval RT_EOK Success.
+ * @retval -RT_ERROR HAL initialization failed.
+ */
+rt_err_t stm32_dma_setup(DMA_HandleTypeDef *dma_handle,
+                         void *parent_handle,
+                         DMA_HandleTypeDef **dma_slot,
+                         const struct stm32_dma_config *dma_config);
+
+/**
+ * @brief Abort and de-initialize one DMA handle.
+ *
+ * The helper uses IRQ reference counting only for known shared DMA IRQ lines:
+ * STM32F1 DMA2_Channel4_5_IRQn, STM32L0 DMA1_Channel4_5_6_7_IRQn and
+ * STM32G0 DMA1_Channel2_3_IRQn. Other series keep direct IRQ disable behavior.
+ *
+ * @param dma_handle DMA handle to de-initialize.
+ * @param dma_config Static DMA endpoint description.
+ * @param abort_first RT_TRUE aborts the DMA transfer before de-initialization.
+ * @retval RT_EOK Success.
+ * @retval -RT_ERROR HAL abort or de-initialization failed.
+ */
+rt_err_t stm32_dma_deinit(DMA_HandleTypeDef *dma_handle,
+                          const struct stm32_dma_config *dma_config,
+                          rt_bool_t abort_first);
+
+#endif /* HAL_DMA_MODULE_ENABLED */
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /*__DRV_DMA_H_ */
+#endif /* __DRV_DMA_H_ */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.c
@@ -79,6 +79,29 @@ static void stm32_i2c_apply_default_config(struct stm32_i2c_config *cfg)
     }
 }
 
+#if defined(BSP_I2C_RX_USING_DMA) || defined(BSP_I2C_TX_USING_DMA)
+static void stm32_i2c_dma_rollback(struct stm32_i2c *i2c_drv, rt_uint16_t dma_flags)
+{
+#if defined(BSP_I2C_RX_USING_DMA)
+    if ((dma_flags & RT_DEVICE_FLAG_DMA_RX) && (i2c_drv->config->dma_rx != RT_NULL))
+    {
+        (void)stm32_dma_deinit(&i2c_drv->dma.handle_rx, i2c_drv->config->dma_rx, RT_FALSE);
+        i2c_drv->dma.handle_rx.Parent = RT_NULL;
+        i2c_drv->handle.hdmarx = RT_NULL;
+    }
+#endif /* defined(BSP_I2C_RX_USING_DMA) */
+
+#if defined(BSP_I2C_TX_USING_DMA)
+    if ((dma_flags & RT_DEVICE_FLAG_DMA_TX) && (i2c_drv->config->dma_tx != RT_NULL))
+    {
+        (void)stm32_dma_deinit(&i2c_drv->dma.handle_tx, i2c_drv->config->dma_tx, RT_FALSE);
+        i2c_drv->dma.handle_tx.Parent = RT_NULL;
+        i2c_drv->handle.hdmatx = RT_NULL;
+    }
+#endif /* defined(BSP_I2C_TX_USING_DMA) */
+}
+#endif /* defined(BSP_I2C_RX_USING_DMA) || defined(BSP_I2C_TX_USING_DMA) */
+
 static rt_err_t stm32_i2c_init(struct stm32_i2c *i2c_drv)
 {
     RT_ASSERT(i2c_drv != RT_NULL);
@@ -129,25 +152,27 @@ static rt_err_t stm32_i2c_init(struct stm32_i2c *i2c_drv)
     /* I2C2 DMA Init */
     if (i2c_drv->i2c_dma_flag & RT_DEVICE_FLAG_DMA_RX)
     {
-        HAL_DMA_Init(&i2c_drv->dma.handle_rx);
-
-        __HAL_LINKDMA(&i2c_drv->handle, hdmarx, i2c_drv->dma.handle_rx);
-
-        /* NVIC configuration for DMA transfer complete interrupt */
-        HAL_NVIC_SetPriority(i2c_drv->config->dma_rx->dma_irq, 0, 0);
-        HAL_NVIC_EnableIRQ(i2c_drv->config->dma_rx->dma_irq);
+        if (stm32_dma_setup(&i2c_drv->dma.handle_rx,
+                            &i2c_drv->handle,
+                            &i2c_drv->handle.hdmarx,
+                            i2c_drv->config->dma_rx) != RT_EOK)
+        {
+            stm32_i2c_dma_rollback(i2c_drv, RT_DEVICE_FLAG_DMA_RX);
+            return -RT_EFAULT;
+        }
     }
 #endif /* defined(BSP_I2C_RX_USING_DMA) */
 #if defined(BSP_I2C_TX_USING_DMA)
     if (i2c_drv->i2c_dma_flag & RT_DEVICE_FLAG_DMA_TX)
     {
-        HAL_DMA_Init(&i2c_drv->dma.handle_tx);
-
-        __HAL_LINKDMA(&i2c_drv->handle, hdmatx, i2c_drv->dma.handle_tx);
-
-        /* NVIC configuration for DMA transfer complete interrupt */
-        HAL_NVIC_SetPriority(i2c_drv->config->dma_tx->dma_irq, 1, 0);
-        HAL_NVIC_EnableIRQ(i2c_drv->config->dma_tx->dma_irq);
+        if (stm32_dma_setup(&i2c_drv->dma.handle_tx,
+                            &i2c_drv->handle,
+                            &i2c_drv->handle.hdmatx,
+                            i2c_drv->config->dma_tx) != RT_EOK)
+        {
+            stm32_i2c_dma_rollback(i2c_drv, RT_DEVICE_FLAG_DMA_TX | (i2c_drv->i2c_dma_flag & RT_DEVICE_FLAG_DMA_RX));
+            return -RT_EFAULT;
+        }
     }
 #endif /* defined(BSP_I2C_TX_USING_DMA) */
 #if defined(BSP_I2C_USING_IRQ)
@@ -533,94 +558,6 @@ int RT_hw_i2c_bus_init(void)
         i2c_objs[i].i2c_bus.config.max_hz = i2c_config[i].timing;
         i2c_objs[i].i2c_bus.config.usage_freq = i2c_config[i].timing;
 #endif
-
-#ifdef BSP_I2C_USING_DMA
-        if ((i2c_objs[i].i2c_dma_flag & RT_DEVICE_FLAG_DMA_RX))
-        {
-            i2c_objs[i].dma.handle_rx.Instance = i2c_config[i].dma_rx->Instance;
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-            i2c_objs[i].dma.handle_rx.Init.Channel = i2c_config[i].dma_rx->channel;
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-            i2c_objs[i].dma.handle_rx.Init.Request = i2c_config[i].dma_rx->request;
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
-#ifndef SOC_SERIES_STM32U5
-            i2c_objs[i].dma.handle_rx.Init.Direction           = DMA_PERIPH_TO_MEMORY;
-            i2c_objs[i].dma.handle_rx.Init.PeriphInc           = DMA_PINC_DISABLE;
-            i2c_objs[i].dma.handle_rx.Init.MemInc              = DMA_MINC_ENABLE;
-            i2c_objs[i].dma.handle_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-            i2c_objs[i].dma.handle_rx.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
-            i2c_objs[i].dma.handle_rx.Init.Mode                = DMA_NORMAL;
-            i2c_objs[i].dma.handle_rx.Init.Priority            = DMA_PRIORITY_LOW;
-#endif
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7)
-            i2c_objs[i].dma.handle_rx.Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
-            i2c_objs[i].dma.handle_rx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
-            i2c_objs[i].dma.handle_rx.Init.MemBurst            = DMA_MBURST_INC4;
-            i2c_objs[i].dma.handle_rx.Init.PeriphBurst         = DMA_PBURST_INC4;
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7) */
-            {
-                rt_uint32_t tmpreg = 0x00U;
-#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0)
-                /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-                SET_BIT(RCC->AHBENR, i2c_config[i].dma_rx->dma_rcc);
-                tmpreg = READ_BIT(RCC->AHBENR, i2c_config[i].dma_rx->dma_rcc);
-#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-                SET_BIT(RCC->AHB1ENR, i2c_config[i].dma_rx->dma_rcc);
-                /* Delay after an RCC peripheral clock enabling */
-                tmpreg = READ_BIT(RCC->AHB1ENR, i2c_config[i].dma_rx->dma_rcc);
-#elif defined(SOC_SERIES_STM32MP1)
-                __HAL_RCC_DMAMUX_CLK_ENABLE();
-                SET_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_rx->dma_rcc);
-                tmpreg = READ_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_rx->dma_rcc);
-#endif /* defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0) */
-                UNUSED(tmpreg); /* To avoid compiler warnings */
-            }
-        }
-
-        if (i2c_objs[i].i2c_dma_flag & RT_DEVICE_FLAG_DMA_TX)
-        {
-            i2c_objs[i].dma.handle_tx.Instance = i2c_config[i].dma_tx->Instance;
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-            i2c_objs[i].dma.handle_tx.Init.Channel = i2c_config[i].dma_tx->channel;
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-            i2c_objs[i].dma.handle_tx.Init.Request = i2c_config[i].dma_tx->request;
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) */
-#ifndef SOC_SERIES_STM32U5
-            i2c_objs[i].dma.handle_tx.Init.Direction           = DMA_MEMORY_TO_PERIPH;
-            i2c_objs[i].dma.handle_tx.Init.PeriphInc           = DMA_PINC_DISABLE;
-            i2c_objs[i].dma.handle_tx.Init.MemInc              = DMA_MINC_ENABLE;
-            i2c_objs[i].dma.handle_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-            i2c_objs[i].dma.handle_tx.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
-            i2c_objs[i].dma.handle_tx.Init.Mode                = DMA_NORMAL;
-            i2c_objs[i].dma.handle_tx.Init.Priority            = DMA_PRIORITY_LOW;
-#endif /* SOC_SERIES_STM32U5 */
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7)
-
-            i2c_objs[i].dma.handle_tx.Init.FIFOMode = DMA_FIFOMODE_DISABLE;
-            i2c_objs[i].dma.handle_tx.Init.FIFOThreshold = DMA_FIFO_THRESHOLD_FULL;
-            i2c_objs[i].dma.handle_tx.Init.MemBurst = DMA_MBURST_INC4;
-            i2c_objs[i].dma.handle_tx.Init.PeriphBurst = DMA_PBURST_INC4;
-#endif /* defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7) */
-            {
-                rt_uint32_t tmpreg = 0x00U;
-#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0)
-                /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-                SET_BIT(RCC->AHBENR, i2c_config[i].dma_tx->dma_rcc);
-                tmpreg = READ_BIT(RCC->AHBENR, i2c_config[i].dma_tx->dma_rcc);
-#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-                SET_BIT(RCC->AHB1ENR, i2c_config[i].dma_tx->dma_rcc);
-                /* Delay after an RCC peripheral clock enabling */
-                tmpreg = READ_BIT(RCC->AHB1ENR, i2c_config[i].dma_tx->dma_rcc);
-#elif defined(SOC_SERIES_STM32MP1)
-                __HAL_RCC_DMAMUX_CLK_ENABLE();
-                SET_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_tx->dma_rcc);
-                tmpreg = READ_BIT(RCC->MP_AHB2ENSETR, i2c_config[i].dma_tx->dma_rcc);
-#endif /* defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0) */
-                UNUSED(tmpreg); /* To avoid compiler warnings */
-            }
-        }
-
-#endif /* BSP_I2C_USING_DMA */
 #if defined(BSP_I2C_USING_IRQ)
         rt_completion_init(&i2c_objs[i].completion);
 #endif /* defined(BSP_I2C_USING_IRQ) */
@@ -653,7 +590,7 @@ static void stm32_get_info(void)
 #endif /* defined (BSP_I2C1_TX_USING_INT) */
 #if defined(BSP_I2C1_TX_USING_DMA)
     i2c_objs[I2C1_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config I2C1_dma_tx = I2C1_TX_DMA_CONFIG;
+    static const struct stm32_dma_config I2C1_dma_tx = I2C1_TX_DMA_CONFIG;
     i2c_config[I2C1_INDEX].dma_tx = &I2C1_dma_tx;
 #endif /* defined (BSP_I2C1_TX_USING_DMA) */
 
@@ -662,7 +599,7 @@ static void stm32_get_info(void)
 #endif /* defined (BSP_I2C1_RX_USING_INT) */
 #if defined(BSP_I2C1_RX_USING_DMA)
     i2c_objs[I2C1_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config I2C1_dma_rx = I2C1_RX_DMA_CONFIG;
+    static const struct stm32_dma_config I2C1_dma_rx = I2C1_RX_DMA_CONFIG;
     i2c_config[I2C1_INDEX].dma_rx = &I2C1_dma_rx;
 #endif /* defined (BSP_I2C1_RX_USING_DMA) */
 
@@ -676,7 +613,7 @@ static void stm32_get_info(void)
 #endif /* defined (BSP_I2C2_TX_USING_INT) */
 #if defined(BSP_I2C2_TX_USING_DMA)
     i2c_objs[I2C2_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config I2C2_dma_tx = I2C2_TX_DMA_CONFIG;
+    static const struct stm32_dma_config I2C2_dma_tx = I2C2_TX_DMA_CONFIG;
     i2c_config[I2C2_INDEX].dma_tx = &I2C2_dma_tx;
 #endif /* defined (BSP_I2C2_TX_USING_DMA) */
 
@@ -685,7 +622,7 @@ static void stm32_get_info(void)
 #endif /* defined (BSP_I2C2_RX_USING_INT) */
 #if defined(BSP_I2C2_RX_USING_DMA)
     i2c_objs[I2C2_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config I2C2_dma_rx = I2C2_RX_DMA_CONFIG;
+    static const struct stm32_dma_config I2C2_dma_rx = I2C2_RX_DMA_CONFIG;
     i2c_config[I2C2_INDEX].dma_rx = &I2C2_dma_rx;
 #endif /* defined (BSP_I2C2_RX_USING_DMA) */
 
@@ -699,7 +636,7 @@ static void stm32_get_info(void)
 #endif /* defined (BSP_I2C3_TX_USING_INT) */
 #if defined(BSP_I2C3_TX_USING_DMA)
     i2c_objs[I2C3_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config I2C3_dma_tx = I2C3_TX_DMA_CONFIG;
+    static const struct stm32_dma_config I2C3_dma_tx = I2C3_TX_DMA_CONFIG;
     i2c_config[I2C3_INDEX].dma_tx = &I2C3_dma_tx;
 #endif /* defined (BSP_I2C3_TX_USING_DMA) */
 
@@ -708,7 +645,7 @@ static void stm32_get_info(void)
 #endif /* defined (BSP_I2C3_RX_USING_INT) */
 #if defined(BSP_I2C3_RX_USING_DMA)
     i2c_objs[I2C3_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config I2C3_dma_rx = I2C3_RX_DMA_CONFIG;
+    static const struct stm32_dma_config I2C3_dma_rx = I2C3_RX_DMA_CONFIG;
     i2c_config[I2C3_INDEX].dma_rx = &I2C3_dma_rx;
 #endif /* defined (BSP_I2C3_RX_USING_DMA) */
 
@@ -722,7 +659,7 @@ static void stm32_get_info(void)
 #endif /* defined (BSP_I2C4_TX_USING_INT) */
 #if defined(BSP_I2C4_TX_USING_DMA)
     i2c_objs[I2C4_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config I2C4_dma_tx = I2C4_TX_DMA_CONFIG;
+    static const struct stm32_dma_config I2C4_dma_tx = I2C4_TX_DMA_CONFIG;
     i2c_config[I2C4_INDEX].dma_tx = &I2C4_dma_tx;
 #endif /* defined (BSP_I2C4_TX_USING_DMA) */
 
@@ -731,7 +668,7 @@ static void stm32_get_info(void)
 #endif /* defined (BSP_I2C4_RX_USING_INT) */
 #if defined(BSP_I2C4_RX_USING_DMA)
     i2c_objs[I2C4_INDEX].i2c_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config I2C4_dma_rx = I2C4_RX_DMA_CONFIG;
+    static const struct stm32_dma_config I2C4_dma_rx = I2C4_RX_DMA_CONFIG;
     i2c_config[I2C4_INDEX].dma_rx = &I2C4_dma_rx;
 #endif /* defined (BSP_I2C4_RX_USING_DMA) */
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_hard_i2c.h
@@ -136,10 +136,10 @@ struct stm32_i2c_config
     IRQn_Type               evirq_type;
     IRQn_Type               erirq_type;
 #ifdef BSP_I2C_RX_USING_DMA
-    struct dma_config       *dma_rx;
+    const struct stm32_dma_config *dma_rx;
 #endif /* BSP_I2C_RX_USING_DMA */
 #ifdef BSP_I2C_TX_USING_DMA
-    struct dma_config       *dma_tx;
+    const struct stm32_dma_config *dma_tx;
 #endif /* BSP_I2C_TX_USING_DMA */
 };
 

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_qspi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_qspi.c
@@ -11,6 +11,7 @@
 
 #include "board.h"
 #include "drv_qspi.h"
+#include "drv_dma.h"
 #include "drv_config.h"
 
 #ifdef RT_USING_QSPI
@@ -32,6 +33,9 @@ struct stm32_qspi_bus
 
 struct rt_spi_bus _qspi_bus1;
 struct stm32_qspi_bus _stm32_qspi_bus;
+#ifdef BSP_QSPI_USING_DMA
+static const struct stm32_dma_config qspi_dma_config = QSPI_DMA_CONFIG;
+#endif
 
 static int stm32_qspi_init(struct rt_qspi_device *device, struct rt_qspi_configuration *qspi_cfg)
 {
@@ -92,29 +96,12 @@ static int stm32_qspi_init(struct rt_qspi_device *device, struct rt_qspi_configu
     /* QSPI interrupts must be enabled when using the HAL_QSPI_Receive_DMA */
     HAL_NVIC_SetPriority(QSPI_IRQn, 0, 0);
     HAL_NVIC_EnableIRQ(QSPI_IRQn);
-    HAL_NVIC_SetPriority(QSPI_DMA_IRQ, 0, 0);
-    HAL_NVIC_EnableIRQ(QSPI_DMA_IRQ);
-
     /* init QSPI DMA */
-    if(QSPI_DMA_RCC  == RCC_AHB1ENR_DMA1EN)
+    if (stm32_dma_setup(&qspi_bus->hdma_quadspi, &qspi_bus->QSPI_Handler, &qspi_bus->QSPI_Handler.hdma, &qspi_dma_config) != RT_EOK)
     {
-        __HAL_RCC_DMA1_CLK_ENABLE();
+        LOG_E("qspi dma init failed");
+        return -RT_ERROR;
     }
-    else
-    {
-        __HAL_RCC_DMA2_CLK_ENABLE();
-    }
-
-    HAL_DMA_DeInit(qspi_bus->QSPI_Handler.hdma);
-    DMA_HandleTypeDef hdma_quadspi_config = QSPI_DMA_CONFIG;
-    qspi_bus->hdma_quadspi = hdma_quadspi_config;
-
-    if (HAL_DMA_Init(&qspi_bus->hdma_quadspi) != HAL_OK)
-    {
-        LOG_E("qspi dma init failed (%d)!", result);
-    }
-
-    __HAL_LINKDMA(&qspi_bus->QSPI_Handler, hdma, qspi_bus->hdma_quadspi);
 #endif /* BSP_QSPI_USING_DMA */
 
     return result;

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_sdio.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_sdio.c
@@ -680,133 +680,66 @@ struct rt_mmcsd_host *sdio_host_create(struct stm32_sdio_des *sdio_des)
 }
 
 /**
-  * @brief  This function configures the DMATX.
-  * @param  BufferSRC: pointer to the source buffer
-  * @param  BufferSize: buffer size
-  * @retval None
+  * @brief  Configure the SDIO DMA TX transfer.
+  * @param  src Pointer to the source buffer.
+  * @param  dst Pointer to the destination address.
+  * @param  BufferSize Number of DMA data units to transfer.
+  * @retval RT_EOK DMA TX transfer is configured and started successfully.
+  * @retval -RT_ERROR DMA TX initialization or start failed.
   */
-void SD_LowLevel_DMA_TxConfig(uint32_t *src, uint32_t *dst, uint32_t BufferSize)
+static rt_err_t SD_LowLevel_DMA_TxConfig(uint32_t *src, uint32_t *dst, uint32_t BufferSize)
 {
-#if defined(SOC_SERIES_STM32F1)
-    static uint32_t size = 0;
-    size += BufferSize * 4;
     sdio_obj.cfg = &sdio_config;
-    sdio_obj.dma.handle_tx.Instance = sdio_config.dma_tx.Instance;
-    sdio_obj.dma.handle_tx.Init.Direction           = DMA_MEMORY_TO_PERIPH;
-    sdio_obj.dma.handle_tx.Init.MemDataAlignment    = DMA_MDATAALIGN_WORD;
-    sdio_obj.dma.handle_tx.Init.MemInc              = DMA_MINC_ENABLE;
-    sdio_obj.dma.handle_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
-    sdio_obj.dma.handle_tx.Init.PeriphInc           = DMA_PINC_DISABLE;
-    sdio_obj.dma.handle_tx.Init.Priority            = DMA_PRIORITY_MEDIUM;
-    /* DMA_PFCTRL */
-    HAL_DMA_DeInit(&sdio_obj.dma.handle_tx);
-    HAL_DMA_Init(&sdio_obj.dma.handle_tx);
 
-    HAL_DMA_Start(&sdio_obj.dma.handle_tx, (uint32_t)src, (uint32_t)dst, BufferSize);
+    if (stm32_dma_init(&sdio_obj.dma.handle_tx, &sdio_config.dma_tx) != RT_EOK)
+    {
+        LOG_E("sdio dma tx init failed");
+        return -RT_ERROR;
+    }
 
-#elif defined(SOC_SERIES_STM32L4)
-    static uint32_t size = 0;
-    size += BufferSize * 4;
-    sdio_obj.cfg = &sdio_config;
-    sdio_obj.dma.handle_tx.Instance = sdio_config.dma_tx.Instance;
-    sdio_obj.dma.handle_tx.Init.Request             = sdio_config.dma_tx.request;
-    sdio_obj.dma.handle_tx.Init.Direction           = DMA_MEMORY_TO_PERIPH;
-    sdio_obj.dma.handle_tx.Init.PeriphInc           = DMA_PINC_DISABLE;
-    sdio_obj.dma.handle_tx.Init.MemInc              = DMA_MINC_ENABLE;
-    sdio_obj.dma.handle_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
-    sdio_obj.dma.handle_tx.Init.MemDataAlignment    = DMA_MDATAALIGN_WORD;
-    sdio_obj.dma.handle_tx.Init.Mode                = DMA_NORMAL;
-    sdio_obj.dma.handle_tx.Init.Priority            = DMA_PRIORITY_MEDIUM;
+    if (HAL_DMA_Start(&sdio_obj.dma.handle_tx, (uint32_t)src, (uint32_t)dst, BufferSize) != HAL_OK)
+    {
+        LOG_E("sdio dma tx start failed");
+        if (stm32_dma_deinit(&sdio_obj.dma.handle_tx, &sdio_config.dma_tx, RT_FALSE) != RT_EOK)
+        {
+            LOG_E("sdio dma tx rollback failed");
+        }
+        return -RT_ERROR;
+    }
 
-    HAL_DMA_DeInit(&sdio_obj.dma.handle_tx);
-    HAL_DMA_Init(&sdio_obj.dma.handle_tx);
-
-    HAL_DMA_Start(&sdio_obj.dma.handle_tx, (uint32_t)src, (uint32_t)dst, BufferSize);
-#else
-    static uint32_t size = 0;
-    size += BufferSize * 4;
-    sdio_obj.cfg = &sdio_config;
-    sdio_obj.dma.handle_tx.Instance = sdio_config.dma_tx.Instance;
-    sdio_obj.dma.handle_tx.Init.Channel = sdio_config.dma_tx.channel;
-    sdio_obj.dma.handle_tx.Init.Direction           = DMA_MEMORY_TO_PERIPH;
-    sdio_obj.dma.handle_tx.Init.PeriphInc           = DMA_PINC_DISABLE;
-    sdio_obj.dma.handle_tx.Init.MemInc              = DMA_MINC_ENABLE;
-    sdio_obj.dma.handle_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
-    sdio_obj.dma.handle_tx.Init.MemDataAlignment    = DMA_MDATAALIGN_WORD;
-    sdio_obj.dma.handle_tx.Init.Mode                = DMA_PFCTRL;
-    sdio_obj.dma.handle_tx.Init.Priority            = DMA_PRIORITY_MEDIUM;
-    sdio_obj.dma.handle_tx.Init.FIFOMode            = DMA_FIFOMODE_ENABLE;
-    sdio_obj.dma.handle_tx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
-    sdio_obj.dma.handle_tx.Init.MemBurst            = DMA_MBURST_INC4;
-    sdio_obj.dma.handle_tx.Init.PeriphBurst         = DMA_PBURST_INC4;
-    /* DMA_PFCTRL */
-    HAL_DMA_DeInit(&sdio_obj.dma.handle_tx);
-    HAL_DMA_Init(&sdio_obj.dma.handle_tx);
-
-    HAL_DMA_Start(&sdio_obj.dma.handle_tx, (uint32_t)src, (uint32_t)dst, BufferSize);
-#endif
+    return RT_EOK;
 }
 
 /**
-  * @brief  This function configures the DMARX.
-  * @param  BufferDST: pointer to the destination buffer
-  * @param  BufferSize: buffer size
-  * @retval None
+  * @brief  Configure the SDIO DMA RX transfer.
+  * @param  src Pointer to the source address.
+  * @param  dst Pointer to the destination buffer.
+  * @param  BufferSize Number of DMA data units to transfer.
+  * @retval RT_EOK DMA RX transfer is configured and started successfully.
+  * @retval -RT_ERROR DMA RX initialization or start failed.
   */
-void SD_LowLevel_DMA_RxConfig(uint32_t *src, uint32_t *dst, uint32_t BufferSize)
+static rt_err_t SD_LowLevel_DMA_RxConfig(uint32_t *src, uint32_t *dst, uint32_t BufferSize)
+static rt_err_t SD_LowLevel_DMA_RxConfig(uint32_t *src, uint32_t *dst, uint32_t BufferSize)
 {
-#if defined(SOC_SERIES_STM32F1)
     sdio_obj.cfg = &sdio_config;
-    sdio_obj.dma.handle_rx.Instance = sdio_config.dma_tx.Instance;
-    sdio_obj.dma.handle_rx.Init.Direction           = DMA_PERIPH_TO_MEMORY;
-    sdio_obj.dma.handle_rx.Init.MemDataAlignment    = DMA_MDATAALIGN_WORD;
-    sdio_obj.dma.handle_rx.Init.MemInc              = DMA_MINC_ENABLE;
-    sdio_obj.dma.handle_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
-    sdio_obj.dma.handle_rx.Init.PeriphInc           = DMA_PINC_DISABLE;
-    sdio_obj.dma.handle_rx.Init.Priority            = DMA_PRIORITY_MEDIUM;
 
-    HAL_DMA_DeInit(&sdio_obj.dma.handle_rx);
-    HAL_DMA_Init(&sdio_obj.dma.handle_rx);
+    if (stm32_dma_init(&sdio_obj.dma.handle_rx, &sdio_config.dma_rx) != RT_EOK)
+    {
+        LOG_E("sdio dma rx init failed");
+        return -RT_ERROR;
+    }
 
-    HAL_DMA_Start(&sdio_obj.dma.handle_rx, (uint32_t)src, (uint32_t)dst, BufferSize);
-#elif defined(SOC_SERIES_STM32L4)
-    sdio_obj.cfg = &sdio_config;
-    sdio_obj.dma.handle_rx.Instance = sdio_config.dma_tx.Instance;
-    sdio_obj.dma.handle_rx.Init.Request             = sdio_config.dma_tx.request;
-    sdio_obj.dma.handle_rx.Init.Direction           = DMA_PERIPH_TO_MEMORY;
-    sdio_obj.dma.handle_rx.Init.PeriphInc           = DMA_PINC_DISABLE;
-    sdio_obj.dma.handle_rx.Init.MemInc              = DMA_MINC_ENABLE;
-    sdio_obj.dma.handle_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
-    sdio_obj.dma.handle_rx.Init.MemDataAlignment    = DMA_MDATAALIGN_WORD;
-    sdio_obj.dma.handle_rx.Init.Mode                = DMA_NORMAL;
-    sdio_obj.dma.handle_rx.Init.Priority            = DMA_PRIORITY_LOW;
+    if (HAL_DMA_Start(&sdio_obj.dma.handle_rx, (uint32_t)src, (uint32_t)dst, BufferSize) != HAL_OK)
+    {
+        LOG_E("sdio dma rx start failed");
+        if (stm32_dma_deinit(&sdio_obj.dma.handle_rx, &sdio_config.dma_rx, RT_FALSE) != RT_EOK)
+        {
+            LOG_E("sdio dma rx rollback failed");
+        }
+        return -RT_ERROR;
+    }
 
-    HAL_DMA_DeInit(&sdio_obj.dma.handle_rx);
-    HAL_DMA_Init(&sdio_obj.dma.handle_rx);
-
-    HAL_DMA_Start(&sdio_obj.dma.handle_rx, (uint32_t)src, (uint32_t)dst, BufferSize);
-#else
-    sdio_obj.cfg = &sdio_config;
-    sdio_obj.dma.handle_rx.Instance = sdio_config.dma_tx.Instance;
-    sdio_obj.dma.handle_rx.Init.Channel = sdio_config.dma_tx.channel;
-    sdio_obj.dma.handle_rx.Init.Direction           = DMA_PERIPH_TO_MEMORY;
-    sdio_obj.dma.handle_rx.Init.PeriphInc           = DMA_PINC_DISABLE;
-    sdio_obj.dma.handle_rx.Init.MemInc              = DMA_MINC_ENABLE;
-    sdio_obj.dma.handle_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
-    sdio_obj.dma.handle_rx.Init.MemDataAlignment    = DMA_MDATAALIGN_WORD;
-    sdio_obj.dma.handle_rx.Init.Mode                = DMA_PFCTRL;
-    sdio_obj.dma.handle_rx.Init.Priority            = DMA_PRIORITY_MEDIUM;
-    sdio_obj.dma.handle_rx.Init.FIFOMode            = DMA_FIFOMODE_ENABLE;
-    sdio_obj.dma.handle_rx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
-    sdio_obj.dma.handle_rx.Init.MemBurst            = DMA_MBURST_INC4;
-    sdio_obj.dma.handle_rx.Init.PeriphBurst         = DMA_PBURST_INC4;
-
-    HAL_DMA_DeInit(&sdio_obj.dma.handle_rx);
-    HAL_DMA_Init(&sdio_obj.dma.handle_rx);
-
-    HAL_DMA_Start(&sdio_obj.dma.handle_rx, (uint32_t)src, (uint32_t)dst, BufferSize);
-#endif
-
+    return RT_EOK;
 }
 
 /**
@@ -821,14 +754,12 @@ static rt_uint32_t stm32_sdio_clock_get(struct stm32_sdio *hw_sdio)
 
 static rt_err_t DMA_TxConfig(rt_uint32_t *src, rt_uint32_t *dst, int Size)
 {
-    SD_LowLevel_DMA_TxConfig((uint32_t *)src, (uint32_t *)dst, Size / 4);
-    return RT_EOK;
+    return SD_LowLevel_DMA_TxConfig((uint32_t *)src, (uint32_t *)dst, Size / 4);
 }
 
 static rt_err_t DMA_RxConfig(rt_uint32_t *src, rt_uint32_t *dst, int Size)
 {
-    SD_LowLevel_DMA_RxConfig((uint32_t *)src, (uint32_t *)dst, Size / 4);
-    return RT_EOK;
+    return SD_LowLevel_DMA_RxConfig((uint32_t *)src, (uint32_t *)dst, Size / 4);
 }
 
 void SDIO_IRQHandler(void)
@@ -847,19 +778,6 @@ int rt_hw_sdio_init(void)
     struct stm32_sdio_des sdio_des;
     SD_HandleTypeDef hsd;
     hsd.Instance = SDCARD_INSTANCE;
-    {
-        rt_uint32_t tmpreg = 0x00U;
-#if defined(SOC_SERIES_STM32F1)
-        /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-        SET_BIT(RCC->AHBENR, sdio_config.dma_rx.dma_rcc);
-        tmpreg = READ_BIT(RCC->AHBENR, sdio_config.dma_rx.dma_rcc);
-#elif defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32F2)
-        SET_BIT(RCC->AHB1ENR, sdio_config.dma_rx.dma_rcc);
-        /* Delay after an RCC peripheral clock enabling */
-        tmpreg = READ_BIT(RCC->AHB1ENR, sdio_config.dma_rx.dma_rcc);
-#endif
-        UNUSED(tmpreg); /* To avoid compiler warnings */
-    }
     HAL_NVIC_SetPriority(SDIO_IRQn, 2, 0);
     HAL_NVIC_EnableIRQ(SDIO_IRQn);
     HAL_SD_MspInit(&hsd);

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_sdio.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_sdio.h
@@ -77,7 +77,7 @@
 #define HW_SDIO_IT_RXDAVL                      (0x01U << 21)
 #define HW_SDIO_IT_SDIOIT                      (0x01U << 22)
 
-#define HW_SDIO_ERRORS \
+#define HW_SDIO_ERRORS                           \
     (HW_SDIO_IT_CCRCFAIL | HW_SDIO_IT_CTIMEOUT | \
      HW_SDIO_IT_DCRCFAIL | HW_SDIO_IT_DTIMEOUT | \
      HW_SDIO_IT_RXOVERR  | HW_SDIO_IT_TXUNDERR)
@@ -169,7 +169,7 @@ struct stm32_sdio_des
 struct stm32_sdio_config
 {
     SDCARD_INSTANCE_TYPE *Instance;
-    struct dma_config dma_rx, dma_tx;
+    struct stm32_dma_config dma_rx, dma_tx;
 };
 
 /* stm32 sdio dirver class */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_spi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_spi.c
@@ -81,6 +81,23 @@ static struct stm32_spi_config spi_config[] =
 
 static struct stm32_spi spi_bus_obj[sizeof(spi_config) / sizeof(spi_config[0])] = {0};
 
+static void stm32_spi_dma_rollback(struct stm32_spi *spi_drv, rt_uint16_t dma_flags)
+{
+    if ((dma_flags & SPI_USING_RX_DMA_FLAG) && (spi_drv->config->dma_rx != RT_NULL))
+    {
+        (void)stm32_dma_deinit(&spi_drv->dma.handle_rx, spi_drv->config->dma_rx, RT_FALSE);
+        spi_drv->dma.handle_rx.Parent = RT_NULL;
+        spi_drv->handle.hdmarx = RT_NULL;
+    }
+
+    if ((dma_flags & SPI_USING_TX_DMA_FLAG) && (spi_drv->config->dma_tx != RT_NULL))
+    {
+        (void)stm32_dma_deinit(&spi_drv->dma.handle_tx, spi_drv->config->dma_tx, RT_FALSE);
+        spi_drv->dma.handle_tx.Parent = RT_NULL;
+        spi_drv->handle.hdmatx = RT_NULL;
+    }
+}
+
 static rt_err_t stm32_spi_init(struct stm32_spi *spi_drv, struct rt_spi_configuration *cfg)
 {
     RT_ASSERT(spi_drv != RT_NULL);
@@ -255,24 +272,26 @@ static rt_err_t stm32_spi_init(struct stm32_spi *spi_drv, struct rt_spi_configur
     /* DMA configuration */
     if (spi_drv->spi_dma_flag & SPI_USING_RX_DMA_FLAG)
     {
-        HAL_DMA_Init(&spi_drv->dma.handle_rx);
-
-        __HAL_LINKDMA(&spi_drv->handle, hdmarx, spi_drv->dma.handle_rx);
-
-        /* NVIC configuration for DMA transfer complete interrupt */
-        HAL_NVIC_SetPriority(spi_drv->config->dma_rx->dma_irq, 0, 0);
-        HAL_NVIC_EnableIRQ(spi_drv->config->dma_rx->dma_irq);
+        if (stm32_dma_setup(&spi_drv->dma.handle_rx,
+                            &spi_drv->handle,
+                            &spi_drv->handle.hdmarx,
+                            spi_drv->config->dma_rx) != RT_EOK)
+        {
+            stm32_spi_dma_rollback(spi_drv, SPI_USING_RX_DMA_FLAG);
+            return -RT_EIO;
+        }
     }
 
     if (spi_drv->spi_dma_flag & SPI_USING_TX_DMA_FLAG)
     {
-        HAL_DMA_Init(&spi_drv->dma.handle_tx);
-
-        __HAL_LINKDMA(&spi_drv->handle, hdmatx, spi_drv->dma.handle_tx);
-
-        /* NVIC configuration for DMA transfer complete interrupt */
-        HAL_NVIC_SetPriority(spi_drv->config->dma_tx->dma_irq, 1, 0);
-        HAL_NVIC_EnableIRQ(spi_drv->config->dma_tx->dma_irq);
+        if (stm32_dma_setup(&spi_drv->dma.handle_tx,
+                            &spi_drv->handle,
+                            &spi_drv->handle.hdmatx,
+                            spi_drv->config->dma_tx) != RT_EOK)
+        {
+            stm32_spi_dma_rollback(spi_drv, SPI_USING_TX_DMA_FLAG | (spi_drv->spi_dma_flag & SPI_USING_RX_DMA_FLAG));
+            return -RT_EIO;
+        }
     }
 
     if(spi_drv->spi_dma_flag & SPI_USING_TX_DMA_FLAG || spi_drv->spi_dma_flag & SPI_USING_RX_DMA_FLAG)
@@ -564,94 +583,6 @@ static int rt_hw_spi_bus_init(void)
         spi_bus_obj[i].config = &spi_config[i];
         spi_bus_obj[i].spi_bus.parent.user_data = &spi_config[i];
         spi_bus_obj[i].handle.Instance = spi_config[i].Instance;
-
-        if (spi_bus_obj[i].spi_dma_flag & SPI_USING_RX_DMA_FLAG)
-        {
-            /* Configure the DMA handler for Transmission process */
-            spi_bus_obj[i].dma.handle_rx.Instance = spi_config[i].dma_rx->Instance;
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-            spi_bus_obj[i].dma.handle_rx.Init.Channel = spi_config[i].dma_rx->channel;
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-            spi_bus_obj[i].dma.handle_rx.Init.Request = spi_config[i].dma_rx->request;
-#endif
-#ifndef SOC_SERIES_STM32U5
-            spi_bus_obj[i].dma.handle_rx.Init.Direction           = DMA_PERIPH_TO_MEMORY;
-            spi_bus_obj[i].dma.handle_rx.Init.PeriphInc           = DMA_PINC_DISABLE;
-            spi_bus_obj[i].dma.handle_rx.Init.MemInc              = DMA_MINC_ENABLE;
-            spi_bus_obj[i].dma.handle_rx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-            spi_bus_obj[i].dma.handle_rx.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
-            spi_bus_obj[i].dma.handle_rx.Init.Mode                = DMA_NORMAL;
-            spi_bus_obj[i].dma.handle_rx.Init.Priority            = DMA_PRIORITY_HIGH;
-#endif
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7)
-            spi_bus_obj[i].dma.handle_rx.Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
-            spi_bus_obj[i].dma.handle_rx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
-            spi_bus_obj[i].dma.handle_rx.Init.MemBurst            = DMA_MBURST_INC4;
-            spi_bus_obj[i].dma.handle_rx.Init.PeriphBurst         = DMA_PBURST_INC4;
-#endif
-
-            {
-                rt_uint32_t tmpreg = 0x00U;
-#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0)
-                /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-                SET_BIT(RCC->AHBENR, spi_config[i].dma_rx->dma_rcc);
-                tmpreg = READ_BIT(RCC->AHBENR, spi_config[i].dma_rx->dma_rcc);
-#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-                SET_BIT(RCC->AHB1ENR, spi_config[i].dma_rx->dma_rcc);
-                /* Delay after an RCC peripheral clock enabling */
-                tmpreg = READ_BIT(RCC->AHB1ENR, spi_config[i].dma_rx->dma_rcc);
-#elif defined(SOC_SERIES_STM32MP1)
-                __HAL_RCC_DMAMUX_CLK_ENABLE();
-                SET_BIT(RCC->MP_AHB2ENSETR, spi_config[i].dma_rx->dma_rcc);
-                tmpreg = READ_BIT(RCC->MP_AHB2ENSETR, spi_config[i].dma_rx->dma_rcc);
-#endif
-                UNUSED(tmpreg); /* To avoid compiler warnings */
-            }
-        }
-
-        if (spi_bus_obj[i].spi_dma_flag & SPI_USING_TX_DMA_FLAG)
-        {
-            /* Configure the DMA handler for Transmission process */
-            spi_bus_obj[i].dma.handle_tx.Instance = spi_config[i].dma_tx->Instance;
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-            spi_bus_obj[i].dma.handle_tx.Init.Channel = spi_config[i].dma_tx->channel;
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-            spi_bus_obj[i].dma.handle_tx.Init.Request = spi_config[i].dma_tx->request;
-#endif
-#ifndef SOC_SERIES_STM32U5
-            spi_bus_obj[i].dma.handle_tx.Init.Direction           = DMA_MEMORY_TO_PERIPH;
-            spi_bus_obj[i].dma.handle_tx.Init.PeriphInc           = DMA_PINC_DISABLE;
-            spi_bus_obj[i].dma.handle_tx.Init.MemInc              = DMA_MINC_ENABLE;
-            spi_bus_obj[i].dma.handle_tx.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-            spi_bus_obj[i].dma.handle_tx.Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
-            spi_bus_obj[i].dma.handle_tx.Init.Mode                = DMA_NORMAL;
-            spi_bus_obj[i].dma.handle_tx.Init.Priority            = DMA_PRIORITY_LOW;
-#endif
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32MP1) || defined(SOC_SERIES_STM32H7)
-            spi_bus_obj[i].dma.handle_tx.Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
-            spi_bus_obj[i].dma.handle_tx.Init.FIFOThreshold       = DMA_FIFO_THRESHOLD_FULL;
-            spi_bus_obj[i].dma.handle_tx.Init.MemBurst            = DMA_MBURST_INC4;
-            spi_bus_obj[i].dma.handle_tx.Init.PeriphBurst         = DMA_PBURST_INC4;
-#endif
-
-            {
-                rt_uint32_t tmpreg = 0x00U;
-#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32F0)
-                /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-                SET_BIT(RCC->AHBENR, spi_config[i].dma_tx->dma_rcc);
-                tmpreg = READ_BIT(RCC->AHBENR, spi_config[i].dma_tx->dma_rcc);
-#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WB) || defined(SOC_SERIES_STM32H7)
-                SET_BIT(RCC->AHB1ENR, spi_config[i].dma_tx->dma_rcc);
-                /* Delay after an RCC peripheral clock enabling */
-                tmpreg = READ_BIT(RCC->AHB1ENR, spi_config[i].dma_tx->dma_rcc);
-#elif defined(SOC_SERIES_STM32MP1)
-                __HAL_RCC_DMAMUX_CLK_ENABLE();
-                SET_BIT(RCC->MP_AHB2ENSETR, spi_config[i].dma_tx->dma_rcc);
-                tmpreg = READ_BIT(RCC->MP_AHB2ENSETR, spi_config[i].dma_tx->dma_rcc);
-#endif
-                UNUSED(tmpreg); /* To avoid compiler warnings */
-            }
-        }
 
         /* initialize completion object */
         rt_completion_init(&spi_bus_obj[i].cpt);
@@ -1019,67 +950,67 @@ static void stm32_get_dma_info(void)
 {
 #ifdef BSP_SPI1_RX_USING_DMA
     spi_bus_obj[SPI1_INDEX].spi_dma_flag |= SPI_USING_RX_DMA_FLAG;
-    static struct dma_config spi1_dma_rx = SPI1_RX_DMA_CONFIG;
+    static const struct stm32_dma_config spi1_dma_rx = SPI1_RX_DMA_CONFIG;
     spi_config[SPI1_INDEX].dma_rx = &spi1_dma_rx;
 #endif
 #ifdef BSP_SPI1_TX_USING_DMA
     spi_bus_obj[SPI1_INDEX].spi_dma_flag |= SPI_USING_TX_DMA_FLAG;
-    static struct dma_config spi1_dma_tx = SPI1_TX_DMA_CONFIG;
+    static const struct stm32_dma_config spi1_dma_tx = SPI1_TX_DMA_CONFIG;
     spi_config[SPI1_INDEX].dma_tx = &spi1_dma_tx;
 #endif
 
 #ifdef BSP_SPI2_RX_USING_DMA
     spi_bus_obj[SPI2_INDEX].spi_dma_flag |= SPI_USING_RX_DMA_FLAG;
-    static struct dma_config spi2_dma_rx = SPI2_RX_DMA_CONFIG;
+    static const struct stm32_dma_config spi2_dma_rx = SPI2_RX_DMA_CONFIG;
     spi_config[SPI2_INDEX].dma_rx = &spi2_dma_rx;
 #endif
 #ifdef BSP_SPI2_TX_USING_DMA
     spi_bus_obj[SPI2_INDEX].spi_dma_flag |= SPI_USING_TX_DMA_FLAG;
-    static struct dma_config spi2_dma_tx = SPI2_TX_DMA_CONFIG;
+    static const struct stm32_dma_config spi2_dma_tx = SPI2_TX_DMA_CONFIG;
     spi_config[SPI2_INDEX].dma_tx = &spi2_dma_tx;
 #endif
 
 #ifdef BSP_SPI3_RX_USING_DMA
     spi_bus_obj[SPI3_INDEX].spi_dma_flag |= SPI_USING_RX_DMA_FLAG;
-    static struct dma_config spi3_dma_rx = SPI3_RX_DMA_CONFIG;
+    static const struct stm32_dma_config spi3_dma_rx = SPI3_RX_DMA_CONFIG;
     spi_config[SPI3_INDEX].dma_rx = &spi3_dma_rx;
 #endif
 #ifdef BSP_SPI3_TX_USING_DMA
     spi_bus_obj[SPI3_INDEX].spi_dma_flag |= SPI_USING_TX_DMA_FLAG;
-    static struct dma_config spi3_dma_tx = SPI3_TX_DMA_CONFIG;
+    static const struct stm32_dma_config spi3_dma_tx = SPI3_TX_DMA_CONFIG;
     spi_config[SPI3_INDEX].dma_tx = &spi3_dma_tx;
 #endif
 
 #ifdef BSP_SPI4_RX_USING_DMA
     spi_bus_obj[SPI4_INDEX].spi_dma_flag |= SPI_USING_RX_DMA_FLAG;
-    static struct dma_config spi4_dma_rx = SPI4_RX_DMA_CONFIG;
+    static const struct stm32_dma_config spi4_dma_rx = SPI4_RX_DMA_CONFIG;
     spi_config[SPI4_INDEX].dma_rx = &spi4_dma_rx;
 #endif
 #ifdef BSP_SPI4_TX_USING_DMA
     spi_bus_obj[SPI4_INDEX].spi_dma_flag |= SPI_USING_TX_DMA_FLAG;
-    static struct dma_config spi4_dma_tx = SPI4_TX_DMA_CONFIG;
+    static const struct stm32_dma_config spi4_dma_tx = SPI4_TX_DMA_CONFIG;
     spi_config[SPI4_INDEX].dma_tx = &spi4_dma_tx;
 #endif
 
 #ifdef BSP_SPI5_RX_USING_DMA
     spi_bus_obj[SPI5_INDEX].spi_dma_flag |= SPI_USING_RX_DMA_FLAG;
-    static struct dma_config spi5_dma_rx = SPI5_RX_DMA_CONFIG;
+    static const struct stm32_dma_config spi5_dma_rx = SPI5_RX_DMA_CONFIG;
     spi_config[SPI5_INDEX].dma_rx = &spi5_dma_rx;
 #endif
 #ifdef BSP_SPI5_TX_USING_DMA
     spi_bus_obj[SPI5_INDEX].spi_dma_flag |= SPI_USING_TX_DMA_FLAG;
-    static struct dma_config spi5_dma_tx = SPI5_TX_DMA_CONFIG;
+    static const struct stm32_dma_config spi5_dma_tx = SPI5_TX_DMA_CONFIG;
     spi_config[SPI5_INDEX].dma_tx = &spi5_dma_tx;
 #endif
 
 #ifdef BSP_SPI6_RX_USING_DMA
     spi_bus_obj[SPI6_INDEX].spi_dma_flag |= SPI_USING_RX_DMA_FLAG;
-    static struct dma_config spi6_dma_rx = SPI6_RX_DMA_CONFIG;
+    static const struct stm32_dma_config spi6_dma_rx = SPI6_RX_DMA_CONFIG;
     spi_config[SPI6_INDEX].dma_rx = &spi6_dma_rx;
 #endif
 #ifdef BSP_SPI6_TX_USING_DMA
     spi_bus_obj[SPI6_INDEX].spi_dma_flag |= SPI_USING_TX_DMA_FLAG;
-    static struct dma_config spi6_dma_tx = SPI6_TX_DMA_CONFIG;
+    static const struct stm32_dma_config spi6_dma_tx = SPI6_TX_DMA_CONFIG;
     spi_config[SPI6_INDEX].dma_tx = &spi6_dma_tx;
 #endif
 }

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_spi.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_spi.h
@@ -34,7 +34,7 @@ struct stm32_spi_config
     SPI_TypeDef *Instance;
     char *bus_name;
     IRQn_Type irq_type;
-    struct dma_config *dma_rx, *dma_tx;
+    const struct stm32_dma_config *dma_rx, *dma_tx;
 };
 
 struct stm32_spi_device

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart.c
@@ -31,7 +31,7 @@
 #endif
 
 #ifdef RT_SERIAL_USING_DMA
-static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag);
+static rt_err_t stm32_uart_dma_config(struct rt_serial_device *serial, rt_ubase_t flag);
 #endif
 
 enum
@@ -262,23 +262,16 @@ static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *ar
         /* disable DMA */
         if (ctrl_arg == RT_DEVICE_FLAG_DMA_RX)
         {
-            HAL_NVIC_DisableIRQ(uart->config->dma_rx->dma_irq);
-            if (HAL_DMA_Abort(&(uart->dma_rx.handle)) != HAL_OK)
+            if (stm32_dma_deinit(&(uart->dma_rx.handle), uart->config->dma_rx, RT_TRUE) != RT_EOK)
             {
-                RT_ASSERT(0);
-            }
-
-            if (HAL_DMA_DeInit(&(uart->dma_rx.handle)) != HAL_OK)
-            {
-                RT_ASSERT(0);
+                LOG_E("%s dma rx deinit failed", uart->config->name);
             }
         }
         else if(ctrl_arg == RT_DEVICE_FLAG_DMA_TX)
         {
-            HAL_NVIC_DisableIRQ(uart->config->dma_tx->dma_irq);
-            if (HAL_DMA_DeInit(&(uart->dma_tx.handle)) != HAL_OK)
+            if (stm32_dma_deinit(&(uart->dma_tx.handle), uart->config->dma_tx, RT_FALSE) != RT_EOK)
             {
-                RT_ASSERT(0);
+                LOG_E("%s dma tx deinit failed", uart->config->name);
             }
         }
 #endif
@@ -303,8 +296,7 @@ static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *ar
 #ifdef RT_SERIAL_USING_DMA
     case RT_DEVICE_CTRL_CONFIG:
     {
-        stm32_dma_config(serial, ctrl_arg);
-        break;
+        return stm32_uart_dma_config(serial, ctrl_arg);
     }
 #endif
 
@@ -312,7 +304,7 @@ static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *ar
     {
         if (HAL_UART_DeInit(&(uart->handle)) != HAL_OK )
         {
-            RT_ASSERT(0)
+            LOG_E("%s uart deinit failed", uart->config->name);
         }
         break;
     }
@@ -927,12 +919,12 @@ static void stm32_uart_get_dma_config(void)
     uart_obj[UART1_INDEX].uart_dma_flag = 0;
 #ifdef BSP_UART1_RX_USING_DMA
     uart_obj[UART1_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart1_dma_rx = UART1_DMA_RX_CONFIG;
+    static const struct stm32_dma_config uart1_dma_rx = UART1_DMA_RX_CONFIG;
     uart_config[UART1_INDEX].dma_rx = &uart1_dma_rx;
 #endif
 #ifdef BSP_UART1_TX_USING_DMA
     uart_obj[UART1_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart1_dma_tx = UART1_DMA_TX_CONFIG;
+    static const struct stm32_dma_config uart1_dma_tx = UART1_DMA_TX_CONFIG;
     uart_config[UART1_INDEX].dma_tx = &uart1_dma_tx;
 #endif
 #endif
@@ -941,12 +933,12 @@ static void stm32_uart_get_dma_config(void)
     uart_obj[UART2_INDEX].uart_dma_flag = 0;
 #ifdef BSP_UART2_RX_USING_DMA
     uart_obj[UART2_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart2_dma_rx = UART2_DMA_RX_CONFIG;
+    static const struct stm32_dma_config uart2_dma_rx = UART2_DMA_RX_CONFIG;
     uart_config[UART2_INDEX].dma_rx = &uart2_dma_rx;
 #endif
 #ifdef BSP_UART2_TX_USING_DMA
     uart_obj[UART2_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart2_dma_tx = UART2_DMA_TX_CONFIG;
+    static const struct stm32_dma_config uart2_dma_tx = UART2_DMA_TX_CONFIG;
     uart_config[UART2_INDEX].dma_tx = &uart2_dma_tx;
 #endif
 #endif
@@ -955,12 +947,12 @@ static void stm32_uart_get_dma_config(void)
     uart_obj[UART3_INDEX].uart_dma_flag = 0;
 #ifdef BSP_UART3_RX_USING_DMA
     uart_obj[UART3_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart3_dma_rx = UART3_DMA_RX_CONFIG;
+    static const struct stm32_dma_config uart3_dma_rx = UART3_DMA_RX_CONFIG;
     uart_config[UART3_INDEX].dma_rx = &uart3_dma_rx;
 #endif
 #ifdef BSP_UART3_TX_USING_DMA
     uart_obj[UART3_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart3_dma_tx = UART3_DMA_TX_CONFIG;
+    static const struct stm32_dma_config uart3_dma_tx = UART3_DMA_TX_CONFIG;
     uart_config[UART3_INDEX].dma_tx = &uart3_dma_tx;
 #endif
 #endif
@@ -969,12 +961,12 @@ static void stm32_uart_get_dma_config(void)
     uart_obj[UART4_INDEX].uart_dma_flag = 0;
 #ifdef BSP_UART4_RX_USING_DMA
     uart_obj[UART4_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart4_dma_rx = UART4_DMA_RX_CONFIG;
+    static const struct stm32_dma_config uart4_dma_rx = UART4_DMA_RX_CONFIG;
     uart_config[UART4_INDEX].dma_rx = &uart4_dma_rx;
 #endif
 #ifdef BSP_UART4_TX_USING_DMA
     uart_obj[UART4_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart4_dma_tx = UART4_DMA_TX_CONFIG;
+    static const struct stm32_dma_config uart4_dma_tx = UART4_DMA_TX_CONFIG;
     uart_config[UART4_INDEX].dma_tx = &uart4_dma_tx;
 #endif
 #endif
@@ -983,12 +975,12 @@ static void stm32_uart_get_dma_config(void)
     uart_obj[UART5_INDEX].uart_dma_flag = 0;
 #ifdef BSP_UART5_RX_USING_DMA
     uart_obj[UART5_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart5_dma_rx = UART5_DMA_RX_CONFIG;
+    static const struct stm32_dma_config uart5_dma_rx = UART5_DMA_RX_CONFIG;
     uart_config[UART5_INDEX].dma_rx = &uart5_dma_rx;
 #endif
 #ifdef BSP_UART5_TX_USING_DMA
     uart_obj[UART5_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart5_dma_tx = UART5_DMA_TX_CONFIG;
+    static const struct stm32_dma_config uart5_dma_tx = UART5_DMA_TX_CONFIG;
     uart_config[UART5_INDEX].dma_tx = &uart5_dma_tx;
 #endif
 #endif
@@ -997,12 +989,12 @@ static void stm32_uart_get_dma_config(void)
     uart_obj[UART6_INDEX].uart_dma_flag = 0;
 #ifdef BSP_UART6_RX_USING_DMA
     uart_obj[UART6_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart6_dma_rx = UART6_DMA_RX_CONFIG;
+    static const struct stm32_dma_config uart6_dma_rx = UART6_DMA_RX_CONFIG;
     uart_config[UART6_INDEX].dma_rx = &uart6_dma_rx;
 #endif
 #ifdef BSP_UART6_TX_USING_DMA
     uart_obj[UART6_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart6_dma_tx = UART6_DMA_TX_CONFIG;
+    static const struct stm32_dma_config uart6_dma_tx = UART6_DMA_TX_CONFIG;
     uart_config[UART6_INDEX].dma_tx = &uart6_dma_tx;
 #endif
 #endif
@@ -1011,12 +1003,12 @@ static void stm32_uart_get_dma_config(void)
     uart_obj[UART7_INDEX].uart_dma_flag = 0;
 #ifdef BSP_UART7_RX_USING_DMA
     uart_obj[UART7_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart7_dma_rx = UART7_DMA_RX_CONFIG;
+    static const struct stm32_dma_config uart7_dma_rx = UART7_DMA_RX_CONFIG;
     uart_config[UART7_INDEX].dma_rx = &uart7_dma_rx;
 #endif
 #ifdef BSP_UART7_TX_USING_DMA
     uart_obj[UART7_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart7_dma_tx = UART7_DMA_TX_CONFIG;
+    static const struct stm32_dma_config uart7_dma_tx = UART7_DMA_TX_CONFIG;
     uart_config[UART7_INDEX].dma_tx = &uart7_dma_tx;
 #endif
 #endif
@@ -1025,12 +1017,12 @@ static void stm32_uart_get_dma_config(void)
     uart_obj[UART8_INDEX].uart_dma_flag = 0;
 #ifdef BSP_UART8_RX_USING_DMA
     uart_obj[UART8_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart8_dma_rx = UART8_DMA_RX_CONFIG;
+    static const struct stm32_dma_config uart8_dma_rx = UART8_DMA_RX_CONFIG;
     uart_config[UART8_INDEX].dma_rx = &uart8_dma_rx;
 #endif
 #ifdef BSP_UART8_TX_USING_DMA
     uart_obj[UART8_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart8_dma_tx = UART8_DMA_TX_CONFIG;
+    static const struct stm32_dma_config uart8_dma_tx = UART8_DMA_TX_CONFIG;
     uart_config[UART8_INDEX].dma_tx = &uart8_dma_tx;
 #endif
 #endif
@@ -1039,18 +1031,18 @@ static void stm32_uart_get_dma_config(void)
     uart_obj[LPUART1_INDEX].uart_dma_flag = 0;
 #ifdef BSP_LPUART1_RX_USING_DMA
     uart_obj[LPUART1_INDEX].uart_dma_flag |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config lpuart1_dma_rx = LPUART1_DMA_CONFIG;
+    static const struct stm32_dma_config lpuart1_dma_rx = LPUART1_DMA_CONFIG;
     uart_config[LPUART1_INDEX].dma_rx = &lpuart1_dma_rx;
 #endif
 #endif
 }
 
 #ifdef RT_SERIAL_USING_DMA
-static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
+static rt_err_t stm32_uart_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
 {
     struct rt_serial_rx_fifo *rx_fifo;
     DMA_HandleTypeDef *DMA_Handle;
-    struct dma_config *dma_config;
+    const struct stm32_dma_config *dma_config;
     struct stm32_uart *uart;
 
     RT_ASSERT(serial != RT_NULL);
@@ -1069,81 +1061,27 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
     }
     LOG_D("%s dma config start", uart->config->name);
 
-    {
-        rt_uint32_t tmpreg = 0x00U;
-#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32G0) \
-    || defined(SOC_SERIES_STM32L0)|| defined(SOC_SERIES_STM32F3) || defined(SOC_SERIES_STM32L1)
-        /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-        SET_BIT(RCC->AHBENR, dma_config->dma_rcc);
-        tmpreg = READ_BIT(RCC->AHBENR, dma_config->dma_rcc);
-#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) \
-    || defined(SOC_SERIES_STM32G4)|| defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32WB)
-        /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-        SET_BIT(RCC->AHB1ENR, dma_config->dma_rcc);
-        tmpreg = READ_BIT(RCC->AHB1ENR, dma_config->dma_rcc);
-#elif defined(SOC_SERIES_STM32MP1)
-        /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-        SET_BIT(RCC->MP_AHB2ENSETR, dma_config->dma_rcc);
-        tmpreg = READ_BIT(RCC->MP_AHB2ENSETR, dma_config->dma_rcc);
-#endif
-
-#if (defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) || defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32WB)) && defined(DMAMUX1)
-        /* enable DMAMUX clock for L4+ and G4 */
-        __HAL_RCC_DMAMUX1_CLK_ENABLE();
-#elif defined(SOC_SERIES_STM32MP1)
-        __HAL_RCC_DMAMUX_CLK_ENABLE();
-#endif
-
-        UNUSED(tmpreg);   /* To avoid compiler warnings */
-    }
-
     if (RT_DEVICE_FLAG_DMA_RX == flag)
     {
-        __HAL_LINKDMA(&(uart->handle), hdmarx, uart->dma_rx.handle);
+        if (stm32_dma_setup(DMA_Handle,
+                            &(uart->handle),
+                            &uart->handle.hdmarx,
+                            dma_config) != RT_EOK)
+        {
+            LOG_E("%s dma rx config failed", uart->config->name);
+            return -RT_ERROR;
+        }
     }
     else if (RT_DEVICE_FLAG_DMA_TX == flag)
     {
-        __HAL_LINKDMA(&(uart->handle), hdmatx, uart->dma_tx.handle);
-    }
-
-#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32L0)|| defined(SOC_SERIES_STM32F3) || defined(SOC_SERIES_STM32L1) || defined(SOC_SERIES_STM32U5) || defined(SOC_SERIES_STM32H5)
-    DMA_Handle->Instance                 = dma_config->Instance;
-#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-    DMA_Handle->Instance                 = dma_config->Instance;
-    DMA_Handle->Init.Channel             = dma_config->channel;
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32WB)\
-    || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32MP1)
-    DMA_Handle->Instance                 = dma_config->Instance;
-    DMA_Handle->Init.Request             = dma_config->request;
-#endif
-    DMA_Handle->Init.PeriphInc           = DMA_PINC_DISABLE;
-    DMA_Handle->Init.MemInc              = DMA_MINC_ENABLE;
-    DMA_Handle->Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-    DMA_Handle->Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
-
-    if (RT_DEVICE_FLAG_DMA_RX == flag)
-    {
-        DMA_Handle->Init.Direction           = DMA_PERIPH_TO_MEMORY;
-        DMA_Handle->Init.Mode                = DMA_CIRCULAR;
-    }
-    else if (RT_DEVICE_FLAG_DMA_TX == flag)
-    {
-        DMA_Handle->Init.Direction           = DMA_MEMORY_TO_PERIPH;
-        DMA_Handle->Init.Mode                = DMA_NORMAL;
-    }
-
-    DMA_Handle->Init.Priority            = DMA_PRIORITY_MEDIUM;
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32MP1)
-    DMA_Handle->Init.FIFOMode            = DMA_FIFOMODE_DISABLE;
-#endif
-    if (HAL_DMA_DeInit(DMA_Handle) != HAL_OK)
-    {
-        RT_ASSERT(0);
-    }
-
-    if (HAL_DMA_Init(DMA_Handle) != HAL_OK)
-    {
-        RT_ASSERT(0);
+        if (stm32_dma_setup(DMA_Handle,
+                            &(uart->handle),
+                            &uart->handle.hdmatx,
+                            dma_config) != RT_EOK)
+        {
+            LOG_E("%s dma tx config failed", uart->config->name);
+            return -RT_ERROR;
+        }
     }
 
     /* enable interrupt */
@@ -1154,21 +1092,26 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         if (HAL_UART_Receive_DMA(&(uart->handle), rx_fifo->buffer, serial->config.bufsz) != HAL_OK)
         {
             /* Transfer error in reception process */
-            RT_ASSERT(0);
+            LOG_E("%s uart dma rx start failed", uart->config->name);
+            if (stm32_dma_deinit(DMA_Handle, dma_config, RT_FALSE) != RT_EOK)
+            {
+                LOG_E("%s uart dma rx rollback failed", uart->config->name);
+            }
+            uart->handle.hdmarx = RT_NULL;
+            DMA_Handle->Parent = RT_NULL;
+            return -RT_ERROR;
         }
         CLEAR_BIT(uart->handle.Instance->CR3, USART_CR3_EIE);
         __HAL_UART_ENABLE_IT(&(uart->handle), UART_IT_IDLE);
     }
-
-    /* DMA irq should set in DMA TX mode, or HAL_UART_TxCpltCallback function will not be called */
-    HAL_NVIC_SetPriority(dma_config->dma_irq, 0, 0);
-    HAL_NVIC_EnableIRQ(dma_config->dma_irq);
 
     HAL_NVIC_SetPriority(uart->config->irq_type, 1, 0);
     HAL_NVIC_EnableIRQ(uart->config->irq_type);
 
     LOG_D("%s dma %s instance: %x", uart->config->name, flag == RT_DEVICE_FLAG_DMA_RX ? "RX" : "TX", DMA_Handle->Instance);
     LOG_D("%s dma config done", uart->config->name);
+
+    return RT_EOK;
 }
 
 /**

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart.h
@@ -21,14 +21,6 @@
 
 int rt_hw_usart_init(void);
 
-#if defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) \
-    || defined(SOC_SERIES_STM32L0) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32WB)|| defined(SOC_SERIES_STM32F3)
-#define DMA_INSTANCE_TYPE              DMA_Channel_TypeDef
-#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) \
-    || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32MP1)
-#define DMA_INSTANCE_TYPE              DMA_Stream_TypeDef
-#endif /*  defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) */
-
 #if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32L5) || defined(SOC_SERIES_STM32WL) \
     || defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32L0) || defined(SOC_SERIES_STM32G0) \
     || defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32WB)|| defined(SOC_SERIES_STM32F3) || defined(SOC_SERIES_STM32U5) \
@@ -51,8 +43,8 @@ struct stm32_uart_config
     const char *name;
     USART_TypeDef *Instance;
     IRQn_Type irq_type;
-    struct dma_config *dma_rx;
-    struct dma_config *dma_tx;
+    const struct stm32_dma_config *dma_rx;
+    const struct stm32_dma_config *dma_tx;
 };
 
 /* stm32 uart dirver class */

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.c
@@ -28,7 +28,7 @@
 #endif
 
 #ifdef RT_SERIAL_USING_DMA
-static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag);
+static rt_err_t stm32_uart_dma_config(struct rt_serial_device *serial, rt_ubase_t flag);
 #endif
 
 enum
@@ -237,28 +237,18 @@ static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *ar
         {
             __HAL_UART_DISABLE_IT(&(uart->handle), UART_IT_RXNE);
 
-            HAL_NVIC_DisableIRQ(uart->config->dma_rx->dma_irq);
-            if (HAL_DMA_Abort(&(uart->dma_rx.handle)) != HAL_OK)
+            if (stm32_dma_deinit(&(uart->dma_rx.handle), uart->config->dma_rx, RT_TRUE) != RT_EOK)
             {
-                RT_ASSERT(0);
-            }
-
-            if (HAL_DMA_DeInit(&(uart->dma_rx.handle)) != HAL_OK)
-            {
-                RT_ASSERT(0);
+                LOG_E("%s dma rx deinit failed", uart->config->name);
             }
         }
         else if (ctrl_arg == RT_DEVICE_FLAG_DMA_TX)
         {
             __HAL_UART_DISABLE_IT(&(uart->handle), UART_IT_TC);
 
-            HAL_NVIC_DisableIRQ(uart->config->dma_tx->dma_irq);
-
-            HAL_DMA_Abort(&(uart->dma_tx.handle));
-
-            if (HAL_DMA_DeInit(&(uart->dma_tx.handle)) != HAL_OK)
+            if (stm32_dma_deinit(&(uart->dma_tx.handle), uart->config->dma_tx, RT_TRUE) != RT_EOK)
             {
-                RT_ASSERT(0);
+                LOG_E("%s dma tx deinit failed", uart->config->name);
             }
         }
 #endif
@@ -279,7 +269,7 @@ static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *ar
         if (ctrl_arg & (RT_DEVICE_FLAG_DMA_RX | RT_DEVICE_FLAG_DMA_TX))
         {
 #ifdef RT_SERIAL_USING_DMA
-            stm32_dma_config(serial, ctrl_arg);
+            stm32_uart_dma_config(serial, ctrl_arg);
 #else
             return -RT_ENOSYS;
 #endif
@@ -300,9 +290,10 @@ static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *ar
     case RT_DEVICE_CTRL_CLOSE:
     {
         uart->error_indicate = RT_NULL;
-        if (HAL_UART_DeInit(&(uart->handle)) != HAL_OK)
+        HAL_StatusTypeDef status = HAL_UART_DeInit(&uart->handle);
+        if (status != HAL_OK)
         {
-            RT_ASSERT(0)
+            LOG_E("(%s) serial deinit error %d!", serial->parent.parent.name, status);
         }
         break;
     }
@@ -941,15 +932,15 @@ static void stm32_uart_get_config(void)
 
 #ifdef BSP_UART1_RX_USING_DMA
     uart_obj[UART1_INDEX].serial.config.dma_ping_bufsz  = BSP_UART1_DMA_PING_BUFSIZE;
-    uart_obj[UART1_INDEX].uart_dma_flag                |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart1_dma_rx               = UART1_DMA_RX_CONFIG;
+    uart_obj[UART1_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_RX;
+    static const struct stm32_dma_config uart1_dma_rx   = UART1_DMA_RX_CONFIG;
     uart_config[UART1_INDEX].dma_rx                     = &uart1_dma_rx;
 #endif
 
 #ifdef BSP_UART1_TX_USING_DMA
-    uart_obj[UART1_INDEX].uart_dma_flag   |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart1_dma_tx  = UART1_DMA_TX_CONFIG;
-    uart_config[UART1_INDEX].dma_tx        = &uart1_dma_tx;
+    uart_obj[UART1_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_TX;
+    static const struct stm32_dma_config uart1_dma_tx   = UART1_DMA_TX_CONFIG;
+    uart_config[UART1_INDEX].dma_tx                     = &uart1_dma_tx;
 #endif
 #endif
 
@@ -962,15 +953,15 @@ static void stm32_uart_get_config(void)
 
 #ifdef BSP_UART2_RX_USING_DMA
     uart_obj[UART2_INDEX].serial.config.dma_ping_bufsz  = BSP_UART2_DMA_PING_BUFSIZE;
-    uart_obj[UART2_INDEX].uart_dma_flag                |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart2_dma_rx               = UART2_DMA_RX_CONFIG;
+    uart_obj[UART2_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_RX;
+    static const struct stm32_dma_config uart2_dma_rx   = UART2_DMA_RX_CONFIG;
     uart_config[UART2_INDEX].dma_rx                     = &uart2_dma_rx;
 #endif
 
 #ifdef BSP_UART2_TX_USING_DMA
-    uart_obj[UART2_INDEX].uart_dma_flag   |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart2_dma_tx  = UART2_DMA_TX_CONFIG;
-    uart_config[UART2_INDEX].dma_tx        = &uart2_dma_tx;
+    uart_obj[UART2_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_TX;
+    static const struct stm32_dma_config uart2_dma_tx   = UART2_DMA_TX_CONFIG;
+    uart_config[UART2_INDEX].dma_tx                     = &uart2_dma_tx;
 #endif
 #endif
 
@@ -983,15 +974,15 @@ static void stm32_uart_get_config(void)
 
 #ifdef BSP_UART3_RX_USING_DMA
     uart_obj[UART3_INDEX].serial.config.dma_ping_bufsz  = BSP_UART3_DMA_PING_BUFSIZE;
-    uart_obj[UART3_INDEX].uart_dma_flag                |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart3_dma_rx               = UART3_DMA_RX_CONFIG;
+    uart_obj[UART3_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_RX;
+    static const struct stm32_dma_config uart3_dma_rx   = UART3_DMA_RX_CONFIG;
     uart_config[UART3_INDEX].dma_rx                     = &uart3_dma_rx;
 #endif
 
 #ifdef BSP_UART3_TX_USING_DMA
-    uart_obj[UART3_INDEX].uart_dma_flag   |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart3_dma_tx  = UART3_DMA_TX_CONFIG;
-    uart_config[UART3_INDEX].dma_tx        = &uart3_dma_tx;
+    uart_obj[UART3_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_TX;
+    static const struct stm32_dma_config uart3_dma_tx   = UART3_DMA_TX_CONFIG;
+    uart_config[UART3_INDEX].dma_tx                     = &uart3_dma_tx;
 #endif
 #endif
 
@@ -1004,15 +995,15 @@ static void stm32_uart_get_config(void)
 
 #ifdef BSP_UART4_RX_USING_DMA
     uart_obj[UART4_INDEX].serial.config.dma_ping_bufsz  = BSP_UART4_DMA_PING_BUFSIZE;
-    uart_obj[UART4_INDEX].uart_dma_flag                |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart4_dma_rx               = UART4_DMA_RX_CONFIG;
+    uart_obj[UART4_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_RX;
+    static const struct stm32_dma_config uart4_dma_rx   = UART4_DMA_RX_CONFIG;
     uart_config[UART4_INDEX].dma_rx                     = &uart4_dma_rx;
 #endif
 
 #ifdef BSP_UART4_TX_USING_DMA
-    uart_obj[UART4_INDEX].uart_dma_flag   |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart4_dma_tx  = UART4_DMA_TX_CONFIG;
-    uart_config[UART4_INDEX].dma_tx        = &uart4_dma_tx;
+    uart_obj[UART4_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_TX;
+    static const struct stm32_dma_config uart4_dma_tx   = UART4_DMA_TX_CONFIG;
+    uart_config[UART4_INDEX].dma_tx                     = &uart4_dma_tx;
 #endif
 #endif
 
@@ -1025,15 +1016,15 @@ static void stm32_uart_get_config(void)
 
 #ifdef BSP_UART5_RX_USING_DMA
     uart_obj[UART5_INDEX].serial.config.dma_ping_bufsz  = BSP_UART5_DMA_PING_BUFSIZE;
-    uart_obj[UART5_INDEX].uart_dma_flag                |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart5_dma_rx               = UART5_DMA_RX_CONFIG;
+    uart_obj[UART5_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_RX;
+    static const struct stm32_dma_config uart5_dma_rx   = UART5_DMA_RX_CONFIG;
     uart_config[UART5_INDEX].dma_rx                     = &uart5_dma_rx;
 #endif
 
 #ifdef BSP_UART5_TX_USING_DMA
-    uart_obj[UART5_INDEX].uart_dma_flag   |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart5_dma_tx  = UART5_DMA_TX_CONFIG;
-    uart_config[UART5_INDEX].dma_tx        = &uart5_dma_tx;
+    uart_obj[UART5_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_TX;
+    static const struct stm32_dma_config uart5_dma_tx   = UART5_DMA_TX_CONFIG;
+    uart_config[UART5_INDEX].dma_tx                     = &uart5_dma_tx;
 #endif
 #endif
 
@@ -1046,15 +1037,15 @@ static void stm32_uart_get_config(void)
 
 #ifdef BSP_UART6_RX_USING_DMA
     uart_obj[UART6_INDEX].serial.config.dma_ping_bufsz  = BSP_UART6_DMA_PING_BUFSIZE;
-    uart_obj[UART6_INDEX].uart_dma_flag                |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart6_dma_rx               = UART6_DMA_RX_CONFIG;
+    uart_obj[UART6_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_RX;
+    static const struct stm32_dma_config uart6_dma_rx   = UART6_DMA_RX_CONFIG;
     uart_config[UART6_INDEX].dma_rx                     = &uart6_dma_rx;
 #endif
 
 #ifdef BSP_UART6_TX_USING_DMA
-    uart_obj[UART6_INDEX].uart_dma_flag   |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart6_dma_tx  = UART6_DMA_TX_CONFIG;
-    uart_config[UART6_INDEX].dma_tx        = &uart6_dma_tx;
+    uart_obj[UART6_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_TX;
+    static const struct stm32_dma_config uart6_dma_tx   = UART6_DMA_TX_CONFIG;
+    uart_config[UART6_INDEX].dma_tx                     = &uart6_dma_tx;
 #endif
 #endif
 
@@ -1067,15 +1058,15 @@ static void stm32_uart_get_config(void)
 
 #ifdef BSP_UART7_RX_USING_DMA
     uart_obj[UART7_INDEX].serial.config.dma_ping_bufsz  = BSP_UART7_DMA_PING_BUFSIZE;
-    uart_obj[UART7_INDEX].uart_dma_flag                |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart7_dma_rx               = UART7_DMA_RX_CONFIG;
+    uart_obj[UART7_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_RX;
+    static const struct stm32_dma_config uart7_dma_rx   = UART7_DMA_RX_CONFIG;
     uart_config[UART7_INDEX].dma_rx                     = &uart7_dma_rx;
 #endif
 
 #ifdef BSP_UART7_TX_USING_DMA
-    uart_obj[UART7_INDEX].uart_dma_flag   |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart7_dma_tx  = UART7_DMA_TX_CONFIG;
-    uart_config[UART7_INDEX].dma_tx        = &uart7_dma_tx;
+    uart_obj[UART7_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_TX;
+    static const struct stm32_dma_config uart7_dma_tx   = UART7_DMA_TX_CONFIG;
+    uart_config[UART7_INDEX].dma_tx                     = &uart7_dma_tx;
 #endif
 #endif
 
@@ -1087,15 +1078,15 @@ static void stm32_uart_get_config(void)
     uart_obj[UART8_INDEX].serial.config.tx_bufsz = BSP_UART8_TX_BUFSIZE;
 
 #ifdef BSP_UART8_RX_USING_DMA
-    uart_obj[UART8_INDEX].uart_dma_flag   |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config uart8_dma_rx  = UART8_DMA_RX_CONFIG;
-    uart_config[UART8_INDEX].dma_rx        = &uart8_dma_rx;
+    uart_obj[UART8_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_RX;
+    static const struct stm32_dma_config uart8_dma_rx   = UART8_DMA_RX_CONFIG;
+    uart_config[UART8_INDEX].dma_rx                     = &uart8_dma_rx;
 #endif
 
 #ifdef BSP_UART8_TX_USING_DMA
     uart_obj[UART8_INDEX].serial.config.dma_ping_bufsz  = BSP_UART8_DMA_PING_BUFSIZE;
-    uart_obj[UART8_INDEX].uart_dma_flag                |= RT_DEVICE_FLAG_DMA_TX;
-    static struct dma_config uart8_dma_tx               = UART8_DMA_TX_CONFIG;
+    uart_obj[UART8_INDEX].uart_dma_flag                 |= RT_DEVICE_FLAG_DMA_TX;
+    static const struct stm32_dma_config uart8_dma_tx   = UART8_DMA_TX_CONFIG;
     uart_config[UART8_INDEX].dma_tx                     = &uart8_dma_tx;
 #endif
 #endif
@@ -1108,19 +1099,19 @@ static void stm32_uart_get_config(void)
     uart_obj[LPUART1_INDEX].serial.config.tx_bufsz = BSP_LPUART1_TX_BUFSIZE;
 
 #ifdef BSP_LPUART1_RX_USING_DMA
-    uart_obj[LPUART1_INDEX].serial.config.dma_ping_bufsz  = BSP_LPUART1_DMA_PING_BUFSIZE;
-    uart_obj[LPUART1_INDEX].uart_dma_flag                |= RT_DEVICE_FLAG_DMA_RX;
-    static struct dma_config lpuart1_dma_rx               = LPUART1_DMA_CONFIG;
-    uart_config[LPUART1_INDEX].dma_rx                     = &lpuart1_dma_rx;
+    uart_obj[LPUART1_INDEX].serial.config.dma_ping_bufsz    = BSP_LPUART1_DMA_PING_BUFSIZE;
+    uart_obj[LPUART1_INDEX].uart_dma_flag                   |= RT_DEVICE_FLAG_DMA_RX;
+    static const struct stm32_dma_config lpuart1_dma_rx     = LPUART1_DMA_CONFIG;
+    uart_config[LPUART1_INDEX].dma_rx                       = &lpuart1_dma_rx;
 #endif
 #endif
 }
 
 #ifdef RT_SERIAL_USING_DMA
-static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
+static rt_err_t stm32_uart_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
 {
     DMA_HandleTypeDef *DMA_Handle;
-    struct dma_config *dma_config;
+    const struct stm32_dma_config *dma_config;
     struct stm32_uart *uart;
 
     RT_ASSERT(serial != RT_NULL);
@@ -1139,81 +1130,27 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
     }
     LOG_D("%s dma config start", uart->config->name);
 
-    {
-        rt_uint32_t tmpreg = 0x00U;
-#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32G0) \
-    || defined(SOC_SERIES_STM32L0)
-        /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-        SET_BIT(RCC->AHBENR, dma_config->dma_rcc);
-        tmpreg = READ_BIT(RCC->AHBENR, dma_config->dma_rcc);
-#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) \
-    || defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32WB)
-        /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-        SET_BIT(RCC->AHB1ENR, dma_config->dma_rcc);
-        tmpreg = READ_BIT(RCC->AHB1ENR, dma_config->dma_rcc);
-#elif defined(SOC_SERIES_STM32MP1)
-        /* enable DMA clock && Delay after an RCC peripheral clock enabling*/
-        SET_BIT(RCC->MP_AHB2ENSETR, dma_config->dma_rcc);
-        tmpreg = READ_BIT(RCC->MP_AHB2ENSETR, dma_config->dma_rcc);
-#endif
-
-#if defined(DMAMUX1) && (defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) || defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32WB))
-        /* enable DMAMUX clock for L4+ and G4 */
-        __HAL_RCC_DMAMUX1_CLK_ENABLE();
-#elif defined(SOC_SERIES_STM32MP1)
-        __HAL_RCC_DMAMUX_CLK_ENABLE();
-#endif
-
-        UNUSED(tmpreg); /* To avoid compiler warnings */
-    }
-
     if (RT_DEVICE_FLAG_DMA_RX == flag)
     {
-        __HAL_LINKDMA(&(uart->handle), hdmarx, uart->dma_rx.handle);
+        if (stm32_dma_setup(DMA_Handle,
+                            &(uart->handle),
+                            &uart->handle.hdmarx,
+                            dma_config) != RT_EOK)
+        {
+            LOG_E("%s dma rx config failed", uart->config->name);
+            return -RT_ERROR;
+        }
     }
     else if (RT_DEVICE_FLAG_DMA_TX == flag)
     {
-        __HAL_LINKDMA(&(uart->handle), hdmatx, uart->dma_tx.handle);
-    }
-
-#if defined(SOC_SERIES_STM32F1) || defined(SOC_SERIES_STM32F0) || defined(SOC_SERIES_STM32L0) || defined(SOC_SERIES_STM32F3) || defined(SOC_SERIES_STM32L1) || defined(SOC_SERIES_STM32U5) || defined(SOC_SERIES_STM32H5)
-    DMA_Handle->Instance = dma_config->Instance;
-#elif defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7)
-    DMA_Handle->Instance     = dma_config->Instance;
-    DMA_Handle->Init.Channel = dma_config->channel;
-#elif defined(SOC_SERIES_STM32L4) || defined(SOC_SERIES_STM32WL) || defined(SOC_SERIES_STM32G0) || defined(SOC_SERIES_STM32G4) || defined(SOC_SERIES_STM32WB) \
-    || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32MP1)
-    DMA_Handle->Instance     = dma_config->Instance;
-    DMA_Handle->Init.Request = dma_config->request;
-#endif
-    DMA_Handle->Init.PeriphInc           = DMA_PINC_DISABLE;
-    DMA_Handle->Init.MemInc              = DMA_MINC_ENABLE;
-    DMA_Handle->Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
-    DMA_Handle->Init.MemDataAlignment    = DMA_MDATAALIGN_BYTE;
-
-    if (RT_DEVICE_FLAG_DMA_RX == flag)
-    {
-        DMA_Handle->Init.Direction = DMA_PERIPH_TO_MEMORY;
-        DMA_Handle->Init.Mode      = DMA_CIRCULAR;
-    }
-    else if (RT_DEVICE_FLAG_DMA_TX == flag)
-    {
-        DMA_Handle->Init.Direction = DMA_MEMORY_TO_PERIPH;
-        DMA_Handle->Init.Mode      = DMA_NORMAL;
-    }
-
-    DMA_Handle->Init.Priority = DMA_PRIORITY_MEDIUM;
-#if defined(SOC_SERIES_STM32F2) || defined(SOC_SERIES_STM32F4) || defined(SOC_SERIES_STM32F7) || defined(SOC_SERIES_STM32H7) || defined(SOC_SERIES_STM32MP1)
-    DMA_Handle->Init.FIFOMode = DMA_FIFOMODE_DISABLE;
-#endif
-    if (HAL_DMA_DeInit(DMA_Handle) != HAL_OK)
-    {
-        RT_ASSERT(0);
-    }
-
-    if (HAL_DMA_Init(DMA_Handle) != HAL_OK)
-    {
-        RT_ASSERT(0);
+        if (stm32_dma_setup(DMA_Handle,
+                            &(uart->handle),
+                            &uart->handle.hdmatx,
+                            dma_config) != RT_EOK)
+        {
+            LOG_E("%s dma tx config failed", uart->config->name);
+            return -RT_ERROR;
+        }
     }
 
     /* enable interrupt */
@@ -1226,21 +1163,26 @@ static void stm32_dma_config(struct rt_serial_device *serial, rt_ubase_t flag)
         if (HAL_UART_Receive_DMA(&(uart->handle), ptr, serial->config.dma_ping_bufsz) != HAL_OK)
         {
             /* Transfer error in reception process */
-            RT_ASSERT(0);
+            LOG_E("%s uart dma rx start failed", uart->config->name);
+            if (stm32_dma_deinit(DMA_Handle, dma_config, RT_FALSE) != RT_EOK)
+            {
+                LOG_E("%s uart dma rx rollback failed", uart->config->name);
+            }
+            uart->handle.hdmarx = RT_NULL;
+            DMA_Handle->Parent = RT_NULL;
+            return -RT_ERROR;
         }
         CLEAR_BIT(uart->handle.Instance->CR3, USART_CR3_EIE);
         __HAL_UART_ENABLE_IT(&(uart->handle), UART_IT_IDLE);
     }
-
-    /* DMA irq should set in DMA TX mode, or HAL_UART_TxCpltCallback function will not be called */
-    HAL_NVIC_SetPriority(dma_config->dma_irq, 0, 0);
-    HAL_NVIC_EnableIRQ(dma_config->dma_irq);
 
     HAL_NVIC_SetPriority(uart->config->irq_type, 1, 0);
     HAL_NVIC_EnableIRQ(uart->config->irq_type);
 
     LOG_D("%s dma %s instance: %x", uart->config->name, flag == RT_DEVICE_FLAG_DMA_RX ? "RX" : "TX", DMA_Handle->Instance);
     LOG_D("%s dma config done", uart->config->name);
+
+    return RT_EOK;
 }
 
 /**

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.h
@@ -57,8 +57,8 @@ struct stm32_uart_config
     IRQn_Type irq_type;
 
 #ifdef RT_SERIAL_USING_DMA
-    struct dma_config *dma_rx;
-    struct dma_config *dma_tx;
+    const struct stm32_dma_config *dma_rx;
+    const struct stm32_dma_config *dma_tx;
 #endif
 };
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

当前 STM32 HAL_Drivers 中 DMA 相关实现分散在两层：

1. 外设驱动层分别维护 DMA 初始化、时钟使能、IRQ 配置、回滚和反初始化逻辑；
2. 各系列配置头文件分别维护 DMA 端点描述，存在大量重复字段展开和系列差异分支。

这种实现方式导致 DMA 接入路径和配置表达方式不统一，增加了维护成本，也不利于后续扩展更多 STM32 系列或外设 DMA 场景。

#### 你的解决方案是什么 (what is your solution)

本次修改统一了驱动侧和配置侧两部分 DMA 逻辑：

1. 在驱动侧新增 `drv_dma.c` / `drv_dma.h`，引入 `stm32_dma_config` 描述结构以及 `stm32_dma_init()`、`stm32_dma_setup()`、`stm32_dma_deinit()` 等公共 helper，用于统一处理 DMA 控制器时钟开启、DMAMUX 使能、HAL DMA 参数下发、NVIC 配置和反初始化流程。

2. 将 `drv_hard_i2c.c`、`drv_spi.c`、`drv_usart.c`、`drv_usart_v2.c`、`drv_qspi.c`、`drv_sdio.c` 中原有分散的 DMA 初始化和回滚逻辑切换为复用公共 helper，并将驱动内部相关 DMA 配置改为 `const struct stm32_dma_config`。

3. 在配置侧，将多个 STM32 系列下 `SPI/UART/I2C/SDIO/QSPI` 的 DMA 配置宏迁移为统一的描述符初始化宏，如 `STM32_DMA_*_CONFIG_INIT_EX` 和 `STM32_DMA_CONFIG_INIT_FIFO_EX`，并补充可覆写的 `DMA_PRIORITY`、`DMA_PREEMPT_PRIORITY`、`DMA_SUB_PRIORITY` 字段，以统一不同系列配置头的表达方式。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
  - 已验证F4 I2C SPI UART DMA RX TX可用

- .config:
  - 需根据实际验证情况补充 DMA 相关配置项
  - 例如：`BSP_SPIx_TX_USING_DMA`、`BSP_SPIx_RX_USING_DMA`、`BSP_UARTx_TX_USING_DMA`、`BSP_UARTx_RX_USING_DMA`、`BSP_I2Cx_TX_USING_DMA`、`BSP_I2Cx_RX_USING_DMA`、`BSP_QSPI_USING_DMA`、`BSP_USING_SDIO`

- action:
  - 当前未提供 PR 分支 action 编译成功链接，需提交者补充

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)