### PR TITLE
[fix] components: serial_v2: preserve RT_DEVICE_FLAG_STREAM when reop…

### DIFF
--- a/components/drivers/serial/dev_serial_v2.c
+++ b/components/drivers/serial/dev_serial_v2.c
@@ -91,8 +91,17 @@ static int serial_fops_open(struct dfs_file *fd)
     if ((fd->flags & O_ACCMODE) != O_WRONLY)
         rt_device_set_rx_indicate(device, serial_fops_rx_ind);
 
+    flags |= RT_SERIAL_RX_BLOCKING | RT_SERIAL_TX_BLOCKING;
+
+    /* preserve RT_DEVICE_FLAG_STREAM if it was set before close */
+    if (device->open_flag & RT_DEVICE_FLAG_STREAM)
+    {
+        flags |= RT_DEVICE_FLAG_STREAM;
+    }
+
     rt_device_close(device);
-    ret = rt_device_open(device, flags | RT_SERIAL_RX_BLOCKING | RT_SERIAL_TX_BLOCKING);
+    ret = rt_device_open(device, flags);
+    
     if (ret == RT_EOK)
     {
         serial                = (struct rt_serial_device *)device;


### PR DESCRIPTION
并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->
HPM6750EVK2

#### 为什么提交这份PR (why to submit this PR)
当使能posix io device时候

<img width="846" height="179" alt="image" src="https://github.com/user-attachments/assets/9a06f248-44fd-469a-8be7-b4e67b357b75" />

<img width="529" height="208" alt="image" src="https://github.com/user-attachments/assets/0ac4b22e-58b5-4157-a6ca-26c994e2ed79" />

msh回车不会移回行首，而是以梯形变化显示，缺少了\r字符


#### 你的解决方案是什么 (what is your solution)

posix使用serail open时候调用serial_fops_open，会先close再open，会导致把flag的RT_DEVICE_FLAG_STREAM覆盖掉，需要先保存flag再close

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: HPM6750EVK2 bsp 1.11.0，可在rtthread stduio下载，其他平台应该也有类似问题
