### PR TITLE
[HUST CSE] dfs/romfs: validate ioctl args for RT_FIOGETADDR

### DIFF
--- a/components/dfs/dfs_v1/filesystems/romfs/dfs_romfs.c
+++ b/components/dfs/dfs_v1/filesystems/romfs/dfs_romfs.c
@@ -44,6 +44,11 @@ int dfs_romfs_ioctl(struct dfs_file *file, int cmd, void *args)
     {
     case RT_FIOGETADDR:
         {
+            if (args == RT_NULL)
+            {
+                ret = -RT_EINVAL;
+                break;
+            }
             *(rt_ubase_t*)args = (rt_ubase_t)dirent->data;
             break;
         }

--- a/components/dfs/dfs_v1/filesystems/romfs/dfs_romfs.c
+++ b/components/dfs/dfs_v1/filesystems/romfs/dfs_romfs.c
@@ -43,19 +43,19 @@ int dfs_romfs_ioctl(struct dfs_file *file, int cmd, void *args)
     switch (cmd)
     {
     case RT_FIOGETADDR:
+    {
+        if (args == RT_NULL)
         {
-            if (args == RT_NULL)
-            {
-                ret = -RT_EINVAL;
-                break;
-            }
-            *(rt_ubase_t*)args = (rt_ubase_t)dirent->data;
+            ret = -RT_EINVAL;
             break;
         }
+        *(rt_ubase_t *)args = (rt_ubase_t)dirent->data;
+        break;
+    }
     case RT_FIOFTRUNCATE:
-        {
-            break;
-        }
+    {
+        break;
+    }
     default:
         ret = -RT_EINVAL;
         break;
@@ -65,8 +65,7 @@ int dfs_romfs_ioctl(struct dfs_file *file, int cmd, void *args)
 
 rt_inline int check_dirent(struct romfs_dirent *dirent)
 {
-    if ((dirent->type != ROMFS_DIRENT_FILE && dirent->type != ROMFS_DIRENT_DIR)
-        || dirent->size == ~0U)
+    if ((dirent->type != ROMFS_DIRENT_FILE && dirent->type != ROMFS_DIRENT_DIR) || dirent->size == ~0U)
         return -1;
     return 0;
 }
@@ -96,31 +95,31 @@ struct romfs_dirent *dfs_romfs_lookup(struct romfs_dirent *root_dirent, const ch
     subpath_end = path;
     /* skip /// */
     while (*subpath_end && *subpath_end == '/')
-        subpath_end ++;
+        subpath_end++;
     subpath = subpath_end;
     while ((*subpath_end != '/') && *subpath_end)
-        subpath_end ++;
+        subpath_end++;
 
     while (dirent != NULL)
     {
         found = 0;
 
         /* search in folder */
-        for (index = 0; index < dirent_size; index ++)
+        for (index = 0; index < dirent_size; index++)
         {
             if (check_dirent(&dirent[index]) != 0)
                 return NULL;
-            if (rt_strlen(dirent[index].name) ==  (rt_size_t)(subpath_end - subpath) &&
-                    rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
+            if (rt_strlen(dirent[index].name) == (rt_size_t)(subpath_end - subpath) &&
+                rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
             {
                 dirent_size = dirent[index].size;
 
                 /* skip /// */
                 while (*subpath_end && *subpath_end == '/')
-                    subpath_end ++;
+                    subpath_end++;
                 subpath = subpath_end;
                 while ((*subpath_end != '/') && *subpath_end)
-                    subpath_end ++;
+                    subpath_end++;
 
                 if (!(*subpath))
                 {
@@ -215,8 +214,7 @@ int dfs_romfs_open(struct dfs_file *file)
     RT_ASSERT(file->vnode->ref_count > 0);
     if (file->vnode->ref_count > 1)
     {
-        if (file->vnode->type == FT_DIRECTORY
-                && !(file->flags & O_DIRECTORY))
+        if (file->vnode->type == FT_DIRECTORY && !(file->flags & O_DIRECTORY))
         {
             return -ENOENT;
         }
@@ -345,14 +343,13 @@ int dfs_romfs_getdents(struct dfs_file *file, struct dirent *dirp, uint32_t coun
         rt_strncpy(d->d_name, name, DIRENT_NAME_MAX);
 
         /* move to next position */
-        ++ file->pos;
+        ++file->pos;
     }
 
     return index * sizeof(struct dirent);
 }
 
-static const struct dfs_file_ops _rom_fops =
-{
+static const struct dfs_file_ops _rom_fops = {
     dfs_romfs_open,
     dfs_romfs_close,
     dfs_romfs_ioctl,
@@ -363,8 +360,7 @@ static const struct dfs_file_ops _rom_fops =
     dfs_romfs_getdents,
     NULL,
 };
-static const struct dfs_filesystem_ops _romfs =
-{
+static const struct dfs_filesystem_ops _romfs = {
     "rom",
     DFS_FS_FLAG_DEFAULT,
     &_rom_fops,
@@ -388,29 +384,56 @@ int dfs_romfs_init(void)
 INIT_COMPONENT_EXPORT(dfs_romfs_init);
 
 #ifndef RT_USING_DFS_ROMFS_USER_ROOT
-static const unsigned char _dummy_dummy_txt[] =
-{
-    0x74, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x66, 0x69, 0x6c, 0x65, 0x21, 0x0d, 0x0a,
+static const unsigned char _dummy_dummy_txt[] = {
+    0x74,
+    0x68,
+    0x69,
+    0x73,
+    0x20,
+    0x69,
+    0x73,
+    0x20,
+    0x61,
+    0x20,
+    0x66,
+    0x69,
+    0x6c,
+    0x65,
+    0x21,
+    0x0d,
+    0x0a,
 };
 
-static const struct romfs_dirent _dummy[] =
-{
-    {ROMFS_DIRENT_FILE, "dummy.txt", _dummy_dummy_txt, sizeof(_dummy_dummy_txt)},
+static const struct romfs_dirent _dummy[] = {
+    { ROMFS_DIRENT_FILE, "dummy.txt", _dummy_dummy_txt, sizeof(_dummy_dummy_txt) },
 };
 
-static const unsigned char _dummy_txt[] =
-{
-    0x74, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x66, 0x69, 0x6c, 0x65, 0x21, 0x0d, 0x0a,
+static const unsigned char _dummy_txt[] = {
+    0x74,
+    0x68,
+    0x69,
+    0x73,
+    0x20,
+    0x69,
+    0x73,
+    0x20,
+    0x61,
+    0x20,
+    0x66,
+    0x69,
+    0x6c,
+    0x65,
+    0x21,
+    0x0d,
+    0x0a,
 };
 
-rt_weak const struct romfs_dirent _root_dirent[] =
-{
-    {ROMFS_DIRENT_DIR, "dummy", (rt_uint8_t *)_dummy, sizeof(_dummy) / sizeof(_dummy[0])},
-    {ROMFS_DIRENT_FILE, "dummy.txt", _dummy_txt, sizeof(_dummy_txt)},
+rt_weak const struct romfs_dirent _root_dirent[] = {
+    { ROMFS_DIRENT_DIR, "dummy", (rt_uint8_t *)_dummy, sizeof(_dummy) / sizeof(_dummy[0]) },
+    { ROMFS_DIRENT_FILE, "dummy.txt", _dummy_txt, sizeof(_dummy_txt) },
 };
 
-rt_weak const struct romfs_dirent romfs_root =
-{
+rt_weak const struct romfs_dirent romfs_root = {
     ROMFS_DIRENT_DIR, "/", (rt_uint8_t *)_root_dirent, sizeof(_root_dirent) / sizeof(_root_dirent[0])
 };
 #endif

--- a/components/dfs/dfs_v1/filesystems/romfs/dfs_romfs.c
+++ b/components/dfs/dfs_v1/filesystems/romfs/dfs_romfs.c
@@ -43,19 +43,19 @@ int dfs_romfs_ioctl(struct dfs_file *file, int cmd, void *args)
     switch (cmd)
     {
     case RT_FIOGETADDR:
-    {
-        if (args == RT_NULL)
         {
-            ret = -RT_EINVAL;
+            if (args == RT_NULL)
+            {
+                ret = -RT_EINVAL;
+                break;
+            }
+            *(rt_ubase_t*)args = (rt_ubase_t)dirent->data;
             break;
         }
-        *(rt_ubase_t *)args = (rt_ubase_t)dirent->data;
-        break;
-    }
     case RT_FIOFTRUNCATE:
-    {
-        break;
-    }
+        {
+            break;
+        }
     default:
         ret = -RT_EINVAL;
         break;
@@ -65,7 +65,8 @@ int dfs_romfs_ioctl(struct dfs_file *file, int cmd, void *args)
 
 rt_inline int check_dirent(struct romfs_dirent *dirent)
 {
-    if ((dirent->type != ROMFS_DIRENT_FILE && dirent->type != ROMFS_DIRENT_DIR) || dirent->size == ~0U)
+    if ((dirent->type != ROMFS_DIRENT_FILE && dirent->type != ROMFS_DIRENT_DIR)
+        || dirent->size == ~0U)
         return -1;
     return 0;
 }
@@ -95,31 +96,31 @@ struct romfs_dirent *dfs_romfs_lookup(struct romfs_dirent *root_dirent, const ch
     subpath_end = path;
     /* skip /// */
     while (*subpath_end && *subpath_end == '/')
-        subpath_end++;
+        subpath_end ++;
     subpath = subpath_end;
     while ((*subpath_end != '/') && *subpath_end)
-        subpath_end++;
+        subpath_end ++;
 
     while (dirent != NULL)
     {
         found = 0;
 
         /* search in folder */
-        for (index = 0; index < dirent_size; index++)
+        for (index = 0; index < dirent_size; index ++)
         {
             if (check_dirent(&dirent[index]) != 0)
                 return NULL;
-            if (rt_strlen(dirent[index].name) == (rt_size_t)(subpath_end - subpath) &&
-                rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
+            if (rt_strlen(dirent[index].name) ==  (rt_size_t)(subpath_end - subpath) &&
+                    rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
             {
                 dirent_size = dirent[index].size;
 
                 /* skip /// */
                 while (*subpath_end && *subpath_end == '/')
-                    subpath_end++;
+                    subpath_end ++;
                 subpath = subpath_end;
                 while ((*subpath_end != '/') && *subpath_end)
-                    subpath_end++;
+                    subpath_end ++;
 
                 if (!(*subpath))
                 {
@@ -214,7 +215,8 @@ int dfs_romfs_open(struct dfs_file *file)
     RT_ASSERT(file->vnode->ref_count > 0);
     if (file->vnode->ref_count > 1)
     {
-        if (file->vnode->type == FT_DIRECTORY && !(file->flags & O_DIRECTORY))
+        if (file->vnode->type == FT_DIRECTORY
+                && !(file->flags & O_DIRECTORY))
         {
             return -ENOENT;
         }
@@ -343,13 +345,14 @@ int dfs_romfs_getdents(struct dfs_file *file, struct dirent *dirp, uint32_t coun
         rt_strncpy(d->d_name, name, DIRENT_NAME_MAX);
 
         /* move to next position */
-        ++file->pos;
+        ++ file->pos;
     }
 
     return index * sizeof(struct dirent);
 }
 
-static const struct dfs_file_ops _rom_fops = {
+static const struct dfs_file_ops _rom_fops =
+{
     dfs_romfs_open,
     dfs_romfs_close,
     dfs_romfs_ioctl,
@@ -360,7 +363,8 @@ static const struct dfs_file_ops _rom_fops = {
     dfs_romfs_getdents,
     NULL,
 };
-static const struct dfs_filesystem_ops _romfs = {
+static const struct dfs_filesystem_ops _romfs =
+{
     "rom",
     DFS_FS_FLAG_DEFAULT,
     &_rom_fops,
@@ -384,56 +388,29 @@ int dfs_romfs_init(void)
 INIT_COMPONENT_EXPORT(dfs_romfs_init);
 
 #ifndef RT_USING_DFS_ROMFS_USER_ROOT
-static const unsigned char _dummy_dummy_txt[] = {
-    0x74,
-    0x68,
-    0x69,
-    0x73,
-    0x20,
-    0x69,
-    0x73,
-    0x20,
-    0x61,
-    0x20,
-    0x66,
-    0x69,
-    0x6c,
-    0x65,
-    0x21,
-    0x0d,
-    0x0a,
+static const unsigned char _dummy_dummy_txt[] =
+{
+    0x74, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x66, 0x69, 0x6c, 0x65, 0x21, 0x0d, 0x0a,
 };
 
-static const struct romfs_dirent _dummy[] = {
-    { ROMFS_DIRENT_FILE, "dummy.txt", _dummy_dummy_txt, sizeof(_dummy_dummy_txt) },
+static const struct romfs_dirent _dummy[] =
+{
+    {ROMFS_DIRENT_FILE, "dummy.txt", _dummy_dummy_txt, sizeof(_dummy_dummy_txt)},
 };
 
-static const unsigned char _dummy_txt[] = {
-    0x74,
-    0x68,
-    0x69,
-    0x73,
-    0x20,
-    0x69,
-    0x73,
-    0x20,
-    0x61,
-    0x20,
-    0x66,
-    0x69,
-    0x6c,
-    0x65,
-    0x21,
-    0x0d,
-    0x0a,
+static const unsigned char _dummy_txt[] =
+{
+    0x74, 0x68, 0x69, 0x73, 0x20, 0x69, 0x73, 0x20, 0x61, 0x20, 0x66, 0x69, 0x6c, 0x65, 0x21, 0x0d, 0x0a,
 };
 
-rt_weak const struct romfs_dirent _root_dirent[] = {
-    { ROMFS_DIRENT_DIR, "dummy", (rt_uint8_t *)_dummy, sizeof(_dummy) / sizeof(_dummy[0]) },
-    { ROMFS_DIRENT_FILE, "dummy.txt", _dummy_txt, sizeof(_dummy_txt) },
+rt_weak const struct romfs_dirent _root_dirent[] =
+{
+    {ROMFS_DIRENT_DIR, "dummy", (rt_uint8_t *)_dummy, sizeof(_dummy) / sizeof(_dummy[0])},
+    {ROMFS_DIRENT_FILE, "dummy.txt", _dummy_txt, sizeof(_dummy_txt)},
 };
 
-rt_weak const struct romfs_dirent romfs_root = {
+rt_weak const struct romfs_dirent romfs_root =
+{
     ROMFS_DIRENT_DIR, "/", (rt_uint8_t *)_root_dirent, sizeof(_root_dirent) / sizeof(_root_dirent[0])
 };
 #endif

--- a/components/dfs/dfs_v2/filesystems/romfs/dfs_romfs.c
+++ b/components/dfs/dfs_v2/filesystems/romfs/dfs_romfs.c
@@ -64,6 +64,11 @@ int dfs_romfs_ioctl(struct dfs_file *file, int cmd, void *args)
     {
     case RT_FIOGETADDR:
         {
+            if (args == RT_NULL)
+            {
+                ret = -RT_EINVAL;
+                break;
+            }
             *(rt_ubase_t*)args = (rt_ubase_t)dirent->data;
             break;
         }

--- a/components/dfs/dfs_v2/filesystems/romfs/dfs_romfs.c
+++ b/components/dfs/dfs_v2/filesystems/romfs/dfs_romfs.c
@@ -22,15 +22,16 @@
 
 static const struct dfs_file_ops _rom_fops;
 
-static const mode_t romfs_modemap[] = {
-    S_IFREG | 0644,    /* regular file */
-    S_IFDIR | 0644,    /* directory */
+static const mode_t romfs_modemap[] =
+{
+    S_IFREG  | 0644,    /* regular file */
+    S_IFDIR  | 0644,    /* directory */
     0,                  /* hard link */
-    S_IFLNK | 0777,    /* symlink */
-    S_IFBLK | 0600,    /* blockdev */
-    S_IFCHR | 0600,    /* chardev */
+    S_IFLNK  | 0777,    /* symlink */
+    S_IFBLK  | 0600,    /* blockdev */
+    S_IFCHR  | 0600,    /* chardev */
     S_IFSOCK | 0644,    /* socket */
-    S_IFIFO | 0644     /* FIFO */
+    S_IFIFO  | 0644     /* FIFO */
 };
 
 static int dfs_romfs_mount(struct dfs_mnt *mnt, unsigned long rwflag, const void *data)
@@ -62,19 +63,19 @@ int dfs_romfs_ioctl(struct dfs_file *file, int cmd, void *args)
     switch (cmd)
     {
     case RT_FIOGETADDR:
-    {
-        if (args == RT_NULL)
         {
-            ret = -RT_EINVAL;
+            if (args == RT_NULL)
+            {
+                ret = -RT_EINVAL;
+                break;
+            }
+            *(rt_ubase_t*)args = (rt_ubase_t)dirent->data;
             break;
         }
-        *(rt_ubase_t *)args = (rt_ubase_t)dirent->data;
-        break;
-    }
     case RT_FIOFTRUNCATE:
-    {
-        break;
-    }
+        {
+            break;
+        }
     default:
         ret = -RT_EINVAL;
         break;
@@ -84,7 +85,9 @@ int dfs_romfs_ioctl(struct dfs_file *file, int cmd, void *args)
 
 rt_inline int check_dirent(struct romfs_dirent *dirent)
 {
-    if (dirent == NULL || (dirent->type != ROMFS_DIRENT_FILE && dirent->type != ROMFS_DIRENT_DIR) || dirent->size == ~0)
+    if (dirent == NULL
+        ||(dirent->type != ROMFS_DIRENT_FILE && dirent->type != ROMFS_DIRENT_DIR)
+        || dirent->size == ~0)
         return -1;
     return 0;
 }
@@ -114,31 +117,31 @@ struct romfs_dirent *__dfs_romfs_lookup(struct romfs_dirent *root_dirent, const 
     subpath_end = path;
     /* skip /// */
     while (*subpath_end && *subpath_end == '/')
-        subpath_end++;
+        subpath_end ++;
     subpath = subpath_end;
     while ((*subpath_end != '/') && *subpath_end)
-        subpath_end++;
+        subpath_end ++;
 
     while (dirent != NULL)
     {
         found = 0;
 
         /* search in folder */
-        for (index = 0; index < dirent_size; index++)
+        for (index = 0; index < dirent_size; index ++)
         {
             if (check_dirent(&dirent[index]) != 0)
                 return NULL;
             if (rt_strlen(dirent[index].name) == (subpath_end - subpath) &&
-                rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
+                    rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
             {
                 dirent_size = dirent[index].size;
 
                 /* skip /// */
                 while (*subpath_end && *subpath_end == '/')
-                    subpath_end++;
+                    subpath_end ++;
                 subpath = subpath_end;
                 while ((*subpath_end != '/') && *subpath_end)
-                    subpath_end++;
+                    subpath_end ++;
 
                 if (!(*subpath))
                 {
@@ -169,7 +172,7 @@ struct romfs_dirent *__dfs_romfs_lookup(struct romfs_dirent *root_dirent, const 
     return NULL;
 }
 
-static struct dfs_vnode *dfs_romfs_lookup(struct dfs_dentry *dentry)
+static struct dfs_vnode *dfs_romfs_lookup (struct dfs_dentry *dentry)
 {
     rt_size_t size;
     struct dfs_vnode *vnode = RT_NULL;
@@ -357,34 +360,37 @@ static int dfs_romfs_getdents(struct dfs_file *file, struct dirent *dirp, uint32
         rt_strncpy(d->d_name, name, DIRENT_NAME_MAX);
 
         /* move to next position */
-        ++file->fpos;
+        ++ file->fpos;
     }
 
     return index * sizeof(struct dirent);
 }
 
-static const struct dfs_file_ops _rom_fops = {
-    .open = dfs_romfs_open,
-    .close = dfs_romfs_close,
-    .ioctl = dfs_romfs_ioctl,
-    .lseek = generic_dfs_lseek,
-    .read = dfs_romfs_read,
-    .getdents = dfs_romfs_getdents,
+static const struct dfs_file_ops _rom_fops =
+{
+    .open             = dfs_romfs_open,
+    .close            = dfs_romfs_close,
+    .ioctl            = dfs_romfs_ioctl,
+    .lseek            = generic_dfs_lseek,
+    .read             = dfs_romfs_read,
+    .getdents         = dfs_romfs_getdents,
 };
 
-static const struct dfs_filesystem_ops _romfs_ops = {
-    .name = "rom",
-    .flags = 0,
-    .default_fops = &_rom_fops,
-    .mount = dfs_romfs_mount,
-    .umount = dfs_romfs_umount,
-    .stat = dfs_romfs_stat,
-    .lookup = dfs_romfs_lookup,
-    .free_vnode = dfs_romfs_free_vnode
+static const struct dfs_filesystem_ops _romfs_ops =
+{
+    .name             ="rom",
+    .flags            = 0,
+    .default_fops     = &_rom_fops,
+    .mount            = dfs_romfs_mount,
+    .umount           = dfs_romfs_umount,
+    .stat             = dfs_romfs_stat,
+    .lookup           = dfs_romfs_lookup,
+    .free_vnode       = dfs_romfs_free_vnode
 };
 
-static struct dfs_filesystem_type _romfs = {
-    .fs_ops = &_romfs_ops,
+static struct dfs_filesystem_type _romfs =
+{
+    .fs_ops           = &_romfs_ops,
 };
 
 int dfs_romfs_init(void)

--- a/components/dfs/dfs_v2/filesystems/romfs/dfs_romfs.c
+++ b/components/dfs/dfs_v2/filesystems/romfs/dfs_romfs.c
@@ -22,16 +22,15 @@
 
 static const struct dfs_file_ops _rom_fops;
 
-static const mode_t romfs_modemap[] =
-{
-    S_IFREG  | 0644,    /* regular file */
-    S_IFDIR  | 0644,    /* directory */
+static const mode_t romfs_modemap[] = {
+    S_IFREG | 0644,    /* regular file */
+    S_IFDIR | 0644,    /* directory */
     0,                  /* hard link */
-    S_IFLNK  | 0777,    /* symlink */
-    S_IFBLK  | 0600,    /* blockdev */
-    S_IFCHR  | 0600,    /* chardev */
+    S_IFLNK | 0777,    /* symlink */
+    S_IFBLK | 0600,    /* blockdev */
+    S_IFCHR | 0600,    /* chardev */
     S_IFSOCK | 0644,    /* socket */
-    S_IFIFO  | 0644     /* FIFO */
+    S_IFIFO | 0644     /* FIFO */
 };
 
 static int dfs_romfs_mount(struct dfs_mnt *mnt, unsigned long rwflag, const void *data)
@@ -63,19 +62,19 @@ int dfs_romfs_ioctl(struct dfs_file *file, int cmd, void *args)
     switch (cmd)
     {
     case RT_FIOGETADDR:
+    {
+        if (args == RT_NULL)
         {
-            if (args == RT_NULL)
-            {
-                ret = -RT_EINVAL;
-                break;
-            }
-            *(rt_ubase_t*)args = (rt_ubase_t)dirent->data;
+            ret = -RT_EINVAL;
             break;
         }
+        *(rt_ubase_t *)args = (rt_ubase_t)dirent->data;
+        break;
+    }
     case RT_FIOFTRUNCATE:
-        {
-            break;
-        }
+    {
+        break;
+    }
     default:
         ret = -RT_EINVAL;
         break;
@@ -85,9 +84,7 @@ int dfs_romfs_ioctl(struct dfs_file *file, int cmd, void *args)
 
 rt_inline int check_dirent(struct romfs_dirent *dirent)
 {
-    if (dirent == NULL
-        ||(dirent->type != ROMFS_DIRENT_FILE && dirent->type != ROMFS_DIRENT_DIR)
-        || dirent->size == ~0)
+    if (dirent == NULL || (dirent->type != ROMFS_DIRENT_FILE && dirent->type != ROMFS_DIRENT_DIR) || dirent->size == ~0)
         return -1;
     return 0;
 }
@@ -117,31 +114,31 @@ struct romfs_dirent *__dfs_romfs_lookup(struct romfs_dirent *root_dirent, const 
     subpath_end = path;
     /* skip /// */
     while (*subpath_end && *subpath_end == '/')
-        subpath_end ++;
+        subpath_end++;
     subpath = subpath_end;
     while ((*subpath_end != '/') && *subpath_end)
-        subpath_end ++;
+        subpath_end++;
 
     while (dirent != NULL)
     {
         found = 0;
 
         /* search in folder */
-        for (index = 0; index < dirent_size; index ++)
+        for (index = 0; index < dirent_size; index++)
         {
             if (check_dirent(&dirent[index]) != 0)
                 return NULL;
             if (rt_strlen(dirent[index].name) == (subpath_end - subpath) &&
-                    rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
+                rt_strncmp(dirent[index].name, subpath, (subpath_end - subpath)) == 0)
             {
                 dirent_size = dirent[index].size;
 
                 /* skip /// */
                 while (*subpath_end && *subpath_end == '/')
-                    subpath_end ++;
+                    subpath_end++;
                 subpath = subpath_end;
                 while ((*subpath_end != '/') && *subpath_end)
-                    subpath_end ++;
+                    subpath_end++;
 
                 if (!(*subpath))
                 {
@@ -172,7 +169,7 @@ struct romfs_dirent *__dfs_romfs_lookup(struct romfs_dirent *root_dirent, const 
     return NULL;
 }
 
-static struct dfs_vnode *dfs_romfs_lookup (struct dfs_dentry *dentry)
+static struct dfs_vnode *dfs_romfs_lookup(struct dfs_dentry *dentry)
 {
     rt_size_t size;
     struct dfs_vnode *vnode = RT_NULL;
@@ -360,37 +357,34 @@ static int dfs_romfs_getdents(struct dfs_file *file, struct dirent *dirp, uint32
         rt_strncpy(d->d_name, name, DIRENT_NAME_MAX);
 
         /* move to next position */
-        ++ file->fpos;
+        ++file->fpos;
     }
 
     return index * sizeof(struct dirent);
 }
 
-static const struct dfs_file_ops _rom_fops =
-{
-    .open             = dfs_romfs_open,
-    .close            = dfs_romfs_close,
-    .ioctl            = dfs_romfs_ioctl,
-    .lseek            = generic_dfs_lseek,
-    .read             = dfs_romfs_read,
-    .getdents         = dfs_romfs_getdents,
+static const struct dfs_file_ops _rom_fops = {
+    .open = dfs_romfs_open,
+    .close = dfs_romfs_close,
+    .ioctl = dfs_romfs_ioctl,
+    .lseek = generic_dfs_lseek,
+    .read = dfs_romfs_read,
+    .getdents = dfs_romfs_getdents,
 };
 
-static const struct dfs_filesystem_ops _romfs_ops =
-{
-    .name             ="rom",
-    .flags            = 0,
-    .default_fops     = &_rom_fops,
-    .mount            = dfs_romfs_mount,
-    .umount           = dfs_romfs_umount,
-    .stat             = dfs_romfs_stat,
-    .lookup           = dfs_romfs_lookup,
-    .free_vnode       = dfs_romfs_free_vnode
+static const struct dfs_filesystem_ops _romfs_ops = {
+    .name = "rom",
+    .flags = 0,
+    .default_fops = &_rom_fops,
+    .mount = dfs_romfs_mount,
+    .umount = dfs_romfs_umount,
+    .stat = dfs_romfs_stat,
+    .lookup = dfs_romfs_lookup,
+    .free_vnode = dfs_romfs_free_vnode
 };
 
-static struct dfs_filesystem_type _romfs =
-{
-    .fs_ops           = &_romfs_ops,
+static struct dfs_filesystem_type _romfs = {
+    .fs_ops = &_romfs_ops,
 };
 
 int dfs_romfs_init(void)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

`dfs_romfs_ioctl()`在处理`RT_FIOGETADDR`命令时会直接解引用`args`。如果调用方传入空指针，DFS v1/v2的romfs实现会在错误路径上触发空指针解引用，而不是稳定返回错误码。

#### 你的解决方案是什么 (what is your solution)

在DFS v1和DFS v2的romfs `RT_FIOGETADDR`分支中增加`args == RT_NULL`检查。当调用方传入空指针时返回`-RT_EINVAL`，避免空指针解引用。
该修改只影响`RT_FIOGETADDR`的异常输入路径，不改变正常传入有效输出参数时的行为，也不影响`RT_FIOFTRUNCATE`等其他ioctl命令。

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:`bsp/simulator`

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:使用`bsp/simulator`当前默认配置，无需额外修改

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:https://github.com/Aphlita/rt-thread/actions/runs/25167095529
本地验证：
- `git diff --check -- components/dfs/dfs_v1/filesystems/romfs/dfs_romfs.c components/dfs/dfs_v2/filesystems/romfs/dfs_romfs.c`
- `scons -C /home/world/rt-thread/bsp/simulator -j2`
- `cppcheck --enable=warning,style,performance,portability --quiet components/dfs/dfs_v1/filesystems/romfs/dfs_romfs.c components/dfs/dfs_v2/filesystems/romfs/dfs_romfs.c`

说明：`cppcheck`仅报告romfs文件中既有style提示，未发现本次新增空指针校验相关问题。
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
