### PR TITLE
rt-smart kernel assert fail after exec failure before task startup

### DIFF
--- a/components/lwp/lwp.c
+++ b/components/lwp/lwp.c
@@ -514,14 +514,14 @@ pid_t lwp_execve(char *filename, int debug, int argc, char **argv, char **envp)
 
     if ((tid = lwp_tid_get()) == 0)
     {
-        lwp_ref_dec(lwp);
+        lwp_pid_rollback(lwp);
         return -ENOMEM;
     }
 #ifdef ARCH_MM_MMU
     if (lwp_user_space_init(lwp, 0) != 0)
     {
         lwp_tid_put(tid);
-        lwp_ref_dec(lwp);
+        lwp_pid_rollback(lwp);
         return -ENOMEM;
     }
 #endif
@@ -529,7 +529,7 @@ pid_t lwp_execve(char *filename, int debug, int argc, char **argv, char **envp)
     if ((aux = argscopy(lwp, argc, argv, envp)) == RT_NULL)
     {
         lwp_tid_put(tid);
-        lwp_ref_dec(lwp);
+        lwp_pid_rollback(lwp);
         return -ENOMEM;
     }
 
@@ -629,7 +629,7 @@ pid_t lwp_execve(char *filename, int debug, int argc, char **argv, char **envp)
     }
 
     lwp_tid_put(tid);
-    lwp_ref_dec(lwp);
+    lwp_pid_rollback(lwp);
 
     return -RT_ERROR;
 }

--- a/components/lwp/lwp_pid.c
+++ b/components/lwp/lwp_pid.c
@@ -336,6 +336,35 @@ void lwp_pid_put(struct rt_lwp *lwp)
 }
 
 /**
+ * @brief Roll back a PID allocated for a process that never became runnable.
+ *
+ * @param[in,out] lwp The lightweight process whose PID allocation should be
+ *                    undone. The LWP must have been allocated a PID, but must
+ *                    not have been made visible as a runnable user task.
+ *
+ * @note This helper is intended for exec/spawn failure paths after PID
+ *       allocation and before task startup. It removes the PID table entry,
+ *       clears lwp->pid, and drops the initial LWP reference.
+ *
+ *       Do not use lwp_pid_put() for this case. lwp_pid_put() has process-exit
+ *       semantics: when the PID tree becomes empty it wakes waiters and keeps
+ *       the PID lock held to prevent new PID allocation. A failed exec rollback
+ *       must release the PID lock unconditionally so later LWP launches can
+ *       still allocate PIDs, especially in init-less boot flows.
+ */
+void lwp_pid_rollback(struct rt_lwp *lwp)
+{
+    _free_proc_dentry(lwp);
+
+    lwp_pid_lock_take();
+    lwp_pid_put_locked(lwp->pid);
+    lwp_pid_lock_release();
+
+    lwp->pid = 0;
+    lwp_ref_dec(lwp);
+}
+
+/**
  * @brief Set the LWP for a given PID while holding the PID lock
  *
  * @param[in] pid The process ID to set the LWP for

--- a/components/lwp/lwp_pid.h
+++ b/components/lwp/lwp_pid.h
@@ -29,6 +29,7 @@ int lwp_pid_init(void);
 int lwp_pid_wait_for_empty(int wait_flags, rt_tick_t to);
 int lwp_pid_for_each(int (*cb)(pid_t pid, void *data), void *data);
 void lwp_pid_put(struct rt_lwp *lwp);
+void lwp_pid_rollback(struct rt_lwp *lwp);
 void lwp_pid_lock_take(void);
 void lwp_pid_lock_release(void);
 


### PR DESCRIPTION
When msh tries to execute a non-ELF path, lwp_execve() may allocate a PID before lwp_load() fails. The old error path only dropped the LWP reference, leaving the PID tree entry pointing to a freed LWP.

In an init-less boot flow, this can poison pid 1 after a failed command from msh. A later LWP launch may then treat the stale pid 1 entry as a valid parent LWP, resulting in invalid pgrp/session state and a job-control assertion during process exit.

Add lwp_pid_rollback() for exec/spawn failures before the process becomes runnable. Unlike lwp_pid_put(), it always releases the PID lock and does not enter the "no more pid allocation" state when the PID tree becomes empty.

Use the rollback helper in lwp_execve() failure paths after PID allocation.

## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->
Test on qemu-virt64-aarch64, which enable rt-smart
Reproduce:
sd.bin must no init binary, which would not start init process, then kernel
would enter msh not ash, run 'bin' which would be fail, then run 'hello',
kernel would assert failuer:
Log:
 \ | /
- RT -     Thread Smart Operating System
 / | \     5.3.0 build May  3 2026 09:19:10
 2006 - 2024 Copyright by RT-Thread team
[I/drivers.serial] Using /dev/ttyS0 as default console
mnt_init!
file system initialization done!
[I/rtdm.mnt] File system initialization done
hello rt-thread
[I/cpu.aa64] Call cpu 1 on success
msh />[I/cpu.aa64] Call cpu 2 on success
[I/cpu.aa64] Call cpu 3 on success

msh />bin
[E/load.elf] elf_file_read : read from offset: 0x0 error
[E/load.elf] elf_load_ehdr : elf_file_read failed, ret : -255
[E/load.elf] lwp_load : elf_file_load error, ret : -255
bin: command not found.
msh />hello
msh />hello world!
(session) assertion failed at function:lwp_jobctrl_on_exit, line number:53
please use: addr2line -e rtthread.elf -a -f
 0xffff00000012c0d8 0xffff000000092f78 0xffff000000098028 0xffff000000097aa8 0xffff000000096198 0xffff00000009dfe0 0xffff000000086c3c 0xffff000000086be0

#### 为什么提交这份PR (why to submit this PR)
RT-Smart kernel will assertion failed in some specific case.

#### 你的解决方案是什么 (what is your solution)
Release a process ID and clean up associated resources after  exec failure.
And must not using lwp_pid_put, because lwp_pid_root would be AVL_EMPTY, msh would
take the pid_mtx,  then if enter ash, it can't fork any new process, lwp_execve would be hanged
in lwp_pid_lock_take.

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:
bsp/qemu-virt64-aarch64
<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:
Just enable RT SMART in the menuconfig

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:
N/A (build verified locally on bsp/qemu-virt64-aarch64)
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
