### PR TITLE
[HUST CSE] bsp/qemu-aarch64: validate RTC control args

### DIFF
--- a/bsp/qemu-virt64-aarch64/drivers/drv_rtc.c
+++ b/bsp/qemu-virt64-aarch64/drivers/drv_rtc.c
@@ -64,6 +64,11 @@ static rt_err_t pl031_rtc_control(rt_device_t dev, int cmd, void *args)
 
     RT_ASSERT(dev != RT_NULL);
 
+    if (args == RT_NULL)
+    {
+        return -RT_EINVAL;
+    }
+
     switch (cmd)
     {
     case RT_DEVICE_CTRL_RTC_GET_TIME:


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

`pl031_rtc_control()`在处理`RT_DEVICE_CTRL_RTC_GET_TIME`和`RT_DEVICE_CTRL_RTC_SET_TIME`命令时会直接解引用`args`。如果调用方传入空指针，QEMU AArch64 BSP的RTC错误路径会触发空指针解引用，而不是稳定返回错误码。
通用PL031 RTC驱动`components/drivers/rtc/rtc-pl031.c`已经对`args`做了空指针检查，因此该BSP本地实现也应该保持一致。

#### 你的解决方案是什么 (what is your solution)

在`pl031_rtc_control()`中增加`args == RT_NULL`检查。当调用方传入空指针时返回`-RT_EINVAL`，避免空指针解引用。
该修改只影响RTC control的异常输入路径，不改变正常传入有效参数时的行为。

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:`bsp/qemu-virt64-aarch64`

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:使用`bsp/qemu-virt64-aarch64`当前默认配置，无需额外修改

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

本地验证：
- `git diff --check -- bsp/qemu-virt64-aarch64/drivers/drv_rtc.c`
- `cppcheck --enable=warning,style,performance,portability --quiet bsp/qemu-virt64-aarch64/drivers/drv_rtc.c`

说明：本地尝试执行`scons -C /home/world/rt-thread/bsp/qemu-virt64-aarch64 -j2`，但当前环境缺少`aarch64-none-elf-gcc` / `aarch64-none-elf-cpp`工具链，因此未完成BSP构建。
]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
