### PR TITLE
Add picolib support to bsp/x86, default to newlib

### DIFF
--- a/.github/workflows/manual_dist.yml
+++ b/.github/workflows/manual_dist.yml
@@ -36,6 +36,7 @@ on:
           - "gcc"
           - "sourcery-riscv32-esp32"
           - "i686-x86-newlib"
+          - "i686-x86-picolib"
       bsp_config:
         description: 'Type a config you want mannual test in .config, like: CONFIG_RT_USING_DEBUG=y,CONFIG_RT_DEBUGING_COLOR=y,CONFIG_RT_DEBUGING_CONTEXT=y'
         required: false
@@ -134,6 +135,13 @@ jobs:
           source tools/ci/toolchain.sh i686-atxhua-newlib-elf-gcc
           echo "RTT_EXEC_PATH=/opt/i686-atxhua-newlib-elf-gcc/bin" >> $GITHUB_ENV
           echo "RTT_CC_PREFIX=i686-atxhua-newlib-elf-" >> $GITHUB_ENV
+
+      - name: Install i686 X86 Picolib ToolChains
+        if: ${{ github.event.inputs.bsp_tool_chain == 'i686-x86-picolib' && success() }}
+        run: |
+          source tools/ci/toolchain.sh i686-atxhua-picolib-elf-gcc
+          echo "RTT_EXEC_PATH=/opt/i686-atxhua-picolib-elf-gcc/bin" >> $GITHUB_ENV
+          echo "RTT_CC_PREFIX=i686-atxhua-picolib-elf-" >> $GITHUB_ENV
 
       - name: Bsp Scons Compile
         if: ${{ success() }}

--- a/bsp/x86/.config
+++ b/bsp/x86/.config
@@ -306,6 +306,7 @@ CONFIG_RT_SERIAL_RB_BUFSZ=64
 # CONFIG_RT_USING_LCD is not set
 # CONFIG_RT_USING_HWCRYPTO is not set
 # CONFIG_RT_USING_WIFI is not set
+# CONFIG_RT_USING_RPMSG is not set
 # CONFIG_RT_USING_BLK is not set
 # CONFIG_RT_USING_REGULATOR is not set
 # CONFIG_RT_USING_POWER_SUPPLY is not set
@@ -944,6 +945,12 @@ CONFIG_RT_LIBC_TZ_DEFAULT_SEC=0
 # CONFIG_PKG_USING_FT32F4_STD_DRIVER is not set
 # CONFIG_PKG_USING_FT32F4_CMSIS_DRIVER is not set
 # end of FT32 HAL & SDK Drivers
+
+#
+# NOVOSNS Drivers
+#
+# CONFIG_PKG_USING_NOVOSNS_SERIES_DRIVER is not set
+# end of NOVOSNS Drivers
 # end of HAL & SDK Drivers
 
 #
@@ -1466,3 +1473,10 @@ CONFIG_RT_LIBC_TZ_DEFAULT_SEC=0
 # end of RT-Thread online packages
 
 CONFIG_IA32=y
+
+#
+# X86 Features
+#
+CONFIG_X86_BSP_USING_LIBC=y
+# CONFIG_X86_BSP_USING_PICOLIBC_PORT is not set
+# end of X86 Features

--- a/bsp/x86/Kconfig
+++ b/bsp/x86/Kconfig
@@ -15,3 +15,23 @@ config IA32
     select RT_USING_COMPONENTS_INIT
     select RT_USING_USER_MAIN
     default y
+
+menu "X86 Features"
+
+choice
+    prompt "C Library type"
+    default X86_BSP_USING_LIBC
+
+config X86_BSP_USING_LIBC
+    bool "Newlib"
+    help
+      Use the standard Newlib implementation.
+
+config X86_BSP_USING_PICOLIBC_PORT
+    bool "Picolibc (tinystdio)"
+    select RT_USING_COMPONENTS_INIT
+    help
+      Use Picolibc with tinystdio for a smaller footprint.
+endchoice
+
+endmenu

--- a/bsp/x86/README.md
+++ b/bsp/x86/README.md
@@ -1,5 +1,59 @@
 # RT-Thread for x86
 
+## Intro
+This x86 BSP support both newlib & picolib, with toolchain available
+  - **Newlib:** `i686-atxhua-newlib-elf-`
+  - **Picolibc:** `i686-atxhua-picolib-elf-`
+
+## Install Toolchain
+To install toolchain run the following command:
+  - **Newlib:** sudo ../../tools/ci/toolchain.sh i686-atxhua-newlib-elf-gcc 
+  - **Picolibc:** sudo ../../tools/ci/toolchain.sh i686-atxhua-picolib-elf-gcc
+
+## Configuration
+Use `menuconfig` to select your preferred C library:
+  1. Run `scons --menuconfig`
+  2. Navigate to `X86 Features` -> `C Library type`
+  3. Select either `Newlib`(default) or `Picolibc`
+
+## Building
+After select the correct library in `menuconfig`, set the toolchain path and prefix:
+### Newlib
+```bash
+export RTT_EXEC_PATH=/opt/i686-atxhua-newlib-elf-gcc/bin
+export RTT_CC_PREFIX=i686-atxhua-newlib-elf-
+scons
+```
+
+### Picolib
+```bash
+export RTT_EXEC_PATH=/opt/i686-atxhua-picolib-elf-gcc/bin
+export RTT_CC_PREFIX=i686-atxhua-picolib-elf-
+scons           
+```
+
+##  Result ELF
+### Newlib
+```
+Memory region         Used Size  Region Size  %age Used
+i686-atxhua-newlib-elf-objcopy -O binary rtthread.elf rtthread.bin
+i686-atxhua-newlib-elf-size rtthread.elf
+   text	   data	    bss	    dec	    hex	filename
+ 212900	   3274	  10844	 227018	  376ca	rtthread.elf
+scons: done building targets.
+
+```
+
+### Picolib
+```
+Memory region         Used Size  Region Size  %age Used
+i686-atxhua-picolib-elf-objcopy -O binary rtthread.elf rtthread.bin
+i686-atxhua-picolib-elf-size rtthread.elf
+   text	   data	    bss	    dec	    hex	filename
+ 174122	   2568	  10528	 187218	  2db52	rtthread.elf
+scons: done building targets.
+```
+
 这是一份基础的RT-Thread针对x86的版本、移植，主要是能够在qemu中执行。以下说明主要针对Linux的环境，如果是Windows环境，请使用Env工具，同时请自行处理生成iso的方法。
 
 ## 编译
@@ -8,6 +62,7 @@
 
 * [i386-unknown-elf_for_x86_64-pc-linux-gnu_latest.tar.bz2](http://117.143.63.254:9012/www/rt-smart/i386-unknown-elf_for_x86_64-pc-linux-gnu_latest.tar.bz2)
 * [ GCC 15.2.0 w/ Newlib 4.6.0.20260123: https://github.com/atxhua/i686-atxhua-newlib-elf/releases/download/15.2.0/i686-atxhua-newlib-elf-linux.tar.gz ](https://github.com/atxhua/i686-atxhua-newlib-elf/releases/download/15.2.0/i686-atxhua-newlib-elf-linux.tar.gz)
+* [ GCC 15.2.0 w/ Picolib 1.8.11: https://github.com/atxhua/i686-atxhua-picolib-elf/releases/download/15.2.0/i686-atxhua-picolib-elf-linux.tar.gz ](https://github.com/atxhua/i686-atxhua-picolib-elf/releases/download/15.2.0/i686-atxhua-picolib-elf-linux.tar.gz)
 
 
 下载后解压，然后配置RTT_EXEC_PATH & RTT_CC_PREFIX 变量

--- a/bsp/x86/picolib/SConscript
+++ b/bsp/x86/picolib/SConscript
@@ -1,0 +1,14 @@
+Import('RTT_ROOT')
+Import('rtconfig')
+from building import *
+
+cwd = GetCurrentDir()
+
+src = Glob('*.c')
+
+CPPPATH = [cwd]
+CPPFLAGS = '-specs=picolibc.specs'
+
+group = DefineGroup('Picolib', src, depend = ['X86_BSP_USING_PICOLIBC_PORT'], CPPPATH = CPPPATH, CPPFLAGS = CPPFLAGS)
+
+Return('group')

--- a/bsp/x86/picolib/picolib_stdio.c
+++ b/bsp/x86/picolib/picolib_stdio.c
@@ -1,0 +1,20 @@
+#include <rtthread.h>
+#include <stdio.h>
+
+static int picolibc_putc(char c, FILE *file)
+{
+    (void)file;
+
+    if (c == '\n')
+    {
+        rt_hw_console_output("\r");
+    }
+
+    rt_hw_console_output((const char *)&c);
+    return c;
+}
+
+static FILE __stdio_out = FDEV_SETUP_STREAM(picolibc_putc, NULL, NULL, _FDEV_SETUP_WRITE);
+
+FILE *const stdout = &__stdio_out;
+FILE *const stderr = &__stdio_out;

--- a/bsp/x86/rtconfig.h
+++ b/bsp/x86/rtconfig.h
@@ -351,6 +351,10 @@
 /* FT32 HAL & SDK Drivers */
 
 /* end of FT32 HAL & SDK Drivers */
+
+/* NOVOSNS Drivers */
+
+/* end of NOVOSNS Drivers */
 /* end of HAL & SDK Drivers */
 
 /* sensors drivers */
@@ -431,5 +435,10 @@
 /* end of Arduino libraries */
 /* end of RT-Thread online packages */
 #define IA32
+
+/* X86 Features */
+
+#define X86_BSP_USING_LIBC
+/* end of X86 Features */
 
 #endif

--- a/bsp/x86/rtconfig.py
+++ b/bsp/x86/rtconfig.py
@@ -1,5 +1,9 @@
 import os
 
+def check_config_key_enable(key):
+    if not os.path.isfile('.config'): return False
+    return (key + '=y') in open('.config').read()
+
 # toolchains options
 ARCH='ia32'
 CPU=''
@@ -30,6 +34,9 @@ if PLATFORM == 'gcc':
     OBJCPY = PREFIX + 'objcopy'
 
     DEVICE = ' -mtune=generic'
+    if check_config_key_enable('CONFIG_X86_BSP_USING_PICOLIBC_PORT'):
+       DEVICE  += ' -specs=picolibc.specs'
+
     CFLAGS = DEVICE + ' -Wall'
     AFLAGS = ' -c' + DEVICE + ' -x assembler-with-cpp'
     LFLAGS = DEVICE + ' -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,_start -T x86_ram.lds -nostartfiles'

--- a/tools/ci/toolchain.sh
+++ b/tools/ci/toolchain.sh
@@ -10,6 +10,7 @@ declare -A download_urls=(
 ["riscv32-esp-elf-gcc"]="https://github.com/espressif/crosstool-NG/releases/download/esp-2022r1-RC1/riscv32-esp-elf-gcc11_2_0-esp-2022r1-RC1-linux-amd64.tar.xz"
 ["clang"]="https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-16.0.0/LLVMEmbeddedToolchainForArm-16.0.0-Linux-x86_64.tar.gz"
 ["i686-atxhua-newlib-elf-gcc"]="https://github.com/atxhua/i686-atxhua-newlib-elf/releases/download/15.2.0/i686-atxhua-newlib-elf-linux.tar.gz"
+["i686-atxhua-picolib-elf-gcc"]="https://github.com/atxhua/i686-atxhua-picolib-elf/releases/download/15.2.0/i686-atxhua-picolib-elf-linux.tar.gz"
 )
 
 show_help() {


### PR DESCRIPTION
    - add i686-atxhua-picolib-elf-gcc toolchain
    - add picolib option to bsp/x86
    - add necessary picolib require library
    - Elf Size comparison between newib vs picolib
        - **newlib** : 
 ```
 i686-atxhua-newlib-elf-size rtthread.elf
   text	   data	    bss	    dec	    hex	filename
 212900	   3274	  10844	 227018	  376ca	rtthread.elf
 ```
         -  **picolib**:  
```
i686-atxhua-picolib-elf-size rtthread.elf
   text	   data	    bss	    dec	    hex	filename
 174122	   2568	  10528	 187218	  2db52	rtthread.elf
``` 

## 拉取/合并请求描述：(PR description)

[
请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;
support both newlib & picolib  in bsp/x86 via menuconfig option, and provides the picolib toolchain. 

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested.
Verified both newlib build and picolib build via qemu, in both ubuntu 24.04 and WSL

#### 为什么提交这份PR (why to submit this PR)
Making bsp/x86 support both newlib and picolib

#### 你的解决方案是什么 (what is your solution)
Kconfig menu option to select between newlib (default) and picolib, and comes with gcc binaries


#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
bsp/x86

- .config:
bsp/x86/.config:
  - **newlib** :  default .config content ( no CONFIG_X86_BSP_USING_PICOLIBC_PORT)
  - **picolib**:  add CONFIG_X86_BSP_USING_PICOLIBC_PORT

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:
  - **newlib** :  https://github.com/atxhua/rt-thread/actions/runs/25937329594/job/76246013809
  - **picolib**:  https://github.com/atxhua/rt-thread/actions/runs/25937481819/job/76246514521

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
