### PR TITLE
[libcpu][arm][cortex-m33] allows rewrite to interrupt enable/disable api to support independent interrupts management

### DIFF
--- a/libcpu/arm/cortex-m33/context_gcc.S
+++ b/libcpu/arm/cortex-m33/context_gcc.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2018, RT-Thread Development Team
+ * Copyright (c) 2006-2026, RT-Thread Development Team
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -10,6 +10,7 @@
  * 2013-06-18     aozima       add restore MSP feature.
  * 2013-06-23     aozima       support lazy stack optimized.
  * 2018-07-24     aozima       enhancement hard fault exception handler.
+ * 2026-05-19     Evlers       allows rewrite to interrupt enable/disable api to support independent interrupts management
  */
 
 /**
@@ -34,6 +35,7 @@
  * rt_base_t rt_hw_interrupt_disable();
  */
 .global rt_hw_interrupt_disable
+.weak rt_hw_interrupt_disable
 .type rt_hw_interrupt_disable, %function
 rt_hw_interrupt_disable:
     MRS     r0, PRIMASK
@@ -44,6 +46,7 @@ rt_hw_interrupt_disable:
  * void rt_hw_interrupt_enable(rt_base_t level);
  */
 .global rt_hw_interrupt_enable
+.weak rt_hw_interrupt_enable
 .type rt_hw_interrupt_enable, %function
 rt_hw_interrupt_enable:
     MSR     PRIMASK, r0
@@ -257,6 +260,10 @@ rt_hw_context_switch_to:
     /* enable interrupts at processor level */
     CPSIE   F
     CPSIE   I
+
+    /* clear the BASEPRI register to disable masking priority */
+    MOV     r0, #0x00
+    MSR     BASEPRI, r0
 
     /* ensure PendSV exception taken place before subsequent operation */
     DSB

--- a/libcpu/arm/cortex-m33/context_iar.S
+++ b/libcpu/arm/cortex-m33/context_iar.S
@@ -1,5 +1,5 @@
 ;/*
-; * Copyright (c) 2006-2018, RT-Thread Development Team
+; * Copyright (c) 2006-2026, RT-Thread Development Team
 ; *
 ; * SPDX-License-Identifier: Apache-2.0
 ; *
@@ -11,6 +11,7 @@
 ; * 2013-06-18     aozima       add restore MSP feature.
 ; * 2013-06-23     aozima       support lazy stack optimized.
 ; * 2018-07-24     aozima       enhancement hard fault exception handler.
+; * 2026-05-19     Evlers       allows rewrite to interrupt enable/disable api to support independent interrupts management
 ; */
 
 ;/**
@@ -39,7 +40,7 @@ NVIC_PENDSVSET  EQU     0x10000000               ; value to trigger PendSV excep
 ;/*
 ; * rt_base_t rt_hw_interrupt_disable();
 ; */
-    EXPORT rt_hw_interrupt_disable
+    PUBWEAK rt_hw_interrupt_disable
 rt_hw_interrupt_disable:
     MRS     r0, PRIMASK
     CPSID   I
@@ -48,7 +49,7 @@ rt_hw_interrupt_disable:
 ;/*
 ; * void rt_hw_interrupt_enable(rt_base_t level);
 ; */
-    EXPORT  rt_hw_interrupt_enable
+    PUBWEAK  rt_hw_interrupt_enable
 rt_hw_interrupt_enable:
     MSR     PRIMASK, r0
     BX      LR
@@ -252,6 +253,10 @@ rt_hw_context_switch_to:
     ; enable interrupts at processor level
     CPSIE   F
     CPSIE   I
+
+    ; clear the BASEPRI register to disable masking priority
+    MOV     r0, #0x00
+    MSR     BASEPRI, r0
 
     ; ensure PendSV exception taken place before subsequent operation
     DSB

--- a/libcpu/arm/cortex-m33/context_rvds.S
+++ b/libcpu/arm/cortex-m33/context_rvds.S
@@ -1,5 +1,5 @@
 ;/*
-;* Copyright (c) 2006-2018, RT-Thread Development Team
+;* Copyright (c) 2006-2026, RT-Thread Development Team
 ;*
 ;* SPDX-License-Identifier: Apache-2.0
 ;*
@@ -10,6 +10,7 @@
 ; * 2013-06-18     aozima       add restore MSP feature.
 ; * 2013-06-23     aozima       support lazy stack optimized.
 ; * 2018-07-24     aozima       enhancement hard fault exception handler.
+; * 2026-05-19     Evlers       allows rewrite to interrupt enable/disable api to support independent interrupts management
 ; */
 
 ;/**
@@ -39,7 +40,7 @@ NVIC_PENDSVSET  EQU     0x10000000               ; value to trigger PendSV excep
 ; * rt_base_t rt_hw_interrupt_disable();
 ; */
 rt_hw_interrupt_disable    PROC
-    EXPORT  rt_hw_interrupt_disable
+    EXPORT  rt_hw_interrupt_disable [WEAK]
     MRS     r0, PRIMASK
     CPSID   I
     BX      LR
@@ -49,7 +50,7 @@ rt_hw_interrupt_disable    PROC
 ; * void rt_hw_interrupt_enable(rt_base_t level);
 ; */
 rt_hw_interrupt_enable    PROC
-    EXPORT  rt_hw_interrupt_enable
+    EXPORT  rt_hw_interrupt_enable [WEAK]
     MSR     PRIMASK, r0
     BX      LR
     ENDP
@@ -253,6 +254,10 @@ rt_hw_context_switch_to    PROC
     ; enable interrupts at processor level
     CPSIE   F
     CPSIE   I
+
+    ; clear the BASEPRI register to disable masking priority
+    MOV     r0, #0x00
+    MSR     BASEPRI, r0
 
     ; ensure PendSV exception taken place before subsequent operation
     DSB


### PR DESCRIPTION
与 https://github.com/RT-Thread/rt-thread/pull/9305 一样，允许重写中断enable/disable API 以支持独立的中断管理