### PR TITLE
[bsp][tools] support env shared package paths

### DIFF
--- a/bsp/ESP/ESP32_C3/SConstruct
+++ b/bsp/ESP/ESP32_C3/SConstruct
@@ -1,6 +1,5 @@
 import os
 import sys
-import rtconfig
 from esptool.bin_image import ELFFile, ImageSegment, LoadFirmwareImage
 from esptool.targets import CHIP_DEFS, CHIP_LIST, ROM_LIST
 
@@ -40,6 +39,7 @@ else:
     RTT_ROOT = os.path.join(os.getcwd(), '..', '..', '..')
 
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
+import rtconfig
 from building import *
 
 TARGET = 'rtthread.' + rtconfig.TARGET_EXT

--- a/bsp/ESP/ESP32_C3/rtconfig.py
+++ b/bsp/ESP/ESP32_C3/rtconfig.py
@@ -1,4 +1,10 @@
 import os
+import sys
+
+BSP_ROOT = os.path.dirname(os.path.abspath(__file__))
+RTT_ROOT = os.getenv('RTT_ROOT') or os.path.normpath(os.path.join(BSP_ROOT, '..', '..', '..'))
+sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
+from env_package import find_package_path
 
 # toolchains options
 ARCH        ='risc-v'
@@ -8,7 +14,7 @@ CROSS_TOOL  ='gcc'
 if os.getenv('RTT_CC'):
     CROSS_TOOL = os.getenv('RTT_CC')
 
-if CROSS_TOOL == 'gcc': 
+if CROSS_TOOL == 'gcc':
     PLATFORM    = 'gcc'
     EXEC_PATH   = r'~/.espressif/tools/riscv32-esp-elf/esp-2022r1-11.2.0/riscv32-esp-elf/bin'
 else:
@@ -38,8 +44,9 @@ if PLATFORM == 'gcc':
     DEVICE  = ' -nostartfiles -march=rv32imc --specs=nosys.specs -fasynchronous-unwind-tables '
     CFLAGS = DEVICE + '-include ../../components/libc/compilers/common/include/sys/ioctl.h -gdwarf-4 -ggdb -Og '
     AFLAGS =  ' -c' + DEVICE + ' -x assembler-with-cpp'
-    LFLAGS = DEVICE + ' -Wl,--cref -Wl,--defsym=IDF_TARGET_ESP32C3=0 -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,_start -T idf_port/ld/memory.ld -T idf_port/ld/sections.ld -T packages/ESP-IDF-latest/components/esp_rom/esp32c3/ld/esp32c3.rom.ld -T packages/ESP-IDF-latest/components/esp_rom/esp32c3/ld/esp32c3.rom.api.ld -T packages/ESP-IDF-latest/components/esp_rom/esp32c3/ld/esp32c3.rom.libgcc.ld -T packages/ESP-IDF-latest/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld -T packages/ESP-IDF-latest/components/esp_rom/esp32c3/ld/esp32c3.rom.version.ld -T packages/ESP-IDF-latest/components/esp_rom/esp32c3/ld/esp32c3.rom.eco3.ld -T packages/ESP-IDF-latest/components/soc/esp32c3/ld/esp32c3.peripherals.ld  -Wl,--wrap=_Unwind_SetEnableExceptionFdeSorting -Wl,--wrap=__register_frame_info_bases -Wl,--wrap=__register_frame_info -Wl,--wrap=__register_frame -Wl,--wrap=__register_frame_info_table_bases -Wl,--wrap=__register_frame_info_table -Wl,--wrap=__register_frame_table -Wl,--wrap=__deregister_frame_info_bases -Wl,--wrap=__deregister_frame_info -Wl,--wrap=_Unwind_Find_FDE -Wl,--wrap=_Unwind_GetGR -Wl,--wrap=_Unwind_GetCFA -Wl,--wrap=_Unwind_GetIP -Wl,--wrap=_Unwind_GetIPInfo -Wl,--wrap=_Unwind_GetRegionStart -Wl,--wrap=_Unwind_GetDataRelBase -Wl,--wrap=_Unwind_GetTextRelBase -Wl,--wrap=_Unwind_SetIP -Wl,--wrap=_Unwind_SetGR -Wl,--wrap=_Unwind_GetLanguageSpecificData -Wl,--wrap=_Unwind_FindEnclosingFunction -Wl,--wrap=_Unwind_Resume -Wl,--wrap=_Unwind_RaiseException -Wl,--wrap=_Unwind_DeleteException -Wl,--wrap=_Unwind_ForcedUnwind -Wl,--wrap=_Unwind_Resume_or_Rethrow -Wl,--wrap=_Unwind_Backtrace -Wl,--wrap=__cxa_call_unexpected -Wl,--eh-frame-hdr -Wl,--wrap=__gxx_personality_v0  -Wl,--cref -Wl,--defsym=IDF_TARGET_ESP32C3=0'
-    CXXFLAGS = CFLAGS 
+    idf_path = find_package_path(BSP_ROOT, 'ESP-IDF-latest', relative_to=BSP_ROOT, pathsep='/')
+    LFLAGS = DEVICE + ' -Wl,--cref -Wl,--defsym=IDF_TARGET_ESP32C3=0 -Wl,--gc-sections,-Map=rtthread.map,-cref,-u,_start -T idf_port/ld/memory.ld -T idf_port/ld/sections.ld -T ' + idf_path + '/components/esp_rom/esp32c3/ld/esp32c3.rom.ld -T ' + idf_path + '/components/esp_rom/esp32c3/ld/esp32c3.rom.api.ld -T ' + idf_path + '/components/esp_rom/esp32c3/ld/esp32c3.rom.libgcc.ld -T ' + idf_path + '/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld -T ' + idf_path + '/components/esp_rom/esp32c3/ld/esp32c3.rom.version.ld -T ' + idf_path + '/components/esp_rom/esp32c3/ld/esp32c3.rom.eco3.ld -T ' + idf_path + '/components/soc/esp32c3/ld/esp32c3.peripherals.ld  -Wl,--wrap=_Unwind_SetEnableExceptionFdeSorting -Wl,--wrap=__register_frame_info_bases -Wl,--wrap=__register_frame_info -Wl,--wrap=__register_frame -Wl,--wrap=__register_frame_info_table_bases -Wl,--wrap=__register_frame_info_table -Wl,--wrap=__register_frame_table -Wl,--wrap=__deregister_frame_info_bases -Wl,--wrap=__deregister_frame_info -Wl,--wrap=_Unwind_Find_FDE -Wl,--wrap=_Unwind_GetGR -Wl,--wrap=_Unwind_GetCFA -Wl,--wrap=_Unwind_GetIP -Wl,--wrap=_Unwind_GetIPInfo -Wl,--wrap=_Unwind_GetRegionStart -Wl,--wrap=_Unwind_GetDataRelBase -Wl,--wrap=_Unwind_GetTextRelBase -Wl,--wrap=_Unwind_SetIP -Wl,--wrap=_Unwind_SetGR -Wl,--wrap=_Unwind_GetLanguageSpecificData -Wl,--wrap=_Unwind_FindEnclosingFunction -Wl,--wrap=_Unwind_Resume -Wl,--wrap=_Unwind_RaiseException -Wl,--wrap=_Unwind_DeleteException -Wl,--wrap=_Unwind_ForcedUnwind -Wl,--wrap=_Unwind_Resume_or_Rethrow -Wl,--wrap=_Unwind_Backtrace -Wl,--wrap=__cxa_call_unexpected -Wl,--eh-frame-hdr -Wl,--wrap=__gxx_personality_v0  -Wl,--cref -Wl,--defsym=IDF_TARGET_ESP32C3=0'
+    CXXFLAGS = CFLAGS
 
     POST_ACTION = OBJCPY + ' -Oihex $TARGET rtthread.hex\n' + SIZE + ' $TARGET \n'
 

--- a/bsp/Infineon/libraries/templates/XMC7200D/SConstruct
+++ b/bsp/Infineon/libraries/templates/XMC7200D/SConstruct
@@ -10,6 +10,7 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_root
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
@@ -36,10 +37,10 @@ Export('rtconfig')
 
 SDK_ROOT = os.path.abspath('./')
 
-if os.path.exists(SDK_ROOT + '/packages'):
-    libraries_path_prefix = SDK_ROOT + '/packages'
-else:
+libraries_path_prefix = find_package_root(SDK_ROOT, package_prefix='Infineon_mtb-pdl-cat1')
+if not libraries_path_prefix:
     print("Error: Packages for HAL_Driver does not exist, pull it in ENV using `pkg --update`.")
+    libraries_path_prefix = os.path.join(SDK_ROOT, 'packages')
 
 SDK_LIB = libraries_path_prefix
 Export('SDK_LIB')

--- a/bsp/Infineon/psoc6-cy8ckit-062-BLE/SConstruct
+++ b/bsp/Infineon/psoc6-cy8ckit-062-BLE/SConstruct
@@ -10,6 +10,7 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_root
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
@@ -36,12 +37,10 @@ Export('rtconfig')
 
 SDK_ROOT = os.path.abspath('./')
 
-libraries_path_prefix = SDK_ROOT
-
-if os.path.exists(SDK_ROOT + '/packages'):
-    libraries_path_prefix = SDK_ROOT + '/packages'
-else:
+libraries_path_prefix = find_package_root(SDK_ROOT, package_prefix='Infineon_mtb-pdl-cat1')
+if not libraries_path_prefix:
     print("Error: Packages for HAL_Driver does not exist, pull it in ENV using `pkg --update`.")
+    libraries_path_prefix = os.path.join(SDK_ROOT, 'packages')
 
 SDK_LIB = libraries_path_prefix
 Export('SDK_LIB')

--- a/bsp/Infineon/psoc6-cy8ckit-062-WIFI-BT/SConstruct
+++ b/bsp/Infineon/psoc6-cy8ckit-062-WIFI-BT/SConstruct
@@ -10,6 +10,7 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_root
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
@@ -36,12 +37,10 @@ Export('rtconfig')
 
 SDK_ROOT = os.path.abspath('./')
 
-libraries_path_prefix = SDK_ROOT
-
-if os.path.exists(SDK_ROOT + '/packages'):
-    libraries_path_prefix = SDK_ROOT + '/packages'
-else:
+libraries_path_prefix = find_package_root(SDK_ROOT, package_prefix='Infineon_mtb-pdl-cat1')
+if not libraries_path_prefix:
     print("Error: Packages for HAL_Driver does not exist, pull it in ENV using `pkg --update`.")
+    libraries_path_prefix = os.path.join(SDK_ROOT, 'packages')
 
 SDK_LIB = libraries_path_prefix
 Export('SDK_LIB')

--- a/bsp/Infineon/psoc6-cy8ckit-062S2-43012/SConstruct
+++ b/bsp/Infineon/psoc6-cy8ckit-062S2-43012/SConstruct
@@ -10,6 +10,7 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_root
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
@@ -36,12 +37,10 @@ Export('rtconfig')
 
 SDK_ROOT = os.path.abspath('./')
 
-libraries_path_prefix = SDK_ROOT
-
-if os.path.exists(SDK_ROOT + '/packages'):
-    libraries_path_prefix = SDK_ROOT + '/packages'
-else:
+libraries_path_prefix = find_package_root(SDK_ROOT, package_prefix='Infineon_mtb-pdl-cat1')
+if not libraries_path_prefix:
     print("Error: Packages for HAL_Driver does not exist, pull it in ENV using `pkg --update`.")
+    libraries_path_prefix = os.path.join(SDK_ROOT, 'packages')
 
 SDK_LIB = libraries_path_prefix
 Export('SDK_LIB')

--- a/bsp/Infineon/psoc6-cy8ckit-062s4/SConstruct
+++ b/bsp/Infineon/psoc6-cy8ckit-062s4/SConstruct
@@ -10,6 +10,7 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_root
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
@@ -36,12 +37,10 @@ Export('rtconfig')
 
 SDK_ROOT = os.path.abspath('./')
 
-libraries_path_prefix = SDK_ROOT
-
-if os.path.exists(SDK_ROOT + '/packages'):
-    libraries_path_prefix = SDK_ROOT + '/packages'
-else:
+libraries_path_prefix = find_package_root(SDK_ROOT, package_prefix='Infineon_mtb-pdl-cat1')
+if not libraries_path_prefix:
     print("Error: Packages for HAL_Driver does not exist, pull it in ENV using `pkg --update`.")
+    libraries_path_prefix = os.path.join(SDK_ROOT, 'packages')
 
 SDK_LIB = libraries_path_prefix
 Export('SDK_LIB')

--- a/bsp/Infineon/psoc6-cy8cproto-062S3-4343W/SConstruct
+++ b/bsp/Infineon/psoc6-cy8cproto-062S3-4343W/SConstruct
@@ -10,6 +10,7 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_root
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
@@ -36,12 +37,10 @@ Export('rtconfig')
 
 SDK_ROOT = os.path.abspath('./')
 
-libraries_path_prefix = SDK_ROOT
-
-if os.path.exists(SDK_ROOT + '/packages'):
-    libraries_path_prefix = SDK_ROOT + '/packages'
-else:
+libraries_path_prefix = find_package_root(SDK_ROOT, package_prefix='Infineon_mtb-pdl-cat1')
+if not libraries_path_prefix:
     print("Error: Packages for HAL_Driver does not exist, pull it in ENV using `pkg --update`.")
+    libraries_path_prefix = os.path.join(SDK_ROOT, 'packages')
 
 SDK_LIB = libraries_path_prefix
 Export('SDK_LIB')

--- a/bsp/Infineon/psoc6-evaluationkit-062S2/SConstruct
+++ b/bsp/Infineon/psoc6-evaluationkit-062S2/SConstruct
@@ -10,6 +10,7 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_root
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
@@ -36,12 +37,10 @@ Export('rtconfig')
 
 SDK_ROOT = os.path.abspath('./')
 
-libraries_path_prefix = SDK_ROOT
-
-if os.path.exists(SDK_ROOT + '/packages'):
-    libraries_path_prefix = SDK_ROOT + '/packages'
-else:
+libraries_path_prefix = find_package_root(SDK_ROOT, package_prefix='Infineon_mtb-pdl-cat1')
+if not libraries_path_prefix:
     print("Error: Packages for HAL_Driver does not exist, pull it in ENV using `pkg --update`.")
+    libraries_path_prefix = os.path.join(SDK_ROOT, 'packages')
 
 SDK_LIB = libraries_path_prefix
 Export('SDK_LIB')

--- a/bsp/Infineon/xmc7100d-f144k4160aa/SConstruct
+++ b/bsp/Infineon/xmc7100d-f144k4160aa/SConstruct
@@ -10,6 +10,7 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_root
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
@@ -36,12 +37,10 @@ Export('rtconfig')
 
 SDK_ROOT = os.path.abspath('./')
 
-libraries_path_prefix = SDK_ROOT
-
-if os.path.exists(SDK_ROOT + '/packages'):
-    libraries_path_prefix = SDK_ROOT + '/packages'
-else:
+libraries_path_prefix = find_package_root(SDK_ROOT, package_prefix='Infineon_mtb-pdl-cat1')
+if not libraries_path_prefix:
     print("Error: Packages for HAL_Driver does not exist, pull it in ENV using `pkg --update`.")
+    libraries_path_prefix = os.path.join(SDK_ROOT, 'packages')
 
 SDK_LIB = libraries_path_prefix
 Export('SDK_LIB')

--- a/bsp/Infineon/xmc7200-kit_xmc7200_evk/SConstruct
+++ b/bsp/Infineon/xmc7200-kit_xmc7200_evk/SConstruct
@@ -10,6 +10,7 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_root
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
@@ -36,12 +37,10 @@ Export('rtconfig')
 
 SDK_ROOT = os.path.abspath('./')
 
-libraries_path_prefix = SDK_ROOT
-
-if os.path.exists(SDK_ROOT + '/packages'):
-    libraries_path_prefix = SDK_ROOT + '/packages'
-else:
+libraries_path_prefix = find_package_root(SDK_ROOT, package_prefix='Infineon_mtb-pdl-cat1')
+if not libraries_path_prefix:
     print("Error: Packages for HAL_Driver does not exist, pull it in ENV using `pkg --update`.")
+    libraries_path_prefix = os.path.join(SDK_ROOT, 'packages')
 
 SDK_LIB = libraries_path_prefix
 Export('SDK_LIB')

--- a/bsp/gd32/risc-v/gd32vw553h-eval/SConscript
+++ b/bsp/gd32/risc-v/gd32vw553h-eval/SConscript
@@ -1,7 +1,11 @@
 # for module compiling
 import os
+import sys
 Import('RTT_ROOT')
 from building import *
+sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
+from env_package import find_package_path
+from env_package import is_libraries_package
 
 cwd = str(Dir('#'))
 
@@ -12,5 +16,17 @@ for d in list:
     path = os.path.join(cwd, d)
     if os.path.isfile(os.path.join(path, 'SConscript')):
         objs = objs + SConscript(os.path.join(d, 'SConscript'))
+
+wifi_pkg_path = find_package_path(cwd, 'gd32vw55x-wifi-latest')
+if wifi_pkg_path and is_libraries_package(wifi_pkg_path) and GetDepend(['PKG_USING_GD32VW55X_WIFI']):
+    lwip_mem = os.path.join(RTT_ROOT, 'components', 'net', 'lwip', 'lwip-2.1.2', 'src', 'core', 'mem.c')
+
+    if os.path.isfile(lwip_mem):
+        objs += DefineGroup('gd32vw55x-wifi-port', [lwip_mem], depend=['PKG_USING_GD32VW55X_WIFI'],
+                            CPPPATH=[
+                                os.path.join(wifi_pkg_path, 'src', 'lwip', 'port'),
+                                os.path.join(wifi_pkg_path, 'src', 'lwip', 'port', 'arch'),
+                                os.path.join(RTT_ROOT, 'components', 'net', 'lwip', 'lwip-2.1.2', 'src', 'include')
+                            ])
 
 Return('objs')

--- a/bsp/gd32/risc-v/gd32vw553h-eval/SConstruct
+++ b/bsp/gd32/risc-v/gd32vw553h-eval/SConstruct
@@ -1,6 +1,5 @@
 import os
 import sys
-import rtconfig
 
 if os.getenv('RTT_ROOT'):
     RTT_ROOT = os.getenv('RTT_ROOT')
@@ -8,21 +7,17 @@ else:
     RTT_ROOT = os.path.normpath(os.getcwd() + '/../../../..')
 
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
+import rtconfig
 try:
     from building import *
+    from env_package import packages_available
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
     exit(-1)
 
 def bsp_pkg_check():
-    import subprocess
-
-    check_paths = [
-        os.path.join("packages", "gd32-riscv-series-latest")
-    ]
-
-    need_update = not all(os.path.exists(p) for p in check_paths)
+    need_update = not packages_available(os.path.abspath('.'), ['gd32-riscv-series-latest'])
 
     if need_update:
         print("\n===============================================================================")

--- a/bsp/gd32/risc-v/gd32vw553h-eval/board/SConscript
+++ b/bsp/gd32/risc-v/gd32vw553h-eval/board/SConscript
@@ -1,8 +1,12 @@
 import os
+import sys
 import rtconfig
 from building import *
 
 Import('SDK_LIB')
+Import('RTT_ROOT')
+sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
+from env_package import find_package_path
 
 cwd = GetCurrentDir()
 
@@ -20,12 +24,20 @@ if GetDepend(['BSP_USING_WLAN']):
 path =  [cwd]
 
 # add startup txt path
-startup_path_prefix = os.getcwd() + '/../'
+package_name = 'gd32-riscv-series-latest'
+package_path = find_package_path(
+    os.path.dirname(cwd),
+    package_name,
+    marker=os.path.join('GD32VW55x', 'RISCV', 'env_Eclipse', 'entry.S'),
+    extra_candidates=[
+        os.path.join(SDK_LIB, package_name),
+        os.path.join(os.path.dirname(SDK_LIB), 'packages', package_name),
+    ])
 
 if rtconfig.PLATFORM in ['gcc']:
     # Use standard peripheral library startup files for compatibility
-    src += [startup_path_prefix + '/packages/gd32-riscv-series-latest/GD32VW55x/RISCV/env_Eclipse/start.S']
-    src += [startup_path_prefix + '/packages/gd32-riscv-series-latest/GD32VW55x/RISCV/env_Eclipse/entry.S']
+    src += [os.path.join(package_path, 'GD32VW55x', 'RISCV', 'env_Eclipse', 'start.S')]
+    src += [os.path.join(package_path, 'GD32VW55x', 'RISCV', 'env_Eclipse', 'entry.S')]
 
 CPPDEFINES = ['GD32VW553H_EVAL']
 group = DefineGroup('Drivers', src, depend = [''], CPPPATH = path, CPPDEFINES = CPPDEFINES)

--- a/bsp/gd32/risc-v/gd32vw553h-eval/rtconfig.py
+++ b/bsp/gd32/risc-v/gd32vw553h-eval/rtconfig.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 # toolchains options
 ARCH='risc-v'
@@ -12,6 +13,12 @@ if os.getenv('RTT_CC'):
     CROSS_TOOL = os.getenv('RTT_CC')
 if os.getenv('RTT_ROOT'):
     RTT_ROOT = os.getenv('RTT_ROOT')
+
+BSP_ROOT = os.path.dirname(os.path.abspath(__file__))
+if not os.getenv('RTT_ROOT'):
+    RTT_ROOT = os.path.normpath(os.path.join(BSP_ROOT, '..', '..', '..', '..'))
+sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
+from env_package import find_package_path
 
 # cross_tool provides the cross compiler
 # EXEC_PATH is the compiler execute path, for example, CodeSourcery, Keil MDK, IAR
@@ -57,7 +64,7 @@ if PLATFORM == 'gcc':
     # Linking Parameters
     # 添加 --no-warn-mismatch 以忽略预编译库与当前工具链的特权规范版本差异
     # 添加 WiFi ROM 符号表
-    wifi_pkg_path = os.path.join(os.path.dirname(__file__), 'packages', 'gd32vw55x-wifi-latest')
+    wifi_pkg_path = find_package_path(BSP_ROOT, 'gd32vw55x-wifi-latest')
     rom_symbol = os.path.join(wifi_pkg_path, 'rom_export', 'symbol', 'rom_symbol_m.gcc')
     rom_symbol_flag = ''
     if os.path.exists(rom_symbol):

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s06_nxp_evk/SConstruct
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s06_nxp_evk/SConstruct
@@ -10,19 +10,15 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_path
+    from env_package import packages_available
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
     exit(-1)
 
 def bsp_pkg_check():
-    import subprocess
-
-    check_paths = [
-        os.path.join("packages", "nxp-lpc55s-series-latest"),
-    ]
-
-    need_update = not all(os.path.exists(p) for p in check_paths)
+    need_update = not packages_available(os.path.abspath('.'), ['nxp-lpc55s-series-latest'])
 
     if need_update:
         print("\n===============================================================================")
@@ -79,7 +75,8 @@ objs = PrepareBuilding(env, RTT_ROOT, has_libcpu=False)
 objs.extend(SConscript(os.path.join(libraries_path_prefix, 'drivers', 'SConscript')))
 
 # include cmsis
-objs.extend(SConscript(os.path.join("packages/nxp-lpc55s-series-latest", rtconfig.BSP_LIBRARY_TYPE, 'SConscript')))
+lpc55s_package_path = find_package_path(SDK_ROOT, 'nxp-lpc55s-series-latest')
+objs.extend(SConscript(os.path.join(lpc55s_package_path, rtconfig.BSP_LIBRARY_TYPE, 'SConscript')))
 
 # make a building
 DoBuilding(TARGET, objs)

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s16_nxp_evk/SConstruct
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s16_nxp_evk/SConstruct
@@ -10,19 +10,15 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_path
+    from env_package import packages_available
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
     exit(-1)
 
 def bsp_pkg_check():
-    import subprocess
-
-    check_paths = [
-        os.path.join("packages", "nxp-lpc55s-series-latest"),
-    ]
-
-    need_update = not all(os.path.exists(p) for p in check_paths)
+    need_update = not packages_available(os.path.abspath('.'), ['nxp-lpc55s-series-latest'])
 
     if need_update:
         print("\n===============================================================================")
@@ -79,7 +75,8 @@ objs = PrepareBuilding(env, RTT_ROOT, has_libcpu=False)
 objs.extend(SConscript(os.path.join(libraries_path_prefix, 'drivers', 'SConscript')))
 
 # include cmsis
-objs.extend(SConscript(os.path.join("packages/nxp-lpc55s-series-latest", rtconfig.BSP_LIBRARY_TYPE, 'SConscript')))
+lpc55s_package_path = find_package_path(SDK_ROOT, 'nxp-lpc55s-series-latest')
+objs.extend(SConscript(os.path.join(lpc55s_package_path, rtconfig.BSP_LIBRARY_TYPE, 'SConscript')))
 
 # make a building
 DoBuilding(TARGET, objs)

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s28_nxp_evk/SConstruct
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s28_nxp_evk/SConstruct
@@ -10,19 +10,15 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_path
+    from env_package import packages_available
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
     exit(-1)
 
 def bsp_pkg_check():
-    import subprocess
-
-    check_paths = [
-        os.path.join("packages", "nxp-lpc55s-series-latest"),
-    ]
-
-    need_update = not all(os.path.exists(p) for p in check_paths)
+    need_update = not packages_available(os.path.abspath('.'), ['nxp-lpc55s-series-latest'])
 
     if need_update:
         print("\n===============================================================================")
@@ -79,7 +75,8 @@ objs = PrepareBuilding(env, RTT_ROOT, has_libcpu=False)
 objs.extend(SConscript(os.path.join(libraries_path_prefix, 'drivers', 'SConscript')))
 
 # include cmsis
-objs.extend(SConscript(os.path.join("packages/nxp-lpc55s-series-latest", rtconfig.BSP_LIBRARY_TYPE, 'SConscript')))
+lpc55s_package_path = find_package_path(SDK_ROOT, 'nxp-lpc55s-series-latest')
+objs.extend(SConscript(os.path.join(lpc55s_package_path, rtconfig.BSP_LIBRARY_TYPE, 'SConscript')))
 
 # make a building
 DoBuilding(TARGET, objs)

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s36_nxp_evk/SConstruct
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s36_nxp_evk/SConstruct
@@ -10,19 +10,15 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_path
+    from env_package import packages_available
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
     exit(-1)
 
 def bsp_pkg_check():
-    import subprocess
-
-    check_paths = [
-        os.path.join("packages", "nxp-lpc55s-series-latest"),
-    ]
-
-    need_update = not all(os.path.exists(p) for p in check_paths)
+    need_update = not packages_available(os.path.abspath('.'), ['nxp-lpc55s-series-latest'])
 
     if need_update:
         print("\n===============================================================================")
@@ -79,7 +75,8 @@ objs = PrepareBuilding(env, RTT_ROOT, has_libcpu=False)
 objs.extend(SConscript(os.path.join(libraries_path_prefix, 'drivers', 'SConscript')))
 
 # include cmsis
-objs.extend(SConscript(os.path.join("packages/nxp-lpc55s-series-latest", rtconfig.BSP_LIBRARY_TYPE, 'SConscript')))
+lpc55s_package_path = find_package_path(SDK_ROOT, 'nxp-lpc55s-series-latest')
+objs.extend(SConscript(os.path.join(lpc55s_package_path, rtconfig.BSP_LIBRARY_TYPE, 'SConscript')))
 
 # make a building
 DoBuilding(TARGET, objs)

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s69_nxp_evk/SConstruct
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s69_nxp_evk/SConstruct
@@ -10,19 +10,15 @@ else:
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 try:
     from building import *
+    from env_package import find_package_path
+    from env_package import packages_available
 except:
     print('Cannot found RT-Thread root directory, please check RTT_ROOT')
     print(RTT_ROOT)
     exit(-1)
 
 def bsp_pkg_check():
-    import subprocess
-
-    check_paths = [
-        os.path.join("packages", "nxp-lpc55s-series-latest"),
-    ]
-
-    need_update = not all(os.path.exists(p) for p in check_paths)
+    need_update = not packages_available(os.path.abspath('.'), ['nxp-lpc55s-series-latest'])
 
     if need_update:
         print("\n===============================================================================")
@@ -79,7 +75,8 @@ objs = PrepareBuilding(env, RTT_ROOT, has_libcpu=False)
 objs.extend(SConscript(os.path.join(libraries_path_prefix, 'drivers', 'SConscript')))
 
 # include cmsis
-objs.extend(SConscript(os.path.join("packages/nxp-lpc55s-series-latest", rtconfig.BSP_LIBRARY_TYPE, 'SConscript')))
+lpc55s_package_path = find_package_path(SDK_ROOT, 'nxp-lpc55s-series-latest')
+objs.extend(SConscript(os.path.join(lpc55s_package_path, rtconfig.BSP_LIBRARY_TYPE, 'SConscript')))
 
 # make a building
 DoBuilding(TARGET, objs)

--- a/bsp/raspberry-pico/RP2040/SConstruct
+++ b/bsp/raspberry-pico/RP2040/SConstruct
@@ -9,6 +9,7 @@ else:
 
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 from building import *
+from env_package import find_package_path
 
 TARGET = 'rtthread-pico.' + rtconfig.TARGET_EXT
 
@@ -24,11 +25,12 @@ env.PrependENVPath('PATH', rtconfig.EXEC_PATH)
 Export('RTT_ROOT')
 Export('rtconfig')
 
+
 # prepare building environment
 objs = PrepareBuilding(env, RTT_ROOT)
 
 ocwd = os.getcwd()
-os.chdir('packages/raspberrypi-pico-sdk-latest')
+os.chdir(find_package_path(os.getcwd(), 'raspberrypi-pico-sdk-latest'))
 print("Enter " + os.getcwd())
 if GetOption('clean'):
     os.system("scons -c")

--- a/bsp/raspberry-pico/RP2350/SConstruct
+++ b/bsp/raspberry-pico/RP2350/SConstruct
@@ -9,6 +9,7 @@ else:
 
 sys.path = sys.path + [os.path.join(RTT_ROOT, 'tools')]
 from building import *
+from env_package import find_package_path
 
 TARGET = 'rtthread-pico.' + rtconfig.TARGET_EXT
 
@@ -24,11 +25,12 @@ env.PrependENVPath('PATH', rtconfig.EXEC_PATH)
 Export('RTT_ROOT')
 Export('rtconfig')
 
+
 # prepare building environment
 objs = PrepareBuilding(env, RTT_ROOT)
 
 ocwd = os.getcwd()
-os.chdir('packages/raspberrypi-pico-rp2350-sdk-latest')
+os.chdir(find_package_path(os.getcwd(), 'raspberrypi-pico-rp2350-sdk-latest'))
 print("Enter " + os.getcwd())
 if GetOption('clean'):
     os.system("scons -c")

--- a/tools/env_package.py
+++ b/tools/env_package.py
@@ -1,0 +1,239 @@
+#
+# File      : env_package.py
+# This file is part of RT-Thread RTOS
+#
+# SPDX-License-Identifier: GPL-2.0+
+#
+# Change Logs:
+# Date           Author       Notes
+# 2026-06-12     CYFS         Add shared package path helpers
+#
+
+import fnmatch
+import os
+
+
+def _same_path(path_a, path_b):
+    return os.path.normcase(os.path.abspath(path_a)) == os.path.normcase(os.path.abspath(path_b))
+
+
+def _format_path(path, relative_to=None, pathsep=None):
+    if relative_to:
+        path = os.path.relpath(path, relative_to)
+
+    if pathsep:
+        path = path.replace(os.path.sep, pathsep)
+        if os.path.altsep:
+            path = path.replace(os.path.altsep, pathsep)
+
+    return path
+
+
+def _marker_exists(package_path, marker):
+    if not marker:
+        return True
+
+    if isinstance(marker, (list, tuple)):
+        for item in marker:
+            if not _marker_exists(package_path, item):
+                return False
+        return True
+
+    return os.path.exists(os.path.join(package_path, marker))
+
+
+def _unique_paths(paths):
+    unique_paths = []
+    seen = set()
+
+    for path in paths:
+        if not path:
+            continue
+
+        key = os.path.normcase(os.path.abspath(path))
+        if key in seen:
+            continue
+
+        seen.add(key)
+        unique_paths.append(path)
+
+    return unique_paths
+
+
+def package_root_candidates(bsp_root):
+    bsp_root = os.path.abspath(bsp_root)
+    ancestors = []
+    current = bsp_root
+
+    while True:
+        if _is_rt_thread_bsp_dir(current):
+            break
+
+        ancestors.append(current)
+
+        parent = os.path.dirname(current)
+        if _same_path(parent, current):
+            break
+
+        current = parent
+
+    library_roots = [os.path.join(root, 'libraries') for root in ancestors]
+    package_roots = [os.path.join(root, 'packages') for root in ancestors]
+
+    return _unique_paths(library_roots + package_roots)
+
+
+def package_candidates(bsp_root, package_name, extra_candidates=None):
+    candidates = []
+    for root in package_root_candidates(bsp_root):
+        candidates.append(os.path.join(root, package_name))
+
+    if extra_candidates:
+        candidates.extend(extra_candidates)
+
+    return _unique_paths(candidates)
+
+
+def find_package_path(bsp_root, package_name, marker=None, extra_candidates=None,
+                      relative_to=None, pathsep=None):
+    candidates = package_candidates(bsp_root, package_name, extra_candidates)
+    existing_paths = []
+
+    for path in candidates:
+        if not os.path.isdir(path):
+            continue
+
+        existing_paths.append(path)
+        if _marker_exists(path, marker):
+            return _format_path(path, relative_to, pathsep)
+
+    if existing_paths:
+        return _format_path(existing_paths[0], relative_to, pathsep)
+
+    fallback_path = os.path.join(os.path.abspath(bsp_root), 'packages', package_name)
+    return _format_path(fallback_path, relative_to, pathsep)
+
+
+def package_exists(bsp_root, package_name, marker=None):
+    path = find_package_path(bsp_root, package_name, marker=marker)
+    return os.path.isdir(path) and _marker_exists(path, marker)
+
+
+def packages_available(bsp_root, package_names):
+    for package_name in package_names:
+        if not package_exists(bsp_root, package_name):
+            return False
+
+    return True
+
+
+def _package_name_match(name, package_name=None, package_prefix=None, package_pattern=None):
+    if package_name and name != package_name:
+        return False
+
+    if package_prefix and not name.startswith(package_prefix):
+        return False
+
+    if package_pattern and not fnmatch.fnmatch(name, package_pattern):
+        return False
+
+    return True
+
+
+def find_package_root(bsp_root, package_name=None, package_prefix=None,
+                      package_pattern=None, marker=None):
+    for root in package_root_candidates(bsp_root):
+        if not os.path.isdir(root):
+            continue
+
+        if package_name:
+            package_path = os.path.join(root, package_name)
+            if os.path.isdir(package_path) and _marker_exists(package_path, marker):
+                return root
+            continue
+
+        try:
+            names = os.listdir(root)
+        except OSError:
+            continue
+
+        for name in names:
+            package_path = os.path.join(root, name)
+            if not os.path.isdir(package_path):
+                continue
+            if not _package_name_match(name, package_name, package_prefix, package_pattern):
+                continue
+            if _marker_exists(package_path, marker):
+                return root
+
+    return None
+
+
+def is_libraries_package(package_path):
+    return os.path.basename(os.path.dirname(os.path.abspath(package_path))).lower() == 'libraries'
+
+
+def _get_existing_libraries_path(root):
+    exact_path = os.path.join(root, 'libraries')
+    if os.path.isdir(exact_path):
+        return exact_path
+
+    try:
+        for name in os.listdir(root):
+            path = os.path.join(root, name)
+            if name.lower() == 'libraries' and os.path.isdir(path):
+                return path
+    except OSError:
+        pass
+
+    return None
+
+
+def _is_rt_thread_bsp_dir(path):
+    parent = os.path.dirname(path)
+    return (
+        os.path.basename(path).lower() == 'bsp'
+        and os.path.isdir(os.path.join(parent, 'bsp'))
+        and os.path.isfile(os.path.join(parent, 'include', 'rtdef.h'))
+    )
+
+
+def find_libraries_path_upward(bsp_root):
+    current = os.path.abspath(bsp_root)
+
+    while True:
+        libraries_path = _get_existing_libraries_path(current)
+        if libraries_path:
+            return libraries_path
+
+        if _is_rt_thread_bsp_dir(current):
+            return None
+
+        parent = os.path.dirname(current)
+        if _same_path(parent, current):
+            return None
+
+        current = parent
+
+
+def is_hal_sdk_package_bridge(package_path):
+    if os.path.isdir(os.path.join(package_path, '.git')):
+        return False
+
+    sconscript_path = os.path.join(package_path, 'SConscript')
+    if not os.path.isfile(sconscript_path):
+        return False
+
+    try:
+        with open(sconscript_path, 'r') as f:
+            content = f.read()
+        return (
+            'hal-sdk package source not found' in content
+            and (
+                'source_candidates' in content
+                or '_find_hal_sdk_libraries_path' in content
+                or 'libraries_path_prefix' in content
+            )
+        )
+    except Exception:
+        return False

--- a/tools/mkdist.py
+++ b/tools/mkdist.py
@@ -22,6 +22,7 @@
 # 2017-10-04     Bernard      The first version
 # 2025-01-07     ZhaoCake     components copy and gen doc
 # 2025-03-02     ZhaoCake     Add MkDist_Strip
+# 2026-06-10     CYFS         Copy shared hal-sdk package libraries for dist
 
 
 import os
@@ -29,6 +30,8 @@ import subprocess
 import shutil
 from shutil import ignore_patterns
 from SCons.Script import *
+from env_package import find_libraries_path_upward
+from env_package import is_hal_sdk_package_bridge
 
 def do_copy_file(src, dst):
     # check source file
@@ -164,6 +167,33 @@ def bsp_update_kconfig_library(dist_dir):
                 line = line.replace('../libraries', 'libraries')
             f.write(line)
 
+def bsp_copy_hal_sdk_package_libraries(bsp_root, dist_dir):
+    packages_dir = os.path.join(dist_dir, 'packages')
+    if not os.path.isdir(packages_dir):
+        return
+
+    libraries_path = find_libraries_path_upward(bsp_root)
+    if not libraries_path:
+        return
+
+    copied = False
+    for package_name in os.listdir(packages_dir):
+        package_path = os.path.join(packages_dir, package_name)
+        if not os.path.isdir(package_path):
+            continue
+        if not is_hal_sdk_package_bridge(package_path):
+            continue
+
+        source_path = os.path.join(libraries_path, package_name)
+        if not os.path.isdir(source_path):
+            print('warning: hal-sdk package library not found: %s' % source_path)
+            continue
+
+        if not copied:
+            print('=> hal-sdk package libraries')
+            copied = True
+        bsp_copy_files(source_path, os.path.join(dist_dir, 'libraries', package_name))
+
 def zip_dist(dist_dir, dist_name):
     import zipfile
 
@@ -198,6 +228,8 @@ def MkDist(program, BSP_ROOT, RTT_ROOT, Env, project_name, project_path):
         print("=> start dist handle")
         dist_handle = Env['dist_handle']
         dist_handle(BSP_ROOT, dist_dir)
+
+    bsp_copy_hal_sdk_package_libraries(BSP_ROOT, dist_dir)
 
     # copy tools directory
     print('=> components')


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

新版 env 会将部分厂商 HAL SDK 软件包下载到 BSP 上层的 `libraries` 目录；旧版 env 仍可能将软件包下载到 BSP 本地的 `packages` 目录。当前部分 BSP 和 dist 脚本对软件包路径有硬编码，在新旧 env 布局切换时可能出现 SDK 源文件找不到，或 dist 打包遗漏上层 `libraries` 中软件包的问题。

#### 你的解决方案是什么 (what is your solution)

- 为相关 BSP 增加新旧 env 路径兼容，优先查找 BSP 本地/上层 `libraries/<package>`，找不到时回退到 BSP 本地/上层 `packages/<package>`。
- 调整 `tools/mkdist.py`，dist 时同步上层 `libraries` 中的共享 HAL SDK 软件包，避免打包工程缺少依赖。
- 修正 ESP32C3、Infineon、GD32VW553、NXP LPC55S、Raspberry Pico 等 BSP 对 HAL SDK、启动文件、链接脚本和 ROM symbol 的路径引用。
- 补充 GD32VW553 WiFi 构建所需的兼容处理，覆盖旧 env `packages` 和新 env `libraries` 两种布局。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
  - `bsp/gd32/risc-v/gd32vw553h-eval`
  - `bsp/ESP/ESP32_C3`
  - `bsp/Infineon/psoc6-*`
  - `bsp/Infineon/xmc7*`
  - `bsp/nxp/lpc/lpc55sxx/*_nxp_evk`
  - `bsp/raspberry-pico/RP2040`
  - `bsp/raspberry-pico/RP2350`

- .config:
  - No new Kconfig option is introduced.
  - Verified with the default/component configs generated by RT-Thread BSP Static Build Check.

- action:
  - `riscv-none` with old env passed: https://github.com/RT-Thread/rt-thread/actions/runs/27267765257/job/80529511332
  - PR checks: https://github.com/RT-Thread/rt-thread/pull/11461/checks

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
