### PR TITLE
fix: with mismatched bound [-Warray-parameter=].

### DIFF
--- a/components/drivers/wlan/dev_wlan_mgnt.c
+++ b/components/drivers/wlan/dev_wlan_mgnt.c
@@ -1132,9 +1132,15 @@ rt_bool_t rt_wlan_is_ready(void)
     return _ready;
 }
 
-rt_err_t rt_wlan_set_mac(rt_uint8_t mac[6])
+rt_err_t rt_wlan_set_mac(rt_uint8_t *mac)
 {
     rt_err_t err = RT_EOK;
+
+    if (mac == RT_NULL)
+    {
+        RT_WLAN_LOG_E("mac addr is null");
+        return -RT_EINVAL;
+    }
 
     if (_sta_is_null())
     {
@@ -1155,9 +1161,15 @@ rt_err_t rt_wlan_set_mac(rt_uint8_t mac[6])
     return err;
 }
 
-rt_err_t rt_wlan_get_mac(rt_uint8_t mac[6])
+rt_err_t rt_wlan_get_mac(rt_uint8_t *mac)
 {
     rt_err_t err = RT_EOK;
+
+    if (mac == RT_NULL)
+    {
+        RT_WLAN_LOG_E("mac addr is null");
+        return -RT_EINVAL;
+    }
 
     if (_sta_is_null())
     {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
解决编译警告

  dev_wlan_mgnt.c:1135:37
  dev_wlan_mgnt.c:1158:37
  .c文件中定义的地方和.h声明的地方不一致，导致的编译警告
  
<img width="1557" height="636" alt="image" src="https://github.com/user-attachments/assets/c5a16205-d132-42d0-b7f4-4f52e2714e2d" />

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
