### PR TITLE
[feat][ci]: reduce duplicate HC32 attachconfig builds

### DIFF
--- a/.github/ALL_BSP_COMPILE.json
+++ b/.github/ALL_BSP_COMPILE.json
@@ -6,6 +6,7 @@
 // Date           Author       Notes
 // 2025-03-22     Supperthomas 添加upload 上传编译固件
 // 2025-03-31     Hydevcode    将需要编译的bsp列表分离，根据修改的文件对相应的bsp编译
+// 2026-06-22     CYFS3        限制重复HC32附加配置构建，缩短CI等待时间
 //
 {
   "legs": [
@@ -27,6 +28,12 @@
     {
       "RTT_BSP": "at32_hc32_ht32",
       "RTT_TOOL_CHAIN": "sourcery-arm",
+      "ATTACHCONFIG_RTT_BSP": [
+        "hc32/ev_hc32f4a8_lqfp176",
+        "hc32/ev_hc32f334_lqfp64",
+        "hc32/ev_hc32f472_lqfp100",
+        "ht32/ht32f53252"
+      ],
       "SUB_RTT_BSP": [
         "at32/at32a403a-start",
         "at32/at32a423-start",

--- a/.github/workflows/bsp_buildings.yml
+++ b/.github/workflows/bsp_buildings.yml
@@ -17,7 +17,16 @@ on:
     branches:
       - master
     paths-ignore:
-      - .github/**
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/CODEOWNERS
+      - .github/CODE_OF_CONDUCT.md
+      - .github/CONTRIBUTING.md
+      - .github/SECURITY.md
+      - .github/copilot-instructions.md
+      - .github/labeler.yml
+      - .github/figures/**
+      - .github/utest/**
       - .gitee/**
       - .hook/**
       - documentation/**
@@ -30,7 +39,16 @@ on:
     branches:
       - master
     paths-ignore:
-      - .github/**
+      - .github/ISSUE_TEMPLATE/**
+      - .github/PULL_REQUEST_TEMPLATE.md
+      - .github/CODEOWNERS
+      - .github/CODE_OF_CONDUCT.md
+      - .github/CONTRIBUTING.md
+      - .github/SECURITY.md
+      - .github/copilot-instructions.md
+      - .github/labeler.yml
+      - .github/figures/**
+      - .github/utest/**
       - .gitee/**
       - .hook/**
       - documentation/**

--- a/.github/workflows/bsp_buildings.yml
+++ b/.github/workflows/bsp_buildings.yml
@@ -269,6 +269,7 @@ jobs:
           RTT_BSP: ${{ matrix.legs.RTT_BSP }}
           RTT_TOOL_CHAIN: ${{ matrix.legs.RTT_TOOL_CHAIN }}
           SRTT_BSP: ${{ join(matrix.legs.SUB_RTT_BSP, ',') }}
+          ATTACHCONFIG_RTT_BSP: ${{ join(matrix.legs.ATTACHCONFIG_RTT_BSP || fromJSON('[]'), ',') }}
           RTT_CI_BUILD_DIST: "1"
         run: |
           source ~/.env/env.sh

--- a/tools/ci/bsp_buildings.py
+++ b/tools/ci/bsp_buildings.py
@@ -382,6 +382,14 @@ if __name__ == "__main__":
 
     rtt_root = os.getcwd()
     srtt_bsp = os.getenv('SRTT_BSP').split(',')
+    attachconfig_rtt_bsp_env = os.getenv('ATTACHCONFIG_RTT_BSP')
+    attachconfig_rtt_bsp = None
+    if attachconfig_rtt_bsp_env:
+        attachconfig_rtt_bsp = {
+            bsp.strip()
+            for bsp in attachconfig_rtt_bsp_env.split(',')
+            if bsp.strip()
+        }
     print(srtt_bsp)
     for bsp in srtt_bsp:
         count += 1
@@ -394,6 +402,11 @@ if __name__ == "__main__":
         else:
             add_summary(f'- ✅ build {bsp} success.')
         print("::endgroup::")
+
+        if attachconfig_rtt_bsp is not None and bsp not in attachconfig_rtt_bsp:
+            print(f"Skip attachconfig build for {bsp}")
+            add_summary(f'\t- ⏭️ skip attachconfig build {bsp}.')
+            continue
 
         yml_files_content = []
         directory = os.path.join(rtt_root, 'bsp', bsp, '.ci/attachconfig')


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

RT-Thread BSP Static Build Check 中 `at32_hc32_ht32` matrix leg 耗时明显偏长。参考 https://github.com/RT-Thread/rt-thread/actions/runs/27336610440/job/80762661792?pr=11469 ，该 job 总耗时约 33 分 30 秒，会拖长整个 CI workflow 的完成时间。

重新分析后，耗时主要不是 matrix 分组本身，而是 `tools/ci/bsp_buildings.py` 的构建流程：每个 BSP 默认编译完成后，还会继续执行该 BSP `.ci/attachconfig/ci.attachconfig.yml` 中的每个附加配置。HC32 这里有多个 BSP 都配置了 attachconfig，且大量 driver/kconfig 组合重复，因此同类 driver 被重复构建多次，导致该 job 拖尾。

同时，当前 `bsp_buildings.yml` 的 `paths-ignore` 直接忽略了 `.github/**`。这会导致修改 `.github/ALL_BSP_COMPILE.json` 或 `.github/workflows/bsp_buildings.yml` 时，BSP Static Build Check 本身不会被 pull request 自动触发，CI matrix 和 workflow 配置变更缺少自动验证。

#### 你的解决方案是什么 (what is your solution)

保留 `at32_hc32_ht32` 统一 matrix 分组，避免拆成多个小 job 后重复下载环境、初始化工具链，并继续利用同一个 job 内已经准备好的构建环境。

新增可选的 `ATTACHCONFIG_RTT_BSP` matrix 字段，并传入 `tools/ci/bsp_buildings.py`：

- 未配置 `ATTACHCONFIG_RTT_BSP` 的 matrix leg 保持原行为，继续对所有 BSP 执行 attachconfig。
- 配置 `ATTACHCONFIG_RTT_BSP` 的 matrix leg 中，所有 BSP 仍执行默认编译，只有指定的代表 BSP 执行 attachconfig。
- `at32_hc32_ht32` 中保留 HC32 代表 BSP `hc32/ev_hc32f4a8_lqfp176`、`hc32/ev_hc32f334_lqfp64`、`hc32/ev_hc32f472_lqfp100` 执行 attachconfig，减少其它 HC32 BSP 重复跑同类 driver 组合。
- `ht32/ht32f53252` 仍保留 attachconfig 构建，避免影响 HT32 原有覆盖。

本 PR 不修改各 BSP 原有的 `.ci/attachconfig/ci.attachconfig.yml` 内容，只在 CI 构建流程中选择代表 BSP 执行附加配置构建。其它 HC32 BSP 仍执行默认 build，但跳过重复 attachconfig。

另外，将 `bsp_buildings.yml` 中对 `.github/**` 的粗粒度忽略改为更细的文档/模板/标签/utest 配置忽略项。这样修改 `.github/ALL_BSP_COMPILE.json` 和 `.github/workflows/bsp_buildings.yml` 时，可以自动触发 BSP Static Build Check 来验证 CI 相关变更；`.github/utest/**` 仍保持忽略，避免 utest 专用配置变更误触发 BSP 编译。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:
  - `at32/at32m416-start`
  - `hc32/ev_hc32f4a8_lqfp176`
  - `hc32/ev_hc32f334_lqfp64`
  - `hc32/ev_hc32f472_lqfp100`
  - `ht32/ht32f53252`

- .config:
  - N/A, this PR only updates CI BSP matrix, attachconfig selection, and workflow trigger paths.

- action:
  - Local validation: rebased onto latest `rtt/master` after upstream `.github` changes.
  - Local validation: comment-stripped `.github/ALL_BSP_COMPILE.json` passed `python -m json.tool`.
  - Local validation: `.github/workflows/bsp_buildings.yml` passed YAML parsing.
  - Local validation: `tools/ci/bsp_buildings.py` passed `py_compile`.
  - Local validation: verified the final PR diff only changes `.github/ALL_BSP_COMPILE.json`, `.github/workflows/bsp_buildings.yml`, and `tools/ci/bsp_buildings.py`; BSP attachconfig files are unchanged.
  - Local validation: verified `.github/ALL_BSP_COMPILE.json` and `.github/workflows/bsp_buildings.yml` are no longer in this workflow's `.github` ignore list, while `.github/utest/**` remains ignored.
  - Reference slow CI job: https://github.com/RT-Thread/rt-thread/actions/runs/27336610440/job/80762661792?pr=11469

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)


