### PR TITLE
feat[serial][v2]: add RX DMA event mode control

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart_v2.c
@@ -269,7 +269,7 @@ static rt_err_t stm32_control(struct rt_serial_device *serial, int cmd, void *ar
         if (ctrl_arg & (RT_DEVICE_FLAG_DMA_RX | RT_DEVICE_FLAG_DMA_TX))
         {
 #ifdef RT_SERIAL_USING_DMA
-            stm32_uart_dma_config(serial, ctrl_arg);
+            return stm32_uart_dma_config(serial, ctrl_arg);
 #else
             return -RT_ENOSYS;
 #endif
@@ -411,12 +411,113 @@ static rt_ssize_t stm32_transmit(struct rt_serial_device *serial,
 }
 
 #ifdef RT_SERIAL_USING_DMA
+/**
+ * @brief Resolve effective STM32 UART RX DMA event mode.
+ * @param request Requested RX DMA event mode.
+ * @param effective Pointer to the output effective mode.
+ * @return Operation status.
+ */
+static rt_err_t stm32_uart_resolve_rx_dma_event_mode(enum rt_serial_rx_dma_event_mode request,
+                                                     enum rt_serial_rx_dma_event_mode *effective)
+{
+    if (effective == RT_NULL)
+    {
+        return -RT_EINVAL;
+    }
+
+    if (request == RT_SERIAL_RX_DMA_EVENT_AUTO)
+    {
+        *effective = RT_SERIAL_RX_DMA_EVENT_HALF_FULL;
+        return RT_EOK;
+    }
+
+    if ((request != RT_SERIAL_RX_DMA_EVENT_NONE) &&
+        (request != RT_SERIAL_RX_DMA_EVENT_FULL_ONLY) &&
+        (request != RT_SERIAL_RX_DMA_EVENT_HALF_FULL))
+    {
+        return -RT_EINVAL;
+    }
+
+    *effective = request;
+    return RT_EOK;
+}
+
+/**
+ * @brief Configure STM32 UART RX DMA transfer event interrupts.
+ * @param dma_handle Pointer to the RX DMA handle linked to the UART.
+ * @param mode Effective serial RX DMA event mode.
+ */
+static void stm32_uart_configure_rx_dma_events(DMA_HandleTypeDef *dma_handle, enum rt_serial_rx_dma_event_mode mode)
+{
+    if (dma_handle == RT_NULL)
+    {
+        return;
+    }
+
+    if (mode == RT_SERIAL_RX_DMA_EVENT_NONE)
+    {
+        __HAL_DMA_DISABLE_IT(dma_handle, DMA_IT_HT);
+        __HAL_DMA_DISABLE_IT(dma_handle, DMA_IT_TC);
+    }
+    else if (mode == RT_SERIAL_RX_DMA_EVENT_FULL_ONLY)
+    {
+        __HAL_DMA_DISABLE_IT(dma_handle, DMA_IT_HT);
+        __HAL_DMA_ENABLE_IT(dma_handle, DMA_IT_TC);
+    }
+    else
+    {
+        __HAL_DMA_ENABLE_IT(dma_handle, DMA_IT_HT);
+        __HAL_DMA_ENABLE_IT(dma_handle, DMA_IT_TC);
+    }
+}
+
+/**
+ * @brief Check whether one STM32 UART RX DMA event should be handled.
+ * @param serial Pointer to the serial device.
+ * @param isr_flag UART RX DMA ISR source flag.
+ * @return RT_TRUE if the event should be handled.
+ */
+static rt_bool_t stm32_uart_rx_dma_event_enabled(struct rt_serial_device *serial, rt_uint8_t isr_flag)
+{
+    enum rt_serial_rx_dma_event_mode mode;
+
+    RT_ASSERT(serial != RT_NULL);
+
+    if (isr_flag == UART_RX_DMA_IT_IDLE_FLAG)
+    {
+        return RT_TRUE;
+    }
+
+    if (stm32_uart_resolve_rx_dma_event_mode(serial->config.rx_dma_event_mode, &mode) != RT_EOK)
+    {
+        return RT_FALSE;
+    }
+
+    if (isr_flag == UART_RX_DMA_IT_HT_FLAG)
+    {
+        return (mode == RT_SERIAL_RX_DMA_EVENT_HALF_FULL) ? RT_TRUE : RT_FALSE;
+    }
+
+    if (isr_flag == UART_RX_DMA_IT_TC_FLAG)
+    {
+        return (mode != RT_SERIAL_RX_DMA_EVENT_NONE) ? RT_TRUE : RT_FALSE;
+    }
+
+    return RT_FALSE;
+}
+
 static void dma_recv_isr(struct rt_serial_device *serial, rt_uint8_t isr_flag)
 {
     struct stm32_uart *uart;
     rt_size_t          recv_len, counter;
 
     RT_ASSERT(serial != RT_NULL);
+
+    if (stm32_uart_rx_dma_event_enabled(serial, isr_flag) != RT_TRUE)
+    {
+        return;
+    }
+
     uart = rt_container_of(serial, struct stm32_uart, serial);
 
     counter = __HAL_DMA_GET_COUNTER(&(uart->dma_rx.handle));
@@ -431,7 +532,7 @@ static void dma_recv_isr(struct rt_serial_device *serial, rt_uint8_t isr_flag)
         rt_uint8_t *ptr = NULL;
         rt_hw_serial_control_isr(serial, RT_HW_SERIAL_CTRL_GET_DMA_PING_BUF, (void *)&ptr);
         SCB_InvalidateDCache_by_Addr((uint32_t *)ptr, serial->config.dma_ping_bufsz);
-#endif
+#endif /* defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U) */
         uart->dma_rx.remaining_cnt = counter;
         rt_hw_serial_isr(serial, RT_SERIAL_EVENT_RX_DMADONE | (recv_len << 8));
     }
@@ -494,13 +595,13 @@ static void uart_isr(struct rt_serial_device *serial)
     }
 
 #ifdef RT_SERIAL_USING_DMA
-    if ((uart->uart_dma_flag) && (__HAL_UART_GET_FLAG(&(uart->handle), UART_FLAG_IDLE))
+    if ((uart->uart_dma_flag & RT_DEVICE_FLAG_DMA_RX) && (__HAL_UART_GET_FLAG(&(uart->handle), UART_FLAG_IDLE))
         && (__HAL_UART_GET_IT_SOURCE(&(uart->handle), UART_IT_IDLE)))
     {
         dma_recv_isr(serial, UART_RX_DMA_IT_IDLE_FLAG);
         __HAL_UART_CLEAR_IDLEFLAG(&uart->handle);
     }
-#endif
+#endif /* RT_SERIAL_USING_DMA */
 
     if (__HAL_UART_GET_FLAG(&(uart->handle), UART_FLAG_ORE))
     {
@@ -1113,6 +1214,7 @@ static rt_err_t stm32_uart_dma_config(struct rt_serial_device *serial, rt_ubase_
     DMA_HandleTypeDef *DMA_Handle;
     const struct stm32_dma_config *dma_config;
     struct stm32_uart *uart;
+    enum rt_serial_rx_dma_event_mode event_mode;
 
     RT_ASSERT(serial != RT_NULL);
     RT_ASSERT(flag == RT_DEVICE_FLAG_DMA_TX || flag == RT_DEVICE_FLAG_DMA_RX);
@@ -1122,6 +1224,11 @@ static rt_err_t stm32_uart_dma_config(struct rt_serial_device *serial, rt_ubase_
     {
         DMA_Handle = &uart->dma_rx.handle;
         dma_config = uart->config->dma_rx;
+        if (stm32_uart_resolve_rx_dma_event_mode(serial->config.rx_dma_event_mode, &event_mode) != RT_EOK)
+        {
+            LOG_E("%s invalid uart dma rx event mode", uart->config->name);
+            return -RT_EINVAL;
+        }
     }
     else /* RT_DEVICE_FLAG_DMA_TX == flag */
     {
@@ -1172,6 +1279,7 @@ static rt_err_t stm32_uart_dma_config(struct rt_serial_device *serial, rt_ubase_
             DMA_Handle->Parent = RT_NULL;
             return -RT_ERROR;
         }
+        stm32_uart_configure_rx_dma_events(DMA_Handle, event_mode);
         CLEAR_BIT(uart->handle.Instance->CR3, USART_CR3_EIE);
         __HAL_UART_ENABLE_IT(&(uart->handle), UART_IT_IDLE);
     }

--- a/components/drivers/include/drivers/dev_serial_v2.h
+++ b/components/drivers/include/drivers/dev_serial_v2.h
@@ -225,21 +225,37 @@
 #define RT_SERIAL_FLOWCONTROL_CTSRTS    1
 #define RT_SERIAL_FLOWCONTROL_NONE      0
 
+#ifdef RT_SERIAL_USING_DMA
+/**
+ * @brief Serial RX DMA data event mode.
+ * @note This mode controls only DMA half/full transfer data events.
+ *       UART IDLE interrupt remains enabled in RX DMA mode.
+ */
+enum rt_serial_rx_dma_event_mode
+{
+    RT_SERIAL_RX_DMA_EVENT_AUTO = 0,  /**< Use the default RX DMA event mode. */
+    RT_SERIAL_RX_DMA_EVENT_NONE,      /**< Disable DMA half/full data events; UART IDLE still reports received data. */
+    RT_SERIAL_RX_DMA_EVENT_FULL_ONLY, /**< Report only DMA transfer-complete data events plus UART IDLE. */
+    RT_SERIAL_RX_DMA_EVENT_HALF_FULL  /**< Report both DMA half-transfer and transfer-complete data events plus UART IDLE. */
+};
+#endif /* RT_SERIAL_USING_DMA */
+
 /* Default config for serial_configure structure */
 #ifdef RT_SERIAL_USING_DMA
-#define RT_SERIAL_CONFIG_DEFAULT                      \
-{                                                     \
-    BAUD_RATE_115200,           /* 115200 bits/s */   \
-    DATA_BITS_8,                /* 8 databits */      \
-    STOP_BITS_1,                /* 1 stopbit */       \
-    PARITY_NONE,                /* No parity  */      \
-    BIT_ORDER_LSB,              /* LSB first sent */  \
-    NRZ_NORMAL,                 /* Normal mode */     \
-    RT_SERIAL_RX_MINBUFSZ,      /* rxBuf size */      \
-    RT_SERIAL_TX_MINBUFSZ,      /* txBuf size */      \
-    RT_SERIAL_FLOWCONTROL_NONE, /* Off flowcontrol */ \
-    0,                          /* reserved */        \
-    RT_SERIAL_RX_MINBUFSZ / 2,  /* dma_ping_bufsz */  \
+#define RT_SERIAL_CONFIG_DEFAULT                         \
+{                                                        \
+    BAUD_RATE_115200,             /* 115200 bits/s */    \
+    DATA_BITS_8,                  /* 8 databits */       \
+    STOP_BITS_1,                  /* 1 stopbit */        \
+    PARITY_NONE,                  /* No parity  */       \
+    BIT_ORDER_LSB,                /* LSB first sent */   \
+    NRZ_NORMAL,                   /* Normal mode */      \
+    RT_SERIAL_RX_MINBUFSZ,        /* rxBuf size */       \
+    RT_SERIAL_TX_MINBUFSZ,        /* txBuf size */       \
+    RT_SERIAL_FLOWCONTROL_NONE,   /* Off flowcontrol */  \
+    0,                            /* reserved */         \
+    RT_SERIAL_RX_MINBUFSZ / 2,    /* dma_ping_bufsz */   \
+    RT_SERIAL_RX_DMA_EVENT_AUTO,  /* rx dma event mode */ \
 }
 #else
 #define RT_SERIAL_CONFIG_DEFAULT                      \
@@ -255,7 +271,7 @@
     RT_SERIAL_FLOWCONTROL_NONE, /* Off flowcontrol */ \
     0,                          /* reserved */        \
 }
-#endif
+#endif /* RT_SERIAL_USING_DMA */
 
 /**
  * @brief Serial receive indicate hook function type
@@ -280,7 +296,8 @@ struct serial_configure
 
 #ifdef RT_SERIAL_USING_DMA
     rt_uint32_t dma_ping_bufsz          :16;
-#endif
+    enum rt_serial_rx_dma_event_mode rx_dma_event_mode; /**< RX DMA half/full data event mode. */
+#endif /* RT_SERIAL_USING_DMA */
 };
 
 /**

--- a/components/drivers/serial/dev_serial_v2.c
+++ b/components/drivers/serial/dev_serial_v2.c
@@ -102,7 +102,7 @@ static int serial_fops_open(struct dfs_file *fd)
 
     rt_device_close(device);
     ret = rt_device_open(device, flags);
-    
+
     if (ret == RT_EOK)
     {
         serial = (struct rt_serial_device *)device;
@@ -1388,6 +1388,21 @@ static void _tc_flush(struct rt_serial_device *serial, int queue)
 }
 #endif /* RT_USING_POSIX_TERMIOS */
 
+#ifdef RT_SERIAL_USING_DMA
+/**
+ * @brief Check whether one serial RX DMA event mode value is valid.
+ * @param mode RX DMA event mode value.
+ * @return RT_TRUE if the mode value is valid.
+ */
+static rt_bool_t rt_serial_rx_dma_event_mode_valid(enum rt_serial_rx_dma_event_mode mode)
+{
+    return ((mode == RT_SERIAL_RX_DMA_EVENT_AUTO) ||
+            (mode == RT_SERIAL_RX_DMA_EVENT_NONE) ||
+            (mode == RT_SERIAL_RX_DMA_EVENT_FULL_ONLY) ||
+            (mode == RT_SERIAL_RX_DMA_EVENT_HALF_FULL)) ? RT_TRUE : RT_FALSE;
+}
+#endif /* RT_SERIAL_USING_DMA */
+
 /**
   * @brief Control the serial device.
   * @param dev The pointer of device driver structure
@@ -1425,20 +1440,36 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
         else
         {
             struct serial_configure *pconfig = (struct serial_configure *)args;
+            struct serial_configure old_config = serial->config;
+
+#ifdef RT_SERIAL_USING_DMA
+            if (rt_serial_rx_dma_event_mode_valid(pconfig->rx_dma_event_mode) != RT_TRUE)
+            {
+                ret = -RT_EINVAL;
+                break;
+            }
+#endif /* RT_SERIAL_USING_DMA */
+
             if (((pconfig->rx_bufsz != serial->config.rx_bufsz) || (pconfig->tx_bufsz != serial->config.tx_bufsz)
 #ifdef RT_SERIAL_USING_DMA
                  || (pconfig->dma_ping_bufsz != serial->config.dma_ping_bufsz)
-#endif
+                 || (pconfig->rx_dma_event_mode != serial->config.rx_dma_event_mode)
+#endif /* RT_SERIAL_USING_DMA */
                      ) &&
                 serial->parent.ref_count != 0)
             {
-                /*can not change buffer size*/
+                /* can not change buffer or DMA event configuration while opened */
                 ret = -RT_EBUSY;
                 break;
             }
+
             /* set serial configure */
             serial->config = *pconfig;
-            serial->ops->configure(serial, (struct serial_configure *)args);
+            ret = serial->ops->configure(serial, (struct serial_configure *)args);
+            if (ret != RT_EOK)
+            {
+                serial->config = old_config;
+            }
         }
         break;
     case RT_SERIAL_CTRL_GET_CONFIG:


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

Serial v2 在 RX DMA 模式下目前缺少统一的 DMA half/full transfer 事件策略配置。STM32 UART RX DMA 场景中，部分应用需要保留 UART IDLE 接收上报，同时减少 DMA half-transfer 中断，或显式选择 half/full transfer 上报策略。

该 PR 为 serial v2 配置增加 RX DMA event mode，并在 STM32 USART v2 驱动中按配置控制 RX DMA HT/TC 中断处理，使默认行为保持兼容，同时允许应用侧选择更低中断频率的 RX DMA 事件模式。

#### 你的解决方案是什么 (what is your solution)

* 在 `struct serial_configure` 中为 DMA 构建增加 `rx_dma_event_mode` 配置项，并在默认配置中使用 `RT_SERIAL_RX_DMA_EVENT_AUTO`。
* 新增 RX DMA event mode 枚举，用于表达默认模式、只上报 full-transfer，以及同时上报 half/full-transfer 的策略。
* 在 serial v2 control 路径中校验 `rx_dma_event_mode`，并在 backend configure 失败时恢复旧配置。
* 在 STM32 USART v2 驱动中解析有效 RX DMA event mode，并据此配置 DMA HT/TC 中断。
* 在 STM32 RX DMA ISR 路径中按事件模式过滤 HT/TC 事件，同时保持 UART IDLE 事件可用于接收数据上报。
* 修正 STM32 USART v2 DMA RX IDLE 判断条件，避免 TX DMA 标志导致 RX DMA IDLE 路径被错误触发。

#### 请提供验证的bsp和config (provide the config and bsp)

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

* BSP: 未在上传材料中提供实测 BSP；提交前建议使用目标 STM32 BSP 验证，例如启用 USART RX DMA 的 `bsp/stm32/<target-board>`。

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

* .config: `RT_USING_SERIAL_V2`, `RT_SERIAL_USING_DMA`, `BSP_USING_UARTx`, `BSP_UARTx_RX_USING_DMA`，以及对应 BSP 的 UART RX DMA 配置。

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

* action: 未在上传材料中提供 action 链接；提交前建议补充 PR 分支触发的 `manual_dist.yml` 或目标 BSP 编译 action 链接。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

* [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
* [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

* [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
* [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
* [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
* [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
* [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
* [ ] 代码是高质量的 Code in this PR is of high quality
* [ ] 已经使用[[formatting](https://github.com/mysterywolf/formatting)](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [[RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
* [ ] 如果是新增bsp, 已经添加ci检查到[[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)