### PR TITLE
fix: stabilize smp_bind_affinity_tc on SMP CI

### DIFF
--- a/components/utilities/Kconfig
+++ b/components/utilities/Kconfig
@@ -214,6 +214,7 @@ config RT_USING_UTEST
     if RT_USING_UTEST
         config UTEST_THR_STACK_SIZE
             int "The utest thread stack size"
+            default 8192 if ARCH_CPU_64BIT
             default 4096
         config UTEST_THR_PRIORITY
             int "The utest thread priority"

--- a/src/utest/smp/smp_bind_affinity_tc.c
+++ b/src/utest/smp/smp_bind_affinity_tc.c
@@ -24,11 +24,10 @@
  * - Verify that threads bound to specific cores run on those cores.
  *
  * Test Scenarios:
- * - RT_CPUS_NR threads (T0~T(RT_CPUS_NR-1)) are created, with only T0 bound to core 0. When thread Tx is running,
- * - thread_tic[x] increments by 1; if x is equal to the core ID, thread_inc[x] also increments by 1. After the
- * - program runs for a period of time, observe the value relationship between the thread_inc and thread_tic arrays.
- * - If thread_inc[x] is equal to thread_tic[x], it indicates that thread Tx is correctly bound to core x. In this test case,
- * - only thread_inc[0] will be equal to thread_tic[0].
+ * - RT_CPUS_NR threads (T0~T(RT_CPUS_NR-1)) are created, with only T0 bound to core 0.
+ * - Each thread samples rt_hw_cpu_id() while running; T0 must stay on core 0.
+ * - Other threads are unbound and only used to add scheduling pressure; their CPU
+ * - placement is printed for observation but not asserted (platform-dependent).
  *
  * Verification Metrics:
  * - Output message: [I/utest] [ PASSED ] [ result ] testcase (core.smp_bind_affinity)
@@ -50,29 +49,39 @@ static rt_thread_t threads[RT_CPUS_NR];
 static struct rt_spinlock lock;
 static int thread_inc[RT_CPUS_NR] = {0};
 static int thread_tic[RT_CPUS_NR] = {0};
-static int finsh_flag = 0;
+static rt_uint32_t thread_core_mask[RT_CPUS_NR] = {0};
+static rt_atomic_t finsh_flag;
 static int                num        = 0;
 
 static void thread_entry(void *parameter)
 {
-    int id   = 0;
+    int id;
     int para = *(int *)parameter;
+
     while (1)
     {
-        thread_tic[para]++;
+        if (thread_tic[para] >= run_num)
+        {
+            /* Spin until cleanup deletes this thread (same as other smp utests) */
+            while (1);
+        }
+
+        rt_sched_lock_level_t slvl;
+
+        /* Sample CPU and counters atomically to avoid migration skew */
+        rt_sched_lock(&slvl);
         id = rt_hw_cpu_id();
+        thread_tic[para]++;
+        thread_core_mask[para] |= (1u << id);
         if (para == id)
         {
             thread_inc[para]++;
         }
+        rt_sched_unlock(slvl);
 
         if (thread_tic[para] == run_num)
         {
-            if (para == 0)
-                uassert_int_equal(thread_inc[para], thread_tic[para]);
-            else
-                uassert_int_not_equal(thread_inc[para], thread_tic[para]);
-            finsh_flag ++;
+            rt_atomic_add(&finsh_flag, 1);
         }
         rt_thread_delay(5);
     }
@@ -104,20 +113,36 @@ static void thread_bind_affinity_tc(void)
         }
     }
 
-    while (finsh_flag != RT_CPUS_NR);
+    while (rt_atomic_load(&finsh_flag) != RT_CPUS_NR);
 
-    /* Displays the number of times a thread was executed on the relevant core */
+    /* Bound thread must always run on core 0 */
+    uassert_int_equal(thread_inc[0], thread_tic[0]);
+    uassert_int_equal(thread_core_mask[0], 1u);
+
+    /* Displays per-thread CPU statistics (unbound threads: observe only) */
     for (j = 0; j < RT_CPUS_NR; j++)
     {
         rt_spin_lock(&lock);
-        rt_kprintf("Total runs[%d], Number of times thread[%d] run on [core%d]: [%4d], always run at core%d ? %s \r\n", run_num, j, j, thread_inc[j], j, (thread_inc[j] == run_num) ? "yes" : "no");
+        rt_kprintf("Total runs[%d], Number of times thread[%d] run on [core%d]: [%4d], core mask: 0x%x, always run at core%d ? %s \r\n",
+                   run_num, j, j, thread_inc[j], thread_core_mask[j], j,
+                   (thread_inc[j] == run_num) ? "yes" : "no");
         rt_spin_unlock(&lock);
     }
 }
 
 static rt_err_t utest_tc_init(void)
 {
+    int i;
+
     rt_spin_lock_init(&lock);
+    rt_atomic_store(&finsh_flag, 0);
+    for (i = 0; i < RT_CPUS_NR; i++)
+    {
+        threads[i] = RT_NULL;
+        thread_inc[i] = 0;
+        thread_tic[i] = 0;
+        thread_core_mask[i] = 0;
+    }
     return RT_EOK;
 }
 
@@ -125,7 +150,11 @@ static rt_err_t utest_tc_cleanup(void)
 {
     for (num = 0; num < RT_CPUS_NR; num++)
     {
-        rt_thread_delete(threads[num]);
+        if (threads[num] != RT_NULL)
+        {
+            rt_thread_delete(threads[num]);
+            threads[num] = RT_NULL;
+        }
     }
     return RT_EOK;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
This change fixes intermittent failures of the `core.smp_bind_affinity`
utest across SMP CI targets. The original failure was a flaky assertion on
unbound threads (`thread_inc[x] != thread_tic[x]` in thread_entry), not
incorrect bind_cpu behavior. CI logs already showed T0 binding worked
(thread_inc[0] == thread_tic[0] == 100) while the not_equal check failed.
The root issue is that unbound-thread CPU placement is platform-dependent
and outside the bind_cpu contract. On dual-core RISC-V/ARMv7 CI, an
unbound thread may legitimately run all iterations on core 0 while T0
delays on the same core, so any assertion requiring cross-core migration
(thread_inc != thread_tic, or core_mask with multiple bits) remains flaky.
This patch narrows the test to what bind_affinity actually verifies: T0
bound to core 0 must always execute on core 0. Unbound threads only add
scheduling pressure; their core_mask is printed for observation but not
asserted.
Changes:
- Sample `rt_hw_cpu_id()` and update counters under `rt_sched_lock` to
  avoid migration skew between counting and CPU sampling.
- Track `thread_core_mask` for diagnostics; assert only T0 binding via
  `thread_inc[0] == thread_tic[0]` and `thread_core_mask[0] == 1`.
- Remove flaky unbound-thread assertions (`thread_inc != thread_tic` and
  multi-core core_mask checks).
- Move T0 assertions to the main test thread after all workers finish.
- Use atomic `finsh_flag`; reset counters and `threads[]` in `utest_tc_init`.
- Spin in worker loops after `run_num` until cleanup deletes them (do not
  return from thread_entry or use `RT_WAITING_FOREVER` with `rt_thread_delay`).
- Guard `rt_thread_delete` in cleanup with non-NULL checks.

```shell
msh />utest_run
msh />
[I/utest] [==========] [ utest    ] loop 1/1
[I/utest] [==========] [ utest    ] started
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri1) started
[I/utest] [==========] utest unit name: (smp_affinity_pri1_tc)
thread                   cpu bind pri  status      sp     stack size max used left tick   error  tcb addr   usage
------------------------ --- ---- ---  ------- ---------- ----------  ------  ---------- ------- ------------------ ---------
T3                         3   3    2  running 0x00000290 0x00002000     15%   0x0000000a OK      0x00000000401a5c30  N/A
T2                         2   2    2  running 0x00000288 0x00002000     15%   0x0000000a OK      0x00000000401a3a98  N/A
T1                         1   1    2  running 0x00000290 0x00002000     15%   0x0000000a OK      0x00000000401a1900  N/A
T0                         0   0   30  running 0x000003a8 0x00002000     20%   0x00000014 OK      0x000000004019f768  N/A
utest                    N/A   4   20  suspend 0x00000440 0x00002000     14%   0x0000000a EINTRPT 0x000000004017f450  N/A
tshell                   N/A   4   20  suspend 0x000004a8 0x00001000     33%   0x0000000a OK      0x000000004019e558  N/A
sys workq                N/A   4   23  suspend 0x00000458 0x00002000     16%   0x00000009 OK      0x00000000401816f8  N/A
tsystem                  N/A   4   30  suspend 0x00000370 0x00002000     14%   0x0000001f EINTRPT 0x0000000040166788  N/A
tidle3                   N/A   3   31  ready   0x000005e0 0x00002000     20%   0x00000007 OK      0x0000000040168c78  N/A
tidle2                   N/A   2   31  ready   0x000005e0 0x00002000     20%   0x00000009 OK      0x0000000040168b50  N/A
tidle1                   N/A   1   31  ready   0x000005e0 0x00002000     20%   0x00000006 OK      0x0000000040168a28  N/A
tidle0                   N/A   0   31  ready   0x000005e0 0x00002000     20%   0x0000000c OK      0x0000000040168900  N/A
timer                    N/A   4    4  suspend 0x00000358 0x00002000     14%   0x00000009 EINTRPT 0x00000000401712f0  N/A
pwr                      N/A   4   16  init    0x00000288 0x00002000      7%   0x00000020 OK      0x0000000040142fd8  N/A
thread                   cpu bind pri  status      sp     stack size max used left tick   error  tcb addr   usage
------------------------ --- ---- ---  ------- ---------- ----------  ------  ---------- ------- ------------------ ---------
Tn                         0   4   10  running 0x00000288 0x00002000     25%   0x00000013 OK      0x00000000401a7dc8  N/A
T3                         3   3    2  running 0x00000290 0x00002000     15%   0x00000008 OK      0x00000000401a5c30  N/A
T2                         2   2    2  running 0x00000288 0x00002000     15%   0x00000008 OK      0x00000000401a3a98  N/A
T1                         1   1    2  running 0x00000290 0x00002000     15%   0x00000008 OK      0x00000000401a1900  N/A
T0                       N/A   0   30  ready   0x00000368 0x00002000     25%   0x00000013 OK      0x000000004019f768  N/A
utest                    N/A   4   20  suspend 0x00000440 0x00002000     14%   0x0000000a EINTRPT 0x000000004017f450  N/A
tshell                   N/A   4   20  suspend 0x000004a8 0x00001000     33%   0x0000000a OK      0x000000004019e558  N/A
sys workq                N/A   4   23  suspend 0x00000458 0x00002000     16%   0x00000009 OK      0x00000000401816f8  N/A
tsystem                  N/A   4   30  suspend 0x00000370 0x00002000     14%   0x0000001f EINTRPT 0x0000000040166788  N/A
tidle3                   N/A   3   31  ready   0x000005e0 0x00002000     20%   0x00000007 OK      0x0000000040168c78  N/A
tidle2                   N/A   2   31  ready   0x000005e0 0x00002000     20%   0x00000009 OK      0x0000000040168b50  N/A
tidle1                   N/A   1   31  ready   0x000005e0 0x00002000     20%   0x00000006 OK      0x0000000040168a28  N/A
tidle0                   N/A   0   31  ready   0x000005e0 0x00002000     20%   0x0000000c OK      0x0000000040168900  N/A
timer                    N/A   4    4  suspend 0x00000358 0x00002000     14%   0x00000009 EINTRPT 0x00000000401712f0  N/A
pwr                      N/A   4   16  init    0x00000288 0x00002000      7%   0x00000020 OK      0x0000000040142fd8  N/A
[I/utest] [  PASSED  ] [ result   ] testcase (core.smp_affinity_pri1)
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri1) finished
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri2) started
[I/utest] [==========] utest unit name: (smp_affinity_pri2_tc)
[I/utest] [  PASSED  ] [ result   ] testcase (core.smp_affinity_pri2)
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri2) finished
[I/utest] [----------] [ testcase ] (core.smp_bind_affinity) started
[I/utest] [==========] utest unit name: (thread_bind_affinity_tc)
Total runs[100], Number of times thread[0] run on [core0]: [ 100], core mask: 0x1, always run at core0 ? yes
Total runs[100], Number of times thread[1] run on [core1]: [   2], core mask: 0xf, always run at core1 ? no
Total runs[100], Number of times thread[2] run on [core2]: [  36], core mask: 0xd, always run at core2 ? no
Total runs[100], Number of times thread[3] run on [core3]: [  41], core mask: 0xf, always run at core3 ? no
[I/utest] [  PASSED  ] [ result   ] testcase (core.smp_bind_affinity)
[I/utest] [----------] [ testcase ] (core.smp_bind_affinity) finished
[I/utest] [==========] [ utest    ] 3 tests from 3 testcase ran.
[I/utest] [  PASSED  ] [ result   ] 3 tests.
[I/utest] [==========] [ utest    ] finished

msh />utest_run
msh />
[I/utest] [==========] [ utest    ] loop 1/1
[I/utest] [==========] [ utest    ] started
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri1) started
[I/utest] [==========] utest unit name: (smp_affinity_pri1_tc)
[I/utest] [  PASSED  ] [ result   ] testcase (core.smp_affinity_pri1)
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri1) finished
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri2) started
[I/utest] [==========] utest unit name: (smp_affinity_pri2_tc)
[I/utest] [  PASSED  ] [ result   ] testcase (core.smp_affinity_pri2)
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri2) finished
[I/utest] [----------] [ testcase ] (core.smp_bind_affinity) started
[I/utest] [==========] utest unit name: (thread_bind_affinity_tc)
Total runs[100], Number of times thread[0] run on [core0]: [ 100], core mask: 0x1, always run at core0 ? yes
Total runs[100], Number of times thread[1] run on [core1]: [   5], core mask: 0xf, always run at core1 ? no
Total runs[100], Number of times thread[2] run on [core2]: [  42], core mask: 0xf, always run at core2 ? no
Total runs[100], Number of times thread[3] run on [core3]: [  42], core mask: 0xf, always run at core3 ? no
[I/utest] [  PASSED  ] [ result   ] testcase (core.smp_bind_affinity)
[I/utest] [----------] [ testcase ] (core.smp_bind_affinity) finished
[I/utest] [==========] [ utest    ] 3 tests from 3 testcase ran.
[I/utest] [  PASSED  ] [ result   ] 3 tests.
[I/utest] [==========] [ utest    ] finished

msh />utest_run
msh />
[I/utest] [==========] [ utest    ] loop 1/1
[I/utest] [==========] [ utest    ] started
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri1) started
[I/utest] [==========] utest unit name: (smp_affinity_pri1_tc)
[I/utest] [  PASSED  ] [ result   ] testcase (core.smp_affinity_pri1)
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri1) finished
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri2) started
[I/utest] [==========] utest unit name: (smp_affinity_pri2_tc)
[I/utest] [  PASSED  ] [ result   ] testcase (core.smp_affinity_pri2)
[I/utest] [----------] [ testcase ] (core.smp_affinity_pri2) finished
[I/utest] [----------] [ testcase ] (core.smp_bind_affinity) started
[I/utest] [==========] utest unit name: (thread_bind_affinity_tc)
Total runs[100], Number of times thread[0] run on [core0]: [ 100], core mask: 0x1, always run at core0 ? yes
Total runs[100], Number of times thread[1] run on [core1]: [  42], core mask: 0xf, always run at core1 ? no
Total runs[100], Number of times thread[2] run on [core2]: [  39], core mask: 0xf, always run at core2 ? no
Total runs[100], Number of times thread[3] run on [core3]: [   2], core mask: 0xf, always run at core3 ? no
[I/utest] [  PASSED  ] [ result   ] testcase (core.smp_bind_affinity)
[I/utest] [----------] [ testcase ] (core.smp_bind_affinity) finished
[I/utest] [==========] [ utest    ] 3 tests from 3 testcase ran.
[I/utest] [  PASSED  ] [ result   ] 3 tests.
[I/utest] [==========] [ utest    ] finished
```

#### 为什么提交这份PR (why to submit this PR)


#### 你的解决方案是什么 (what is your solution)



#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
