### PR TITLE
fix(ipc): guard LOG_D against null thread pointer in rt_susp_list_dequeue

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -44,7 +44,7 @@
  * 2022-04-08     Stanley      Correct descriptions
  * 2022-10-15     Bernard      add nested mutex feature
  * 2022-10-16     Bernard      add prioceiling feature in mutex
- * 2023-04-16     Xin-zheqi    redesigen queue recv and send function return real message size
+ * 2023-04-16     Xin-zheqi    redesign queue recv and send function return real message size
  * 2023-09-15     xqyjlj       perf rt_hw_interrupt_disable/enable
  */
 
@@ -140,7 +140,7 @@ struct rt_thread *rt_susp_list_dequeue(rt_list_t *susp_list, rt_err_t thread_err
     }
     rt_sched_unlock(slvl);
 
-    LOG_D("resume thread:%s\n", thread->parent.name);
+    LOG_D("resume thread:%s\n", (thread == RT_NULL) ? "NULL" : thread->parent.name);
 
     return thread;
 }


### PR DESCRIPTION
## Description

rt_susp_list_dequeue() can return RT_NULL when the suspend list is empty or when the dequeued thread has been cleaned up. The LOG_D call dereferences thread->parent.name unconditionally, causing a null pointer dereference crash when thread is NULL.

## Changes

- src/ipc.c: Guard LOG_D with null check using ternary operator
- src/ipc.c: Fix typo in changelog comment (redesigen -> redesign)

## Testing

- Existing IPC tests pass
- 1 file changed, 2 lines modified

Replaces #11337 (rebased onto current master to fix CI).