### PR TITLE
[components/drivers/usb/cherryusb/common] modify macro-define: __USED…

### DIFF
--- a/components/drivers/usb/cherryusb/common/usb_util.h
+++ b/components/drivers/usb/cherryusb/common/usb_util.h
@@ -52,7 +52,7 @@
 #endif
 
 #ifndef __USED
-#if defined(__ICCARM_V8) || defined(__ICCRISCV__)
+#if defined(__ICCRISCV__)
 #define __USED __attribute__((used))
 #else
 #define __USED __root

--- a/components/drivers/usb/cherryusb/common/usb_util.h
+++ b/components/drivers/usb/cherryusb/common/usb_util.h
@@ -46,9 +46,9 @@
 #endif
 #elif defined(__ICCARM__) || defined(__ICCRX__) || defined(__ICCRISCV__)
 #if (__VER__ >= 8000000)
-  #define __ICCARM_V8 1
+#define __ICCARM_V8 1
 #else
-  #define __ICCARM_V8 0
+#define __ICCARM_V8 0
 #endif
 
 #ifndef __USED
@@ -228,8 +228,8 @@
 
 #define USB_MEM_ALIGNX __attribute__((aligned(CONFIG_USB_ALIGN_SIZE)))
 
-#define USB_ALIGN_UP(size, align) (((size) + (align)-1) & ~((align)-1))
-#define USB_ALIGN_DOWN(size, align) ((size) & ~((align)-1))
+#define USB_ALIGN_UP(size, align)   (((size) + (align) - 1) & ~((align) - 1))
+#define USB_ALIGN_DOWN(size, align) ((size) & ~((align) - 1))
 
 #ifndef usb_phyaddr2ramaddr
 #define usb_phyaddr2ramaddr(addr) (addr)


### PR DESCRIPTION
RT-Thread Version
master

Hardware Type/Architectures
ARM contex-M4

Develop Toolchain
IAR

Describe the bug
usb_util.h 宏定义__USED针对__ICCARM_V8的定义是无效的，导致CLASS_INFO_DEFINE失效，会被编译器优化。

__ICCARM_V8应该使用__root
#define __USED __root

<img width="870" height="432" alt="image" src="https://github.com/user-attachments/assets/d31d5630-1083-487b-9e28-67b9f2ad86f6" />
