### PR TITLE
[fix][elm]解决块设备扇区大小校验失败时存在的disk泄漏问题

### DIFF
--- a/components/dfs/dfs_v1/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/dfs_v1/filesystems/elmfat/dfs_elm.c
@@ -117,8 +117,6 @@ int dfs_elm_mount(struct dfs_filesystem *fs, unsigned long rwflag, const void *d
         return -ENOENT;
     logic_nbr[0] = '0' + index;
 
-    /* save device */
-    disk[index] = fs->dev_id;
     /* check sector size */
     if (rt_device_control(fs->dev_id, RT_DEVICE_CTRL_BLK_GETGEOME, &geometry) == RT_EOK)
     {
@@ -128,6 +126,8 @@ int dfs_elm_mount(struct dfs_filesystem *fs, unsigned long rwflag, const void *d
             return -EINVAL;
         }
     }
+    /* save device */
+    disk[index] = fs->dev_id;
 
     fat = (FATFS *)rt_malloc(sizeof(FATFS));
     if (fat == RT_NULL)

--- a/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
@@ -150,8 +150,6 @@ static int dfs_elm_mount(struct dfs_mnt *mnt, unsigned long rwflag, const void *
     }
     logic_nbr[0] = '0' + index;
 
-    /* save device */
-    disk[index] = mnt->dev_id;
     /* check sector size */
     if (rt_device_control(mnt->dev_id, RT_DEVICE_CTRL_BLK_GETGEOME, &geometry) == RT_EOK)
     {
@@ -162,6 +160,8 @@ static int dfs_elm_mount(struct dfs_mnt *mnt, unsigned long rwflag, const void *
             return -EINVAL;
         }
     }
+    /* save device */
+    disk[index] = mnt->dev_id;
 
     fat = (FATFS *)rt_malloc(sizeof(FATFS));
     if (fat == RT_NULL)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
--当扇区大小检查失败时（设备扇区大小大于 FF_MAX_SS ）， disk[index] 没有被重置为 RT_NULL ，导致该槽位被永久占用，无法再被使用。

#### 你的解决方案是什么 (what is your solution)
--- 先校验 sector size ：在占用 disk 数组槽位之前先检查扇区大小，校验通过后再占用槽位 ：只有确认扇区大小没问题后，才执行 disk[index] = mnt->dev_id。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:private
- .config:private
- action:

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
