### PR TITLE
[bsp] reduce SConscript absolute path usage

### DIFF
--- a/bsp/hpmicro/hpm5300evk/startup/SConscript
+++ b/bsp/hpmicro/hpm5300evk/startup/SConscript
@@ -7,7 +7,7 @@ from building import *
 cwd = GetCurrentDir()
 objs = []
 
-objs = objs + SConscript(os.path.join(cwd, rtconfig.CHIP_NAME, 'SConscript'))
+objs = objs + SConscript(os.path.join(rtconfig.CHIP_NAME, 'SConscript'))
 ASFLAGS = ' -I' + cwd
 
 Return('objs')

--- a/bsp/hpmicro/hpm5301evklite/startup/SConscript
+++ b/bsp/hpmicro/hpm5301evklite/startup/SConscript
@@ -7,7 +7,7 @@ from building import *
 cwd = GetCurrentDir()
 objs = []
 
-objs = objs + SConscript(os.path.join(cwd, rtconfig.CHIP_NAME, 'SConscript'))
+objs = objs + SConscript(os.path.join(rtconfig.CHIP_NAME, 'SConscript'))
 ASFLAGS = ' -I' + cwd
 
 Return('objs')

--- a/bsp/hpmicro/hpm5e00evk/startup/SConscript
+++ b/bsp/hpmicro/hpm5e00evk/startup/SConscript
@@ -7,7 +7,7 @@ from building import *
 cwd = GetCurrentDir()
 objs = []
 
-objs = objs + SConscript(os.path.join(cwd, rtconfig.CHIP_NAME, 'SConscript'))
+objs = objs + SConscript(os.path.join(rtconfig.CHIP_NAME, 'SConscript'))
 ASFLAGS = ' -I' + cwd
 
 Return('objs')

--- a/bsp/hpmicro/hpm6200evk/startup/SConscript
+++ b/bsp/hpmicro/hpm6200evk/startup/SConscript
@@ -7,7 +7,7 @@ from building import *
 cwd = GetCurrentDir()
 objs = []
 
-objs = objs + SConscript(os.path.join(cwd, rtconfig.CHIP_NAME, 'SConscript'))
+objs = objs + SConscript(os.path.join(rtconfig.CHIP_NAME, 'SConscript'))
 ASFLAGS = ' -I' + cwd
 
 Return('objs')

--- a/bsp/hpmicro/hpm6300evk/startup/SConscript
+++ b/bsp/hpmicro/hpm6300evk/startup/SConscript
@@ -7,7 +7,7 @@ from building import *
 cwd = GetCurrentDir()
 objs = []
 
-objs = objs + SConscript(os.path.join(cwd, rtconfig.CHIP_NAME, 'SConscript'))
+objs = objs + SConscript(os.path.join(rtconfig.CHIP_NAME, 'SConscript'))
 ASFLAGS = ' -I' + cwd
 
 Return('objs')

--- a/bsp/hpmicro/hpm6750evk/startup/SConscript
+++ b/bsp/hpmicro/hpm6750evk/startup/SConscript
@@ -7,7 +7,7 @@ from building import *
 cwd = GetCurrentDir()
 objs = []
 
-objs = objs + SConscript(os.path.join(cwd, rtconfig.CHIP_NAME, 'SConscript'))
+objs = objs + SConscript(os.path.join(rtconfig.CHIP_NAME, 'SConscript'))
 ASFLAGS = ' -I' + cwd
 
 Return('objs')

--- a/bsp/hpmicro/hpm6750evk2/startup/SConscript
+++ b/bsp/hpmicro/hpm6750evk2/startup/SConscript
@@ -7,7 +7,7 @@ from building import *
 cwd = GetCurrentDir()
 objs = []
 
-objs = objs + SConscript(os.path.join(cwd, rtconfig.CHIP_NAME, 'SConscript'))
+objs = objs + SConscript(os.path.join(rtconfig.CHIP_NAME, 'SConscript'))
 ASFLAGS = ' -I' + cwd
 
 Return('objs')

--- a/bsp/hpmicro/hpm6750evkmini/startup/SConscript
+++ b/bsp/hpmicro/hpm6750evkmini/startup/SConscript
@@ -7,7 +7,7 @@ from building import *
 cwd = GetCurrentDir()
 objs = []
 
-objs = objs + SConscript(os.path.join(cwd, rtconfig.CHIP_NAME, 'SConscript'))
+objs = objs + SConscript(os.path.join(rtconfig.CHIP_NAME, 'SConscript'))
 ASFLAGS = ' -I' + cwd
 
 Return('objs')

--- a/bsp/hpmicro/hpm6800evk/startup/SConscript
+++ b/bsp/hpmicro/hpm6800evk/startup/SConscript
@@ -7,7 +7,7 @@ from building import *
 cwd = GetCurrentDir()
 objs = []
 
-objs = objs + SConscript(os.path.join(cwd, rtconfig.CHIP_NAME, 'SConscript'))
+objs = objs + SConscript(os.path.join(rtconfig.CHIP_NAME, 'SConscript'))
 ASFLAGS = ' -I' + cwd
 
 Return('objs')

--- a/bsp/hpmicro/hpm6e00evk/startup/SConscript
+++ b/bsp/hpmicro/hpm6e00evk/startup/SConscript
@@ -7,7 +7,7 @@ from building import *
 cwd = GetCurrentDir()
 objs = []
 
-objs = objs + SConscript(os.path.join(cwd, rtconfig.CHIP_NAME, 'SConscript'))
+objs = objs + SConscript(os.path.join(rtconfig.CHIP_NAME, 'SConscript'))
 ASFLAGS = ' -I' + cwd
 
 Return('objs')

--- a/bsp/hpmicro/hpm6p00evk/startup/SConscript
+++ b/bsp/hpmicro/hpm6p00evk/startup/SConscript
@@ -7,7 +7,7 @@ from building import *
 cwd = GetCurrentDir()
 objs = []
 
-objs = objs + SConscript(os.path.join(cwd, rtconfig.CHIP_NAME, 'SConscript'))
+objs = objs + SConscript(os.path.join(rtconfig.CHIP_NAME, 'SConscript'))
 ASFLAGS = ' -I' + cwd
 
 Return('objs')

--- a/bsp/n32/n32hxxx/libraries/N32_Drivers/SConscript
+++ b/bsp/n32/n32hxxx/libraries/N32_Drivers/SConscript
@@ -9,9 +9,9 @@ src = ['drv_common.c']
 path = [cwd]
 
 if GetDepend(['RT_USING_NANO']):
-    group = group + SConscript(os.path.join(cwd, 'nano', 'SConscript'))
+    group = group + SConscript(os.path.join('nano', 'SConscript'))
 else:
-    group = group + SConscript(os.path.join(cwd, 'drivers', 'SConscript'))
+    group = group + SConscript(os.path.join('drivers', 'SConscript'))
 
 group = group + DefineGroup('Drivers', src, depend = [''], CPPPATH = path)
 

--- a/bsp/nxp/lpc/lpc43xx/M0/SConscript
+++ b/bsp/nxp/lpc/lpc43xx/M0/SConscript
@@ -7,7 +7,7 @@ for d in os.listdir(os.path.join(cwd, '..')):
     if d not in ('M0', 'M4'):
         path = os.path.join('..', d, 'SConscript')
         if os.path.isfile(os.path.join(cwd, path)):
-            objs = objs + SConscript(os.path.join(cwd, path))
+            objs = objs + SConscript(path)
 
 for d in os.listdir(cwd):
     p = os.path.join(d, 'SConscript');

--- a/bsp/nxp/lpc/lpc43xx/M4/SConscript
+++ b/bsp/nxp/lpc/lpc43xx/M4/SConscript
@@ -7,7 +7,7 @@ for d in os.listdir(os.path.join(cwd, '..')):
     if d not in ('M0', 'M4'):
         path = os.path.join('..', d, 'SConscript')
         if os.path.isfile(os.path.join(cwd, path)):
-            objs = objs + SConscript(os.path.join(cwd, path))
+            objs = objs + SConscript(path)
 
 for d in os.listdir(cwd):
     p = os.path.join(d, 'SConscript');

--- a/bsp/renesas/libraries/HAL_Drivers/SConscript
+++ b/bsp/renesas/libraries/HAL_Drivers/SConscript
@@ -9,9 +9,9 @@ src = ['drv_common.c']
 path = [cwd]
 
 if GetDepend(['RT_USING_NANO']):
-    group = group + SConscript(os.path.join(cwd, 'nano', 'SConscript'))
+    group = group + SConscript(os.path.join('nano', 'SConscript'))
 else:
-    group = group + SConscript(os.path.join(cwd, 'drivers', 'SConscript'))
+    group = group + SConscript(os.path.join('drivers', 'SConscript'))
 
 group = group + DefineGroup('Drivers', src, depend = [''], CPPPATH = path)
 

--- a/bsp/stm32/libraries/HAL_Drivers/SConscript
+++ b/bsp/stm32/libraries/HAL_Drivers/SConscript
@@ -12,9 +12,9 @@ if not GetDepend('PKG_USING_CMSIS_CORE'):
     path += [os.path.join(cwd, 'CMSIS', 'Include')]
 
 if GetDepend(['RT_USING_NANO']):
-    group = group + SConscript(os.path.join(cwd, 'nano', 'SConscript'))
+    group = group + SConscript(os.path.join('nano', 'SConscript'))
 else:
-    group = group + SConscript(os.path.join(cwd, 'drivers', 'SConscript'))
+    group = group + SConscript(os.path.join('drivers', 'SConscript'))
 
 group = group + DefineGroup('Drivers', src, depend = [''], CPPPATH = path)
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

本 PR 是对 RT-Thread/rt-thread#11513 的同类问题补充修复。#11513 已经修复了 `bsp/novosns/ns800/libraries/HAL_Drivers/SConscript` 中普通子目录 `SConscript()` 调用传入绝对路径的问题；本 PR 继续修复其他 BSP 中相同模式的问题。

这些脚本原来会把 `cwd` 拼接后的源码绝对路径传给普通子目录或相邻目录的 `SConscript()` 调用。在部分构建场景下，这会让 SCons 依赖源码目录的绝对路径，甚至可能把中间产物残留到源码目录中。该问题与 RT-Thread/rt-thread#10477 相关。

#### 你的解决方案是什么 (what is your solution)

将其他 BSP 中普通子目录/相邻目录脚本调用从 `SConscript(os.path.join(cwd, ...))` 改为相对路径调用，避免把源码目录绝对路径传给普通 `SConscript()` 调用。

本次修复保留带 `variant_dir` 的特殊调用原状，因为这些调用依赖 SCons 的源码目录到变体目录映射，不能简单改成相对路径。

本次修改涉及以下 BSP 位置：
- `bsp/hpmicro/*/startup/SConscript`
- `bsp/n32/n32hxxx/libraries/N32_Drivers/SConscript`
- `bsp/nxp/lpc/lpc43xx/M0/SConscript`
- `bsp/nxp/lpc/lpc43xx/M4/SConscript`
- `bsp/renesas/libraries/HAL_Drivers/SConscript`
- `bsp/stm32/libraries/HAL_Drivers/SConscript`

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP: 以上列出的 BSP `SConscript` 路径清理。

- .config: 未修改 `.config`。

- action: 已在本地执行以下检查：
  - `git diff --check rtt/master..HEAD`
  - 对所有改动的 `SConscript` 文件执行 Python `compile()` 语法检查。
  - 根据 CI 结果恢复了 `mm32` 和 `rockchip` 中带 `variant_dir` 的调用，避免破坏 SCons 变体目录映射。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
