### PR TITLE
[hpmicro][uart] Fix serial v2 putc return value

### DIFF
--- a/bsp/hpmicro/libraries/drivers/drv_uart_v2.c
+++ b/bsp/hpmicro/libraries/drivers/drv_uart_v2.c
@@ -1107,7 +1107,7 @@ static int hpm_uart_putc(struct rt_serial_device *serial, char ch)
     struct hpm_uart *uart  = (struct hpm_uart *)serial->parent.user_data;
     uart_send_byte(uart->uart_base, ch);
     uart_flush(uart->uart_base);
-    return ch;
+    return 1;
 }
 
 static int hpm_uart_getc(struct rt_serial_device *serial)


### PR DESCRIPTION
﻿## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)
Fixed #11392 
修复 issue #11392。HPMicro 串口 V2 驱动的 hpm_uart_putc() 在发送成功后返回传入的 char 值；当发送中文等 UTF-8 数据时，高位字节在 char 为有符号类型的平台上会被解释为负值，进而被串口 V2 的 _serial_poll_tx() 判断为发送失败并提前中断，导致中文输出丢数据。

#### 你的解决方案是什么 (what is your solution)

将 hpm_uart_putc() 的成功返回值由 ch 改为 1，表示已经成功发送 1 个字符，避免把合法的高位字节误判为负错误码。该返回语义也与 STM32 等串口 V2 驱动保持一致。

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: bsp/hpmicro/hpm6750evk

- .config: CONFIG_RT_USING_SERIAL_V2=y

- action: 本地已执行 git diff --check；当前环境未安装 scons，未进行完整 BSP 编译。

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含#if 0代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
