### PR TITLE
[kernel] Prevent duplicate defunct enqueue for deleted threads.

### DIFF
--- a/include/rtsched.h
+++ b/include/rtsched.h
@@ -53,6 +53,7 @@ struct rt_sched_thread_ctx
     rt_uint8_t                  stat;                   /**< thread status */
     rt_uint8_t                  sched_flag_locked:1;    /**< calling thread have the scheduler locked */
     rt_uint8_t                  sched_flag_ttmr_set:1;  /**< thread timer is start */
+    rt_uint8_t                  sched_flag_defunct:1;   /**< thread has been enqueued to defunct */
 
 #ifdef ARCH_USING_HW_THREAD_SELF
     rt_uint8_t                  critical_switch_flag:1; /**< critical switch pending */

--- a/src/scheduler_comm.c
+++ b/src/scheduler_comm.c
@@ -35,6 +35,7 @@ void rt_sched_thread_init_ctx(struct rt_thread *thread, rt_uint32_t tick, rt_uin
 {
     /* setup thread status */
     RT_SCHED_CTX(thread).stat = RT_THREAD_INIT;
+    RT_SCHED_CTX(thread).sched_flag_defunct = 0;
 
 #ifdef RT_USING_SMP
     /* not bind on any cpu */

--- a/src/thread.c
+++ b/src/thread.c
@@ -114,6 +114,22 @@ static void _thread_detach_from_mutex(rt_thread_t thread)
 static void _thread_detach_from_mutex(rt_thread_t thread) {}
 #endif
 
+static rt_err_t _thread_mark_defunct(rt_thread_t thread)
+{
+    rt_err_t error = -RT_ERROR;
+    rt_base_t level;
+
+    level = rt_spin_lock_irqsave(&thread->spinlock);
+    if (!RT_SCHED_CTX(thread).sched_flag_defunct)
+    {
+        RT_SCHED_CTX(thread).sched_flag_defunct = 1;
+        error = RT_EOK;
+    }
+    rt_spin_unlock_irqrestore(&thread->spinlock, level);
+
+    return error;
+}
+
 static void _thread_exit(void)
 {
     struct rt_thread *thread;
@@ -126,10 +142,13 @@ static void _thread_exit(void)
 
     rt_thread_close(thread);
 
-    _thread_detach_from_mutex(thread);
+    if (_thread_mark_defunct(thread) == RT_EOK)
+    {
+        _thread_detach_from_mutex(thread);
 
-    /* insert to defunct thread list */
-    rt_thread_defunct_enqueue(thread);
+        /* insert to defunct thread list */
+        rt_thread_defunct_enqueue(thread);
+    }
 
     rt_exit_critical_safe(critical_level);
 
@@ -513,10 +532,17 @@ static rt_err_t _thread_detach(rt_thread_t thread)
 
     error = rt_thread_close(thread);
 
-    _thread_detach_from_mutex(thread);
+    if (error == RT_EOK)
+    {
+        error = _thread_mark_defunct(thread);
+        if (error == RT_EOK)
+        {
+            _thread_detach_from_mutex(thread);
 
-    /* insert to defunct thread list */
-    rt_thread_defunct_enqueue(thread);
+            /* insert to defunct thread list */
+            rt_thread_defunct_enqueue(thread);
+        }
+    }
 
     rt_exit_critical_safe(critical_level);
     return error;

--- a/src/utest/thread_tc.c
+++ b/src/utest/thread_tc.c
@@ -26,6 +26,7 @@
  *
  * Test Scenarios:
  * - Create, start, and delete a dynamic thread to verify dynamic thread lifecycle management
+ * - Let a dynamic thread exit normally, then call rt_thread_delete again in cleanup to verify duplicate delete handling
  * - Initialize, start, and detach a static thread to verify static thread lifecycle management
  * - Delay a thread for a specific tick count and check timing accuracy
  * - Register and remove an idle hook, verifying it is called as expected
@@ -37,6 +38,7 @@
  *
  * Verification Metrics:
  * - Threads are created, started, deleted, and detached successfully
+ * - Repeated deletion after normal thread exit returns an error without abnormal cleanup
  * - The precision of both relative delay and absolute delay is correct.
  * - Idle hook is invoked as expected during thread idle periods
  * - Thread yield causes correct scheduling among threads of the same priority
@@ -71,6 +73,7 @@ static struct rt_thread thread2;
     static rt_thread_t tid5 = RT_NULL;
     static rt_thread_t tid6 = RT_NULL;
     static rt_thread_t tid7 = RT_NULL;
+    static rt_thread_t tid9 = RT_NULL;
 #endif /* RT_USING_HEAP */
 
 static volatile rt_uint32_t tid3_delay_pass_flag = 0;
@@ -78,6 +81,9 @@ static volatile rt_uint32_t tid3_finish_flag = 0;
 static volatile rt_uint32_t tid4_finish_flag = 0;
 static volatile rt_uint32_t tid6_finish_flag = 0;
 static volatile rt_uint32_t thread5_source = 0;
+static rt_atomic_t thread9_exit_flag = 0;
+static rt_atomic_t thread9_cleanup_flag = 0;
+static rt_atomic_t thread9_delete_ret = -RT_ERROR;
 
 #ifndef RT_USING_SMP
     static volatile rt_uint32_t thread_yield_flag = 0;
@@ -452,6 +458,66 @@ static void test_thread_priority(void)
     return;
 }
 
+#ifdef RT_USING_HEAP
+static void thread9_entry(void *parameter)
+{
+    RT_UNUSED(parameter);
+
+    while (rt_atomic_load(&thread9_exit_flag) == 0)
+    {
+        rt_thread_mdelay(1);
+    }
+}
+
+static void thread9_cleanup(struct rt_thread *thread)
+{
+    rt_atomic_store(&thread9_delete_ret, rt_thread_delete(thread));
+    rt_atomic_store(&thread9_cleanup_flag, 1);
+}
+
+static void test_thread_exit_delete_again(void)
+{
+    rt_err_t ret_startup = -RT_ERROR;
+
+    rt_atomic_store(&thread9_exit_flag, 0);
+    rt_atomic_store(&thread9_cleanup_flag, 0);
+    rt_atomic_store(&thread9_delete_ret, RT_EOK);
+
+    tid9 = rt_thread_create("thread9",
+                            thread9_entry,
+                            RT_NULL,
+                            THREAD_STACK_SIZE,
+                            UTEST_THR_PRIORITY - 1,
+                            THREAD_TIMESLICE);
+    if (tid9 == RT_NULL)
+    {
+        LOG_E("rt_thread_create failed!");
+        uassert_false(tid9 == RT_NULL);
+        return;
+    }
+
+    tid9->cleanup = thread9_cleanup;
+
+    ret_startup = rt_thread_startup(tid9);
+    if (ret_startup != RT_EOK)
+    {
+        LOG_E("rt_thread_startup failed!");
+        uassert_false(ret_startup != RT_EOK);
+        rt_thread_delete(tid9);
+        return;
+    }
+
+    rt_atomic_store(&thread9_exit_flag, 1);
+
+    while (rt_atomic_load(&thread9_cleanup_flag) == 0)
+    {
+        rt_thread_mdelay(1);
+    }
+
+    uassert_int_equal(rt_atomic_load(&thread9_delete_ret), -RT_ERROR);
+}
+#endif /* RT_USING_HEAP */
+
 static void test_delay_until(void)
 {
     rt_tick_t tick;
@@ -756,6 +822,9 @@ static rt_err_t utest_tc_init(void)
     tid3_finish_flag = 0;
     tid4_finish_flag = 0;
     tid6_finish_flag = 0;
+    rt_atomic_store(&thread9_exit_flag, 0);
+    rt_atomic_store(&thread9_cleanup_flag, 0);
+    rt_atomic_store(&thread9_delete_ret, -RT_ERROR);
     entry_idle_hook_times = 0;
     count = 0;
     return RT_EOK;
@@ -772,6 +841,8 @@ static void testcase(void)
     UTEST_UNIT_RUN(test_static_thread);
     /* create, delete */
     UTEST_UNIT_RUN(test_dynamic_thread);
+    /* exit, duplicate delete */
+    UTEST_UNIT_RUN(test_thread_exit_delete_again);
     /* delay */
     UTEST_UNIT_RUN(test_thread_delay);
     /* idle_sethook, idle_delhook */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

RT-Thread 线程正常退出时会通过 _thread_exit() 进入 defunct 队列，随后由 idle/system defunct 线程完成资源回收。但应用层仍可能误调用 rt_thread_delete() 或 rt_thread_detach()，导致同一个线程被重复加入 defunct 队列，存在链表破坏、重复销毁和资源回收异常的风险。

这类误用在实际 APP 中比较容易出现，例如线程主循环自然退出后，外部管理逻辑又再次删除线程，因此内核侧需要提供保护，避免应用层错误使用直接破坏线程生命周期管理。

#### 你的解决方案是什么 (what is your solution)

为线程调度上下文增加 sched_flag_defunct 标志，用于记录线程是否已经进入 defunct 队列，并在 rt_sched_thread_init_ctx() 中初始化。
新增 _thread_mark_defunct()，通过线程自身的 spinlock 保护该标志的检查和设置，确保 _thread_exit()、rt_thread_delete()、rt_thread_detach() 只有第一次能将线程加入 defunct 队列。后续重复 delete/detach 会返回错误，不再重复执行 mutex detach 和 defunct enqueue。
同时补充 core.thread_tc 回归测试，覆盖：
- 动态线程重复 rt_thread_delete()。
- 动态线程主循环自然退出触发 _thread_exit() 后，再调用 rt_thread_delete()。
- 静态线程重复 rt_thread_detach()。
- 静态线程自然退出触发 _thread_exit() 后，再调用 rt_thread_detach()。

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
