### PR TITLE
lwIP: require TLS certificate verification when CA is configured

### DIFF
--- a/components/net/lwip/lwip-2.1.2/src/apps/altcp_tls/altcp_tls_mbedtls.c
+++ b/components/net/lwip/lwip-2.1.2/src/apps/altcp_tls/altcp_tls_mbedtls.c
@@ -890,7 +890,7 @@ altcp_tls_free_config(struct altcp_tls_config *conf)
   }
   if (conf->ca) {
     mbedtls_x509_crt_free(conf->ca);
-  }  
+  }
   altcp_mbedtls_free_config(conf);
 }
 

--- a/components/net/lwip/lwip-2.1.2/src/apps/altcp_tls/altcp_tls_mbedtls.c
+++ b/components/net/lwip/lwip-2.1.2/src/apps/altcp_tls/altcp_tls_mbedtls.c
@@ -732,7 +732,11 @@ altcp_tls_create_config(int is_server, int have_cert, int have_pkey, int have_ca
     altcp_mbedtls_free_config(conf);
     return NULL;
   }
-  mbedtls_ssl_conf_authmode(&conf->conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+  if (!is_server && have_ca) {
+    mbedtls_ssl_conf_authmode(&conf->conf, MBEDTLS_SSL_VERIFY_REQUIRED);
+  } else {
+    mbedtls_ssl_conf_authmode(&conf->conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+  }
 
   mbedtls_ssl_conf_rng(&conf->conf, mbedtls_ctr_drbg_random, &conf->ctr_drbg);
 #if ALTCP_MBEDTLS_DEBUG != LWIP_DBG_OFF


### PR DESCRIPTION
﻿#### why to submit this PR

ALTCP TLS client configurations should require server certificate verification when a CA certificate is configured. This keeps certificate validation in the TLS configuration layer and makes the configured trust anchor effective.

#### what is your solution

Use `MBEDTLS_SSL_VERIFY_REQUIRED` for client TLS configurations that provide a CA certificate. Keep the existing optional verification mode for server configurations and client configurations without a CA certificate to preserve current compatibility.

#### provide the config and bsp

- BSP: `bsp/bouffalo_lab/bl808/m0`
- .config: `CONFIG_RT_USING_LWIP212=y`, `CONFIG_PKG_USING_MBEDTLS=y`
- action: no fork action run was available after pushing the branch

#### validation

- `git diff --check`
- static source check confirmed both `altcp_tls_create_config_client()` and `altcp_tls_create_config_client_2wayauth()` use the shared client configuration path
- `scons -j4` in `bsp/bouffalo_lab/bl808/m0` did not reach compilation because the configured toolchain path `/opt/Xuantie-900-gcc-elf-newlib-x86_64-V2.6.1/bin` is not available on this Windows host
