### PR TITLE
[bsp][n32] fix board image path in n32h760zil7-stb readme

### DIFF
--- a/bsp/n32/n32hxxx/n32h760zil7-stb/README_zh.md
+++ b/bsp/n32/n32hxxx/n32h760zil7-stb/README_zh.md
@@ -18,7 +18,7 @@ N32H760ZIL7-STB 是 NSING 推出的一款基于 ARM Cortex-M7 内核的开发板
 
 开发板外观如下图所示：
 
-![board](figures/board.png)
+![board](figures/board.jpg)
 
 该开发板常用 **板载资源** 如下：
 


### PR DESCRIPTION
## Why to submit this PR

The BSP document for `n32h760zil7-stb` references a board image path that does not exist in the repository.
As a result, the board picture cannot be rendered when browsing the README.

## What is your solution

- Update the image path in `bsp/n32/n32hxxx/n32h760zil7-stb/README_zh.md`
- Replace `figures/board.png` with the actual existing file `figures/board.jpg`

## Provide the config and bsp

- BSP: `bsp/n32/n32hxxx/n32h760zil7-stb`
- .config: N/A (documentation-only change)
- action: N/A (documentation-only change)

## Verification

- Verified that `figures/board.jpg` exists in the BSP directory
- Verified that `figures/board.png` does not exist
- Checked that the diff only updates the README image path
