### PR TITLE
[examples] fix udpclient argument parsing

### DIFF
--- a/examples/network/udpclient.c
+++ b/examples/network/udpclient.c
@@ -134,7 +134,9 @@ static void udpclient_test(int argc, char** argv)
             is_running = 0;
             return;
         }
-        else if (rt_strcmp(argv[1], "-h") == 0 && rt_strcmp(argv[3], "-p") == 0)
+        else if ((argc == 5 || argc == 7) &&
+                 rt_strcmp(argv[1], "-h") == 0 &&
+                 rt_strcmp(argv[3], "-p") == 0)
         {
             if (started)
             {
@@ -143,9 +145,14 @@ static void udpclient_test(int argc, char** argv)
                 return;
             }
 
-            if (argc == 7 && rt_strcmp(argv[6], "--cnt") == 0)
+            if (argc == 7)
             {
-                count = atoi(argv[7]);
+                if (rt_strcmp(argv[5], "--cnt") != 0)
+                {
+                    goto __usage;
+                }
+
+                count = atoi(argv[6]);
             }
 
             if (rt_strlen(argv[2]) > sizeof(url))


### PR DESCRIPTION
## Why to submit this PR

`examples/network/udpclient.c` has an argument parsing issue in the `--cnt` handling path.
The current code checks `argc == 7` but then reads `argv[7]`, and it also checks the `--cnt` option at the wrong index.
For invalid command formats, this can lead to out-of-bounds access during argument parsing.

## What is your solution

- Restrict the normal `-h <host> -p <port>` path to valid argument counts only
- Fix the `--cnt` option index from `argv[6]` to `argv[5]`
- Fix the count value index from `argv[7]` to `argv[6]`
- Reject malformed 7-argument input by falling back to usage output

## Provide the config and bsp

- BSP: N/A
- .config: N/A
- action: N/A

## Verification

- Reviewed the updated parsing flow for:
  - `udpclient --help`
  - `udpclient --stop`
  - `udpclient -h <host> -p <port>`
  - `udpclient -h <host> -p <port> --cnt <count>`
- Verified the new logic no longer reads beyond the valid `argv` range for the `--cnt` path
- Verified the diff only updates `examples/network/udpclient.c`
