### PR TITLE
[components][pthreads] fix cond wait scheduling

### DIFF
--- a/components/libc/posix/pthreads/pthread_cond.c
+++ b/components/libc/posix/pthreads/pthread_cond.c
@@ -434,6 +434,7 @@ rt_err_t _pthread_cond_timedwait(pthread_cond_t *cond,
 
                 /* exit critical and do schedule */
                 rt_exit_critical();
+                rt_schedule();
 
                 result = thread->error;
 


### PR DESCRIPTION
## What changed

Add the missing scheduler invocation in `_pthread_cond_timedwait()` after the current thread has been suspended, the pthread mutex has been released, and the critical section has been exited.

## Root cause

The wait path put the current thread onto the condition semaphore suspend list, but only called `rt_exit_critical()` before reading `thread->error` and re-locking the mutex. Without `rt_schedule()`, the suspended thread could continue running instead of yielding to the scheduler, which breaks pthread condition wait users such as pthread read/write locks.

## Scope

This keeps the fix in the condition variable wait implementation, which is the layer that directly suspends the thread. It does not add duplicate scheduling behavior in pthread rwlock callers.

Closes #11532

## Validation

- `git diff --check`
- `gh search prs 'pthread_cond_timedwait rt_schedule' --repo RT-Thread/rt-thread --state open --limit 20 --json number,title,author,url,isDraft` returned no duplicate open PRs.
- Tried `python -m SCons -n` on pthread-enabled BSPs (`bsp/mipssim`, `bsp/microchip/samd51-adafruit-metro-m4`), but local cross-toolchain paths are not installed, so BSP build validation could not complete locally.