### PR TITLE
[components][dfs] fix dfs_statfs fullpath leak

### DIFF
--- a/components/dfs/dfs_v2/src/dfs_fs.c
+++ b/components/dfs/dfs_v2/src/dfs_fs.c
@@ -650,6 +650,8 @@ int dfs_statfs(const char *path, struct statfs *buffer)
         }
     }
 
+    rt_free(fullpath);
+
     return ret;
 }
 


### PR DESCRIPTION
## What changed

Release the normalized `fullpath` buffer before `dfs_statfs()` returns in DFSv2.

## Root cause

`dfs_statfs()` allocates `fullpath` with `dfs_normalize_path(NULL, path)`, uses it to find the mount point, and then returns without freeing the temporary path buffer. Other DFSv2 functions that normalize paths free the temporary path before returning.

## Scope

The fix stays in `dfs_statfs()`, which owns the temporary path allocation. It does not change filesystem `statfs` callbacks or mount lookup behavior.

Closes #11495

## Validation

- `git diff --check`
- `gh search prs 'dfs_statfs fullpath rt_free' --repo RT-Thread/rt-thread --state open --limit 20 --json number,title,author,url,isDraft` returned no duplicate open PRs.
- Confirmed `bsp/qemu-vexpress-a9` enables DFSv2, but local `python -m SCons -n` stops because the configured toolchain path `/usr/bin` is not available on this Windows machine and no local `gcc` is installed.