### PR TITLE
[components][ulog] include stdlib.h for atoi

### DIFF
--- a/components/utilities/ulog/ulog.c
+++ b/components/utilities/ulog/ulog.c
@@ -9,6 +9,7 @@
  */
 
 #include <stdarg.h>
+#include <stdlib.h>
 #include "ulog.h"
 #include "rthw.h"
 


### PR DESCRIPTION
﻿## What changed

Add `<stdlib.h>` to `components/utilities/ulog/ulog.c` so the `atoi()` calls used by the ulog filter FinSH commands have a direct declaration.

## Why

When `ULOG_USING_FILTER` and the ulog FinSH commands are enabled, `ulog.c` calls `atoi()` in `ulog_be_lvl`, `ulog_tag_lvl`, and `ulog_lvl`. The file did not include `<stdlib.h>` directly, so toolchains that do not provide an indirect declaration can emit warnings or fail the build.

Fixes #11317.

## Validation

- Static check: confirmed `ulog.c` uses `atoi()` and now includes `<stdlib.h>`.
- `git diff --check`
- Verified the modified file uses CRLF line endings.

I could not run an RT-Thread build locally because this environment does not have `scons` or `gcc` installed.