### PR TITLE
[components][serial] fix serial v2 rx indicate setup

### DIFF
--- a/components/drivers/serial/dev_serial_v2.c
+++ b/components/drivers/serial/dev_serial_v2.c
@@ -89,9 +89,6 @@ static int serial_fops_open(struct dfs_file *fd)
         break;
     }
 
-    if ((fd->flags & O_ACCMODE) != O_WRONLY)
-        rt_device_set_rx_indicate(device, serial_fops_rx_ind);
-
     flags |= RT_SERIAL_RX_BLOCKING | RT_SERIAL_TX_BLOCKING;
 
     /* preserve RT_DEVICE_FLAG_STREAM if it was set before close */
@@ -105,6 +102,9 @@ static int serial_fops_open(struct dfs_file *fd)
 
     if (ret == RT_EOK)
     {
+        if ((fd->flags & O_ACCMODE) != O_WRONLY)
+            rt_device_set_rx_indicate(device, serial_fops_rx_ind);
+
         serial = (struct rt_serial_device *)device;
         serial->is_posix_mode = RT_TRUE;
     }


### PR DESCRIPTION
﻿## Summary

- Move the POSIX serial v2 rx indication callback setup until after the close/open sequence in `serial_fops_open()`.
- Keep `rt_serial_close()` cleanup behavior unchanged.
- Avoid leaving `serial_fops_rx_ind` cleared by the internal `rt_device_close()` call, so poll/select waiters can be woken after opening the serial device through DFS.

Closes #11538

## Validation

- `git diff --check`
- Rechecked open PRs for duplicate `serial_fops_open` / `rx_indicate` fixes.
- Reviewed the call chain: `serial_fops_open()` -> `rt_device_close()` -> `rt_serial_close()` clears `rx_indicate`, then `rt_device_open()` returns.

Build not run locally: this Windows environment does not have `scons` or `gcc` in PATH.
