### PR TITLE
[bsp][stm32] clarify BSP template copy path

### DIFF
--- a/bsp/stm32/docs/How to make a STM32 BSP for RT-Thread.md
+++ b/bsp/stm32/docs/How to make a STM32 BSP for RT-Thread.md
@@ -50,6 +50,12 @@ Copy the `stm32f10x` folder under the template folder and change the name of the
 
 ![Copying common templates](./figures_en/copy.png)
 
+Note: Do not run `menuconfig` or `scons` directly inside `bsp/stm32/libraries/templates/<series>`.
+The template directory is two levels deeper than a real BSP because of `libraries/templates`, so the
+relative paths in `Kconfig` match only after the template has been copied to `bsp/stm32/<board>`.
+Copy the matching series template into `bsp/stm32/`, rename it to the target BSP name, and then run
+`menuconfig`, `pkgs --update`, and `scons` from the new BSP directory.
+
 Modify the configuration file in the board folder. The modified content is shown in the following table: 
 
 | Item                      | Instruction                                                  |

--- a/bsp/stm32/docs/STM32系列BSP制作教程.md
+++ b/bsp/stm32/docs/STM32系列BSP制作教程.md
@@ -83,6 +83,11 @@ BSP 的制作过程分为如下五个步骤：
 
 ![复制通用模板](./figures/copy.png)
 
+注意：不要直接在 `bsp/stm32/libraries/templates/<series>` 模板目录中执行 `menuconfig` 或 `scons`。
+模板目录比实际 BSP 目录多了 `libraries/templates` 两级，`Kconfig` 中的相对路径只在模板被复制到
+`bsp/stm32/<board>` 后才匹配。请先将同系列模板复制到 `bsp/stm32/` 目录下并重命名为目标 BSP 名称，
+再进入新的 BSP 目录执行 `menuconfig`、`pkgs --update` 和 `scons`。
+
 在接下来的 BSP 的制作过程中，将会修改 board 文件夹内的配置文件，将 F1 系列的 BSP 模板变成一个适用于正点原子 `stm32f103-atk-nano` 开发板的 BSP ，下表总结了 board 文件夹中需要修改的内容：
 
 | 项目 | 需要修改的内容说明 |


### PR DESCRIPTION
## Summary

- Clarify that STM32 BSP templates should be copied into `bsp/stm32/<board>` before running `menuconfig`, `pkgs --update`, or `scons`.
- Explain why running these commands directly under `bsp/stm32/libraries/templates/<series>` fails: the template directory is two levels deeper than a real BSP, so the relative `Kconfig` paths do not resolve to the RT-Thread root.
- Update both the Chinese and English STM32 BSP creation guides.

Addresses #11341.

## Validation

- `git diff --check`
- Verified the relative path layout locally:
  - real BSP `../../../` resolves to the repository root
  - template `../../../` resolves to `bsp/stm32`
  - template `../../../../..` resolves to the repository root

Docs-only change; no build was run.