### PR TITLE
[components][usb] configure CDC VCOM strings

### DIFF
--- a/components/legacy/usb/Kconfig
+++ b/components/legacy/usb/Kconfig
@@ -119,6 +119,12 @@ menu "Using USB legacy version"
                     config RT_VCOM_TX_USE_DMA
                         bool "Enable to use dma for vcom tx"
                         default n
+                    config RT_VCOM_MANUFACTURER_STRING
+                        string "virtual com manufacturer string"
+                        default "RT-Thread Team."
+                    config RT_VCOM_PRODUCT_STRING
+                        string "virtual com product string"
+                        default "RTT Virtual Serial"
                     config RT_VCOM_SERNO
                         string "serial number of virtual com"
                         default "32021919830108"

--- a/components/legacy/usb/usbdevice/class/cdc_vcom.c
+++ b/components/legacy/usb/usbdevice/class/cdc_vcom.c
@@ -49,6 +49,18 @@
 #define VCOM_TX_USE_DMA
 #endif /*RT_VCOM_TX_USE_DMA*/
 
+#ifdef RT_VCOM_MANUFACTURER_STRING
+#define VCOM_MANUFACTURER_STRING RT_VCOM_MANUFACTURER_STRING
+#else /*!RT_VCOM_MANUFACTURER_STRING*/
+#define VCOM_MANUFACTURER_STRING "RT-Thread Team."
+#endif /*RT_VCOM_MANUFACTURER_STRING*/
+
+#ifdef RT_VCOM_PRODUCT_STRING
+#define VCOM_PRODUCT_STRING RT_VCOM_PRODUCT_STRING
+#else /*!RT_VCOM_PRODUCT_STRING*/
+#define VCOM_PRODUCT_STRING "RTT Virtual Serial"
+#endif /*RT_VCOM_PRODUCT_STRING*/
+
 #ifdef RT_VCOM_SERNO
 #define _SER_NO RT_VCOM_SERNO
 #else /*!RT_VCOM_SERNO*/
@@ -250,8 +262,8 @@ rt_align(4)
 const static char* _ustring[] =
 {
     "Language",
-    "RT-Thread Team.",
-    "RTT Virtual Serial",
+    VCOM_MANUFACTURER_STRING,
+    VCOM_PRODUCT_STRING,
     serno,
     "Configuration",
     "Interface",


### PR DESCRIPTION
## Summary

- Add Kconfig options for CDC VCOM manufacturer and product strings.
- Keep the existing default descriptors: `RT-Thread Team.` and `RTT Virtual Serial`.
- Use the configured strings in the CDC VCOM USB string descriptor table.

Fixes #11466

## Testing

- `git diff --check origin/master...HEAD`
- Static check: verified the new Kconfig symbols are the only new CDC VCOM string inputs.