### PR TITLE
fix: name anonymous Kconfig choices

### DIFF
--- a/bsp/ESP/libraries/drivers/Kconfig
+++ b/bsp/ESP/libraries/drivers/Kconfig
@@ -14,7 +14,7 @@ config SOC_ESP32_C3
 
 menu "Hardware Drivers Config"
 
-choice
+choice BSP_BOARD_SEL
     prompt "Select BSP board "
     default BSP_BOARD_LUATOS_ESP32C3
 

--- a/bsp/Infineon/libraries/templates/PSOC62/board/Kconfig
+++ b/bsp/Infineon/libraries/templates/PSOC62/board/Kconfig
@@ -199,7 +199,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/Infineon/psoc6-cy8ckit-062-BLE/board/Kconfig
+++ b/bsp/Infineon/psoc6-cy8ckit-062-BLE/board/Kconfig
@@ -199,7 +199,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/Infineon/psoc6-cy8ckit-062-WIFI-BT/board/Kconfig
+++ b/bsp/Infineon/psoc6-cy8ckit-062-WIFI-BT/board/Kconfig
@@ -207,7 +207,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/Infineon/psoc6-cy8ckit-062S2-43012/board/Kconfig
+++ b/bsp/Infineon/psoc6-cy8ckit-062S2-43012/board/Kconfig
@@ -211,7 +211,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/Infineon/psoc6-cy8ckit-062s4/board/Kconfig
+++ b/bsp/Infineon/psoc6-cy8ckit-062s4/board/Kconfig
@@ -199,7 +199,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/Infineon/psoc6-cy8cproto-062S3-4343W/board/Kconfig
+++ b/bsp/Infineon/psoc6-cy8cproto-062S3-4343W/board/Kconfig
@@ -211,7 +211,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/Infineon/psoc6-evaluationkit-062S2/board/Kconfig
+++ b/bsp/Infineon/psoc6-evaluationkit-062S2/board/Kconfig
@@ -255,7 +255,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/acm32/acm32f4xx-nucleo/drivers/Kconfig
+++ b/bsp/acm32/acm32f4xx-nucleo/drivers/Kconfig
@@ -1,6 +1,6 @@
 menu "Hardware Drivers Config"
 
-choice
+choice SOC_ACM32F403_SEL
     prompt "select chip type"
     default SOC_ACM32F403RET7
 

--- a/bsp/allwinner/libraries/drivers/Kconfig
+++ b/bsp/allwinner/libraries/drivers/Kconfig
@@ -1,6 +1,6 @@
 menu "General Drivers Configuration"
 
-choice
+choice BOARD_SEL
     prompt "Choose Board"
 
     default BSP_USING_M7
@@ -15,7 +15,7 @@ menuconfig BSP_USING_UART0
     bool "Enable UART0"
     default y
     if BSP_USING_UART0
-        choice
+        choice UART0_TX_GPIO_SEL
             prompt "UART0 TX PIN"
             default UART0_TX_USING_GPIOE2 if BOARD_allwinnerd1s
             default UART0_TX_USING_GPIOB8 if BOARD_allwinnerd1
@@ -29,7 +29,7 @@ menuconfig BSP_USING_UART0
             config UART0_TX_USING_GPIOF2
                 bool "GPIOF02"
         endchoice
-        choice
+        choice UART0_RX_GPIO_SEL
             prompt "UART0 RX PIN"
             default UART0_RX_USING_GPIOE3 if BOARD_allwinnerd1s
             default UART0_RX_USING_GPIOB9 if BOARD_allwinnerd1
@@ -49,7 +49,7 @@ menuconfig BSP_USING_UART1
     bool "Enable UART1"
     default n
     if BSP_USING_UART1
-        choice
+        choice UART1_TX_GPIO_SEL
             prompt "UART1 TX PIN"
             config UART1_TX_USING_GPIOD21
                 bool "GPIOD21"
@@ -60,7 +60,7 @@ menuconfig BSP_USING_UART1
             config UART1_TX_USING_GPIOG12
                 bool "GPIOG12"
         endchoice
-        choice
+        choice UART1_RX_GPIO_SEL
             prompt "UART1 RX PIN"
             config UART1_RX_USING_GPIOD22
                 bool "GPIOD22"
@@ -77,14 +77,14 @@ menuconfig BSP_USING_UART2
     bool "Enable UART2"
     default n
     if BSP_USING_UART2
-        choice
+        choice UART2_TX_GPIO_SEL
             prompt "UART2 TX PIN"
             config UART2_TX_USING_GPIOD1
                 bool "GPIOD01"
             config UART2_TX_USING_GPIOE2
                 bool "GPIOE02"
         endchoice
-        choice
+        choice UART2_RX_GPIO_SEL
             prompt "UART2 RX PIN"
             config UART2_RX_USING_GPIOD2
                 bool "GPIOD02"
@@ -97,7 +97,7 @@ menuconfig BSP_USING_UART3
     bool "Enable UART3"
     default n
     if BSP_USING_UART3
-        choice
+        choice UART3_TX_GPIO_SEL
             prompt "UART3 TX PIN"
             config UART3_TX_USING_GPIOB6
                 bool "GPIOB06"
@@ -112,7 +112,7 @@ menuconfig BSP_USING_UART3
             config UART3_TX_USING_GPIOG8
                 bool "GPIOG08"
         endchoice
-        choice
+        choice UART3_RX_GPIO_SEL
             prompt "UART3 RX PIN"
             config UART3_RX_USING_GPIOB7
                 bool "GPIOB07"
@@ -133,7 +133,7 @@ menuconfig BSP_USING_UART4
     bool "Enable UART4"
     default n
     if BSP_USING_UART4
-        choice
+        choice UART4_TX_GPIO_SEL
             prompt "UART4 TX PIN"
             config UART4_TX_USING_GPIOB2
                 bool "GPIOB02"
@@ -144,7 +144,7 @@ menuconfig BSP_USING_UART4
             config UART4_TX_USING_GPIOG2
                 bool "GPIOG02"
         endchoice
-        choice
+        choice UART4_RX_PIN_SEL
             prompt "UART4 RX PIN"
             config UART4_RX_USING_GPIOB3
                 bool "GPIOB03"
@@ -161,7 +161,7 @@ menuconfig BSP_USING_UART5
     bool "Enable UART5"
     default n
     if BSP_USING_UART5
-        choice
+        choice UART5_TX_GPIO_SEL
             prompt "UART5 TX PIN"
             config UART5_TX_USING_GPIOB4
                 bool "GPIOB04"
@@ -172,7 +172,7 @@ menuconfig BSP_USING_UART5
             config UART5_TX_USING_GPIOG4
                 bool "GPIOG04"
         endchoice
-        choice
+        choice UART5_RX_GPIO_SEL
             prompt "UART5 RX PIN"
             config UART5_RX_USING_GPIOB5
                 bool "GPIOB05"

--- a/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/Kconfig
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/Kconfig
@@ -10,7 +10,7 @@ config DISP2_SUNXI
     ---help---
       Display driver for sunxi based boards.
 
-choice
+choice SUNXI_DISP2_FB_SEL
     prompt "DISP2 Framebuffer rotation support"
     default SUNXI_DISP2_FB_DISABLE_ROTATE
 

--- a/bsp/allwinner/libraries/sunxi-hal/hal/source/gmac/Kconfig
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/source/gmac/Kconfig
@@ -4,7 +4,7 @@ config DRIVERS_GMAC
     bool "enable GMAC driver"
     default n
     if DRIVERS_GMAC
-        choice
+        choice GMAC_R_SEL
             prompt "GMAC media independent interface"
             default GMAC_USING_RMII if BOARD_allwinnerd1s
             default GMAC_USING_RGMII if BOARD_allwinnerd1
@@ -14,7 +14,7 @@ config DRIVERS_GMAC
             config GMAC_USING_RMII
                 bool "RMII"
         endchoice
-        choice
+        choice GMAC_GPIO_SEL
             prompt "GMAC GPIO GROUP"
             default GMAC_USING_GPIOG if BOARD_allwinnerd1s
             default GMAC_USING_GPIOE if BOARD_allwinnerd1

--- a/bsp/apm32/apm32e103ze-evalboard/board/Kconfig
+++ b/bsp/apm32/apm32e103ze-evalboard/board/Kconfig
@@ -107,7 +107,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/apm32/apm32e103ze-tinyboard/board/Kconfig
+++ b/bsp/apm32/apm32e103ze-tinyboard/board/Kconfig
@@ -75,7 +75,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/apm32/apm32f030r8-miniboard/board/Kconfig
+++ b/bsp/apm32/apm32f030r8-miniboard/board/Kconfig
@@ -56,7 +56,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/apm32/apm32f051r8-evalboard/board/Kconfig
+++ b/bsp/apm32/apm32f051r8-evalboard/board/Kconfig
@@ -81,7 +81,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/apm32/apm32f072vb-miniboard/board/Kconfig
+++ b/bsp/apm32/apm32f072vb-miniboard/board/Kconfig
@@ -56,7 +56,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/apm32/apm32f091vc-miniboard/board/Kconfig
+++ b/bsp/apm32/apm32f091vc-miniboard/board/Kconfig
@@ -56,7 +56,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/apm32/apm32f103vb-miniboard/board/Kconfig
+++ b/bsp/apm32/apm32f103vb-miniboard/board/Kconfig
@@ -58,7 +58,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/apm32/apm32f103xe-minibroard/board/Kconfig
+++ b/bsp/apm32/apm32f103xe-minibroard/board/Kconfig
@@ -69,7 +69,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/apm32/apm32f107vc-evalboard/board/Kconfig
+++ b/bsp/apm32/apm32f107vc-evalboard/board/Kconfig
@@ -101,7 +101,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/apm32/apm32f407ig-minibroard/board/Kconfig
+++ b/bsp/apm32/apm32f407ig-minibroard/board/Kconfig
@@ -58,7 +58,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/apm32/apm32f407zg-evalboard/board/Kconfig
+++ b/bsp/apm32/apm32f407zg-evalboard/board/Kconfig
@@ -100,7 +100,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/apm32/apm32s103vb-miniboard/board/Kconfig
+++ b/bsp/apm32/apm32s103vb-miniboard/board/Kconfig
@@ -63,7 +63,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/at32/at32a403a-start/board/Kconfig
+++ b/bsp/at32/at32a403a-start/board/Kconfig
@@ -38,7 +38,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32a423-start/board/Kconfig
+++ b/bsp/at32/at32a423-start/board/Kconfig
@@ -53,7 +53,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f402-start/board/Kconfig
+++ b/bsp/at32/at32f402-start/board/Kconfig
@@ -64,7 +64,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f403a-start/board/Kconfig
+++ b/bsp/at32/at32f403a-start/board/Kconfig
@@ -38,7 +38,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f405-start/board/Kconfig
+++ b/bsp/at32/at32f405-start/board/Kconfig
@@ -83,7 +83,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f407-start/board/Kconfig
+++ b/bsp/at32/at32f407-start/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_LWIP
         if BSP_USING_EMAC
-            choice
+            choice PHY_DM9162_SEL
                 prompt "Select phy"
                 default PHY_USING_DM9162
 
@@ -61,7 +61,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f413-start/board/Kconfig
+++ b/bsp/at32/at32f413-start/board/Kconfig
@@ -38,7 +38,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f415-start/board/Kconfig
+++ b/bsp/at32/at32f415-start/board/Kconfig
@@ -53,7 +53,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f421-start/board/Kconfig
+++ b/bsp/at32/at32f421-start/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f423-start/board/Kconfig
+++ b/bsp/at32/at32f423-start/board/Kconfig
@@ -53,7 +53,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f425-start/board/Kconfig
+++ b/bsp/at32/at32f425-start/board/Kconfig
@@ -53,7 +53,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f435-start/board/Kconfig
+++ b/bsp/at32/at32f435-start/board/Kconfig
@@ -87,7 +87,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f437-start/board/Kconfig
+++ b/bsp/at32/at32f437-start/board/Kconfig
@@ -72,7 +72,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_LWIP
         if BSP_USING_EMAC
-            choice
+            choice PHY_DM9162_SEL
                 prompt "Select phy"
                 default PHY_USING_DM9162
 
@@ -110,7 +110,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f455-start/board/Kconfig
+++ b/bsp/at32/at32f455-start/board/Kconfig
@@ -57,7 +57,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_LWIP
         if BSP_USING_EMAC
-            choice
+            choice PHY_DM9162_SEL
                 prompt "Select phy"
                 default PHY_USING_DM9162
 
@@ -91,7 +91,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f456-start/board/Kconfig
+++ b/bsp/at32/at32f456-start/board/Kconfig
@@ -57,7 +57,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_LWIP
         if BSP_USING_EMAC
-            choice
+            choice PHY_DM9162_SEL
                 prompt "Select phy"
                 default PHY_USING_DM9162
 
@@ -91,7 +91,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32f457-start/board/Kconfig
+++ b/bsp/at32/at32f457-start/board/Kconfig
@@ -57,7 +57,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_LWIP
         if BSP_USING_EMAC
-            choice
+            choice PHY_DM9162_SEL
                 prompt "Select phy"
                 default PHY_USING_DM9162
 
@@ -91,7 +91,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32m412-start/board/Kconfig
+++ b/bsp/at32/at32m412-start/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/at32/at32m416-start/board/Kconfig
+++ b/bsp/at32/at32m416-start/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_L_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LEXT
 

--- a/bsp/avr32/at32uc3a0256/Kconfig
+++ b/bsp/avr32/at32uc3a0256/Kconfig
@@ -20,7 +20,7 @@ config SOC_AVR32
     bool
     default y
 
-choice
+choice BSP_BOARD_SEL
     prompt "Select BSP board"
     default BSP_BOARD_MIZAR32B
 
@@ -44,7 +44,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART0"
                 default n
             if BSP_USING_UART0
-                choice
+                choice BSP_UART0_TX_PIN_SEL
                     prompt "uart0 tx pin number (GP)"
                     depends on BSP_USING_UART0
                     default BSP_UART0_TX_PIN_43
@@ -61,7 +61,7 @@ menu "On-chip Peripheral Drivers"
                     int
                     default 0 if BSP_UART0_TX_PIN_19
                     default 2 if BSP_UART0_TX_PIN_43
-                choice
+                choice BSP_UART0_RX_PIN_SEL
                     prompt "uart0 rx pin number (GP)"
                     depends on BSP_USING_UART0
                     default BSP_UART0_RX_PIN_42
@@ -84,7 +84,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART1"
                 default y
             if BSP_USING_UART1
-                choice
+                choice BSP_UART1_TX_PIN_SEL
                     prompt "uart1 tx pin number (GP)"
                     depends on BSP_USING_UART1
                     default BSP_UART1_TX_PIN_6
@@ -101,7 +101,7 @@ menu "On-chip Peripheral Drivers"
 		    int
 		    default 0 if BSP_UART1_TX_PIN_6
 		    default 1 if BSP_UART1_TX_PIN_95
-                choice
+                choice BSP_UART1_RX_PIN_SEL
                     prompt "uart1 rx pin number (GP)"
                     depends on BSP_USING_UART1
                     default BSP_UART1_RX_PIN_5

--- a/bsp/avr32/at32uc3b0256/Kconfig
+++ b/bsp/avr32/at32uc3b0256/Kconfig
@@ -20,7 +20,7 @@ config SOC_AVR32
     bool
     default y
 
-choice
+choice BSP_BOARD_SEL
     prompt "Select BSP board"
     default BSP_BOARD_MCUZONE_AVR32DEV1
 
@@ -44,7 +44,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART0"
                 default n
             if BSP_USING_UART0
-                choice
+                choice BSP_UART0_TX_PIN_SEL
                     prompt "uart0 tx pin number (GP)"
                     depends on BSP_USING_UART0
                     default BSP_UART0_TX_PIN_43
@@ -61,7 +61,7 @@ menu "On-chip Peripheral Drivers"
                     int
                     default 0 if BSP_UART0_TX_PIN_19
                     default 2 if BSP_UART0_TX_PIN_43
-                choice
+                choice BSP_UART0_RX_PIN_SEL
                     prompt "uart0 rx pin number (GP)"
                     depends on BSP_USING_UART0
                     default BSP_UART0_RX_PIN_42
@@ -84,7 +84,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART1"
                 default y
             if BSP_USING_UART1
-                choice
+                choice BSP_UART1_TX_PIN_SEL
                     prompt "uart1 tx pin number (GP)"
                     depends on BSP_USING_UART1
                     default BSP_UART1_TX_PIN_34
@@ -101,7 +101,7 @@ menu "On-chip Peripheral Drivers"
 		    int
 		    default 2 if BSP_UART1_TX_PIN_34
 		    default 0 if BSP_UART1_TX_PIN_23
-                choice
+                choice BSP_UART1_RX_PIN_SEL
                     prompt "uart1 rx pin number (GP)"
                     depends on BSP_USING_UART1
                     default BSP_UART1_RX_PIN_35

--- a/bsp/bouffalo_lab/bl61x/board/Kconfig
+++ b/bsp/bouffalo_lab/bl61x/board/Kconfig
@@ -16,7 +16,7 @@ config BSP_USING_PSRAM
     bool "Enable PSRAM"
     default n
 
-choice
+choice BSP_BL61X_MODULE_SEL
     prompt "Choose Module"
 
     default BSP_USING_BL61X_MODULE_DEFAULT

--- a/bsp/bouffalo_lab/bl808/d0/board/Kconfig
+++ b/bsp/bouffalo_lab/bl808/d0/board/Kconfig
@@ -33,7 +33,7 @@ menu "General Drivers Configuration"
         bool "Enable UART3"
         default y
         if BSP_USING_UART3
-            choice
+            choice UART3_TX_GPIO_SEL
                 prompt "UART3 TX PIN"
                 default UART3_TX_USING_GPIO16
 
@@ -62,7 +62,7 @@ menu "General Drivers Configuration"
                 config UART3_TX_USING_GPIO44
                     bool "GPIO_44"
             endchoice
-            choice
+            choice UART3_RX_GPIO_SEL
                 prompt "UART3 RX PIN"
                 default UART3_RX_USING_GPIO17
 
@@ -106,7 +106,7 @@ menu "General Drivers Configuration"
                     bool "Enable I2C2 (hardware)"
                     default n
                     if BSP_USING_I2C2
-                        choice 
+                        choice I2C2_SCL_SEL
                             prompt "I2C2 SCL"
                             default I2C2_SCL_USING_GPIO14
 
@@ -169,7 +169,7 @@ menu "General Drivers Configuration"
                                 bool "GPIO_44"
                         endchoice
 
-                        choice
+                        choice I2C2_SDA_GPIO_SEL
                             prompt "I2C2 SDA"
                             default I2C2_SDA_USING_GPIO15
 
@@ -244,7 +244,7 @@ menu "General Drivers Configuration"
                     bool "Enable I2C3 (hardware)"
                     default n
                     if BSP_USING_I2C3
-                        choice 
+                        choice I2C3_SCL_SEL
                             prompt "I2C3 SCL"
                             default I2C3_SCL_USING_GPIO0
 
@@ -301,7 +301,7 @@ menu "General Drivers Configuration"
                                 bool "GPIO_44"
                         endchoice
 
-                        choice
+                        choice I2C3_SDA_GPIO_SEL
                             prompt "I2C3 SDA"
                             default I2C3_SDA_USING_GPIO1
 
@@ -374,7 +374,7 @@ menu "General Drivers Configuration"
         default n
 
         if BSP_USING_SPI
-            choice
+            choice SPI_SCK_GPIO_SEL
                 prompt "SPI SCK PIN"
                 default SPI_SCK_USING_GPIO19
 
@@ -402,7 +402,7 @@ menu "General Drivers Configuration"
                     bool "GPIO_43"
             endchoice
 
-            choice
+            choice SPI_MISO_GPIO_SEL
                 prompt "SPI MISO PIN"
                 default SPI_MISO_USING_GPIO22
 
@@ -432,7 +432,7 @@ menu "General Drivers Configuration"
                     bool "GPIO_42"
             endchoice
 
-            choice
+            choice SPI_MOSI_GPIO_SEL
                 prompt "SPI MOSI PIN"
                 default SPI_MOSI_USING_GPIO21
 

--- a/bsp/bouffalo_lab/libraries/Kconfig
+++ b/bsp/bouffalo_lab/libraries/Kconfig
@@ -9,7 +9,7 @@ menu "General Drivers Configuration"
         bool "Enable UART0"
         default y
         if BSP_USING_UART0
-            choice
+            choice UART0_TX_GPIO_SEL
                 prompt "UART0 TX PIN"
                 default UART0_TX_USING_GPIO16 if BSP_USING_BL60X
                 default UART0_TX_USING_GPIO21 if BSP_USING_BL61X
@@ -123,7 +123,7 @@ menu "General Drivers Configuration"
                     bool "GPIO_45"
             endchoice
 
-            choice
+            choice UART0_RX_GPIO_SEL
                 prompt "UART0 RX PIN"
                 default UART0_RX_USING_GPIO7 if BSP_USING_BL60X
                 default UART0_RX_USING_GPIO22 if BSP_USING_BL61X
@@ -241,7 +241,7 @@ menu "General Drivers Configuration"
         bool "Enable UART1"
         default n
         if BSP_USING_UART1
-            choice
+            choice UART1_TX_GPIO_SEL
                 prompt "UART1 TX PIN"
                 default UART1_TX_USING_GPIO4 if BSP_USING_BL60X
                 default UART1_TX_USING_GPIO16 if BSP_USING_BL61X
@@ -353,7 +353,7 @@ menu "General Drivers Configuration"
                     bool "GPIO_45"
             endchoice
 
-            choice
+            choice UART1_RX_GPIO_SEL
                 prompt "UART1 RX PIN"
                 default UART1_RX_USING_GPIO3 if BSP_USING_BL60X
                 default UART1_RX_USING_GPIO17 if BSP_USING_BL61X
@@ -471,7 +471,7 @@ menu "General Drivers Configuration"
             bool "Enable UART2"
             default n
             if BSP_USING_UART2
-                choice
+                choice UART2_TX_GPIO_SEL
                     prompt "UART2 TX PIN"
                     default UART2_TX_USING_GPIO20
 
@@ -560,7 +560,7 @@ menu "General Drivers Configuration"
                     config UART2_TX_USING_GPIO45
                         bool "GPIO_45"
                 endchoice
-                choice
+                choice UART2_RX_GPIO_SEL
                     prompt "UART2 RX PIN"
                     default UART2_RX_USING_GPIO21
 
@@ -817,7 +817,7 @@ menu "General Drivers Configuration"
                     bool "Enable I2C0 (hardware)"
                     default n
                     if BSP_USING_I2C0
-                        choice
+                        choice I2C0_SCL_SEL
                             prompt "I2C0 SCL"
                             default I2C0_SCL_USING_GPIO14
 
@@ -880,7 +880,7 @@ menu "General Drivers Configuration"
                                 bool "GPIO_44"
                         endchoice
 
-                        choice
+                        choice I2C0_SDA_GPIO_SEL
                             prompt "I2C0 SDA"
                             default I2C0_SDA_USING_GPIO15
 
@@ -955,7 +955,7 @@ menu "General Drivers Configuration"
                     bool "Enable I2C1 (hardware)"
                     default n
                     if BSP_USING_I2C1
-                        choice
+                        choice I2C1_SCL_SEL
                             prompt "I2C1 SCL"
                             default I2C1_SCL_USING_GPIO0
 
@@ -1012,7 +1012,7 @@ menu "General Drivers Configuration"
                                 bool "GPIO_44"
                         endchoice
 
-                        choice
+                        choice I2C1_SDA_GPIO_SEL
                             prompt "I2C1 SDA"
                             default I2C1_SDA_USING_GPIO1
 
@@ -1104,7 +1104,7 @@ menu "General Drivers Configuration"
         default n
 
         if BSP_USING_SPI
-            choice
+            choice SPI_SCK_GPIO_SEL
                 prompt "SPI SCK PIN"
                 default SPI_SCK_USING_GPIO3 if BSP_USING_BL60X
                 default SPI_SCK_USING_GPIO13 if BSP_USING_BL61X
@@ -1173,7 +1173,7 @@ menu "General Drivers Configuration"
                     bool "GPIO_43"
             endchoice
 
-            choice
+            choice SPI_MISO_GPIO_SEL
                 prompt "SPI MISO PIN"
                 default SPI_MISO_USING_GPIO0 if BSP_USING_BL60X
                 default SPI_MISO_USING_GPIO10 if BSP_USING_BL61X
@@ -1257,7 +1257,7 @@ menu "General Drivers Configuration"
                     bool "GPIO_42"
             endchoice
 
-            choice
+            choice SPI_MOSI_GPIO_SEL
                 prompt "SPI MOSI PIN"
                 default SPI_MOSI_USING_GPIO1 if BSP_USING_BL60X
                 default SPI_MOSI_USING_GPIO11 if BSP_USING_BL61X

--- a/bsp/cvitek/c906_little/Kconfig
+++ b/bsp/cvitek/c906_little/Kconfig
@@ -51,7 +51,7 @@ config SOC_TYPE_SG2002
     bool
     default n
 
-choice
+choice BOARD_TYPE_MILKV_DUO_SEL
     prompt "Board Type"
     default BOARD_TYPE_MILKV_DUO256M
 

--- a/bsp/cvitek/cv18xx_aarch64/Kconfig
+++ b/bsp/cvitek/cv18xx_aarch64/Kconfig
@@ -34,7 +34,7 @@ config SOC_TYPE_SG2002
     bool
     default n
 
-choice
+choice BOARD_TYPE_SEL
     prompt "Board Type"
     default BOARD_TYPE_MILKV_DUO256M
 

--- a/bsp/cvitek/cv18xx_aarch64/board/Kconfig
+++ b/bsp/cvitek/cv18xx_aarch64/board/Kconfig
@@ -7,7 +7,7 @@ menu "General Drivers Configuration"
         bool
         default y
 
-    choice
+    choice BSP_GICV_SEL
         prompt "GIC Version"
         default BSP_USING_GICV2
 

--- a/bsp/cvitek/cv18xx_risc-v/Kconfig
+++ b/bsp/cvitek/cv18xx_risc-v/Kconfig
@@ -56,7 +56,7 @@ config SOC_TYPE_SG2002
     bool
     default n
 
-choice
+choice BOARD_TYPE_MILKV_DUO_SEL
     prompt "Board Type"
     default BOARD_TYPE_MILKV_DUO256M
 

--- a/bsp/ft32/ft32f072xb-starter/board/Kconfig
+++ b/bsp/ft32/ft32f072xb-starter/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 

--- a/bsp/ft32/ft32f407xe-starter/board/Kconfig
+++ b/bsp/ft32/ft32f407xe-starter/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 

--- a/bsp/gd32/arm/gd32103c-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32103c-eval/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -287,7 +287,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32105c-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32105c-eval/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -283,7 +283,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32105r-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32105r-start/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -291,7 +291,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32107c-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32107c-eval/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -283,7 +283,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32205r-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32205r-start/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -287,7 +287,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32207i-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32207i-eval/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -287,7 +287,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32303c-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32303c-start/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 

--- a/bsp/gd32/arm/gd32303e-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32303e-eval/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -287,7 +287,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32305r-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32305r-start/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -283,7 +283,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32307e-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32307e-start/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -283,7 +283,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32405rg/board/Kconfig
+++ b/bsp/gd32/arm/gd32405rg/board/Kconfig
@@ -27,7 +27,7 @@ menu "On-chip Peripheral Drivers"
         default y
         select RT_USING_SERIAL
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -226,7 +226,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_I2C
         default n
         if BSP_USING_HARD_I2C
-            choice
+            choice BSP_HARD_I2C_RECEIVING_SEL
                 prompt "Select I2C Receiving Scheme"
                 default BSP_USING_RECEIVING_A
 
@@ -427,7 +427,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32407v-lckfb/board/Kconfig
+++ b/bsp/gd32/arm/gd32407v-lckfb/board/Kconfig
@@ -46,7 +46,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -307,7 +307,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32407v-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32407v-start/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -287,7 +287,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32450z-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32450z-eval/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -287,7 +287,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 
@@ -342,7 +342,7 @@ menu "On-chip Peripheral Drivers"
                 default n
 
             if BSP_USING_CAN0
-                choice
+                choice BSP_CAN0_TX_P_SEL
                     prompt "Select CAN0 TX source"
                     default BSP_CAN0_TX_PD1
 
@@ -356,7 +356,7 @@ menu "On-chip Peripheral Drivers"
                         bool "GPIOH pin 13"
                 endchoice
 
-                choice
+                choice BSP_CAN0_RX_P_SEL
                     prompt "Select CAN0 RX source"
                     default BSP_CAN0_RX_PD0
 
@@ -376,7 +376,7 @@ menu "On-chip Peripheral Drivers"
                 default n
 
             if BSP_USING_CAN1
-                choice
+                choice BSP_CAN1_TX_PB_SEL
                     prompt "Select CAN1 TX source"
                     default BSP_CAN1_TX_PB6
 
@@ -386,7 +386,7 @@ menu "On-chip Peripheral Drivers"
                         bool "GPIOB pin 13"
                 endchoice
 
-                choice
+                choice BSP_CAN1_RX_P_SEL
                     prompt "Select CAN1 RX source"
                     default BSP_CAN1_RX_PB5
 

--- a/bsp/gd32/arm/gd32470i-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32470i-eval/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -280,7 +280,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32470z-lckfb/board/Kconfig
+++ b/bsp/gd32/arm/gd32470z-lckfb/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -357,7 +357,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32527I-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32527I-eval/board/Kconfig
@@ -27,7 +27,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -297,7 +297,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 
@@ -358,7 +358,7 @@ menu "On-chip Peripheral Drivers"
                 default n
 
             if BSP_USING_CAN0
-                choice
+                choice BSP_CAN0_TX_P_SEL
                     prompt "Select CAN0 TX source"
                     default BSP_CAN0_TX_PH13
 
@@ -372,7 +372,7 @@ menu "On-chip Peripheral Drivers"
                         bool "GPIOH pin 13"
                 endchoice
 
-                choice
+                choice BSP_CAN0_RX_P_SEL
                     prompt "Select CAN0 RX source"
                     default BSP_CAN0_RX_PI9
 

--- a/bsp/gd32/arm/gd32e230-lckfb/board/Kconfig
+++ b/bsp/gd32/arm/gd32e230-lckfb/board/Kconfig
@@ -36,7 +36,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -336,7 +336,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32e503v-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32e503v-eval/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -287,7 +287,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/gd32h759i-eval/board/Kconfig
+++ b/bsp/gd32/arm/gd32h759i-eval/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 

--- a/bsp/gd32/arm/gd32h759i-start/board/Kconfig
+++ b/bsp/gd32/arm/gd32h759i-start/board/Kconfig
@@ -26,7 +26,7 @@ menu "On-chip Peripheral Drivers"
         bool "Enable UART"
         default y
         if BSP_USING_UART
-            choice
+            choice BSP_SERIAL_V_SEL
                 prompt "Select UART framework version"
                 default BSP_USING_SERIAL_V1
                 
@@ -230,7 +230,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_ALARM
                 default n
             if BSP_USING_ALARM
-                choice
+                choice BSP_ALARM_SEL
                     prompt "Select rtc alarm device"
                     default BSP_USING_ALARM0
 

--- a/bsp/gd32/arm/libraries/gd32_drivers/Kconfig
+++ b/bsp/gd32/arm/libraries/gd32_drivers/Kconfig
@@ -25,7 +25,7 @@ if BSP_USING_USBD
 endif
 
 if BSP_USING_HARD_I2C
-    choice
+    choice BSP_RECEIVING_SEL
         prompt "Select I2C Receiving Scheme"
         default BSP_USING_RECEIVING_A
 

--- a/bsp/gd32/risc-v/gd32vf103r-start/board/Kconfig
+++ b/bsp/gd32/risc-v/gd32vf103r-start/board/Kconfig
@@ -156,7 +156,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/gd32/risc-v/gd32vf103v-eval/board/Kconfig
+++ b/bsp/gd32/risc-v/gd32vf103v-eval/board/Kconfig
@@ -159,7 +159,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/gd32/risc-v/gd32vw553h-eval/board/Kconfig
+++ b/bsp/gd32/risc-v/gd32vw553h-eval/board/Kconfig
@@ -118,7 +118,7 @@ menu "On-chip Peripheral Drivers"
             config BSP_USING_WWDT
                 bool "Enable WWDT"
                 default n
-            choice
+            choice WDT_TYPE_SEL
                 prompt "Select WDT type"
                 default BSP_USING_FWDT
                 config BSP_USING_FWDT
@@ -138,7 +138,7 @@ menu "On-chip Peripheral Drivers"
                 default n
 
             # config i2c0 pins
-            choice
+            choice BSP_HW_I2C0_PIN_P_SEL
                 prompt "Select I2C0 pins"
                 depends on BSP_USING_HW_I2C0
                 config BSP_HW_I2C0_PIN_PA2_PA3
@@ -163,7 +163,7 @@ menu "On-chip Peripheral Drivers"
                 default n
 
             # config i2c1 pins
-            choice
+            choice BSP_HW_I2C1_PIN_P_SEL
                 prompt "Select I2C1 pins"
                 depends on BSP_USING_HW_I2C1
                 config BSP_HW_I2C1_PIN_PA6_PA7

--- a/bsp/hc32/ev_hc32f334_lqfp64/board/Kconfig
+++ b/bsp/hc32/ev_hc32f334_lqfp64/board/Kconfig
@@ -323,7 +323,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_WDT
         if BSP_USING_WDT_TMR
-            choice
+            choice SWDT_WDT_SEL
                 prompt "Select SWDT/WDT"
                 default BSP_USING_SWDT
 
@@ -343,7 +343,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_XTAL32
 
@@ -360,7 +360,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_PM
         if BSP_USING_PM
-            choice
+            choice BSP_WKTM_SEL
                 prompt "Select WKTM Clock Src"
                 default BSP_USING_WKTM_LRC
 
@@ -399,7 +399,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_AES
             if BSP_USING_AES
-                choice
+                choice AES_MODE_SEL
                     prompt "Select AES Mode"
                     default BSP_USING_AES_ECB
 
@@ -414,7 +414,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_SHA2
             if BSP_USING_HASH
-                choice
+                choice HASH_MODE_SEL
                     prompt "Select Hash Mode"
                     default BSP_USING_SHA2_256
 

--- a/bsp/hc32/ev_hc32f448_lqfp80/board/Kconfig
+++ b/bsp/hc32/ev_hc32f448_lqfp80/board/Kconfig
@@ -420,7 +420,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_WDT
         if BSP_USING_WDT_TMR
-            choice
+            choice SWDT_WDT_SEL
                 prompt "Select SWDT/WDT"
                 default BSP_USING_SWDT
 
@@ -440,7 +440,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_XTAL32
 
@@ -460,7 +460,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_PM
         if BSP_USING_PM
-            choice
+            choice BSP_WKTM_SEL
                 prompt "Select WKTM Clock Src"
                 default BSP_USING_WKTM_LRC
 
@@ -499,7 +499,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_AES
             if BSP_USING_AES
-                choice
+                choice AES_MODE_SEL
                     prompt "Select AES Mode"
                     default BSP_USING_AES_ECB
 
@@ -514,7 +514,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_SHA2
             if BSP_USING_HASH
-                choice
+                choice HASH_MODE_SEL
                     prompt "Select Hash Mode"
                     default BSP_USING_SHA2_256
 

--- a/bsp/hc32/ev_hc32f460_lqfp100_v2/board/Kconfig
+++ b/bsp/hc32/ev_hc32f460_lqfp100_v2/board/Kconfig
@@ -391,7 +391,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_XTAL32
 
@@ -421,7 +421,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_PM
         if BSP_USING_PM
-            choice
+            choice BSP_WKTM_SEL
                 prompt "Select WKTM Clock Src"
                 default BSP_USING_WKTM_LRC
 
@@ -460,7 +460,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_AES
             if BSP_USING_AES
-                choice
+                choice AES_MODE_SEL
                     prompt "Select AES Mode"
                     default BSP_USING_AES_ECB
 
@@ -475,7 +475,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_SHA2
             if BSP_USING_HASH
-                choice
+                choice HASH_MODE_SEL
                     prompt "Select Hash Mode"
                     default BSP_USING_SHA2_256
 
@@ -571,7 +571,7 @@ menu "On-chip Peripheral Drivers"
                 bool
                 default y
 
-            choice
+            choice BSP_USB_SEL
                 prompt "Select USB Mode"
                 default BSP_USING_USBD
 

--- a/bsp/hc32/ev_hc32f467_lqfp144/board/Kconfig
+++ b/bsp/hc32/ev_hc32f467_lqfp144/board/Kconfig
@@ -32,7 +32,7 @@ menu "Onboard Peripheral Drivers"
         select RT_LWIP_USING_HW_CHECKSUM
 
         if BSP_USING_ETH
-            choice
+            choice ETH_PHY_SEL
                 prompt "Select ETH PHY type"
                 default ETH_PHY_USING_RTL8201F
 
@@ -43,7 +43,7 @@ menu "Onboard Peripheral Drivers"
                     select BSP_USING_TCA9539
             endchoice
 
-            choice
+            choice ETH_IF_SEL
                 prompt "Select ETH Communication Interface"
                 default ETH_INTERFACE_USING_RMII
 
@@ -56,7 +56,7 @@ menu "Onboard Peripheral Drivers"
         bool "Enable EXMC"
         default n
         if BSP_USING_EXMC
-            choice
+            choice SDRAM_NAND_SEL
                 prompt "Using SDRAM or NAND"
                 default BSP_USING_NAND
 
@@ -544,7 +544,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_WDT
         if BSP_USING_WDT_TMR
-            choice
+            choice SWDT_WDT_SEL
                 prompt "Select SWDT/WDT"
                 default BSP_USING_SWDT
 
@@ -564,7 +564,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice RTC_CLK_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_XTAL32
 
@@ -595,7 +595,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_PM
         if BSP_USING_PM
-            choice
+            choice WKTM_CLK_SEL
                 prompt "Select WKTM Clock Src"
                 default BSP_USING_WKTM_LRC
 
@@ -634,7 +634,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_AES
             if BSP_USING_AES
-                choice
+                choice AES_MODE_SEL
                     prompt "Select AES Mode"
                     default BSP_USING_AES_ECB
 
@@ -649,7 +649,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_SHA2
             if BSP_USING_HASH
-                choice
+                choice HASH_MODE_SEL
                     prompt "Select Hash Mode"
                     default BSP_USING_SHA2_256
 
@@ -749,7 +749,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Use USBFS Core"
                 default n
             if BSP_USING_USBFS
-                choice
+                choice USBFS_MODE_SEL
                     prompt "Select USB Mode"
                     default BSP_USING_USBD_FS
 
@@ -783,7 +783,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Use USBHS Core"
                 default n
             if BSP_USING_USBHS
-                choice
+                choice USBHS_MODE_SEL
                     prompt "Select USB Mode"
                     default BSP_USING_USBH_HS
 
@@ -799,7 +799,7 @@ menu "On-chip Peripheral Drivers"
                         select RT_USING_USB_HOST
                         depends on !BSP_USING_USBH_FS
                 endchoice
-                choice
+                choice USBHS_PHY_SEL
                     prompt "Select USB PHY"
                     default BSP_USING_USBHS_PHY_EMBED
 

--- a/bsp/hc32/ev_hc32f472_lqfp100/board/Kconfig
+++ b/bsp/hc32/ev_hc32f472_lqfp100/board/Kconfig
@@ -447,7 +447,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_WDT
         if BSP_USING_WDT_TMR
-            choice
+            choice SWDT_WDT_SEL
                 prompt "Select SWDT/WDT"
                 default BSP_USING_SWDT
 
@@ -467,7 +467,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_XTAL32
 
@@ -491,7 +491,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_PM
         if BSP_USING_PM
-            choice
+            choice BSP_WKTM_SEL
                 prompt "Select WKTM Clock Src"
                 default BSP_USING_WKTM_LRC
 
@@ -530,7 +530,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_AES
             if BSP_USING_AES
-                choice
+                choice AES_MODE_SEL
                     prompt "Select AES Mode"
                     default BSP_USING_AES_ECB
 
@@ -545,7 +545,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_SHA2
             if BSP_USING_HASH
-                choice
+                choice HASH_MODE_SEL
                     prompt "Select Hash Mode"
                     default BSP_USING_SHA2_256
 
@@ -751,7 +751,7 @@ menu "On-chip Peripheral Drivers"
                 bool
                 default y
 
-            choice
+            choice BSP_USB_SEL
                 prompt "Select USB Mode"
                 default BSP_USING_USBD
 

--- a/bsp/hc32/ev_hc32f4a0_lqfp176/board/Kconfig
+++ b/bsp/hc32/ev_hc32f4a0_lqfp176/board/Kconfig
@@ -32,7 +32,7 @@ menu "Onboard Peripheral Drivers"
         select RT_LWIP_USING_HW_CHECKSUM
 
         if BSP_USING_ETH
-            choice
+            choice ETH_PHY_TYPE_SEL
                 prompt "Select ETH PHY type"
                 default ETH_PHY_USING_RTL8201F
 
@@ -43,7 +43,7 @@ menu "Onboard Peripheral Drivers"
                     select BSP_USING_TCA9539
             endchoice
 
-            choice
+            choice ETH_IF_SEL
                 prompt "Select ETH Communication Interface"
                 default ETH_INTERFACE_USING_MII
 
@@ -68,7 +68,7 @@ menu "Onboard Peripheral Drivers"
         bool "Enable EXMC"
         default n
         if BSP_USING_EXMC
-            choice
+            choice SDRAM_OR_NAND_SEL
                 prompt "Using SDRAM or NAND"
                 default BSP_USING_NAND
 
@@ -643,7 +643,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_WDT
         if BSP_USING_WDT_TMR
-            choice
+            choice SWDT_WDT_SEL
                 prompt "Select SWDT/WDT"
                 default BSP_USING_SWDT
 
@@ -663,7 +663,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_XTAL32
 
@@ -693,7 +693,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_PM
         if BSP_USING_PM
-            choice
+            choice BSP_WKTM_SEL
                 prompt "Select WKTM Clock Src"
                 default BSP_USING_WKTM_LRC
 
@@ -732,7 +732,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_AES
             if BSP_USING_AES
-                choice
+                choice AES_MODE_SEL
                     prompt "Select AES Mode"
                     default BSP_USING_AES_ECB
 
@@ -747,7 +747,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_SHA2
             if BSP_USING_HASH
-                choice
+                choice HASH_MODE_SEL
                     prompt "Select Hash Mode"
                     default BSP_USING_SHA2_256
 
@@ -847,7 +847,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Use USBFS Core"
                 default n
             if BSP_USING_USBFS
-                choice
+                choice BSP_USBFS_MODE_SEL
                     prompt "Select USB Mode"
                     default BSP_USING_USBD_FS
 
@@ -881,7 +881,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Use USBHS Core"
                 default n
             if BSP_USING_USBHS
-                choice
+                choice BSP_USBHS_MODE_SEL
                     prompt "Select USB Mode"
                     default BSP_USING_USBH_HS
 
@@ -897,7 +897,7 @@ menu "On-chip Peripheral Drivers"
                         select RT_USING_USB_HOST
                         depends on !BSP_USING_USBH_FS
                 endchoice
-                choice
+                choice BSP_USBHS_PHY_E_SEL
                     prompt "Select USB PHY"
                     default BSP_USING_USBHS_PHY_EMBED
 

--- a/bsp/hc32/ev_hc32f4a2_lqfp176/board/Kconfig
+++ b/bsp/hc32/ev_hc32f4a2_lqfp176/board/Kconfig
@@ -32,7 +32,7 @@ menu "Onboard Peripheral Drivers"
         select RT_LWIP_USING_HW_CHECKSUM
 
         if BSP_USING_ETH
-            choice
+            choice ETH_PHY_SEL
                 prompt "Select ETH PHY type"
                 default ETH_PHY_USING_RTL8201F
 
@@ -43,7 +43,7 @@ menu "Onboard Peripheral Drivers"
                     select BSP_USING_TCA9539
             endchoice
 
-            choice
+            choice ETH_IF_SEL
                 prompt "Select ETH Communication Interface"
                 default ETH_INTERFACE_USING_MII
 
@@ -68,7 +68,7 @@ menu "Onboard Peripheral Drivers"
         bool "Enable EXMC"
         default n
         if BSP_USING_EXMC
-            choice
+            choice SDRAM_NAND_SEL
                 prompt "Using SDRAM or NAND"
                 default BSP_USING_NAND
 
@@ -654,7 +654,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_WDT
         if BSP_USING_WDT_TMR
-            choice
+            choice SWDT_WDT_SEL
                 prompt "Select SWDT/WDT"
                 default BSP_USING_SWDT
 
@@ -674,7 +674,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice RTC_CLK_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_XTAL32
 
@@ -705,7 +705,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_PM
         if BSP_USING_PM
-            choice
+            choice WKTM_CLK_SEL
                 prompt "Select WKTM Clock Src"
                 default BSP_USING_WKTM_LRC
 
@@ -744,7 +744,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_AES
             if BSP_USING_AES
-                choice
+                choice AES_MODE_SEL
                     prompt "Select AES Mode"
                     default BSP_USING_AES_ECB
 
@@ -759,7 +759,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_SHA2
             if BSP_USING_HASH
-                choice
+                choice HASH_MODE_SEL
                     prompt "Select Hash Mode"
                     default BSP_USING_SHA2_256
 
@@ -859,7 +859,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Use USBFS Core"
                 default n
             if BSP_USING_USBFS
-                choice
+                choice USBFS_MODE_SEL
                     prompt "Select USB Mode"
                     default BSP_USING_USBD_FS
 
@@ -893,7 +893,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Use USBHS Core"
                 default n
             if BSP_USING_USBHS
-                choice
+                choice USBHS_MODE_SEL
                     prompt "Select USB Mode"
                     default BSP_USING_USBH_HS
 
@@ -909,7 +909,7 @@ menu "On-chip Peripheral Drivers"
                         select RT_USING_USB_HOST
                         depends on !BSP_USING_USBH_FS
                 endchoice
-                choice
+                choice USBHS_PHY_SEL
                     prompt "Select USB PHY"
                     default BSP_USING_USBHS_PHY_EMBED
 

--- a/bsp/hc32/ev_hc32f4a8_lqfp176/board/Kconfig
+++ b/bsp/hc32/ev_hc32f4a8_lqfp176/board/Kconfig
@@ -32,7 +32,7 @@ menu "Onboard Peripheral Drivers"
         select RT_LWIP_USING_HW_CHECKSUM
 
         if BSP_USING_ETH
-            choice
+            choice ETH_PHY_TYPE_SEL
                 prompt "Select ETH PHY type"
                 default ETH_PHY_USING_RTL8201F
 
@@ -43,7 +43,7 @@ menu "Onboard Peripheral Drivers"
                     select BSP_USING_TCA9539
             endchoice
 
-            choice
+            choice ETH_IF_SEL
                 prompt "Select ETH Communication Interface"
                 default ETH_INTERFACE_USING_MII
 
@@ -58,7 +58,7 @@ menu "Onboard Peripheral Drivers"
         bool "Enable EXMC"
         default n
         if BSP_USING_EXMC
-            choice
+            choice SDRAM_OR_NAND_SEL
                 prompt "Using SDRAM or NAND"
                 default BSP_USING_NAND
 
@@ -648,7 +648,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_WDT
         if BSP_USING_WDT_TMR
-            choice
+            choice SWDT_WDT_SEL
                 prompt "Select SWDT/WDT"
                 default BSP_USING_SWDT
 
@@ -668,7 +668,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_XTAL32
 
@@ -701,7 +701,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_PM
         if BSP_USING_PM
-            choice
+            choice BSP_WKTM_SEL
                 prompt "Select WKTM Clock Src"
                 default BSP_USING_WKTM_LRC
 
@@ -745,7 +745,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_SHA2
             if BSP_USING_HASH
-                choice
+                choice HASH_MODE_SEL
                     prompt "Select Hash Mode"
                     default BSP_USING_SHA2_256
 
@@ -845,7 +845,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Use USBFS Core "
                 default n
             if BSP_USING_USBFS
-                choice
+                choice BSP_USBFS_MODE_SEL
                     prompt "Select USB Mode"
                     default BSP_USING_USBD_FS
 
@@ -879,7 +879,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Use USBHS Core "
                 default n
             if BSP_USING_USBHS
-                choice
+                choice BSP_USBHS_MODE_SEL
                     prompt "Select USB Mode"
                     default BSP_USING_USBH_HS
 
@@ -895,7 +895,7 @@ menu "On-chip Peripheral Drivers"
                         select RT_USING_USB_HOST
                         depends on !BSP_USING_USBH_FS
                 endchoice
-                choice
+                choice BSP_USBHS_PHY_E_SEL
                     prompt "Select USB PHY"
                     default BSP_USING_USBHS_PHY_EMBED
 

--- a/bsp/hc32/lckfb-hc32f4a0-lqfp100/board/Kconfig
+++ b/bsp/hc32/lckfb-hc32f4a0-lqfp100/board/Kconfig
@@ -32,7 +32,7 @@ menu "Onboard Peripheral Drivers"
         select RT_LWIP_USING_HW_CHECKSUM
 
         if BSP_USING_ETH
-            choice
+            choice ETH_PHY_TYPE_SEL
                 prompt "Select ETH PHY type"
                 default ETH_PHY_USING_RTL8201F
 
@@ -43,7 +43,7 @@ menu "Onboard Peripheral Drivers"
                     select BSP_USING_TCA9539
             endchoice
 
-            choice
+            choice ETH_IF_SEL
                 prompt "Select ETH Communication Interface"
                 default ETH_INTERFACE_USING_MII
 
@@ -68,7 +68,7 @@ menu "Onboard Peripheral Drivers"
         bool "Enable EXMC"
         default n
         if BSP_USING_EXMC
-            choice
+            choice SDRAM_OR_NAND_SEL
                 prompt "Using SDRAM or NAND"
                 default BSP_USING_NAND
 
@@ -624,7 +624,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_WDT
         if BSP_USING_WDT_TMR
-            choice
+            choice SWDT_WDT_SEL
                 prompt "Select SWDT/WDT"
                 default BSP_USING_SWDT
 
@@ -644,7 +644,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_XTAL32
 
@@ -674,7 +674,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_PM
         if BSP_USING_PM
-            choice
+            choice BSP_WKTM_SEL
                 prompt "Select WKTM Clock Src"
                 default BSP_USING_WKTM_LRC
 
@@ -713,7 +713,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_AES
             if BSP_USING_AES
-                choice
+                choice AES_MODE_SEL
                     prompt "Select AES Mode"
                     default BSP_USING_AES_ECB
 
@@ -728,7 +728,7 @@ menu "On-chip Peripheral Drivers"
             default n
             select RT_HWCRYPTO_USING_SHA2
             if BSP_USING_HASH
-                choice
+                choice HASH_MODE_SEL
                     prompt "Select Hash Mode"
                     default BSP_USING_SHA2_256
 
@@ -819,7 +819,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_USB_DEVICE if BSP_USING_USBD
         select RT_USING_USB_HOST if BSP_USING_USBH
         if BSP_USING_USB
-            choice
+            choice BSP_USBFS_USB_SEL
                 prompt "Select USB FS/HS Core"
                 default BSP_USING_USBFS
 
@@ -830,7 +830,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Use USBHS Core"
             endchoice
 
-            choice
+            choice BSP_USBHS_PHY_E_SEL
                 depends on BSP_USING_USBHS
                 prompt "Select USB PHY"
                 default BSP_USING_USBHS_PHY_EMBED
@@ -844,7 +844,7 @@ menu "On-chip Peripheral Drivers"
                     select BSP_USING_TCA9539
             endchoice
 
-            choice
+            choice BSP_USBHS_MODE_SEL
                 prompt "Select USB Mode"
                 default BSP_USING_USBD
 

--- a/bsp/hk32/hk32f030c8-mini/board/Kconfig
+++ b/bsp/hk32/hk32f030c8-mini/board/Kconfig
@@ -33,7 +33,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/hpmicro/hpm5300evk/board/Kconfig
+++ b/bsp/hpmicro/hpm5300evk/board/Kconfig
@@ -228,7 +228,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI0 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI0_CS_SEL
                         prompt "Select SPI0 CS TYPE"
                         default BSP_SPI0_USING_SOFT_CS
                         config BSP_SPI0_USING_SOFT_CS
@@ -236,7 +236,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI0_USING_HARD_CS
                             bool "Enable SPI0 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI0_IO_MODE_SEL
                         prompt "Select SPI0 IO mode"
                         default BSP_SPI0_USING_SINGLE_IO
                         config BSP_SPI0_USING_SINGLE_IO
@@ -258,7 +258,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI1 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI1_CS_SEL
                         prompt "Select SPI1 CS TYPE"
                         default BSP_SPI1_USING_SOFT_CS
                         config BSP_SPI1_USING_SOFT_CS
@@ -266,7 +266,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI1_USING_HARD_CS
                             bool "Enable SPI1 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI1_IO_MODE_SEL
                         prompt "Select SPI1 IO mode"
                         default BSP_SPI1_USING_SINGLE_IO
                         config BSP_SPI1_USING_SINGLE_IO
@@ -288,7 +288,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI2 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI2_CS_SEL
                         prompt "Select SPI2 CS TYPE"
                         default BSP_SPI2_USING_SOFT_CS
                         config BSP_SPI2_USING_SOFT_CS
@@ -296,7 +296,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI2_USING_HARD_CS
                             bool "Enable SPI2 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI2_IO_MODE_SEL
                         prompt "Select SPI2 IO mode"
                         default BSP_SPI2_USING_SINGLE_IO
                         config BSP_SPI2_USING_SINGLE_IO
@@ -318,7 +318,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI3 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI3_CS_SEL
                         prompt "Select SPI3 CS TYPE"
                         default BSP_SPI3_USING_SOFT_CS
                         config BSP_SPI3_USING_SOFT_CS
@@ -326,7 +326,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI3_USING_HARD_CS
                             bool "Enable SPI3 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI3_IO_MODE_SEL
                         prompt "Select SPI3 IO mode"
                         default BSP_SPI3_USING_SINGLE_IO
                         config BSP_SPI3_USING_SINGLE_IO

--- a/bsp/hpmicro/hpm5301evklite/board/Kconfig
+++ b/bsp/hpmicro/hpm5301evklite/board/Kconfig
@@ -151,7 +151,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI0 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI0_CS_SEL
                         prompt "Select SPI0 CS TYPE"
                         default BSP_SPI0_USING_SOFT_CS
                         config BSP_SPI0_USING_SOFT_CS
@@ -159,7 +159,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI0_USING_HARD_CS
                             bool "Enable SPI0 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI0_IO_MODE_SEL
                         prompt "Select SPI0 IO mode"
                         default BSP_SPI0_USING_SINGLE_IO
                         config BSP_SPI0_USING_SINGLE_IO
@@ -181,7 +181,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI1 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI1_CS_SEL
                         prompt "Select SPI1 CS TYPE"
                         default BSP_SPI1_USING_SOFT_CS
                         config BSP_SPI1_USING_SOFT_CS
@@ -189,7 +189,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI1_USING_HARD_CS
                             bool "Enable SPI1 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI1_IO_MODE_SEL
                         prompt "Select SPI1 IO mode"
                         default BSP_SPI1_USING_SINGLE_IO
                         config BSP_SPI1_USING_SINGLE_IO
@@ -211,7 +211,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI2 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI2_CS_SEL
                         prompt "Select SPI2 CS TYPE"
                         default BSP_SPI2_USING_SOFT_CS
                         config BSP_SPI2_USING_SOFT_CS
@@ -219,7 +219,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI2_USING_HARD_CS
                             bool "Enable SPI2 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI2_IO_MODE_SEL
                         prompt "Select SPI2 IO mode"
                         default BSP_SPI2_USING_SINGLE_IO
                         config BSP_SPI2_USING_SINGLE_IO
@@ -241,7 +241,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI3 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI3_CS_SEL
                         prompt "Select SPI3 CS TYPE"
                         default BSP_SPI3_USING_SOFT_CS
                         config BSP_SPI3_USING_SOFT_CS
@@ -249,7 +249,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI3_USING_HARD_CS
                             bool "Enable SPI3 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI3_IO_MODE_SEL
                         prompt "Select SPI3 IO mode"
                         default BSP_SPI3_USING_SINGLE_IO
                         config BSP_SPI3_USING_SINGLE_IO

--- a/bsp/hpmicro/hpm5e00evk/board/Kconfig
+++ b/bsp/hpmicro/hpm5e00evk/board/Kconfig
@@ -269,7 +269,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI0 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI0_CS_SEL
                         prompt "Select SPI0 CS TYPE"
                         default BSP_SPI0_USING_SOFT_CS
                         config BSP_SPI0_USING_SOFT_CS
@@ -277,7 +277,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI0_USING_HARD_CS
                             bool "Enable SPI0 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI0_IO_MODE_SEL
                         prompt "Select SPI0 IO mode"
                         default BSP_SPI0_USING_SINGLE_IO
                         config BSP_SPI0_USING_SINGLE_IO
@@ -299,7 +299,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI1 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI1_CS_SEL
                         prompt "Select SPI1 CS TYPE"
                         default BSP_SPI1_USING_SOFT_CS
                         config BSP_SPI1_USING_SOFT_CS
@@ -307,7 +307,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI1_USING_HARD_CS
                             bool "Enable SPI1 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI1_IO_MODE_SEL
                         prompt "Select SPI1 IO mode"
                         default BSP_SPI1_USING_SINGLE_IO
                         config BSP_SPI1_USING_SINGLE_IO
@@ -329,7 +329,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI2 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI2_CS_SEL
                         prompt "Select SPI2 CS TYPE"
                         default BSP_SPI2_USING_SOFT_CS
                         config BSP_SPI2_USING_SOFT_CS
@@ -337,7 +337,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI2_USING_HARD_CS
                             bool "Enable SPI2 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI2_IO_MODE_SEL
                         prompt "Select SPI2 IO mode"
                         default BSP_SPI2_USING_SINGLE_IO
                         config BSP_SPI2_USING_SINGLE_IO
@@ -359,7 +359,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI3 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI3_CS_SEL
                         prompt "Select SPI3 CS TYPE"
                         default BSP_SPI3_USING_SOFT_CS
                         config BSP_SPI3_USING_SOFT_CS
@@ -367,7 +367,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI3_USING_HARD_CS
                             bool "Enable SPI3 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI3_IO_MODE_SEL
                         prompt "Select SPI3 IO mode"
                         default BSP_SPI3_USING_SINGLE_IO
                         config BSP_SPI3_USING_SINGLE_IO
@@ -388,7 +388,7 @@ menu "On-chip Peripheral Drivers"
        select RT_USING_PHY if BSP_USING_ETH
 
        if BSP_USING_ETH
-           choice
+           choice BSP_ETH0_SEL
                prompt "ETH"
                default BSP_USING_ETH0
 

--- a/bsp/hpmicro/hpm6300evk/board/Kconfig
+++ b/bsp/hpmicro/hpm6300evk/board/Kconfig
@@ -269,7 +269,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI0 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI0_CS_SEL
                         prompt "Select SPI0 CS TYPE"
                         default BSP_SPI0_USING_SOFT_CS
                         config BSP_SPI0_USING_SOFT_CS
@@ -277,7 +277,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI0_USING_HARD_CS
                             bool "Enable SPI0 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI0_IO_MODE_SEL
                         prompt "Select SPI0 IO mode"
                         default BSP_SPI0_USING_SINGLE_IO
                         config BSP_SPI0_USING_SINGLE_IO
@@ -299,7 +299,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI1 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI1_CS_SEL
                         prompt "Select SPI1 CS TYPE"
                         default BSP_SPI1_USING_SOFT_CS
                         config BSP_SPI1_USING_SOFT_CS
@@ -307,7 +307,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI1_USING_HARD_CS
                             bool "Enable SPI1 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI1_IO_MODE_SEL
                         prompt "Select SPI1 IO mode"
                         default BSP_SPI1_USING_SINGLE_IO
                         config BSP_SPI1_USING_SINGLE_IO
@@ -329,7 +329,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI2 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI2_CS_SEL
                         prompt "Select SPI2 CS TYPE"
                         default BSP_SPI2_USING_SOFT_CS
                         config BSP_SPI2_USING_SOFT_CS
@@ -337,7 +337,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI2_USING_HARD_CS
                             bool "Enable SPI2 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI2_IO_MODE_SEL
                         prompt "Select SPI2 IO mode"
                         default BSP_SPI2_USING_SINGLE_IO
                         config BSP_SPI2_USING_SINGLE_IO
@@ -359,7 +359,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI3 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI3_CS_SEL
                         prompt "Select SPI3 CS TYPE"
                         default BSP_SPI3_USING_SOFT_CS
                         config BSP_SPI3_USING_SOFT_CS
@@ -367,7 +367,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI3_USING_HARD_CS
                             bool "Enable SPI3 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI3_IO_MODE_SEL
                         prompt "Select SPI3 IO mode"
                         default BSP_SPI3_USING_SINGLE_IO
                         config BSP_SPI3_USING_SINGLE_IO
@@ -393,7 +393,7 @@ menu "On-chip Peripheral Drivers"
        select RT_USING_PHY if BSP_USING_ETH
 
        if BSP_USING_ETH
-            choice
+            choice BSP_ETH0_SEL
         prompt "ETH"
             config BSP_USING_ETH0
             bool "Enable ETH0"
@@ -414,7 +414,7 @@ menu "On-chip Peripheral Drivers"
                 config BSP_SDXC0_ENABLE_INTERRUPT_DRIVEN
                     bool "Enable Interrupt-driven mode"
                     default n
-                choice
+                choice BSP_SDXC0_SEL
                     prompt "Select buffer type for unaligned data transfer"
                     default BSP_SDXC0_USE_CACHEABLE_BUFFER
                     config BSP_SDXC0_USE_CACHEABLE_BUFFER
@@ -442,7 +442,7 @@ menu "On-chip Peripheral Drivers"
                     int "SDXC Interrupt Priority"
                     range 1 7
                     default 1
-                choice
+                choice BSP_SDXC0_BUS_WIDTH_SEL
                     prompt "Select BUS_WIDTH"
                     default BSP_SDXC0_BUS_WIDTH_4BIT
                     config BSP_SDXC0_BUS_WIDTH_1BIT
@@ -450,7 +450,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_SDXC0_BUS_WIDTH_4BIT
                         bool "4-bit"
                 endchoice
-                choice
+                choice VOLT_SEL
                     prompt "Select Voltage"
                     default BSP_SDXC0_VOLTAGE_3V3
                     config BSP_SDXC0_VOLTAGE_3V3

--- a/bsp/hpmicro/hpm6750evk/board/Kconfig
+++ b/bsp/hpmicro/hpm6750evk/board/Kconfig
@@ -185,7 +185,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable SDXC0"
                 default n
             if BSP_USING_SDXC0
-                choice
+                choice BSP_SDXC0_BUS_WIDTH_SEL
                     prompt "Select BUS_WIDTH"
                     default BSP_SDXC0_BUS_WIDTH_8BIT
                     config BSP_SDXC0_BUS_WIDTH_1BIT
@@ -195,7 +195,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_SDXC0_BUS_WIDTH_8BIT
                         bool "8-bit"
                 endchoice
-                choice
+                choice BSP_SDXC0_VOLT_SEL
                     prompt "Select Voltage"
                     default BSP_SDXC0_VOLTAGE_3V3
                     config BSP_SDXC0_VOLTAGE_3V3
@@ -217,7 +217,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable SDXC1"
                 default n
             if BSP_USING_SDXC1
-                choice
+                choice BSP_SDXC1_BUS_WIDTH_SEL
                     prompt "Select BUS_WIDTH"
                     default BSP_SDXC1_BUS_WIDTH_4BIT
                     config BSP_SDXC1_BUS_WIDTH_1BIT
@@ -225,7 +225,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_SDXC1_BUS_WIDTH_4BIT
                         bool "4-bit"
                 endchoice
-                choice
+                choice BSP_SDXC1_VOLT_SEL
                     prompt "Select Voltage"
                     default BSP_SDXC1_VOLTAGE_3V3
                     config BSP_SDXC1_VOLTAGE_3V3

--- a/bsp/hpmicro/hpm6750evk2/board/Kconfig
+++ b/bsp/hpmicro/hpm6750evk2/board/Kconfig
@@ -485,7 +485,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI0 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI0_CS_SEL
                         prompt "Select SPI0 CS TYPE"
                         default BSP_SPI0_USING_SOFT_CS
                         config BSP_SPI0_USING_SOFT_CS
@@ -493,7 +493,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI0_USING_HARD_CS
                             bool "Enable SPI0 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI0_IO_MODE_SEL
                         prompt "Select SPI0 IO mode"
                         default BSP_SPI0_USING_SINGLE_IO
                         config BSP_SPI0_USING_SINGLE_IO
@@ -515,7 +515,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI1 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI1_CS_SEL
                         prompt "Select SPI1 CS TYPE"
                         default BSP_SPI1_USING_SOFT_CS
                         config BSP_SPI1_USING_SOFT_CS
@@ -523,7 +523,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI1_USING_HARD_CS
                             bool "Enable SPI1 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI1_IO_MODE_SEL
                         prompt "Select SPI1 IO mode"
                         default BSP_SPI1_USING_SINGLE_IO
                         config BSP_SPI1_USING_SINGLE_IO
@@ -545,7 +545,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI2 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI2_CS_SEL
                         prompt "Select SPI2 CS TYPE"
                         default BSP_SPI2_USING_SOFT_CS
                         config BSP_SPI2_USING_SOFT_CS
@@ -553,7 +553,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI2_USING_HARD_CS
                             bool "Enable SPI2 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI2_IO_MODE_SEL
                         prompt "Select SPI2 IO mode"
                         default BSP_SPI2_USING_SINGLE_IO
                         config BSP_SPI2_USING_SINGLE_IO
@@ -575,7 +575,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI3 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI3_CS_SEL
                         prompt "Select SPI3 CS TYPE"
                         default BSP_SPI3_USING_SOFT_CS
                         config BSP_SPI3_USING_SOFT_CS
@@ -583,7 +583,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI3_USING_HARD_CS
                             bool "Enable SPI3 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI3_IO_MODE_SEL
                         prompt "Select SPI3 IO mode"
                         default BSP_SPI3_USING_SINGLE_IO
                         config BSP_SPI3_USING_SINGLE_IO
@@ -633,7 +633,7 @@ menu "On-chip Peripheral Drivers"
                 config BSP_SDXC0_ENABLE_INTERRUPT_DRIVEN
                     bool "Enable Interrupt-driven mode"
                     default n
-                choice
+                choice BSP_SDXC0_SEL
                     prompt "Select buffer type for unaligned data transfer"
                     default BSP_SDXC0_USE_CACHEABLE_BUFFER
                     config BSP_SDXC0_USE_CACHEABLE_BUFFER
@@ -661,7 +661,7 @@ menu "On-chip Peripheral Drivers"
                     int "SDXC Interrupt Priority"
                     range 1 7
                     default 1
-                choice
+                choice BSP_SDXC0_BUS_WIDTH_SEL
                     prompt "Select BUS_WIDTH"
                     default BSP_SDXC0_BUS_WIDTH_8BIT
                     config BSP_SDXC0_BUS_WIDTH_1BIT
@@ -671,7 +671,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_SDXC0_BUS_WIDTH_8BIT
                         bool "8-bit"
                 endchoice
-                choice
+                choice BSP_SDXC0_VOLT_SEL
                     prompt "Select Voltage"
                     default BSP_SDXC0_VOLTAGE_3V3
                     config BSP_SDXC0_VOLTAGE_3V3
@@ -696,7 +696,7 @@ menu "On-chip Peripheral Drivers"
                 config BSP_SDXC1_ENABLE_INTERRUPT_DRIVEN
                         bool "Enable Interrupt-driven mode"
                         default n
-                choice
+                choice BSP_SDXC1_SEL
                     prompt "Select buffer type for unaligned data transfer"
                     default BSP_SDXC1_USE_CACHEABLE_BUFFER
                     config BSP_SDXC1_USE_CACHEABLE_BUFFER
@@ -723,7 +723,7 @@ menu "On-chip Peripheral Drivers"
                     int "SDXC Interrupt Priority"
                     range 1 7
                     default 1
-                choice
+                choice BSP_SDXC1_BUS_WIDTH_SEL
                     prompt "Select BUS_WIDTH"
                     default BSP_SDXC1_BUS_WIDTH_4BIT
                     config BSP_SDXC1_BUS_WIDTH_1BIT
@@ -731,7 +731,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_SDXC1_BUS_WIDTH_4BIT
                         bool "4-bit"
                 endchoice
-                choice
+                choice BSP_SDXC1_VOLT_SEL
                     prompt "Select Voltage"
                     default BSP_SDXC1_VOLTAGE_3V3
                     config BSP_SDXC1_VOLTAGE_3V3

--- a/bsp/hpmicro/hpm6750evkmini/board/Kconfig
+++ b/bsp/hpmicro/hpm6750evkmini/board/Kconfig
@@ -496,7 +496,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI0 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI0_CS_SEL
                         prompt "Select SPI0 CS TYPE"
                         default BSP_SPI0_USING_SOFT_CS
                         config BSP_SPI0_USING_SOFT_CS
@@ -504,7 +504,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI0_USING_HARD_CS
                             bool "Enable SPI0 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI0_IO_MODE_SEL
                         prompt "Select SPI0 IO mode"
                         default BSP_SPI0_USING_SINGLE_IO
                         config BSP_SPI0_USING_SINGLE_IO
@@ -526,7 +526,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI1 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI1_CS_SEL
                         prompt "Select SPI1 CS TYPE"
                         default BSP_SPI1_USING_SOFT_CS
                         config BSP_SPI1_USING_SOFT_CS
@@ -534,7 +534,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI1_USING_HARD_CS
                             bool "Enable SPI1 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI1_IO_MODE_SEL
                         prompt "Select SPI1 IO mode"
                         default BSP_SPI1_USING_SINGLE_IO
                         config BSP_SPI1_USING_SINGLE_IO
@@ -556,7 +556,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI2 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI2_CS_SEL
                         prompt "Select SPI2 CS TYPE"
                         default BSP_SPI2_USING_SOFT_CS
                         config BSP_SPI2_USING_SOFT_CS
@@ -564,7 +564,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI2_USING_HARD_CS
                             bool "Enable SPI2 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI2_IO_MODE_SEL
                         prompt "Select SPI2 IO mode"
                         default BSP_SPI2_USING_SINGLE_IO
                         config BSP_SPI2_USING_SINGLE_IO
@@ -586,7 +586,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI3 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI3_CS_SEL
                         prompt "Select SPI3 CS TYPE"
                         default BSP_SPI3_USING_SOFT_CS
                         config BSP_SPI3_USING_SOFT_CS
@@ -594,7 +594,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI3_USING_HARD_CS
                             bool "Enable SPI3 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI3_IO_MODE_SEL
                         prompt "Select SPI3 IO mode"
                         default BSP_SPI3_USING_SINGLE_IO
                         config BSP_SPI3_USING_SINGLE_IO
@@ -639,7 +639,7 @@ menu "On-chip Peripheral Drivers"
                 config BSP_SDXC0_ENABLE_INTERRUPT_DRIVEN
                     bool "Enable Interrupt-driven mode"
                     default n
-                choice
+                choice BSP_SDXC0_SEL
                     prompt "Select buffer type for unaligned data transfer"
                     default BSP_SDXC0_USE_CACHEABLE_BUFFER
                     config BSP_SDXC0_USE_CACHEABLE_BUFFER
@@ -667,7 +667,7 @@ menu "On-chip Peripheral Drivers"
                     int "SDXC Interrupt Priority"
                     range 1 7
                     default 1
-                choice
+                choice BSP_SDXC0_BUS_WIDTH_SEL
                     prompt "Select BUS_WIDTH"
                     default BSP_SDXC0_BUS_WIDTH_8BIT
                     config BSP_SDXC0_BUS_WIDTH_1BIT
@@ -677,7 +677,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_SDXC0_BUS_WIDTH_8BIT
                         bool "8-bit"
                 endchoice
-                choice
+                choice BSP_SDXC0_VOLT_SEL
                     prompt "Select Voltage"
                     default BSP_SDXC0_VOLTAGE_3V3
                     config BSP_SDXC0_VOLTAGE_3V3
@@ -702,7 +702,7 @@ menu "On-chip Peripheral Drivers"
                 config BSP_SDXC1_ENABLE_INTERRUPT_DRIVEN
                         bool "Enable Interrupt-driven mode"
                         default n
-                choice
+                choice BSP_SDXC1_SEL
                     prompt "Select buffer type for unaligned data transfer"
                     default BSP_SDXC1_USE_CACHEABLE_BUFFER
                     config BSP_SDXC1_USE_CACHEABLE_BUFFER
@@ -729,7 +729,7 @@ menu "On-chip Peripheral Drivers"
                     int "SDXC Interrupt Priority"
                     range 1 7
                     default 1
-                choice
+                choice BSP_SDXC1_BUS_WIDTH_SEL
                     prompt "Select BUS_WIDTH"
                     default BSP_SDXC1_BUS_WIDTH_4BIT
                     config BSP_SDXC1_BUS_WIDTH_1BIT
@@ -737,7 +737,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_SDXC1_BUS_WIDTH_4BIT
                         bool "4-bit"
                 endchoice
-                choice
+                choice BSP_SDXC1_VOLT_SEL
                     prompt "Select Voltage"
                     default BSP_SDXC1_VOLTAGE_3V3
                     config BSP_SDXC1_VOLTAGE_3V3

--- a/bsp/hpmicro/hpm6800evk/board/Kconfig
+++ b/bsp/hpmicro/hpm6800evk/board/Kconfig
@@ -268,7 +268,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI0 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI0_CS_SEL
                         prompt "Select SPI0 CS TYPE"
                         default BSP_SPI0_USING_SOFT_CS
                         config BSP_SPI0_USING_SOFT_CS
@@ -276,7 +276,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI0_USING_HARD_CS
                             bool "Enable SPI0 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI0_IO_MODE_SEL
                         prompt "Select SPI0 IO mode"
                         default BSP_SPI0_USING_SINGLE_IO
                         config BSP_SPI0_USING_SINGLE_IO
@@ -298,7 +298,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI1 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI1_CS_SEL
                         prompt "Select SPI1 CS TYPE"
                         default BSP_SPI1_USING_SOFT_CS
                         config BSP_SPI1_USING_SOFT_CS
@@ -306,7 +306,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI1_USING_HARD_CS
                             bool "Enable SPI1 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI1_IO_MODE_SEL
                         prompt "Select SPI1 IO mode"
                         default BSP_SPI1_USING_SINGLE_IO
                         config BSP_SPI1_USING_SINGLE_IO
@@ -328,7 +328,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI2 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI2_CS_SEL
                         prompt "Select SPI2 CS TYPE"
                         default BSP_SPI2_USING_SOFT_CS
                         config BSP_SPI2_USING_SOFT_CS
@@ -336,7 +336,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI2_USING_HARD_CS
                             bool "Enable SPI2 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI2_IO_MODE_SEL
                         prompt "Select SPI2 IO mode"
                         default BSP_SPI2_USING_SINGLE_IO
                         config BSP_SPI2_USING_SINGLE_IO
@@ -358,7 +358,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI3 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI3_CS_SEL
                         prompt "Select SPI3 CS TYPE"
                         default BSP_SPI3_USING_SOFT_CS
                         config BSP_SPI3_USING_SOFT_CS
@@ -366,7 +366,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI3_USING_HARD_CS
                             bool "Enable SPI3 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI3_IO_MODE_SEL
                         prompt "Select SPI3 IO mode"
                         default BSP_SPI3_USING_SINGLE_IO
                         config BSP_SPI3_USING_SINGLE_IO
@@ -392,7 +392,7 @@ menu "On-chip Peripheral Drivers"
        select RT_USING_PHY if BSP_USING_ETH
 
        if BSP_USING_ETH
-           choice
+           choice BSP_ETH0_SEL
                prompt "ETH"
                default BSP_USING_ETH0
 
@@ -415,7 +415,7 @@ menu "On-chip Peripheral Drivers"
                 config BSP_SDXC0_ENABLE_INTERRUPT_DRIVEN
                     bool "Enable Interrupt-driven mode"
                     default n
-                choice
+                choice BSP_SDXC0_SEL
                     prompt "Select buffer type for unaligned data transfer"
                     default BSP_SDXC0_USE_CACHEABLE_BUFFER
                     config BSP_SDXC0_USE_CACHEABLE_BUFFER
@@ -443,7 +443,7 @@ menu "On-chip Peripheral Drivers"
                     int "SDXC Interrupt Priority"
                     range 1 7
                     default 1
-                choice
+                choice BSP_SDXC0_BUS_WIDTH_SEL
                     prompt "Select BUS_WIDTH"
                     default BSP_SDXC0_BUS_WIDTH_8BIT
                     config BSP_SDXC0_BUS_WIDTH_1BIT
@@ -453,7 +453,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_SDXC0_BUS_WIDTH_8BIT
                         bool "8-bit"
                 endchoice
-                choice
+                choice BSP_SDXC0_VOLT_SEL
                     prompt "Select Voltage"
                     default BSP_SDXC0_VOLTAGE_1V8
                     config BSP_SDXC0_VOLTAGE_3V3
@@ -478,7 +478,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_SDXC1_ENABLE_INTERRUPT_DRIVEN
                         bool "Enable Interrupt-driven mode"
                         default n
-                choice
+                choice BSP_SDXC1_SEL
                     prompt "Select buffer type for unaligned data transfer"
                     default BSP_SDXC1_USE_CACHEABLE_BUFFER
                     config BSP_SDXC1_USE_CACHEABLE_BUFFER
@@ -505,7 +505,7 @@ menu "On-chip Peripheral Drivers"
                     int "SDXC Interrupt Priority"
                     range 1 7
                     default 1
-                choice
+                choice BSP_SDXC1_BUS_WIDTH_SEL
                     prompt "Select BUS_WIDTH"
                     default BSP_SDXC1_BUS_WIDTH_4BIT
                     config BSP_SDXC1_BUS_WIDTH_1BIT
@@ -513,7 +513,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_SDXC1_BUS_WIDTH_4BIT
                         bool "4-bit"
                 endchoice
-                choice
+                choice BSP_SDXC1_VOLT_SEL
                     prompt "Select Voltage"
                     default BSP_SDXC1_VOLTAGE_3V3
                     config BSP_SDXC1_VOLTAGE_3V3
@@ -860,7 +860,7 @@ menu "On-chip Peripheral Drivers"
             select BSP_USING_CAM if BSP_USING_CAMERA
             select BSP_USING_MIPI_CSI if BSP_USING_CAMERA
             if BSP_USING_CAMERA
-                choice
+                choice BSP_CAMERA_SEL
                     prompt "Select camera"
                     default BSP_USING_CAMERA_OV5640
                     config BSP_USING_CAMERA_MT9M114
@@ -886,7 +886,7 @@ menu "On-chip Peripheral Drivers"
         select BSP_USING_MIPI_DSI if BSP_USING_PANEL
         select BSP_USING_PIXELMUX if BSP_USING_PANEL
         if BSP_USING_PANEL
-            choice
+            choice BSP_USEING_PANEL_SEL
                 prompt "Select Panel"
                 default BSP_USEING_PANEL_MIPI_MC10128007_31B
                 config BSP_USEING_PANEL_RGB_TM070RDH13

--- a/bsp/hpmicro/hpm6e00evk/board/Kconfig
+++ b/bsp/hpmicro/hpm6e00evk/board/Kconfig
@@ -489,7 +489,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI0 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI0_CS_SEL
                         prompt "Select SPI0 CS TYPE"
                         default BSP_SPI0_USING_SOFT_CS
                         config BSP_SPI0_USING_SOFT_CS
@@ -497,7 +497,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI0_USING_HARD_CS
                             bool "Enable SPI0 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI0_IO_MODE_SEL
                         prompt "Select SPI0 IO mode"
                         default BSP_SPI0_USING_SINGLE_IO
                         config BSP_SPI0_USING_SINGLE_IO
@@ -519,7 +519,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI1 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI1_CS_SEL
                         prompt "Select SPI1 CS TYPE"
                         default BSP_SPI1_USING_SOFT_CS
                         config BSP_SPI1_USING_SOFT_CS
@@ -527,7 +527,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI1_USING_HARD_CS
                             bool "Enable SPI1 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI1_IO_MODE_SEL
                         prompt "Select SPI1 IO mode"
                         default BSP_SPI1_USING_SINGLE_IO
                         config BSP_SPI1_USING_SINGLE_IO
@@ -549,7 +549,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI2 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI2_CS_SEL
                         prompt "Select SPI2 CS TYPE"
                         default BSP_SPI2_USING_SOFT_CS
                         config BSP_SPI2_USING_SOFT_CS
@@ -557,7 +557,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI2_USING_HARD_CS
                             bool "Enable SPI2 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI2_IO_MODE_SEL
                         prompt "Select SPI2 IO mode"
                         default BSP_SPI2_USING_SINGLE_IO
                         config BSP_SPI2_USING_SINGLE_IO
@@ -579,7 +579,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI3 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI3_CS_SEL
                         prompt "Select SPI3 CS TYPE"
                         default BSP_SPI3_USING_SOFT_CS
                         config BSP_SPI3_USING_SOFT_CS
@@ -587,7 +587,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI3_USING_HARD_CS
                             bool "Enable SPI3 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI3_IO_MODE_SEL
                         prompt "Select SPI3 IO mode"
                         default BSP_SPI3_USING_SINGLE_IO
                         config BSP_SPI3_USING_SINGLE_IO
@@ -609,7 +609,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI4 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI4_CS_SEL
                         prompt "Select SPI4 CS TYPE"
                         default BSP_SPI4_USING_SOFT_CS
                         config BSP_SPI4_USING_SOFT_CS
@@ -617,7 +617,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI4_USING_HARD_CS
                             bool "Enable SPI4 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI4_IO_MODE_SEL
                         prompt "Select SPI4 IO mode"
                         default BSP_SPI4_USING_SINGLE_IO
                         config BSP_SPI4_USING_SINGLE_IO
@@ -639,7 +639,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI5 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI5_CS_SEL
                         prompt "Select SPI5 CS TYPE"
                         default BSP_SPI5_USING_SOFT_CS
                         config BSP_SPI5_USING_SOFT_CS
@@ -647,7 +647,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI5_USING_HARD_CS
                             bool "Enable SPI5 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI5_IO_MODE_SEL
                         prompt "Select SPI5 IO mode"
                         default BSP_SPI5_USING_SINGLE_IO
                         config BSP_SPI5_USING_SINGLE_IO
@@ -669,7 +669,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI6 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI6_CS_SEL
                         prompt "Select SPI6 CS TYPE"
                         default BSP_SPI6_USING_SOFT_CS
                         config BSP_SPI6_USING_SOFT_CS
@@ -677,7 +677,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI6_USING_HARD_CS
                             bool "Enable SPI6 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI6_IO_MODE_SEL
                         prompt "Select SPI6 IO mode"
                         default BSP_SPI6_USING_SINGLE_IO
                         config BSP_SPI6_USING_SINGLE_IO
@@ -699,7 +699,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI7 Interrupt Priority"
                         range 1 7
                         default 1
-                choice
+                choice BSP_SPI7_CS_SEL
                     prompt "Select SPI7 CS TYPE"
                     default BSP_SPI7_USING_SOFT_CS
                     config BSP_SPI7_USING_SOFT_CS
@@ -707,7 +707,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_SPI7_USING_HARD_CS
                         bool "Enable SPI7 hardware cs"
                 endchoice
-                    choice
+                    choice BSP_SPI7_IO_MODE_SEL
                         prompt "Select SPI7 IO mode"
                         default BSP_SPI7_USING_SINGLE_IO
                         config BSP_SPI7_USING_SINGLE_IO
@@ -740,7 +740,7 @@ menu "On-chip Peripheral Drivers"
        select RT_USING_PHY if BSP_USING_ETH
 
        if BSP_USING_ETH
-           choice
+           choice BSP_ETH0_SEL
                prompt "ETH"
                default BSP_USING_ETH0
 

--- a/bsp/hpmicro/hpm6p00evk/board/Kconfig
+++ b/bsp/hpmicro/hpm6p00evk/board/Kconfig
@@ -269,7 +269,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI0 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI0_CS_SEL
                         prompt "Select SPI0 CS TYPE"
                         default BSP_SPI0_USING_SOFT_CS
                         config BSP_SPI0_USING_SOFT_CS
@@ -277,7 +277,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI0_USING_HARD_CS
                             bool "Enable SPI0 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI0_IO_MODE_SEL
                         prompt "Select SPI0 IO mode"
                         default BSP_SPI0_USING_SINGLE_IO
                         config BSP_SPI0_USING_SINGLE_IO
@@ -299,7 +299,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI1 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI1_CS_SEL
                         prompt "Select SPI1 CS TYPE"
                         default BSP_SPI1_USING_SOFT_CS
                         config BSP_SPI1_USING_SOFT_CS
@@ -307,7 +307,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI1_USING_HARD_CS
                             bool "Enable SPI1 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI1_IO_MODE_SEL
                         prompt "Select SPI1 IO mode"
                         default BSP_SPI1_USING_SINGLE_IO
                         config BSP_SPI1_USING_SINGLE_IO
@@ -329,7 +329,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI2 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI2_CS_SEL
                         prompt "Select SPI2 CS TYPE"
                         default BSP_SPI2_USING_SOFT_CS
                         config BSP_SPI2_USING_SOFT_CS
@@ -337,7 +337,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI2_USING_HARD_CS
                             bool "Enable SPI2 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI2_IO_MODE_SEL
                         prompt "Select SPI2 IO mode"
                         default BSP_SPI2_USING_SINGLE_IO
                         config BSP_SPI2_USING_SINGLE_IO
@@ -359,7 +359,7 @@ menu "On-chip Peripheral Drivers"
                         int "SPI3 Interrupt Priority"
                         range 1 7
                         default 1
-                    choice
+                    choice BSP_SPI3_CS_SEL
                         prompt "Select SPI3 CS TYPE"
                         default BSP_SPI3_USING_SOFT_CS
                         config BSP_SPI3_USING_SOFT_CS
@@ -367,7 +367,7 @@ menu "On-chip Peripheral Drivers"
                         config BSP_SPI3_USING_HARD_CS
                             bool "Enable SPI3 hardware cs"
                     endchoice
-                    choice
+                    choice BSP_SPI3_IO_MODE_SEL
                         prompt "Select SPI3 IO mode"
                         default BSP_SPI3_USING_SINGLE_IO
                         config BSP_SPI3_USING_SINGLE_IO
@@ -388,7 +388,7 @@ menu "On-chip Peripheral Drivers"
        select RT_USING_PHY if BSP_USING_ETH
 
        if BSP_USING_ETH
-           choice
+           choice BSP_ETH0_SEL
                prompt "ETH"
                default BSP_USING_ETH0
 

--- a/bsp/ht32/ht32f12366/board/Kconfig
+++ b/bsp/ht32/ht32f12366/board/Kconfig
@@ -8,7 +8,7 @@ menu "Chip Configuration"
         select RT_USING_COMPONENTS_INIT
         select RT_USING_USER_MAIN
         default y
-        choice
+        choice CORTEX_M_SEL
             prompt "Select the kernel"
             default CORTEX_M0
             config CORTEX_M0
@@ -17,7 +17,7 @@ menu "Chip Configuration"
                 bool "CORTEX_M3" 
         endchoice
 
-    choice
+    choice SOC_HT32F_SEL
         prompt "Select the chip you are using"
         depends on CORTEX_M0
         default HT32F52352
@@ -85,7 +85,7 @@ menu "Chip Configuration"
                 bool "HT32F67741"
     endchoice
     
-    choice
+    choice SOC_HT32F1_SEL
         prompt "Select the chip you are using"
         depends on CORTEX_M3
         default HT32F52352
@@ -299,7 +299,7 @@ menu "On-chip Peripheral Drivers"
         default "can"
         if BSP_USING_CAN
             config CAN_DEFAULT_BASE_CONFIGURATION  
-                choice
+                choice BSP_CAN_BAUD_SEL
                     prompt "Default CAN baud rate"
                     default BSP_USING_CAN500kBaud
                     config BSP_USING_CAN1MBaud
@@ -321,7 +321,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_USING_CAN10kBaud
                         bool "CAN10kBaud"
                 endchoice
-                choice
+                choice BSP_RT_CAN_MODE_SEL
                     prompt "Default CAN mode"
                     default BSP_USING_RT_CAN_MODE_NORMAL
                     config BSP_USING_RT_CAN_MODE_NORMAL
@@ -354,7 +354,7 @@ menu "On-chip Peripheral Drivers"
                 default 3 if BSP_USING_RT_CAN_MODE_LOOPBACKANLISTEN
             
             config CAN_DEFAULT_FILTER_TABLE_CONFIGURATION
-                choice
+                choice BSP_CAN_MODE_STD_SEL
                     prompt "Default filter id mode"
                     default BSP_USING_CAN_STD_ID
                     config BSP_USING_CAN_STD_ID
@@ -363,7 +363,7 @@ menu "On-chip Peripheral Drivers"
                         bool "CAN_EXT_ID"
                 endchoice
 
-                choice
+                choice BSP_CAN_MODE_DATA_SEL
                     prompt "Default filter frame mode"
                     default BSP_USING_CAN_DATA_FRAME
                     config BSP_USING_CAN_DATA_FRAME

--- a/bsp/ht32/ht32f52352/board/Kconfig
+++ b/bsp/ht32/ht32f52352/board/Kconfig
@@ -8,7 +8,7 @@ menu "Chip Configuration"
         select RT_USING_COMPONENTS_INIT
         select RT_USING_USER_MAIN
         default y
-        choice
+        choice CORTEX_M_SEL
             prompt "Select the kernel"
             default CORTEX_M0
             config CORTEX_M0
@@ -17,7 +17,7 @@ menu "Chip Configuration"
                 bool "CORTEX_M3" 
         endchoice
 
-    choice
+    choice SOC_HT32F_SEL
         prompt "Select the chip you are using"
         depends on CORTEX_M0
         default HT32F52352
@@ -85,7 +85,7 @@ menu "Chip Configuration"
                 bool "HT32F67741"
     endchoice
     
-    choice
+    choice SOC_HT32F1_SEL
         prompt "Select the chip you are using"
         depends on CORTEX_M3
         default HT32F52352
@@ -299,7 +299,7 @@ menu "On-chip Peripheral Drivers"
         default "can"
         if BSP_USING_CAN
             config CAN_DEFAULT_BASE_CONFIGURATION  
-                choice
+                choice BSP_CAN_BAUD_SEL
                     prompt "Default CAN baud rate"
                     default BSP_USING_CAN500kBaud
                     config BSP_USING_CAN1MBaud
@@ -321,7 +321,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_USING_CAN10kBaud
                         bool "CAN10kBaud"
                 endchoice
-                choice
+                choice BSP_RT_CAN_MODE_SEL
                     prompt "Default CAN mode"
                     default BSP_USING_RT_CAN_MODE_NORMAL
                     config BSP_USING_RT_CAN_MODE_NORMAL
@@ -354,7 +354,7 @@ menu "On-chip Peripheral Drivers"
                 default 3 if BSP_USING_RT_CAN_MODE_LOOPBACKANLISTEN
             
             config CAN_DEFAULT_FILTER_TABLE_CONFIGURATION
-                choice
+                choice BSP_CAN_MODE_STD_SEL
                     prompt "Default filter id mode"
                     default BSP_USING_CAN_STD_ID
                     config BSP_USING_CAN_STD_ID
@@ -363,7 +363,7 @@ menu "On-chip Peripheral Drivers"
                         bool "CAN_EXT_ID"
                 endchoice
 
-                choice
+                choice BSP_CAN_MODE_DATA_SEL
                     prompt "Default filter frame mode"
                     default BSP_USING_CAN_DATA_FRAME
                     config BSP_USING_CAN_DATA_FRAME

--- a/bsp/ht32/ht32f53252/board/Kconfig
+++ b/bsp/ht32/ht32f53252/board/Kconfig
@@ -8,7 +8,7 @@ menu "Chip Configuration"
         select RT_USING_COMPONENTS_INIT
         select RT_USING_USER_MAIN
         default y
-        choice
+        choice CORTEX_M_SEL
             prompt "Select the kernel"
             default CORTEX_M0
             config CORTEX_M0
@@ -17,7 +17,7 @@ menu "Chip Configuration"
                 bool "CORTEX_M3" 
         endchoice
 
-    choice
+    choice SOC_HT32F_SEL
         prompt "Select the chip you are using"
         depends on CORTEX_M0
         default HT32F52352
@@ -85,7 +85,7 @@ menu "Chip Configuration"
                 bool "HT32F67741"
     endchoice
     
-    choice
+    choice SOC_HT32F1_SEL
         prompt "Select the chip you are using"
         depends on CORTEX_M3
         default HT32F52352
@@ -299,7 +299,7 @@ menu "On-chip Peripheral Drivers"
         default "can"
         if BSP_USING_CAN
             config CAN_DEFAULT_BASE_CONFIGURATION  
-                choice
+                choice BSP_CAN_BAUD_SEL
                     prompt "Default CAN baud rate"
                     default BSP_USING_CAN500kBaud
                     config BSP_USING_CAN1MBaud
@@ -321,7 +321,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_USING_CAN10kBaud
                         bool "CAN10kBaud"
                 endchoice
-                choice
+                choice BSP_RT_CAN_MODE_SEL
                     prompt "Default CAN mode"
                     default BSP_USING_RT_CAN_MODE_NORMAL
                     config BSP_USING_RT_CAN_MODE_NORMAL
@@ -354,7 +354,7 @@ menu "On-chip Peripheral Drivers"
                 default 3 if BSP_USING_RT_CAN_MODE_LOOPBACKANLISTEN
             
             config CAN_DEFAULT_FILTER_TABLE_CONFIGURATION
-                choice
+                choice BSP_CAN_MODE_STD_SEL
                     prompt "Default filter id mode"
                     default BSP_USING_CAN_STD_ID
                     config BSP_USING_CAN_STD_ID
@@ -363,7 +363,7 @@ menu "On-chip Peripheral Drivers"
                         bool "CAN_EXT_ID"
                 endchoice
 
-                choice
+                choice BSP_CAN_MODE_DATA_SEL
                     prompt "Default filter frame mode"
                     default BSP_USING_CAN_DATA_FRAME
                     config BSP_USING_CAN_DATA_FRAME

--- a/bsp/k210/drivers/Kconfig
+++ b/bsp/k210/drivers/Kconfig
@@ -141,7 +141,7 @@ if BSP_USING_LCD
     config BSP_LCD_BACKLIGHT_PIN
         int "Backlight control pin number (-1 for not used)"
         default -1
-    choice
+    choice BSP_LCD_BACKLIGHT_ACTIVE_SEL
         prompt "backlight active polarity"
         default BSP_LCD_BACKLIGHT_ACTIVE_LOW
 
@@ -155,7 +155,7 @@ if BSP_USING_LCD
         int "Lcd max clk frequency"
         default 15000000
 
-    choice
+    choice BSP_BOARD_SEL
         prompt "lcd scan direction"
         default BSP_BOARD_K210_OPENMV_TEST
 

--- a/bsp/loongson/ls1cdev/Kconfig
+++ b/bsp/loongson/ls1cdev/Kconfig
@@ -16,7 +16,7 @@ config SOC_LS1C300
     select RT_USING_USER_MAIN
     default y
 
-choice
+choice BOARD_TYPE_SEL
     prompt "Board Type"
         config RT_LS1C_OPENLOONGSON
             bool "OpenLoongson Board"
@@ -92,7 +92,7 @@ config RT_CAN_USING_HDR
     default y
 endif
 
-choice
+choice TOUCH_FORMAT_SEL
     prompt "Touch format"
     default NO_TOUCH
 

--- a/bsp/microchip/samc21/board/Kconfig
+++ b/bsp/microchip/samc21/board/Kconfig
@@ -1,6 +1,6 @@
 menu "Hardware Drivers Config"
 
-choice
+choice SOC_SAMC21_SEL
     prompt "select chip type"
     default SOC_SAMC21J18
 

--- a/bsp/microchip/samd51-adafruit-metro-m4/board/Kconfig
+++ b/bsp/microchip/samd51-adafruit-metro-m4/board/Kconfig
@@ -1,6 +1,6 @@
 menu "Hardware Drivers Config"
 
-choice
+choice CHIP_TYPE_SEL
     prompt "select chip type"
     default SOC_SAMD51J19
 

--- a/bsp/microchip/samd51-seeed-wio-terminal/board/Kconfig
+++ b/bsp/microchip/samd51-seeed-wio-terminal/board/Kconfig
@@ -1,6 +1,6 @@
 menu "Hardware Drivers Config"
 
-choice
+choice CHIP_TYPE_SEL
     prompt "select chip type"
     default SOC_SAMD51P19
 

--- a/bsp/microchip/same54/board/Kconfig
+++ b/bsp/microchip/same54/board/Kconfig
@@ -1,6 +1,6 @@
 menu "Hardware Drivers Config"
 
-choice
+choice SOC_SAME5_SEL
     prompt "select chip type"
     default SOC_SAME54P20
 

--- a/bsp/microchip/same70/board/Kconfig
+++ b/bsp/microchip/same70/board/Kconfig
@@ -1,6 +1,6 @@
 menu "Hardware Drivers Config"
 
-choice
+choice SOC_SAME70_SEL
     prompt "select chip type"
     default SOC_SAME70Q21
 

--- a/bsp/microchip/saml10/board/Kconfig
+++ b/bsp/microchip/saml10/board/Kconfig
@@ -1,6 +1,6 @@
 menu "Hardware Drivers Config"
 
-choice
+choice SOC_SAML10_SEL
     prompt "select chip type"
     default SOC_SAML10E16
 

--- a/bsp/mini2440/Kconfig
+++ b/bsp/mini2440/Kconfig
@@ -14,7 +14,7 @@ config BOARD_MINI2440
     select RT_USING_USER_MAIN
     default y
 
-choice
+choice RT_MINI2440_LCD_SEL
     prompt "Lcd for mini2440"
     default RT_MINI2440_LCD_T35
     depends on PKG_USING_GUIENGINE

--- a/bsp/n32/n32gxx_lxx/n32g43xcl-stb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32g43xcl-stb/board/Kconfig
@@ -88,7 +88,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -177,7 +177,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM1 output PWM"
             default n
             if BSP_USING_TIM1_PWM
-                choice
+                choice TIM1_REMAP_SEL
                     prompt "Select Pin"
                     default TIM1_REMAP_0
                     config TIM1_REMAP_0
@@ -203,7 +203,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM2 output PWM"
             default n
             if BSP_USING_TIM2_PWM
-                 choice
+                 choice TIM2_REMAP_SEL
                     prompt "Select Pin"
                     default TIM2_REMAP_0
                     config TIM2_REMAP_0
@@ -233,7 +233,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM3 output PWM"
             default n
             if BSP_USING_TIM3_PWM
-                 choice
+                 choice TIM3_REMAP_SEL
                     prompt "Select Pin"
                     default TIM3_REMAP_0
                     config TIM3_REMAP_0

--- a/bsp/n32/n32gxx_lxx/n32g457qel-stb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32g457qel-stb/board/Kconfig
@@ -99,7 +99,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -202,7 +202,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM1 output PWM"
             default n
             if BSP_USING_TIM1_PWM
-                choice
+                choice TIM1_REMAP_SEL
                     prompt "Select Pin"
                     default TIM1_REMAP_0
                     config TIM1_REMAP_0
@@ -229,7 +229,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM2 output PWM"
             default n
             if BSP_USING_TIM2_PWM
-                 choice
+                 choice TIM2_REMAP_SEL
                     prompt "Select Pin"
                     default TIM2_REMAP_0
                     config TIM2_REMAP_0
@@ -260,7 +260,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM3 output PWM"
             default n
             if BSP_USING_TIM3_PWM
-                 choice
+                 choice TIM3_REMAP_SEL
                     prompt "Select Pin"
                     default TIM3_REMAP_0
                     config TIM3_REMAP_0

--- a/bsp/n32/n32gxx_lxx/n32g45xcl-stb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32g45xcl-stb/board/Kconfig
@@ -96,7 +96,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -201,7 +201,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM1 output PWM"
             default n
             if BSP_USING_TIM1_PWM
-                choice
+                choice TIM1_REMAP_SEL
                     prompt "Select Pin"
                     default TIM1_REMAP_0
                     config TIM1_REMAP_0
@@ -228,7 +228,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM2 output PWM"
             default n
             if BSP_USING_TIM2_PWM
-                 choice
+                 choice TIM2_REMAP_SEL
                     prompt "Select Pin"
                     default TIM2_REMAP_0
                     config TIM2_REMAP_0
@@ -259,7 +259,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM3 output PWM"
             default n
             if BSP_USING_TIM3_PWM
-                 choice
+                 choice TIM3_REMAP_SEL
                     prompt "Select Pin"
                     default TIM3_REMAP_0
                     config TIM3_REMAP_0

--- a/bsp/n32/n32gxx_lxx/n32g45xml-stb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32g45xml-stb/board/Kconfig
@@ -99,7 +99,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -202,7 +202,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM1 output PWM"
             default n
             if BSP_USING_TIM1_PWM
-                choice
+                choice TIM1_REMAP_SEL
                     prompt "Select Pin"
                     default TIM1_REMAP_0
                     config TIM1_REMAP_0
@@ -229,7 +229,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM2 output PWM"
             default n
             if BSP_USING_TIM2_PWM
-                 choice
+                 choice TIM2_REMAP_SEL
                     prompt "Select Pin"
                     default TIM2_REMAP_0
                     config TIM2_REMAP_0
@@ -260,7 +260,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM3 output PWM"
             default n
             if BSP_USING_TIM3_PWM
-                 choice
+                 choice TIM3_REMAP_SEL
                     prompt "Select Pin"
                     default TIM3_REMAP_0
                     config TIM3_REMAP_0

--- a/bsp/n32/n32gxx_lxx/n32g45xrl-stb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32g45xrl-stb/board/Kconfig
@@ -99,7 +99,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -202,7 +202,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM1 output PWM"
             default n
             if BSP_USING_TIM1_PWM
-                choice
+                choice TIM1_REMAP_SEL
                     prompt "Select Pin"
                     default TIM1_REMAP_0
                     config TIM1_REMAP_0
@@ -229,7 +229,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM2 output PWM"
             default n
             if BSP_USING_TIM2_PWM
-                 choice
+                 choice TIM2_REMAP_SEL
                     prompt "Select Pin"
                     default TIM2_REMAP_0
                     config TIM2_REMAP_0
@@ -260,7 +260,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM3 output PWM"
             default n
             if BSP_USING_TIM3_PWM
-                 choice
+                 choice TIM3_REMAP_SEL
                     prompt "Select Pin"
                     default TIM3_REMAP_0
                     config TIM3_REMAP_0

--- a/bsp/n32/n32gxx_lxx/n32g45xvl-stb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32g45xvl-stb/board/Kconfig
@@ -31,7 +31,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable USART1"
                 default y
                 if BSP_USING_USART1
-                    choice
+                    choice BSP_USART1_AFIO_MODE_P_SEL
                         prompt "Set usart1 afio mode"
                         default BSP_USART1_AFIO_MODE_PA9_PA10
 
@@ -77,7 +77,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable USART2"
                 default n
                 if BSP_USING_USART2
-                    choice
+                    choice BSP_USART2_AFIO_MODE_P_SEL
                         prompt "Set usart2 afio mode"
                         default BSP_USART2_AFIO_MODE_PA2_PA3
 
@@ -131,7 +131,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable USART3"
                 default n
                 if BSP_USING_USART3
-                    choice
+                    choice BSP_USART3_AFIO_MODE_P_SEL
                         prompt "Set usart3 afio mode"
                         default BSP_USART3_AFIO_MODE_PB10_PB11
 
@@ -181,7 +181,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART4"
                 default n
                 if BSP_USING_UART4
-                    choice
+                    choice BSP_UART4_AFIO_MODE_P_SEL
                         prompt "Set uart4 afio mode"
                         default BSP_UART4_AFIO_MODE_PC10_PC11
 
@@ -235,7 +235,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART5"
                 default n
                 if BSP_USING_UART5
-                    choice
+                    choice BSP_UART5_AFIO_MODE_P_SEL
                         prompt "Set uart5 afio mode"
                         default BSP_UART5_AFIO_MODE_PC12_PD2
 
@@ -289,7 +289,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART6"
                 default n
                 if BSP_USING_UART6
-                    choice
+                    choice BSP_UART6_AFIO_MODE_P_SEL
                         prompt "Set uart6 afio mode"
                         default BSP_UART6_AFIO_MODE_PE2_PE3
 
@@ -339,7 +339,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART7"
                 default n
                 if BSP_USING_UART7
-                    choice
+                    choice BSP_UART_SEL
                         prompt "Set uart7 afio mode"
                         default BSP_UART7_AFIO_MODE_PC4_PC5
 
@@ -429,7 +429,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -535,7 +535,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM1 output PWM"
             default n
             if BSP_USING_TIM1_PWM
-                choice
+                choice TIM1_REMAP_SEL
                     prompt "Select Pin"
                     default TIM1_REMAP_0
                     config TIM1_REMAP_0
@@ -562,7 +562,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM2 output PWM"
             default n
             if BSP_USING_TIM2_PWM
-                 choice
+                 choice TIM2_REMAP_SEL
                     prompt "Select Pin"
                     default TIM2_REMAP_0
                     config TIM2_REMAP_0
@@ -593,7 +593,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM3 output PWM"
             default n
             if BSP_USING_TIM3_PWM
-                 choice
+                 choice TIM3_REMAP_SEL
                     prompt "Select Pin"
                     default TIM3_REMAP_0
                     config TIM3_REMAP_0

--- a/bsp/n32/n32gxx_lxx/n32g4frml-stb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32g4frml-stb/board/Kconfig
@@ -99,7 +99,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -203,7 +203,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM1 output PWM"
             default n
             if BSP_USING_TIM1_PWM
-                choice
+                choice TIM1_REMAP_SEL
                     prompt "Select Pin"
                     default TIM1_REMAP_0
                     config TIM1_REMAP_0
@@ -228,7 +228,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM2 output PWM"
             default n
             if BSP_USING_TIM2_PWM
-                 choice
+                 choice TIM2_REMAP_SEL
                     prompt "Select Pin"
                     default TIM2_REMAP_0
                     config TIM2_REMAP_0
@@ -259,7 +259,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM3 output PWM"
             default n
             if BSP_USING_TIM3_PWM
-                 choice
+                 choice TIM3_REMAP_SEL
                     prompt "Select Pin"
                     default TIM3_REMAP_0
                     config TIM3_REMAP_0

--- a/bsp/n32/n32gxx_lxx/n32l40xcl-stb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32l40xcl-stb/board/Kconfig
@@ -88,7 +88,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -201,7 +201,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 1"
                     default n
                     if BSP_USING_TIM2_PWM_CH1
-                        choice
+                        choice TIM2_PWM_CH1_PA_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH1_PA0
                         config TIM2_PWM_CH1_PA0
@@ -214,7 +214,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 2"
                     default n
                     if BSP_USING_TIM2_PWM_CH2
-                        choice
+                        choice TIM2_PWM_CH2_P_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH2_PA1
                         config TIM2_PWM_CH2_PA1
@@ -227,7 +227,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 3"
                     default n
                     if BSP_USING_TIM2_PWM_CH3
-                        choice
+                        choice TIM2_PWM_CH3_P_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH3_PA2
                         config TIM2_PWM_CH3_PA2
@@ -249,7 +249,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 1"
                     default n
                     if BSP_USING_TIM3_PWM_CH1
-                        choice
+                        choice TIM3_PWM_CH1_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH1_PA6
                         config TIM3_PWM_CH1_PA6
@@ -264,7 +264,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 2"
                     default n
                     if BSP_USING_TIM3_PWM_CH2
-                        choice
+                        choice TIM3_PWM_CH2_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH2_PA7
                         config TIM3_PWM_CH2_PA7
@@ -279,7 +279,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 3"
                     default n
                     if BSP_USING_TIM3_PWM_CH3
-                        choice
+                        choice TIM3_PWM_CH3_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH3_PB0
                         config TIM3_PWM_CH3_PB0
@@ -292,7 +292,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 4 AF2 PB11"
                     default n
                     if BSP_USING_TIM3_PWM_CH4
-                        choice
+                        choice TIM3_PWM_CH4_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH4_PB1
                         config TIM3_PWM_CH4_PB1

--- a/bsp/n32/n32gxx_lxx/n32l436-evb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32l436-evb/board/Kconfig
@@ -88,7 +88,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -199,7 +199,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 1"
                     default n
                     if BSP_USING_TIM2_PWM_CH1
-                        choice
+                        choice TIM2_PWM_CH1_PA_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH1_PA0
                         config TIM2_PWM_CH1_PA0
@@ -212,7 +212,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 2"
                     default n
                     if BSP_USING_TIM2_PWM_CH2
-                        choice
+                        choice TIM2_PWM_CH2_P_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH2_PA1
                         config TIM2_PWM_CH2_PA1
@@ -225,7 +225,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 3"
                     default n
                     if BSP_USING_TIM2_PWM_CH3
-                        choice
+                        choice TIM2_PWM_CH3_P_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH3_PA2
                         config TIM2_PWM_CH3_PA2
@@ -247,7 +247,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 1"
                     default n
                     if BSP_USING_TIM3_PWM_CH1
-                        choice
+                        choice TIM3_PWM_CH1_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH1_PA6
                         config TIM3_PWM_CH1_PA6
@@ -262,7 +262,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 2"
                     default n
                     if BSP_USING_TIM3_PWM_CH2
-                        choice
+                        choice TIM3_PWM_CH2_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH2_PA7
                         config TIM3_PWM_CH2_PA7
@@ -277,7 +277,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 3"
                     default n
                     if BSP_USING_TIM3_PWM_CH3
-                        choice
+                        choice TIM3_PWM_CH3_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH3_PB0
                         config TIM3_PWM_CH3_PB0
@@ -290,7 +290,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 4 AF2 PB11"
                     default n
                     if BSP_USING_TIM3_PWM_CH4
-                        choice
+                        choice TIM3_PWM_CH4_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH4_PB1
                         config TIM3_PWM_CH4_PB1

--- a/bsp/n32/n32gxx_lxx/n32l43xml-stb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32l43xml-stb/board/Kconfig
@@ -88,7 +88,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -198,7 +198,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 1"
                     default n
                     if BSP_USING_TIM2_PWM_CH1
-                        choice
+                        choice TIM2_PWM_CH1_PA_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH1_PA0
                         config TIM2_PWM_CH1_PA0
@@ -211,7 +211,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 2"
                     default n
                     if BSP_USING_TIM2_PWM_CH2
-                        choice
+                        choice TIM2_PWM_CH2_P_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH2_PA1
                         config TIM2_PWM_CH2_PA1
@@ -224,7 +224,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 3"
                     default n
                     if BSP_USING_TIM2_PWM_CH3
-                        choice
+                        choice TIM2_PWM_CH3_P_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH3_PA2
                         config TIM2_PWM_CH3_PA2
@@ -246,7 +246,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 1"
                     default n
                     if BSP_USING_TIM3_PWM_CH1
-                        choice
+                        choice TIM3_PWM_CH1_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH1_PA6
                         config TIM3_PWM_CH1_PA6
@@ -261,7 +261,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 2"
                     default n
                     if BSP_USING_TIM3_PWM_CH2
-                        choice
+                        choice TIM3_PWM_CH2_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH2_PA7
                         config TIM3_PWM_CH2_PA7
@@ -276,7 +276,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 3"
                     default n
                     if BSP_USING_TIM3_PWM_CH3
-                        choice
+                        choice TIM3_PWM_CH3_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH3_PB0
                         config TIM3_PWM_CH3_PB0
@@ -289,7 +289,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 4 AF2 PB11"
                     default n
                     if BSP_USING_TIM3_PWM_CH4
-                        choice
+                        choice TIM3_PWM_CH4_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH4_PB1
                         config TIM3_PWM_CH4_PB1

--- a/bsp/n32/n32gxx_lxx/n32l43xrl-stb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32l43xrl-stb/board/Kconfig
@@ -88,7 +88,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -199,7 +199,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 1"
                     default n
                     if BSP_USING_TIM2_PWM_CH1
-                        choice
+                        choice TIM2_PWM_CH1_PA_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH1_PA0
                         config TIM2_PWM_CH1_PA0
@@ -212,7 +212,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 2"
                     default n
                     if BSP_USING_TIM2_PWM_CH2
-                        choice
+                        choice TIM2_PWM_CH2_P_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH2_PA1
                         config TIM2_PWM_CH2_PA1
@@ -225,7 +225,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM2 channel 3"
                     default n
                     if BSP_USING_TIM2_PWM_CH3
-                        choice
+                        choice TIM2_PWM_CH3_P_SEL
                         prompt "Select Pin"
                         default TIM2_PWM_CH3_PA2
                         config TIM2_PWM_CH3_PA2
@@ -247,7 +247,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 1"
                     default n
                     if BSP_USING_TIM3_PWM_CH1
-                        choice
+                        choice TIM3_PWM_CH1_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH1_PA6
                         config TIM3_PWM_CH1_PA6
@@ -262,7 +262,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 2"
                     default n
                     if BSP_USING_TIM3_PWM_CH2
-                        choice
+                        choice TIM3_PWM_CH2_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH2_PA7
                         config TIM3_PWM_CH2_PA7
@@ -277,7 +277,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 3"
                     default n
                     if BSP_USING_TIM3_PWM_CH3
-                        choice
+                        choice TIM3_PWM_CH3_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH3_PB0
                         config TIM3_PWM_CH3_PB0
@@ -290,7 +290,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable TIM3 channel 4 AF2 PB11"
                     default n
                     if BSP_USING_TIM3_PWM_CH4
-                        choice
+                        choice TIM3_PWM_CH4_P_SEL
                         prompt "Select Pin"
                         default TIM3_PWM_CH4_PB1
                         config TIM3_PWM_CH4_PB1

--- a/bsp/n32/n32gxx_lxx/n32wb45xl-evb/board/Kconfig
+++ b/bsp/n32/n32gxx_lxx/n32wb45xl-evb/board/Kconfig
@@ -99,7 +99,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 
@@ -198,7 +198,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM1 output PWM"
             default n
             if BSP_USING_TIM1_PWM
-                choice
+                choice TIM1_REMAP_SEL
                     prompt "Select Pin"
                     default TIM1_REMAP_0
                     config TIM1_REMAP_0
@@ -225,7 +225,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM2 output PWM"
             default n
             if BSP_USING_TIM2_PWM
-                 choice
+                 choice TIM2_REMAP_SEL
                     prompt "Select Pin"
                     default TIM2_REMAP_0
                     config TIM2_REMAP_0
@@ -256,7 +256,7 @@ menu "On-chip Peripheral Drivers"
             bool "Enable TIM3 output PWM"
             default n
             if BSP_USING_TIM3_PWM
-                 choice
+                 choice TIM3_REMAP_SEL
                     prompt "Select Pin"
                     default TIM3_REMAP_0
                     config TIM3_REMAP_0

--- a/bsp/n32/n32hxxx/n32h760zil7-stb/board/Kconfig
+++ b/bsp/n32/n32hxxx/n32h760zil7-stb/board/Kconfig
@@ -125,7 +125,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/n32g452xx/n32g452xx-mini-system/board/Kconfig
+++ b/bsp/n32g452xx/n32g452xx-mini-system/board/Kconfig
@@ -19,7 +19,7 @@ endmenu
 
 menu "On-chip Peripheral Drivers"
 
-            choice
+            choice N32G45X_PIN_NUMS_SEL
                 prompt "Package of N32G45NXX chip:"
                 default N32G45X_PIN_NUMBERS_64
                 config N32G45X_PIN_NUMBERS_48
@@ -48,7 +48,7 @@ menu "On-chip Peripheral Drivers"
         if BSP_USING_GPIO
 
             menu "Remap JTAG Port"
-                choice
+                choice BSP_RMP_SW_JTAG_SEL
                     prompt "Remap JTAG Port"
                         default BSP_RMP_SW_JTAG_SW_ENABLE
                         config BSP_RMP_SW_JTAG_FULL_ENABLE
@@ -81,7 +81,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable USART1"
                 default y
                 if BSP_USING_UART1
-                    choice
+                    choice BSP_UART1_SEL
                         prompt "Select TX/RX Pin of USART1"
                         default BSP_USING_UART1_NO_RMP
                         config BSP_USING_UART1_PIN_RMP
@@ -95,7 +95,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable USART2"
                 default n
                 if BSP_USING_UART2
-                    choice
+                    choice BSP_UART2_SEL
                         prompt "Select TX/RX Pin of USART2"
                         default BSP_USING_UART2_NO_RMP
                         config BSP_USING_UART2_NO_RMP
@@ -114,7 +114,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable USART3"
                 default n
                 if BSP_USING_UART3
-                    choice
+                    choice BSP_UART3_PIN_SEL
                         prompt "Select TX/RX Pin of USART3"
                         default BSP_USING_UART3_PIN_NO_RMP
                         config BSP_USING_UART3_PIN_NO_RMP
@@ -130,7 +130,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART4"
                 default n
                 if BSP_USING_UART4
-                    choice
+                    choice BSP_UART4_PIN_SEL
                         prompt "Select TX/RX Pin of UART4"
                         default BSP_USING_UART4_PIN_NORMP
                         config BSP_USING_UART4_PIN_NORMP
@@ -148,7 +148,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART5"
                 default n
                 if BSP_USING_UART5
-                    choice
+                    choice BSP_UART5_PIN_SEL
                         prompt "Select TX/RX Pin of UART5"
                         default BSP_USING_UART5_PIN_NORMP
                         config BSP_USING_UART5_PIN_NORMP
@@ -166,7 +166,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART6"
                 default n
                 if BSP_USING_UART6
-                    choice
+                    choice BSP_UART6_PIN_SEL
                         prompt "Select TX/RX Pin of UART6"
                         default BSP_USING_UART6_PIN_NORMP
                         config BSP_USING_UART6_PIN_NORMP
@@ -182,7 +182,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART7"
                 default n
                 if BSP_USING_UART7
-                    choice
+                    choice BSP_UART7_PIN_SEL
                         prompt "Select TX/RX Pin of UART7"
                         default BSP_USING_UART7_PIN_NORMP
                         config BSP_USING_UART7_PIN_NORMP

--- a/bsp/novosns/ns800/ns800rt7p65-nssinepad/board/Kconfig
+++ b/bsp/novosns/ns800/ns800rt7p65-nssinepad/board/Kconfig
@@ -201,7 +201,7 @@ menu "On-chip Peripheral Drivers"
             Enable the board-level RTC framework for an external RTC chip.
 
         if BSP_USING_RTC
-            choice
+            choice EXTERNAL_RTC_BACKEND_SEL
                 prompt "External RTC backend"
                 default BSP_RTC_USING_DS1307
 

--- a/bsp/nrf5x/libraries/templates/nrfx/board/Kconfig
+++ b/bsp/nrf5x/libraries/templates/nrfx/board/Kconfig
@@ -10,7 +10,7 @@ config SOC_NORDIC
     bool
     default y
 
-choice
+choice BSP_BOARD_SEL
     prompt "Select BSP board "
     default BSP_BOARD_PCA_10056
 

--- a/bsp/nrf5x/nrf51822/board/Kconfig
+++ b/bsp/nrf5x/nrf51822/board/Kconfig
@@ -10,7 +10,7 @@ config SOC_NORDIC
     bool
     default y
 
-choice
+choice BSP_BOARD_MICROBIT_1_SEL
     prompt "Select BSP board "
     default BSP_BOARD_MICROBIT_1_5
 

--- a/bsp/nrf5x/nrf52832/board/Kconfig
+++ b/bsp/nrf5x/nrf52832/board/Kconfig
@@ -162,7 +162,7 @@ menu "On-chip Peripheral Drivers"
         default y
         select RT_USING_SERIAL
         if BSP_USING_UART
-        choice
+        choice NRFX_UART_SEL
         prompt "UART or UARTE"
         default NRFX_USING_UART
         help
@@ -471,7 +471,7 @@ menu "On-chip Peripheral Drivers"
         endif
 endmenu
 
-choice
+choice BLE_STACK_SEL
 prompt "BLE STACK"
 default BLE_STACK_USING_NULL
 help

--- a/bsp/nrf5x/nrf52833/board/Kconfig
+++ b/bsp/nrf5x/nrf52833/board/Kconfig
@@ -10,7 +10,7 @@ config SOC_NORDIC
     bool
     default y
 
-choice
+choice BSP_BOARD_SEL
     prompt "Select BSP board "
     default BSP_BOARD_PCA_10100
 
@@ -91,7 +91,7 @@ if BSP_USING_UART
     depends on BSP_USING_UART0
 endif
 
-choice
+choice BLE_STACK_SEL
 prompt "BLE STACK"
 default BLE_STACK_USING_NULL
 help

--- a/bsp/nrf5x/nrf52840/board/Kconfig
+++ b/bsp/nrf5x/nrf52840/board/Kconfig
@@ -10,7 +10,7 @@ config SOC_NORDIC
     bool
     default y
 
-choice
+choice BSP_BOARD_SEL
     prompt "Select BSP board "
     default BSP_BOARD_PCA_10056
 
@@ -94,7 +94,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_SERIAL
         if BSP_USING_UART
-        choice
+        choice NRFX_UART_SEL
         prompt "UART or UARTE"
         default NRFX_USING_UART
         help
@@ -569,7 +569,7 @@ menu "On-chip Peripheral Drivers"
 
 endmenu
 
-choice
+choice BLE_STACK_SEL
 prompt "BLE STACK"
 default BLE_STACK_USING_NULL
 help

--- a/bsp/nrf5x/nrf5340/board/Kconfig
+++ b/bsp/nrf5x/nrf5340/board/Kconfig
@@ -10,7 +10,7 @@ config SOC_NORDIC
     bool
     default y
 
-choice
+choice BSP_BOARD_PCA_10_SEL
     prompt "Select BSP board "
     default BSP_BOARD_PCA_10095
 
@@ -91,7 +91,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_SERIAL
         if BSP_USING_UART
-        choice
+        choice NRFX_UART_SEL
         prompt "UART or UARTE"
         default NRFX_USING_UARTE
         help
@@ -546,7 +546,7 @@ menu "On-chip Peripheral Drivers"
 
 endmenu
 
-choice
+choice BLE_STACK_SEL
 prompt "BLE STACK"
 default BLE_STACK_USING_NULL
 help

--- a/bsp/nuvoton/libraries/m031/rtt_port/Kconfig
+++ b/bsp/nuvoton/libraries/m031/rtt_port/Kconfig
@@ -87,7 +87,7 @@ config SOC_SERIES_M032
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR0
-            choice
+            choice BSP_TIMER0_SEL
                 prompt "Select TIMER0 function mode"
 
                 config BSP_USING_TIMER0
@@ -112,7 +112,7 @@ config SOC_SERIES_M032
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR1
-            choice
+            choice BSP_TIMER1_SEL
                 prompt "Select TIMER1 function mode"
 
                 config BSP_USING_TIMER1
@@ -136,7 +136,7 @@ config SOC_SERIES_M032
             depends on BSP_USING_TMR
 
          if BSP_USING_TMR2
-            choice
+            choice BSP_TIMER2_SEL
                 prompt "Select TIMER2 function mode"
 
                 config BSP_USING_TIMER2
@@ -160,7 +160,7 @@ config SOC_SERIES_M032
             depends on BSP_USING_TMR && !BSP_USING_CLK
 
         if BSP_USING_TMR3
-            choice
+            choice BSP_TIMER3_SEL
                 prompt "Select TIMER3 function mode"
 
                 config BSP_USING_TIMER3
@@ -307,7 +307,7 @@ config SOC_SERIES_M032
             bool "Enable USCI0"
 
         if BSP_USING_USCI0
-            choice
+            choice BSP_USCI0_FUNC_SEL
                 prompt "Select USCI0 function mode"
 
                 config BSP_USING_UUART0
@@ -350,7 +350,7 @@ config SOC_SERIES_M032
             bool "Enable USCI1"
 
             if BSP_USING_USCI1
-                choice
+                choice BSP_USCI1_FUNC_SEL
                     prompt "Select USCI1 function mode"
 
                     config BSP_USING_UUART1
@@ -400,7 +400,7 @@ config SOC_SERIES_M032
             config BSP_USING_BPWM_CAPTURE
                 bool
 
-            choice
+            choice BSP_BPWM0_SEL
                 prompt "Select BPWM0 function mode"
                 config BSP_USING_BPWM0
                     select RT_USING_PWM
@@ -423,7 +423,7 @@ config SOC_SERIES_M032
                     default 0
             endif
 
-            choice
+            choice BSP_BPWM1_SEL
                 prompt "Select BPWM1 function mode"
                 config BSP_USING_BPWM1
                     select RT_USING_PWM
@@ -456,7 +456,7 @@ config SOC_SERIES_M032
             config BSP_USING_PWM_CAPTURE
                 bool
 
-            choice
+            choice BSP_PWM0_SEL
                 prompt "Select PWM0 function mode"
                 config BSP_USING_PWM0
                     select RT_USING_PWM
@@ -479,7 +479,7 @@ config SOC_SERIES_M032
                     default 0
             endif
 
-            choice
+            choice BSP_PWM1_SEL
                 prompt "Select PWM1 function mode"
                 config BSP_USING_PWM1
                     select RT_USING_PWM
@@ -517,7 +517,7 @@ config SOC_SERIES_M032
             bool
             default n
 
-            choice
+            choice BSP_SPI_SEL
                 prompt "Select SPI0 function mode"
                 config BSP_USING_SPI0_NONE
                 bool "NONE"

--- a/bsp/nuvoton/libraries/m2354/rtt_port/Kconfig
+++ b/bsp/nuvoton/libraries/m2354/rtt_port/Kconfig
@@ -92,7 +92,7 @@ config SOC_SERIES_M2354
                 depends on BSP_USING_TMR
 
             if BSP_USING_TMR0
-                choice
+                choice BSP_TIMER0_FUNC_SEL
                     prompt "Select TIMER0 function mode"
 
                     config BSP_USING_TIMER0
@@ -124,7 +124,7 @@ config SOC_SERIES_M2354
                 depends on BSP_USING_TMR
 
             if BSP_USING_TMR1
-                choice
+                choice BSP_TIMER1_FUNC_SEL
                     prompt "Select TIMER1 function mode"
 
                     config BSP_USING_TIMER1
@@ -155,7 +155,7 @@ config SOC_SERIES_M2354
                 depends on BSP_USING_TMR
 
              if BSP_USING_TMR2
-                choice
+                choice BSP_TIMER2_FUNC_SEL
                     prompt "Select TIMER2 function mode"
 
                     config BSP_USING_TIMER2
@@ -186,7 +186,7 @@ config SOC_SERIES_M2354
                 depends on BSP_USING_TMR
 
             if BSP_USING_TMR3
-                choice
+                choice BSP_TIMER3_FUNC_SEL
                     prompt "Select TIMER3 function mode"
 
                     config BSP_USING_TIMER3
@@ -217,7 +217,7 @@ config SOC_SERIES_M2354
                 depends on BSP_USING_TMR
 
             if BSP_USING_TMR4
-                choice
+                choice BSP_TIMER4_FUNC_SEL
                     prompt "Select TIMER4 function mode"
 
                     config BSP_USING_TIMER4
@@ -248,7 +248,7 @@ config SOC_SERIES_M2354
                 depends on BSP_USING_TMR && !BSP_USING_CLK
 
             if BSP_USING_TMR5
-                choice
+                choice BSP_TIMER5_FUNC_SEL
                     prompt "Select TIMER5 function mode"
 
                     config BSP_USING_TIMER5
@@ -384,7 +384,7 @@ config SOC_SERIES_M2354
             bool "Enable USCI0"
 
         if BSP_USING_USCI0
-            choice
+            choice BSP_USCI0_FUNC_SEL
                 prompt "Select USCI0 function mode"
 
                 config BSP_USING_UUART0
@@ -427,7 +427,7 @@ config SOC_SERIES_M2354
             bool "Enable USCI1"
 
             if BSP_USING_USCI1
-                choice
+                choice BSP_USCI1_FUNC_SEL
                     prompt "Select USCI1 function mode"
 
                     config BSP_USING_UUART1
@@ -499,7 +499,7 @@ config SOC_SERIES_M2354
             config BSP_USING_BPWM_CAPTURE
                 bool
 
-            choice
+            choice BSP_BPWM0_SEL
                 prompt "Select BPWM0 function mode"
                 config BSP_USING_BPWM0
                     select RT_USING_PWM
@@ -522,7 +522,7 @@ config SOC_SERIES_M2354
                     default 0
             endif
 
-            choice
+            choice BSP_BPWM1_SEL
                 prompt "Select BPWM1 function mode"
                 config BSP_USING_BPWM1
                     select RT_USING_PWM
@@ -555,7 +555,7 @@ config SOC_SERIES_M2354
             config BSP_USING_EPWM_CAPTURE
                 bool
 
-            choice
+            choice BSP_EPWM0_SEL
                 prompt "Select EPWM0 function mode"
                 config BSP_USING_EPWM0
                     select RT_USING_PWM
@@ -578,7 +578,7 @@ config SOC_SERIES_M2354
                     default 0
             endif
 
-            choice
+            choice BSP_EPWM1_SEL
                 prompt "Select EPWM1 function mode"
                 config BSP_USING_EPWM1
                     select RT_USING_PWM
@@ -616,7 +616,7 @@ config SOC_SERIES_M2354
             bool
             default n
 
-            choice
+            choice BSP_SPI0_FUNC_SEL
                 prompt "Select SPI0 function mode"
                 config BSP_USING_SPI0_NONE
                 bool "NONE"
@@ -643,7 +643,7 @@ config SOC_SERIES_M2354
                        depends on BSP_USING_SPI0
             endif
 
-            choice
+            choice BSP_SPI1_FUNC_SEL
                 prompt "Select SPI1 function mode"
                 config BSP_USING_SPI1_NONE
                 bool "NONE"
@@ -670,7 +670,7 @@ config SOC_SERIES_M2354
                        depends on BSP_USING_SPI1
               endif
 
-            choice
+            choice BSP_SPI2_FUNC_SEL
                 prompt "Select SPI2 function mode"
                 config BSP_USING_SPI2_NONE
                 bool "NONE"
@@ -697,7 +697,7 @@ config SOC_SERIES_M2354
                        depends on BSP_USING_SPI2
               endif
 
-            choice
+            choice BSP_SPI3_FUNC_SEL
                 prompt "Select SPI3 function mode"
                 config BSP_USING_SPI3_NONE
                 bool "NONE"

--- a/bsp/nuvoton/libraries/m460/rtt_port/Kconfig
+++ b/bsp/nuvoton/libraries/m460/rtt_port/Kconfig
@@ -108,7 +108,7 @@ config SOC_SERIES_M460
                 bool "Enable TIMER0"
 
             if BSP_USING_TMR0
-                choice
+                choice BSP_TIMER0_FUNC_SEL
                     prompt "Select TIMER0 function mode"
 
                     config BSP_USING_TIMER0
@@ -139,7 +139,7 @@ config SOC_SERIES_M460
                 bool "Enable TIMER1"
 
             if BSP_USING_TMR1
-                choice
+                choice BSP_TIMER1_FUNC_SEL
                     prompt "Select TIMER1 function mode"
 
                     config BSP_USING_TIMER1
@@ -169,7 +169,7 @@ config SOC_SERIES_M460
                 bool "Enable TIMER2"
 
              if BSP_USING_TMR2
-                choice
+                choice BSP_TIMER2_FUNC_SEL
                     prompt "Select TIMER2 function mode"
 
                     config BSP_USING_TIMER2
@@ -199,7 +199,7 @@ config SOC_SERIES_M460
                 bool "Enable TIMER3"
 
             if BSP_USING_TMR3
-                choice
+                choice BSP_TIMER3_FUNC_SEL
                     prompt "Select TIMER3 function mode"
 
                     config BSP_USING_TIMER3
@@ -387,7 +387,7 @@ config SOC_SERIES_M460
             bool "Enable USCI0"
 
         if BSP_USING_USCI0
-            choice
+            choice BSP_U_SEL
                 prompt "Select USCI0 function mode"
 
                 config BSP_USING_UUART0
@@ -468,7 +468,7 @@ config SOC_SERIES_M460
             config BSP_USING_BPWM_CAPTURE
                 bool
 
-            choice
+            choice BSP_BPWM0_SEL
                 prompt "Select BPWM0 function mode"
                 config BSP_USING_BPWM0_NONE
                     bool "Disable BPWM0"
@@ -489,7 +489,7 @@ config SOC_SERIES_M460
                         Choose this option if you need PWM capture function mode.
             endchoice
 
-            choice
+            choice BSP_BPWM1_SEL
                 prompt "Select BPWM1 function mode"
                 config BSP_USING_BPWM1_NONE
                     bool "Disable BPWM1"
@@ -520,7 +520,7 @@ config SOC_SERIES_M460
             config BSP_USING_EPWM_CAPTURE
                 bool
 
-            choice
+            choice BSP_EPWM0_SEL
                 prompt "Select EPWM0 function mode"
                 config BSP_USING_EPWM0_NONE
                     bool "Disable EPWM0"
@@ -541,7 +541,7 @@ config SOC_SERIES_M460
                         Choose this option if you need PWM capture function mode.
             endchoice
 
-            choice
+            choice BSP_EPWM1_SEL
                 prompt "Select EPWM1 function mode"
                 config BSP_USING_EPWM1_NONE
                     bool "Disable EPWM1"
@@ -577,7 +577,7 @@ config SOC_SERIES_M460
             bool
             default n
 
-            choice
+            choice BSP_SPI0_FUNC_SEL
                 prompt "Select SPI0 function mode"
                 config BSP_USING_SPI0_NONE
                 bool "NONE"
@@ -604,7 +604,7 @@ config SOC_SERIES_M460
                     depends on BSP_USING_SPI0
             endif
 
-            choice
+            choice BSP_SPI1_FUNC_SEL
                 prompt "Select SPI1 function mode"
                 config BSP_USING_SPI1_NONE
                 bool "NONE"
@@ -631,7 +631,7 @@ config SOC_SERIES_M460
                     depends on BSP_USING_SPI1
             endif
 
-            choice
+            choice BSP_SPI2_FUNC_SEL
                 prompt "Select SPI2 function mode"
                 config BSP_USING_SPI2_NONE
                 bool "NONE"
@@ -658,7 +658,7 @@ config SOC_SERIES_M460
                     depends on BSP_USING_SPI2
             endif
 
-            choice
+            choice BSP_SPI3_FUNC_SEL
                 prompt "Select SPI3 function mode"
                 config BSP_USING_SPI3_NONE
                 bool "NONE"
@@ -685,7 +685,7 @@ config SOC_SERIES_M460
                     depends on BSP_USING_SPI3
             endif
 
-            choice
+            choice BSP_SPI4_FUNC_SEL
                 prompt "Select SPI4 function mode"
                 config BSP_USING_SPI4_NONE
                 bool "NONE"
@@ -712,7 +712,7 @@ config SOC_SERIES_M460
                     depends on BSP_USING_SPI4
             endif
 
-            choice
+            choice BSP_SPI5_FUNC_SEL
                 prompt "Select SPI5 function mode"
                 config BSP_USING_SPI5_NONE
                 bool "NONE"
@@ -739,7 +739,7 @@ config SOC_SERIES_M460
                     depends on BSP_USING_SPI5
             endif
 
-            choice
+            choice BSP_SPI6_FUNC_SEL
                 prompt "Select SPI6 function mode"
                 config BSP_USING_SPI6_NONE
                 bool "NONE"
@@ -766,7 +766,7 @@ config SOC_SERIES_M460
                     depends on BSP_USING_SPI6
             endif
 
-            choice
+            choice BSP_SPI7_FUNC_SEL
                 prompt "Select SPI7 function mode"
                 config BSP_USING_SPI7_NONE
                 bool "NONE"
@@ -793,7 +793,7 @@ config SOC_SERIES_M460
                     depends on BSP_USING_SPI7
             endif
 
-            choice
+            choice BSP_SPI8_FUNC_SEL
                 prompt "Select SPI8 function mode"
                 config BSP_USING_SPI8_NONE
                 bool "NONE"
@@ -821,7 +821,7 @@ config SOC_SERIES_M460
             endif
 
 
-            choice
+            choice BSP_SPI9_FUNC_SEL
                 prompt "Select SPI9 function mode"
                 config BSP_USING_SPI9_NONE
                 bool "NONE"
@@ -848,7 +848,7 @@ config SOC_SERIES_M460
                     depends on BSP_USING_SPI9
             endif
 
-            choice
+            choice BSP_SPI10_FUNC_SEL
                 prompt "Select SPI10 function mode"
                 config BSP_USING_SPI10_NONE
                 bool "NONE"

--- a/bsp/nuvoton/libraries/m480/rtt_port/Kconfig
+++ b/bsp/nuvoton/libraries/m480/rtt_port/Kconfig
@@ -110,7 +110,7 @@ config SOC_SERIES_M480
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR0
-            choice
+            choice BSP_TIMER0_FUNC_SEL
                 prompt "Select TIMER0 function mode"
 
                 config BSP_USING_TIMER0
@@ -142,7 +142,7 @@ config SOC_SERIES_M480
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR1
-            choice
+            choice BSP_TIMER1_FUNC_SEL
                 prompt "Select TIMER1 function mode"
 
                 config BSP_USING_TIMER1
@@ -173,7 +173,7 @@ config SOC_SERIES_M480
             depends on BSP_USING_TMR
 
          if BSP_USING_TMR2
-            choice
+            choice BSP_TIMER2_FUNC_SEL
                 prompt "Select TIMER2 function mode"
 
                 config BSP_USING_TIMER2
@@ -204,7 +204,7 @@ config SOC_SERIES_M480
             depends on BSP_USING_TMR && !BSP_USING_CLK
 
         if BSP_USING_TMR3
-            choice
+            choice BSP_TIMER3_FUNC_SEL
                 prompt "Select TIMER3 function mode"
 
                 config BSP_USING_TIMER3
@@ -361,7 +361,7 @@ config SOC_SERIES_M480
             bool "Enable USCI0"
 
         if BSP_USING_USCI0
-            choice
+            choice BSP_USCI0_FUNC_SEL
                 prompt "Select USCI0 function mode"
 
                 config BSP_USING_UUART0
@@ -404,7 +404,7 @@ config SOC_SERIES_M480
             bool "Enable USCI1"
 
             if BSP_USING_USCI1
-                choice
+                choice BSP_USCI1_FUNC_SEL
                     prompt "Select USCI1 function mode"
 
                     config BSP_USING_UUART1
@@ -479,7 +479,7 @@ config SOC_SERIES_M480
             config BSP_USING_BPWM_CAPTURE
                 bool
 
-            choice
+            choice BSP_BPWM0_SEL
                 prompt "Select BPWM0 function mode"
                 config BSP_USING_BPWM0
                     select RT_USING_PWM
@@ -502,7 +502,7 @@ config SOC_SERIES_M480
                     default 0
             endif
 
-            choice
+            choice BSP_BPWM1_SEL
                 prompt "Select BPWM1 function mode"
                 config BSP_USING_BPWM1
                     select RT_USING_PWM
@@ -535,7 +535,7 @@ config SOC_SERIES_M480
             config BSP_USING_EPWM_CAPTURE
                 bool
 
-            choice
+            choice BSP_EPWM0_SEL
                 prompt "Select EPWM0 function mode"
                 config BSP_USING_EPWM0
                     select RT_USING_PWM
@@ -558,7 +558,7 @@ config SOC_SERIES_M480
                     default 0
             endif
 
-            choice
+            choice BSP_EPWM1_SEL
                 prompt "Select EPWM1 function mode"
                 config BSP_USING_EPWM1
                     select RT_USING_PWM
@@ -596,7 +596,7 @@ config SOC_SERIES_M480
             bool
             default n
 
-            choice
+            choice BSP_SPI0_FUNC_SEL
                 prompt "Select SPI0 function mode"
                 config BSP_USING_SPI0_NONE
                 bool "NONE"
@@ -623,7 +623,7 @@ config SOC_SERIES_M480
                        depends on BSP_USING_SPI0
             endif
 
-            choice
+            choice BSP_SPI1_FUNC_SEL
                 prompt "Select SPI1 function mode"
                 config BSP_USING_SPI1_NONE
                 bool "NONE"
@@ -650,7 +650,7 @@ config SOC_SERIES_M480
                        depends on BSP_USING_SPI1
               endif
 
-            choice
+            choice BSP_SPI2_FUNC_SEL
                 prompt "Select SPI2 function mode"
                 config BSP_USING_SPI2_NONE
                 bool "NONE"
@@ -677,7 +677,7 @@ config SOC_SERIES_M480
                        depends on BSP_USING_SPI2
               endif
 
-            choice
+            choice BSP_SPI3_FUNC_SEL
                 prompt "Select SPI3 function mode"
                 config BSP_USING_SPI3_NONE
                 bool "NONE"

--- a/bsp/nuvoton/libraries/ma35/rtt_port/Kconfig
+++ b/bsp/nuvoton/libraries/ma35/rtt_port/Kconfig
@@ -168,7 +168,7 @@
             depends on BSP_USING_TMR && !USE_MA35D1_SUBM
 
         if BSP_USING_TMR0
-            choice
+            choice BSP_TIMER0_FUNC_SEL
                 prompt "Select TIMER0 function mode"
 
                 config BSP_USING_TIMER0
@@ -193,7 +193,7 @@
             depends on BSP_USING_TMR && !USE_MA35D1_SUBM
 
         if BSP_USING_TMR1
-            choice
+            choice BSP_TIMER1_FUNC_SEL
                 prompt "Select TIMER1 function mode"
 
                 config BSP_USING_TIMER1
@@ -217,7 +217,7 @@
             depends on BSP_USING_TMR
 
          if BSP_USING_TMR2
-            choice
+            choice BSP_TIMER2_FUNC_SEL
                 prompt "Select TIMER2 function mode"
 
                 config BSP_USING_TIMER2
@@ -241,7 +241,7 @@
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR3
-            choice
+            choice BSP_TIMER3_FUNC_SEL
                 prompt "Select TIMER3 function mode"
 
                 config BSP_USING_TIMER3
@@ -265,7 +265,7 @@
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR4
-            choice
+            choice BSP_TIMER4_FUNC_SEL
                 prompt "Select TIMER4 function mode"
 
                 config BSP_USING_TIMER4
@@ -290,7 +290,7 @@
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR5
-            choice
+            choice BSP_TIMER5_FUNC_SEL
                 prompt "Select TIMER5 function mode"
 
                 config BSP_USING_TIMER5
@@ -315,7 +315,7 @@
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR6
-            choice
+            choice BSP_TIMER6_FUNC_SEL
                 prompt "Select TIMER6 function mode"
 
                 config BSP_USING_TIMER6
@@ -341,7 +341,7 @@
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR7
-            choice
+            choice BSP_TIMER7_FUNC_SEL
                 prompt "Select TIMER7 function mode"
 
                 config BSP_USING_TIMER7
@@ -366,7 +366,7 @@
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR8
-            choice
+            choice BSP_TIMER8_FUNC_SEL
                 prompt "Select TIMER8 function mode"
 
                 config BSP_USING_TIMER8
@@ -391,7 +391,7 @@
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR9
-            choice
+            choice BSP_TIMER9_FUNC_SEL
                 prompt "Select TIMER9 function mode"
 
                 config BSP_USING_TIMER9
@@ -416,7 +416,7 @@
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR10
-            choice
+            choice BSP_TIMER10_FUNC_SEL
                 prompt "Select TIMER10 function mode"
 
                 config BSP_USING_TIMER10
@@ -441,7 +441,7 @@
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR11
-            choice
+            choice BSP_TIMER11_FUNC_SEL
                 prompt "Select TIMER11 function mode"
 
                 config BSP_USING_TIMER11
@@ -728,7 +728,7 @@
                 bool
 
             if BSP_USING_EPWM0
-                choice
+                choice BSP_EPWM0_SEL
                 prompt "Select EPWM0 function mode"
                 config BSP_USING_EPWM0_PWM
                     select RT_USING_PWM
@@ -750,7 +750,7 @@
                 depends on BSP_USING_EPWM && !USE_MA35D1_SUBM
 
             if BSP_USING_EPWM1
-                choice
+                choice BSP_EPWM1_SEL
                 prompt "Select EPWM1 function mode"
                 config BSP_USING_EPWM1_PWM
                     select RT_USING_PWM
@@ -772,7 +772,7 @@
                 depends on BSP_USING_EPWM && !USE_MA35D1_SUBM
 
             if BSP_USING_EPWM2
-                choice
+                choice BSP_EPWM2_SEL
                 prompt "Select EPWM2 function mode"
                 config BSP_USING_EPWM2_PWM
                     select RT_USING_PWM
@@ -803,7 +803,7 @@
             config BSP_USING_SPII2S
             bool
 
-            choice
+            choice BSP_SPI0_FUNC_SEL
                 prompt "Select SPI0 function mode"
                 config BSP_USING_SPI0_NONE
                 bool "NONE"
@@ -831,7 +831,7 @@
                        depends on BSP_USING_SPI0
             endif
 
-            choice
+            choice BSP_SPI1_FUNC_SEL
                 prompt "Select SPI1 function mode"
                 config BSP_USING_SPI1_NONE
                 bool "NONE"
@@ -859,7 +859,7 @@
                     depends on BSP_USING_SPI1
             endif
 
-            choice
+            choice BSP_SPI2_FUNC_SEL
                 prompt "Select SPI2 function mode"
                 config BSP_USING_SPI2_NONE
                 bool "NONE"
@@ -887,7 +887,7 @@
                     depends on BSP_USING_SPI2
             endif
 
-            choice
+            choice BSP_SPI3_FUNC_SEL
                 prompt "Select SPI3 function mode"
                 config BSP_USING_SPI3_NONE
                 bool "NONE"
@@ -1059,7 +1059,7 @@
         default y
 
         if BSP_USING_DISP
-            choice
+            choice LCM_F_SEL
                 prompt "Select Supported LCM panel"
                 default LCM_USING_FW070TFT_WSVGA
                 config LCM_USING_FW070TFT_WSVGA

--- a/bsp/nuvoton/libraries/n9h30/rtt_port/Kconfig
+++ b/bsp/nuvoton/libraries/n9h30/rtt_port/Kconfig
@@ -88,7 +88,7 @@ config SOC_SERIES_N9H30
             depends on BSP_USING_ETMR
 
         if BSP_USING_ETMR0
-            choice
+            choice BSP_ETIMER0_SEL
                 prompt "Select ETIMER0 function mode"
 
                 config BSP_USING_ETIMER0
@@ -113,7 +113,7 @@ config SOC_SERIES_N9H30
             depends on BSP_USING_ETMR
 
         if BSP_USING_ETMR1
-            choice
+            choice BSP_ETIMER1_SEL
                 prompt "Select ETIMER1 function mode"
 
                 config BSP_USING_ETIMER1
@@ -137,7 +137,7 @@ config SOC_SERIES_N9H30
             depends on BSP_USING_ETMR
 
          if BSP_USING_ETMR2
-            choice
+            choice BSP_ETIMER2_SEL
                 prompt "Select ETIMER2 function mode"
 
                 config BSP_USING_ETIMER2
@@ -161,7 +161,7 @@ config SOC_SERIES_N9H30
             depends on BSP_USING_ETMR
 
          if BSP_USING_ETMR3
-            choice
+            choice BSP_ETIMER3_SEL
                 prompt "Select ETIMER3 function mode"
 
                 config BSP_USING_ETIMER3
@@ -331,7 +331,7 @@ config SOC_SERIES_N9H30
        select RT_USING_SPI
 
        if BSP_USING_QSPI
-            choice
+            choice BSP_QSPI0_SEL
                 prompt "Select QSPI0 function mode"
                 config BSP_USING_QSPI0_NONE
                 bool "NONE"
@@ -344,7 +344,7 @@ config SOC_SERIES_N9H30
                     Choose this option if you need QSPI function mode.
             endchoice
 
-            choice
+            choice BSP_QSPI1_SEL
                 prompt "Select QSPI1 function mode"
                 config BSP_USING_QSPI1_NONE
                 bool "NONE"
@@ -459,7 +459,7 @@ config SOC_SERIES_N9H30
         default y
 
         if BSP_USING_VPOST
-            choice
+            choice SUPPORTED_LCM_PANEL_SEL
                 prompt "Select Supported LCM panel"
                 default LCM_USING_FW070TFT
                 config LCM_USING_E50A2V1

--- a/bsp/nuvoton/libraries/nu_packages/Kconfig
+++ b/bsp/nuvoton/libraries/nu_packages/Kconfig
@@ -50,7 +50,7 @@ menu "Nuvoton Packages Config"
 
         if NU_PKG_USING_ILI9341
 
-            choice
+            choice NU_PKG_ILI9341_SEL
                 prompt "Select ili9341 interface"
 
                 config NU_PKG_USING_ILI9341_SPI
@@ -110,7 +110,7 @@ menu "Nuvoton Packages Config"
 
         if NU_PKG_USING_SSD1963
 
-            choice
+            choice SSD1963_IF_SEL
                 prompt "Select SSD1963 interface"
 
                 config NU_PKG_USING_SSD1963_EBI
@@ -152,7 +152,7 @@ menu "Nuvoton Packages Config"
 
         if NU_PKG_USING_FSA506
 
-            choice
+            choice FSA506_IF_SEL
                 prompt "Select FSA506 interface"
 
                 config NU_PKG_USING_FSA506_EBI
@@ -194,7 +194,7 @@ menu "Nuvoton Packages Config"
         select RT_USING_I2C
 
     if NU_PKG_USING_TPC
-        choice
+        choice NU_PKG_TPC_SEL
             prompt "Select TPC drivers"
             config NU_PKG_USING_TPC_ILI
                 bool "ILI Series TPC"

--- a/bsp/nuvoton/libraries/nuc980/rtt_port/Kconfig
+++ b/bsp/nuvoton/libraries/nuc980/rtt_port/Kconfig
@@ -98,7 +98,7 @@ config SOC_SERIES_NUC980
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR0
-            choice
+            choice BSP_TIMER0_SEL
                 prompt "Select TIMER0 function mode"
 
                 config BSP_USING_TIMER0
@@ -123,7 +123,7 @@ config SOC_SERIES_NUC980
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR1
-            choice
+            choice BSP_TIMER1_SEL
                 prompt "Select TIMER1 function mode"
 
                 config BSP_USING_TIMER1
@@ -147,7 +147,7 @@ config SOC_SERIES_NUC980
             depends on BSP_USING_TMR
 
          if BSP_USING_TMR2
-            choice
+            choice BSP_TIMER2_SEL
                 prompt "Select TIMER2 function mode"
 
                 config BSP_USING_TIMER2
@@ -171,7 +171,7 @@ config SOC_SERIES_NUC980
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR3
-            choice
+            choice BSP_TIMER3_SEL
                 prompt "Select TIMER3 function mode"
 
                 config BSP_USING_TIMER3
@@ -195,7 +195,7 @@ config SOC_SERIES_NUC980
             depends on BSP_USING_TMR
 
         if BSP_USING_TMR4
-            choice
+            choice BSP_TIMER4_SEL
                 prompt "Select TIMER4 function mode"
 
                 config BSP_USING_TIMER4
@@ -422,7 +422,7 @@ config SOC_SERIES_NUC980
             bool
             default n
 
-            choice
+            choice BSP_SPI0_SEL
                 prompt "Select SPI0 function mode"
                 config BSP_USING_SPI0_NONE
                 bool "NONE"
@@ -442,7 +442,7 @@ config SOC_SERIES_NUC980
                        depends on BSP_USING_SPI0
             endif
 
-            choice
+            choice BSP_SPI1_SEL
                 prompt "Select SPI1 function mode"
                 config BSP_USING_SPI1_NONE
                 bool "NONE"

--- a/bsp/nuvoton/nk-n9h30/board/Kconfig
+++ b/bsp/nuvoton/nk-n9h30/board/Kconfig
@@ -69,7 +69,7 @@ menu "Hardware Drivers Config"
 
         if BOARD_USING_LCM
 
-            choice
+            choice BOARD_LCM_FW0_SEL
                 prompt "Select LCD panel devices.(Over VPOST)"
                     default BOARD_USING_LCM_FW070TFT_WVGA
 
@@ -95,7 +95,7 @@ menu "Hardware Drivers Config"
                         Choose this option if you use 7" 1024x600x32b LCD panel.
             endchoice
 
-            choice
+            choice TOUCH_DEVICES_SEL
                 prompt "Select Touch devices."
                     default BOARD_USING_ADCTOUCH
 

--- a/bsp/nuvoton/numaker-hmi-ma35d1/board/Kconfig
+++ b/bsp/nuvoton/numaker-hmi-ma35d1/board/Kconfig
@@ -84,7 +84,7 @@ menu "Hardware Drivers Config"
 
         if BOARD_USING_LCM
 
-            choice
+            choice BOARD_LCM_FW070TFT_W_SEL
                 prompt "Select LCD panel devices.(Over DISP)"
                     default BOARD_USING_LCM_FW070TFT_WSVGA
 
@@ -103,7 +103,7 @@ menu "Hardware Drivers Config"
                         Choose this option if you use 7" 1024x600x32b LCD panel.
             endchoice
 
-            choice
+            choice TOUCH_DEVICES_SEL
                 prompt "Select Touch devices."
                     default BOARD_USING_GT911
 

--- a/bsp/nuvoton/numaker-iot-m467/board/Kconfig
+++ b/bsp/nuvoton/numaker-iot-m467/board/Kconfig
@@ -67,7 +67,7 @@ menu "Hardware Drivers Config"
                 Choose this option if you need USB function.
 
         if BOARD_USING_USB_D_H
-            choice
+            choice BOARD_HS_SEL
                 prompt "Select FS/HS USB Ports"
 
                 config BOARD_USING_HSUSBD

--- a/bsp/nuvoton/numaker-iot-m487/board/Kconfig
+++ b/bsp/nuvoton/numaker-iot-m487/board/Kconfig
@@ -60,7 +60,7 @@ menu "Hardware Drivers Config"
                 Choose this option if you need USB function.
 
         if BOARD_USING_USB_D_H
-            choice
+            choice BOARD_HS_SEL
                 prompt "Select FS/HS USB Ports"
 
                 config BOARD_USING_HSUSBD

--- a/bsp/nuvoton/numaker-m2354/board/Kconfig
+++ b/bsp/nuvoton/numaker-m2354/board/Kconfig
@@ -28,7 +28,7 @@ menu "Hardware Drivers Config"
             select BSP_USING_SDH0
             default n
 
-        choice
+        choice FS_USB_PORTS_SEL
             prompt "Select FS USB Ports"
 
             config BOARD_USING_USBD

--- a/bsp/nuvoton/numaker-m467hj/board/Kconfig
+++ b/bsp/nuvoton/numaker-m467hj/board/Kconfig
@@ -68,7 +68,7 @@ menu "Hardware Drivers Config"
                 Choose this option if you need USB function.
 
         if BOARD_USING_USB_D_H
-            choice
+            choice BOARD_HS_SEL
                 prompt "Select FS/HS USB Ports"
 
                 config BOARD_USING_HSUSBD

--- a/bsp/nuvoton/numaker-pfm-m487/board/Kconfig
+++ b/bsp/nuvoton/numaker-pfm-m487/board/Kconfig
@@ -43,7 +43,7 @@ menu "Hardware Drivers Config"
                 Choose this option if you need USB function.
 
         if BOARD_USING_USB_D_H
-            choice
+            choice BOARD_HS_SEL
                 prompt "Select FS/HS USB Ports"
 
                 config BOARD_USING_HSUSBD

--- a/bsp/nxp/imx/imxrt/imxrt1021-nxp-evk/board/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1021-nxp-evk/board/Kconfig
@@ -118,7 +118,7 @@ menu "On-chip Peripheral Drivers"
             config BSP_USING_I2C1
                 bool "Enable I2C1"
                 default n
-            choice
+            choice HW_I2C1_BADURATE_SEL
                 prompt "Select I2C1 badurate"
                 default HW_I2C1_BADURATE_100kHZ
 

--- a/bsp/nxp/imx/imxrt/imxrt1052-fire-pro/board/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1052-fire-pro/board/Kconfig
@@ -142,7 +142,7 @@ menu "On-chip Peripheral Drivers"
             config BSP_USING_I2C1
                 bool "Enable I2C1"
                 default n
-            choice
+            choice HW_I2C1_BADURATE_SEL
                 prompt "Select I2C1 badurate"
                 default HW_I2C1_BADURATE_100kHZ
 

--- a/bsp/nxp/imx/imxrt/imxrt1052-nxp-evk/board/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1052-nxp-evk/board/Kconfig
@@ -94,7 +94,7 @@ menu "On-chip Peripheral Drivers"
             config BSP_USING_I2C1
                 bool "Enable I2C1"
                 default n
-            choice
+            choice HW_I2C1_BADURATE_SEL
                 prompt "Select I2C1 badurate"
                 default HW_I2C1_BADURATE_100kHZ
 

--- a/bsp/nxp/imx/imxrt/imxrt1060-nxp-evk/board/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1060-nxp-evk/board/Kconfig
@@ -114,7 +114,7 @@ menu "Onboard Peripheral Drivers"
         select BSP_USING_LCD
         default n
         if BSP_USING_TOUCHPAD
-            choice
+            choice DEMO_PANEL_RK043FN_SEL
                 prompt "Select panel"
                 default DEMO_PANEL_RK043FN66HS
 
@@ -215,7 +215,7 @@ menu "On-chip Peripheral Drivers"
             config BSP_USING_I2C1
                 bool
                 default y
-            choice
+            choice HW_I2C1_BADURATE_SEL
                 prompt "Select I2C1 badurate"
                 default HW_I2C1_BADURATE_100kHZ
 

--- a/bsp/nxp/imx/imxrt/imxrt1170-nxp-evk/board/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1170-nxp-evk/board/Kconfig
@@ -234,7 +234,7 @@ menu "Onboard Peripheral Drivers"
         default n
 
         if BSP_USING_VGLITE
-            choice
+            choice DISP_RK055_SEL
                 prompt "Select display panel"
                 default DISPLAY_USING_RK055AHD091
                 
@@ -248,7 +248,7 @@ menu "Onboard Peripheral Drivers"
                     bool "RK055MHD091A0-CTG (RK055HDMIPI4MA0 720 * 1280)"
             endchoice
 
-            choice
+            choice DISP_CTRL_SEL
                 prompt "Select display controller"
                 default BSP_USING_LCDIFV2
                 

--- a/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm33/board/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm33/board/Kconfig
@@ -188,7 +188,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable I2C3"
                     default n
 
-                choice
+                choice I2C2_BAUD_SEL
                     prompt "Select I2C2 badurate"
                     default HW_I2C2_BADURATE_100kHZ
 
@@ -199,7 +199,7 @@ menu "On-chip Peripheral Drivers"
                         bool "Badurate 400kHZ"
                 endchoice
 
-                choice
+                choice I2C3_BAUD_SEL
                     prompt "Select I2C3 badurate"
                     default HW_I2C3_BADURATE_100kHZ
 

--- a/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm7/board/Kconfig
+++ b/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm7/board/Kconfig
@@ -144,7 +144,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable I2C3"
                     default n
 
-                choice
+                choice I2C2_BAUD_SEL
                     prompt "Select I2C2 badurate"
                     default HW_I2C2_BADURATE_100kHZ
 
@@ -155,7 +155,7 @@ menu "On-chip Peripheral Drivers"
                         bool "Badurate 400kHZ"
                 endchoice
 
-                choice
+                choice I2C3_BAUD_SEL
                     prompt "Select I2C3 badurate"
                     default HW_I2C3_BADURATE_100kHZ
 
@@ -296,7 +296,7 @@ menu "Onboard Peripheral Drivers"
         default n
 
         if BSP_USING_VGLITE
-            choice
+            choice DISP_RK055_SEL
                 prompt "Select display panel"
                 default DISPLAY_USING_RK055AHD091
 
@@ -310,7 +310,7 @@ menu "Onboard Peripheral Drivers"
                     bool "RK055MHD091A0-CTG (RK055HDMIPI4MA0 720 * 1280)"
             endchoice
 
-            choice
+            choice DISP_CTRL_SEL
                 prompt "Select display controller"
                 default BSP_USING_LCDIFV2
 

--- a/bsp/nxp/imx/imxrt/libraries/templates/imxrt1050xxx/board/Kconfig
+++ b/bsp/nxp/imx/imxrt/libraries/templates/imxrt1050xxx/board/Kconfig
@@ -103,7 +103,7 @@ menu "On-chip Peripheral Drivers"
             config BSP_USING_I2C1
                 bool "Enable I2C1"
                 default n
-            choice
+            choice HW_I2C1_BADURATE_SEL
                 prompt "Select I2C1 badurate"
                 default HW_I2C1_BADURATE_100kHZ
 

--- a/bsp/nxp/lpc/lpc55sxx/libraries/template/lpc55s6xxxx/board/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/libraries/template/lpc55s6xxxx/board/Kconfig
@@ -30,7 +30,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm0 as UART"
                     default y
                     if BSP_USING_UART0
-                        choice
+                        choice HW_UART0_BAUD_SEL
                             prompt "Select UART0 badurate"
                             default HW_UART0_BAUDRATE_115200
 
@@ -46,7 +46,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm2 as UART"
                     default n
                     if BSP_USING_UART2
-                        choice
+                        choice HW_UART2_BAUD_SEL
                             prompt "Select UART2 badurate"
                             default HW_UART2_BAUDRATE_115200
 
@@ -71,7 +71,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm1 I2C"
                     default y
                     if BSP_USING_I2C1
-                        choice
+                        choice HW_I2C1_BAUD_SEL
                             prompt "Select I2C1 badurate"
                             default HW_I2C1_BAUDRATE_100kHZ
 
@@ -87,7 +87,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm4 I2C"
                     default y
                     if BSP_USING_I2C4
-                        choice
+                        choice HW_I2C4_BAUD_SEL
                             prompt "Select I2C4 badurate"
                             default HW_I2C4_BAUDRATE_100kHZ
 

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s06_nxp_evk/board/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s06_nxp_evk/board/Kconfig
@@ -30,7 +30,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm0 as UART"
                     default y
                     if BSP_USING_UART0
-                        choice
+                        choice HW_UART0_BAUD_SEL
                             prompt "Select UART0 badurate"
                             default HW_UART0_BAUDRATE_115200
 
@@ -46,7 +46,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm2 as UART"
                     default n
                     if BSP_USING_UART2
-                        choice
+                        choice HW_UART2_BAUD_SEL
                             prompt "Select UART2 badurate"
                             default HW_UART2_BAUDRATE_115200
 
@@ -71,7 +71,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm1 I2C"
                     default n
                     if BSP_USING_I2C1
-                        choice
+                        choice HW_I2C1_BAUD_SEL
                             prompt "Select I2C1 badurate"
                             default HW_I2C1_BAUDRATE_100kHZ
 
@@ -87,7 +87,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm4 I2C"
                     default n
                     if BSP_USING_I2C4
-                        choice
+                        choice HW_I2C4_BAUD_SEL
                             prompt "Select I2C4 badurate"
                             default HW_I2C4_BAUDRATE_100kHZ
 

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s16_nxp_evk/board/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s16_nxp_evk/board/Kconfig
@@ -30,7 +30,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm0 as UART"
                     default y
                     if BSP_USING_UART0
-                        choice
+                        choice HW_UART0_BAUD_SEL
                             prompt "Select UART0 badurate"
                             default HW_UART0_BAUDRATE_115200
 
@@ -46,7 +46,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm2 as UART"
                     default n
                     if BSP_USING_UART2
-                        choice
+                        choice HW_UART2_BAUD_SEL
                             prompt "Select UART2 badurate"
                             default HW_UART2_BAUDRATE_115200
 
@@ -71,7 +71,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm1 I2C"
                     default n
                     if BSP_USING_I2C1
-                        choice
+                        choice HW_I2C1_BAUD_SEL
                             prompt "Select I2C1 badurate"
                             default HW_I2C1_BAUDRATE_100kHZ
 
@@ -87,7 +87,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm4 I2C"
                     default n
                     if BSP_USING_I2C4
-                        choice
+                        choice HW_I2C4_BAUD_SEL
                             prompt "Select I2C4 badurate"
                             default HW_I2C4_BAUDRATE_100kHZ
 

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s28_nxp_evk/board/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s28_nxp_evk/board/Kconfig
@@ -30,7 +30,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm0 as UART"
                     default y
                     if BSP_USING_UART0
-                        choice
+                        choice HW_UART0_BAUD_SEL
                             prompt "Select UART0 badurate"
                             default HW_UART0_BAUDRATE_115200
 
@@ -46,7 +46,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm2 as UART"
                     default n
                     if BSP_USING_UART2
-                        choice
+                        choice HW_UART2_BAUD_SEL
                             prompt "Select UART2 badurate"
                             default HW_UART2_BAUDRATE_115200
 
@@ -71,7 +71,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm1 I2C"
                     default n
                     if BSP_USING_I2C1
-                        choice
+                        choice HW_I2C1_BAUD_SEL
                             prompt "Select I2C1 badurate"
                             default HW_I2C1_BAUDRATE_100kHZ
 
@@ -87,7 +87,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm4 I2C"
                     default n
                     if BSP_USING_I2C4
-                        choice
+                        choice HW_I2C4_BAUD_SEL
                             prompt "Select I2C4 badurate"
                             default HW_I2C4_BAUDRATE_100kHZ
 

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s36_nxp_evk/board/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s36_nxp_evk/board/Kconfig
@@ -30,7 +30,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm0 as UART"
                     default y
                     if BSP_USING_UART0
-                        choice
+                        choice HW_UART0_BAUD_SEL
                             prompt "Select UART0 badurate"
                             default HW_UART0_BAUDRATE_115200
 
@@ -46,7 +46,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm2 as UART"
                     default n
                     if BSP_USING_UART2
-                        choice
+                        choice HW_UART2_BAUD_SEL
                             prompt "Select UART2 badurate"
                             default HW_UART2_BAUDRATE_115200
 
@@ -71,7 +71,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm1 I2C"
                     default n
                     if BSP_USING_I2C1
-                        choice
+                        choice HW_I2C1_BAUD_SEL
                             prompt "Select I2C1 badurate"
                             default HW_I2C1_BAUDRATE_100kHZ
 
@@ -87,7 +87,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm4 I2C"
                     default n
                     if BSP_USING_I2C4
-                        choice
+                        choice HW_I2C4_BAUD_SEL
                             prompt "Select I2C4 badurate"
                             default HW_I2C4_BAUDRATE_100kHZ
 

--- a/bsp/nxp/lpc/lpc55sxx/lpc55s69_nxp_evk/board/Kconfig
+++ b/bsp/nxp/lpc/lpc55sxx/lpc55s69_nxp_evk/board/Kconfig
@@ -30,7 +30,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm0 as UART"
                     default y
                     if BSP_USING_UART0
-                        choice
+                        choice HW_UART0_BAUD_SEL
                             prompt "Select UART0 badurate"
                             default HW_UART0_BAUDRATE_115200
 
@@ -46,7 +46,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm1 as UART"
                     default n
                     if BSP_USING_UART1
-                    choice
+                    choice HW_UART1_BAUD_SEL
                         prompt "Select UART1 badurate"
                         default HW_UART1_BAUDRATE_115200
 
@@ -62,7 +62,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm2 as UART"
                     default n
                     if BSP_USING_UART2
-                        choice
+                        choice HW_UART2_BAUD_SEL
                             prompt "Select UART2 badurate"
                             default HW_UART2_BAUDRATE_115200
 
@@ -88,7 +88,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                     if BSP_USING_I2C1
-                        choice
+                        choice HW_I2C1_BAUD_SEL
                             prompt "Select I2C1 badurate"
                             default HW_I2C1_BAUDRATE_100kHZ
 
@@ -104,7 +104,7 @@ menu "On-chip Peripheral Drivers"
                     bool "Enable Flexcomm4 I2C"
                     default n
                     if BSP_USING_I2C4
-                        choice
+                        choice HW_I2C4_BAUD_SEL
                             prompt "Select I2C4 badurate"
                             default HW_I2C4_BAUDRATE_100kHZ
 

--- a/bsp/phytium/libraries/drivers/Kconfig
+++ b/bsp/phytium/libraries/drivers/Kconfig
@@ -25,7 +25,7 @@ menu "On-chip Peripheral Drivers"
         select USE_SERIAL # sdk serial component
         select RT_USING_SERIAL
         if BSP_USING_UART_LAYER
-            choice
+            choice BSP_UART_SEL
                 prompt "Select Uart Mode"
                 config BSP_USING_UART
                     bool "Standard Uart"
@@ -71,7 +71,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_SPI
         if BSP_USING_SPI_LAYER
-            choice
+            choice BSP_SPI_SEL
                 prompt "Select SPI Mode"
                 config BSP_USING_SPI
                     bool "Standard SPI"
@@ -119,7 +119,7 @@ menu "On-chip Peripheral Drivers"
         default n
         select RT_USING_I2C
         if BSP_USING_I2C_LAYER
-            choice
+            choice BSP_I2C_SEL
                 prompt "Select I2C Mode"
                 config BSP_USING_I2C
                     bool "Standard I2C"
@@ -279,7 +279,7 @@ menu "On-chip Peripheral Drivers"
                         range 1500 2000
                         default 1700
             
-            choice
+            choice BSP_ETH_SEL
                 prompt "Select ETH Mode"
                 config BSP_USING_ETH
                     bool "Standard ETH"
@@ -365,7 +365,7 @@ menu "On-chip Peripheral Drivers"
                 select RT_USING_DFS_ELMFAT
                 default n
 
-            choice
+            choice BSP_SDIF_SEL
                 prompt "Select SD Mode"
                 default BSP_USING_SDIF
                 config BSP_USING_SDIF
@@ -384,7 +384,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                 if USING_SDIF0
-                    choice 
+                    choice USE_SDIF0_SEL
                         prompt "Select SD0 Usage"
                         default USE_SDIF0_TF
                         config USE_SDIF0_TF
@@ -400,7 +400,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                 if USING_SDIF1
-                    choice 
+                    choice USE_SDIF1_SEL
                         prompt "Select SD1 Usage"
                         default USE_SDIF1_TF
                         config USE_SDIF1_TF
@@ -431,7 +431,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_AUDIO
         select BSP_USING_DEVICE
         if BSP_USING_I2S_LAYER
-            choice
+            choice BSP_I2S_SEL
                 prompt "Select I2S Mode"
                 config BSP_USING_I2S
                     bool "Standard I2S"

--- a/bsp/qemu-virt64-riscv/Kconfig
+++ b/bsp/qemu-virt64-riscv/Kconfig
@@ -32,7 +32,7 @@ config ENABLE_VECTOR
     default n
 
 if ENABLE_VECTOR
-    choice
+    choice ARCH_VECTOR_VLEN_SEL
     prompt "Vector Registers Length in Bits"
     default ARCH_VECTOR_VLEN_128
 

--- a/bsp/raspberry-pico/RP2040/board/Kconfig
+++ b/bsp/raspberry-pico/RP2040/board/Kconfig
@@ -59,7 +59,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART0"
                 default y
             if BSP_USING_UART0
-                choice
+                choice BSP_UART0_TX_PIN_SEL
                     prompt "uart0 tx pin number (GP)"
                     depends on BSP_USING_UART0
                     default BSP_UART0_TX_PIN_0
@@ -76,7 +76,7 @@ menu "On-chip Peripheral Drivers"
                     default 12 if BSP_UART0_TX_PIN_12
                     default 16 if BSP_UART0_TX_PIN_16
 
-                choice
+                choice BSP_UART0_RX_PIN_1_SEL
                     prompt "uart0 rx pin number (GP)"
                     depends on BSP_USING_UART0
                     default BSP_UART0_RX_PIN_1
@@ -98,7 +98,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART1"
                 default n
             if BSP_USING_UART1
-                choice
+                choice BSP_UART1_TX_PIN_SEL
                     prompt "uart1 tx pin number (GP)"
                     depends on BSP_USING_UART1
                     default BSP_UART1_TX_PIN_8
@@ -112,7 +112,7 @@ menu "On-chip Peripheral Drivers"
                     default 4 if BSP_UART1_TX_PIN_4
                     default 8 if BSP_UART1_TX_PIN_8
 
-                choice
+                choice BSP_UART1_RX_PIN_SEL
                     prompt "uart1 rx pin number (GP)"
                     depends on BSP_USING_UART1
                     default BSP_UART1_RX_PIN_9
@@ -270,7 +270,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable SPI0"
                 default n
             if BSP_USING_SPI0
-                choice
+                choice BSP_SPI0_MOSI_PIN_SEL
                     prompt "spi0 MOSI pin number (GP)"
                     depends on BSP_USING_SPI0
                     default BSP_SPI0_MOSI_PIN_19 if BSP_USING_ARDUINO
@@ -287,7 +287,7 @@ menu "On-chip Peripheral Drivers"
                     default 7 if BSP_SPI0_MOSI_PIN_7
                     default 19 if BSP_SPI0_MOSI_PIN_19
 
-                choice
+                choice BSP_SPI0_MISO_PIN_SEL
                     prompt "spi0 MISO pin number (GP)"
                     depends on BSP_USING_SPI0
                     default BSP_SPI0_MISO_PIN_16 if BSP_USING_ARDUINO
@@ -304,7 +304,7 @@ menu "On-chip Peripheral Drivers"
                     default 4 if BSP_SPI0_MISO_PIN_4
                     default 16 if BSP_SPI0_MISO_PIN_16
 
-                choice
+                choice BSP_SPI0_SCK_PIN_SEL
                     prompt "spi0 SCK pin number (GP)"
                     depends on BSP_USING_SPI0
                     default BSP_SPI0_SCK_PIN_18 if BSP_USING_ARDUINO
@@ -321,7 +321,7 @@ menu "On-chip Peripheral Drivers"
                     default 6 if BSP_SPI0_SCK_PIN_6
                     default 18 if BSP_SPI0_SCK_PIN_18
 
-                choice
+                choice BSP_SPI0_CS_PIN_SEL
                     prompt "spi0 CS pin number (GP)"
                     depends on BSP_USING_SPI0
                     default BSP_SPI0_CS_PIN_17 if BSP_USING_ARDUINO
@@ -343,7 +343,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable SPI1"
                 default n
             if BSP_USING_SPI1
-                choice
+                choice BSP_SPI1_MOSI_PIN_1_SEL
                     prompt "spi1 MOSI pin number (GP)"
                     depends on BSP_USING_SPI1
                     default BSP_SPI1_MOSI_PIN_15 if BSP_USING_ARDUINO
@@ -357,7 +357,7 @@ menu "On-chip Peripheral Drivers"
                     default 11 if BSP_SPI1_MOSI_PIN_11
                     default 15 if BSP_SPI1_MOSI_PIN_15
 
-                choice
+                choice BSP_SPI1_MISO_PIN_SEL
                     prompt "spi1 MISO pin number (GP)"
                     depends on BSP_USING_SPI1
                     default BSP_SPI1_MISO_PIN_12 if BSP_USING_ARDUINO
@@ -371,7 +371,7 @@ menu "On-chip Peripheral Drivers"
                     default 8 if BSP_SPI1_MISO_PIN_8
                     default 12 if BSP_SPI1_MISO_PIN_12
 
-                choice
+                choice BSP_SPI1_SCK_PIN_1_SEL
                     prompt "spi1 SCK pin number (GP)"
                     depends on BSP_USING_SPI1
                     default BSP_SPI1_SCK_PIN_14 if BSP_USING_ARDUINO
@@ -385,7 +385,7 @@ menu "On-chip Peripheral Drivers"
                     default 10 if BSP_SPI1_SCK_PIN_10
                     default 14 if BSP_SPI1_SCK_PIN_14
 
-                choice
+                choice BSP_SPI1_CS_PIN_SEL
                     prompt "spi1 CS pin number (GP)"
                     depends on BSP_USING_SPI1
                     default BSP_SPI1_CS_PIN_13 if BSP_USING_ARDUINO
@@ -410,7 +410,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM0"
                 default n
                 if BSP_USING_PWM0
-                    choice
+                    choice BSP_PWM0_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM0
                         default BSP_PWM0_A_PIN_16
@@ -423,7 +423,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 0 if BSP_PWM0_A_PIN_0
                         default 16 if BSP_PWM0_A_PIN_16
-                    choice
+                    choice BSP_PWM0_B_PIN_1_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM0
                         default BSP_PWM0_B_PIN_17
@@ -448,7 +448,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM1"
                 default n
                 if BSP_USING_PWM1
-                    choice
+                    choice BSP_PWM1_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM1
                         default BSP_PWM1_A_PIN_18
@@ -461,7 +461,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 2 if BSP_PWM1_A_PIN_2
                         default 18 if BSP_PWM1_A_PIN_18
-                    choice
+                    choice BSP_PWM1_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM1
                         default BSP_PWM1_B_PIN_19
@@ -486,7 +486,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM2"
                 default n
                 if BSP_USING_PWM2
-                    choice
+                    choice BSP_PWM2_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM2
                         default BSP_PWM2_A_PIN_20
@@ -499,7 +499,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 4 if BSP_PWM2_A_PIN_4
                         default 20 if BSP_PWM2_A_PIN_20
-                    choice
+                    choice BSP_PWM2_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM2
                         default BSP_PWM2_B_PIN_21
@@ -524,7 +524,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM3"
                 default n
                 if BSP_USING_PWM3
-                    choice
+                    choice BSP_PWM3_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM3
                         default BSP_PWM3_A_PIN_22
@@ -537,7 +537,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 6 if BSP_PWM3_A_PIN_6
                         default 22 if BSP_PWM3_A_PIN_22
-                    choice
+                    choice BSP_PWM3_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM3
                         default BSP_PWM3_B_PIN_23
@@ -562,7 +562,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM4"
                 default n
                 if BSP_USING_PWM4
-                    choice
+                    choice BSP_PWM4_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM4
                         default BSP_PWM4_A_PIN_24
@@ -575,7 +575,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 8 if BSP_PWM4_A_PIN_8
                         default 24 if BSP_PWM4_A_PIN_24
-                    choice
+                    choice BSP_PWM4_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM4
                         default BSP_PWM4_B_PIN_25
@@ -600,7 +600,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM5"
                 default n
                 if BSP_USING_PWM5
-                    choice
+                    choice BSP_PWM5_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM5
                         default BSP_PWM5_A_PIN_10
@@ -613,7 +613,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 10 if BSP_PWM5_A_PIN_10
                         default 26 if BSP_PWM5_A_PIN_26
-                    choice
+                    choice BSP_PWM5_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM5
                         default BSP_PWM5_B_PIN_11
@@ -638,7 +638,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM6"
                 default n
                 if BSP_USING_PWM6
-                    choice
+                    choice BSP_PWM6_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM6
                         default BSP_PWM6_A_PIN_12
@@ -651,7 +651,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 12 if BSP_PWM6_A_PIN_12
                         default 28 if BSP_PWM6_A_PIN_28
-                    choice
+                    choice BSP_PWM6_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM6
                         default BSP_PWM6_B_PIN_13
@@ -676,7 +676,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM7"
                 default n
                 if BSP_USING_PWM7
-                    choice
+                    choice PWM_SLICE_A_PIN_GP_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM7
                         default BSP_PWM7_A_PIN_14
@@ -686,7 +686,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_PWM7_A_PIN
                         int
                         default 14 if BSP_PWM7_A_PIN_14
-                    choice
+                    choice PWM_SLICE_B_PIN_GP_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM7
                         default BSP_PWM7_B_PIN_15
@@ -732,7 +732,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable I2C0"
                 default n
                 if BSP_USING_I2C0
-                    choice
+                    choice BSP_I2C0_SCL_PIN_SEL
                         prompt "i2c0 scl pin number (GP)"
                         depends on BSP_USING_I2C0
                         default BSP_I2C0_SCL_PIN_5 if BSP_USING_ARDUINO
@@ -758,7 +758,7 @@ menu "On-chip Peripheral Drivers"
                         default 17 if BSP_I2C0_SCL_PIN_17
                         default 21 if BSP_I2C0_SCL_PIN_21
 
-                    choice
+                    choice BSP_I2C0_SDA_PIN_SEL
                         prompt "i2c0 sda pin number (GP)"
                         depends on BSP_USING_I2C0
                         default BSP_I2C0_SDA_PIN_4 if BSP_USING_ARDUINO
@@ -789,7 +789,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable I2C1"
                 default n
                 if BSP_USING_I2C1
-                    choice
+                    choice BSP_I2C1_SCL_PIN_SEL
                         prompt "i2c1 scl pin number (GP)"
                         depends on BSP_USING_I2C1
                         config BSP_I2C1_SCL_PIN_3
@@ -814,7 +814,7 @@ menu "On-chip Peripheral Drivers"
                         default 19 if BSP_I2C1_SCL_PIN_19
                         default 27 if BSP_I2C1_SCL_PIN_27
 
-                    choice
+                    choice BSP_I2C1_SDA_PIN_SEL
                         prompt "i2c1 sda pin number (GP)"
                         depends on BSP_USING_I2C1
                         config BSP_I2C1_SDA_PIN_2

--- a/bsp/raspberry-pico/RP2350/board/Kconfig
+++ b/bsp/raspberry-pico/RP2350/board/Kconfig
@@ -59,7 +59,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART0"
                 default y
             if BSP_USING_UART0
-                choice
+                choice BSP_UART0_TX_PIN_SEL
                     prompt "uart0 tx pin number (GP)"
                     depends on BSP_USING_UART0
                     default BSP_UART0_TX_PIN_0
@@ -76,7 +76,7 @@ menu "On-chip Peripheral Drivers"
                     default 12 if BSP_UART0_TX_PIN_12
                     default 16 if BSP_UART0_TX_PIN_16
 
-                choice
+                choice BSP_UART0_RX_PIN_1_SEL
                     prompt "uart0 rx pin number (GP)"
                     depends on BSP_USING_UART0
                     default BSP_UART0_RX_PIN_1
@@ -98,7 +98,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable UART1"
                 default n
             if BSP_USING_UART1
-                choice
+                choice BSP_UART1_TX_PIN_SEL
                     prompt "uart1 tx pin number (GP)"
                     depends on BSP_USING_UART1
                     default BSP_UART1_TX_PIN_8
@@ -112,7 +112,7 @@ menu "On-chip Peripheral Drivers"
                     default 4 if BSP_UART1_TX_PIN_4
                     default 8 if BSP_UART1_TX_PIN_8
 
-                choice
+                choice BSP_UART1_RX_PIN_SEL
                     prompt "uart1 rx pin number (GP)"
                     depends on BSP_USING_UART1
                     default BSP_UART1_RX_PIN_9
@@ -270,7 +270,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable SPI0"
                 default n
             if BSP_USING_SPI0
-                choice
+                choice BSP_SPI0_MOSI_PIN_SEL
                     prompt "spi0 MOSI pin number (GP)"
                     depends on BSP_USING_SPI0
                     default BSP_SPI0_MOSI_PIN_19 if BSP_USING_ARDUINO
@@ -287,7 +287,7 @@ menu "On-chip Peripheral Drivers"
                     default 7 if BSP_SPI0_MOSI_PIN_7
                     default 19 if BSP_SPI0_MOSI_PIN_19
 
-                choice
+                choice BSP_SPI0_MISO_PIN_SEL
                     prompt "spi0 MISO pin number (GP)"
                     depends on BSP_USING_SPI0
                     default BSP_SPI0_MISO_PIN_16 if BSP_USING_ARDUINO
@@ -304,7 +304,7 @@ menu "On-chip Peripheral Drivers"
                     default 4 if BSP_SPI0_MISO_PIN_4
                     default 16 if BSP_SPI0_MISO_PIN_16
 
-                choice
+                choice BSP_SPI0_SCK_PIN_SEL
                     prompt "spi0 SCK pin number (GP)"
                     depends on BSP_USING_SPI0
                     default BSP_SPI0_SCK_PIN_18 if BSP_USING_ARDUINO
@@ -321,7 +321,7 @@ menu "On-chip Peripheral Drivers"
                     default 6 if BSP_SPI0_SCK_PIN_6
                     default 18 if BSP_SPI0_SCK_PIN_18
 
-                choice
+                choice BSP_SPI0_CS_PIN_SEL
                     prompt "spi0 CS pin number (GP)"
                     depends on BSP_USING_SPI0
                     default BSP_SPI0_CS_PIN_17 if BSP_USING_ARDUINO
@@ -343,7 +343,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable SPI1"
                 default n
             if BSP_USING_SPI1
-                choice
+                choice BSP_SPI1_MOSI_PIN_1_SEL
                     prompt "spi1 MOSI pin number (GP)"
                     depends on BSP_USING_SPI1
                     default BSP_SPI1_MOSI_PIN_15 if BSP_USING_ARDUINO
@@ -357,7 +357,7 @@ menu "On-chip Peripheral Drivers"
                     default 11 if BSP_SPI1_MOSI_PIN_11
                     default 15 if BSP_SPI1_MOSI_PIN_15
 
-                choice
+                choice BSP_SPI1_MISO_PIN_SEL
                     prompt "spi1 MISO pin number (GP)"
                     depends on BSP_USING_SPI1
                     default BSP_SPI1_MISO_PIN_12 if BSP_USING_ARDUINO
@@ -371,7 +371,7 @@ menu "On-chip Peripheral Drivers"
                     default 8 if BSP_SPI1_MISO_PIN_8
                     default 12 if BSP_SPI1_MISO_PIN_12
 
-                choice
+                choice BSP_SPI1_SCK_PIN_1_SEL
                     prompt "spi1 SCK pin number (GP)"
                     depends on BSP_USING_SPI1
                     default BSP_SPI1_SCK_PIN_14 if BSP_USING_ARDUINO
@@ -385,7 +385,7 @@ menu "On-chip Peripheral Drivers"
                     default 10 if BSP_SPI1_SCK_PIN_10
                     default 14 if BSP_SPI1_SCK_PIN_14
 
-                choice
+                choice BSP_SPI1_CS_PIN_SEL
                     prompt "spi1 CS pin number (GP)"
                     depends on BSP_USING_SPI1
                     default BSP_SPI1_CS_PIN_13 if BSP_USING_ARDUINO
@@ -410,7 +410,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM0"
                 default n
                 if BSP_USING_PWM0
-                    choice
+                    choice BSP_PWM0_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM0
                         default BSP_PWM0_A_PIN_16
@@ -423,7 +423,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 0 if BSP_PWM0_A_PIN_0
                         default 16 if BSP_PWM0_A_PIN_16
-                    choice
+                    choice BSP_PWM0_B_PIN_1_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM0
                         default BSP_PWM0_B_PIN_17
@@ -448,7 +448,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM1"
                 default n
                 if BSP_USING_PWM1
-                    choice
+                    choice BSP_PWM1_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM1
                         default BSP_PWM1_A_PIN_18
@@ -461,7 +461,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 2 if BSP_PWM1_A_PIN_2
                         default 18 if BSP_PWM1_A_PIN_18
-                    choice
+                    choice BSP_PWM1_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM1
                         default BSP_PWM1_B_PIN_19
@@ -486,7 +486,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM2"
                 default n
                 if BSP_USING_PWM2
-                    choice
+                    choice BSP_PWM2_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM2
                         default BSP_PWM2_A_PIN_20
@@ -499,7 +499,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 4 if BSP_PWM2_A_PIN_4
                         default 20 if BSP_PWM2_A_PIN_20
-                    choice
+                    choice BSP_PWM2_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM2
                         default BSP_PWM2_B_PIN_21
@@ -524,7 +524,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM3"
                 default n
                 if BSP_USING_PWM3
-                    choice
+                    choice BSP_PWM3_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM3
                         default BSP_PWM3_A_PIN_22
@@ -537,7 +537,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 6 if BSP_PWM3_A_PIN_6
                         default 22 if BSP_PWM3_A_PIN_22
-                    choice
+                    choice BSP_PWM3_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM3
                         default BSP_PWM3_B_PIN_23
@@ -562,7 +562,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM4"
                 default n
                 if BSP_USING_PWM4
-                    choice
+                    choice BSP_PWM4_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM4
                         default BSP_PWM4_A_PIN_24
@@ -575,7 +575,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 8 if BSP_PWM4_A_PIN_8
                         default 24 if BSP_PWM4_A_PIN_24
-                    choice
+                    choice BSP_PWM4_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM4
                         default BSP_PWM4_B_PIN_25
@@ -600,7 +600,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM5"
                 default n
                 if BSP_USING_PWM5
-                    choice
+                    choice BSP_PWM5_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM5
                         default BSP_PWM5_A_PIN_10
@@ -613,7 +613,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 10 if BSP_PWM5_A_PIN_10
                         default 26 if BSP_PWM5_A_PIN_26
-                    choice
+                    choice BSP_PWM5_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM5
                         default BSP_PWM5_B_PIN_11
@@ -638,7 +638,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM6"
                 default n
                 if BSP_USING_PWM6
-                    choice
+                    choice BSP_PWM6_A_PIN_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM6
                         default BSP_PWM6_A_PIN_12
@@ -651,7 +651,7 @@ menu "On-chip Peripheral Drivers"
                         int
                         default 12 if BSP_PWM6_A_PIN_12
                         default 28 if BSP_PWM6_A_PIN_28
-                    choice
+                    choice BSP_PWM6_B_PIN_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM6
                         default BSP_PWM6_B_PIN_13
@@ -676,7 +676,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable PWM7"
                 default n
                 if BSP_USING_PWM7
-                    choice
+                    choice PWM_SLICE_A_PIN_GP_SEL
                         prompt "pwm slice A pin number (GP)"
                         depends on BSP_USING_PWM7
                         default BSP_PWM7_A_PIN_14
@@ -686,7 +686,7 @@ menu "On-chip Peripheral Drivers"
                     config BSP_PWM7_A_PIN
                         int
                         default 14 if BSP_PWM7_A_PIN_14
-                    choice
+                    choice PWM_SLICE_B_PIN_GP_SEL
                         prompt "pwm slice B pin number (GP)"
                         depends on BSP_USING_PWM7
                         default BSP_PWM7_B_PIN_15
@@ -732,7 +732,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable I2C0"
                 default n
                 if BSP_USING_I2C0
-                    choice
+                    choice BSP_I2C0_SCL_PIN_SEL
                         prompt "i2c0 scl pin number (GP)"
                         depends on BSP_USING_I2C0
                         default BSP_I2C0_SCL_PIN_5 if BSP_USING_ARDUINO
@@ -758,7 +758,7 @@ menu "On-chip Peripheral Drivers"
                         default 17 if BSP_I2C0_SCL_PIN_17
                         default 21 if BSP_I2C0_SCL_PIN_21
 
-                    choice
+                    choice BSP_I2C0_SDA_PIN_SEL
                         prompt "i2c0 sda pin number (GP)"
                         depends on BSP_USING_I2C0
                         default BSP_I2C0_SDA_PIN_4 if BSP_USING_ARDUINO
@@ -789,7 +789,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable I2C1"
                 default n
                 if BSP_USING_I2C1
-                    choice
+                    choice BSP_I2C1_SCL_PIN_SEL
                         prompt "i2c1 scl pin number (GP)"
                         depends on BSP_USING_I2C1
                         config BSP_I2C1_SCL_PIN_3
@@ -814,7 +814,7 @@ menu "On-chip Peripheral Drivers"
                         default 19 if BSP_I2C1_SCL_PIN_19
                         default 27 if BSP_I2C1_SCL_PIN_27
 
-                    choice
+                    choice BSP_I2C1_SDA_PIN_SEL
                         prompt "i2c1 sda pin number (GP)"
                         depends on BSP_USING_I2C1
                         config BSP_I2C1_SDA_PIN_2

--- a/bsp/renesas/ebf_qi_min_6m5/board/Kconfig
+++ b/bsp/renesas/ebf_qi_min_6m5/board/Kconfig
@@ -122,7 +122,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -153,7 +153,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -184,7 +184,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -215,7 +215,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -246,7 +246,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -277,7 +277,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -308,7 +308,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -339,7 +339,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -370,7 +370,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -401,7 +401,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/libraries/Kconfig
+++ b/bsp/renesas/libraries/Kconfig
@@ -86,7 +86,7 @@ config SOC_SERIES_R7FA2A1
     default n
 
 if RT_USING_NANO
-choice
+choice RT_NANO_CONSOLE_UART_SEL
 prompt "Choice nano console device(Renesas)"
 default RT_NANO_CONSOLE_UART0
 depends on RT_USING_CONSOLE

--- a/bsp/renesas/ra2a1-ek/board/Kconfig
+++ b/bsp/renesas/ra2a1-ek/board/Kconfig
@@ -124,7 +124,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -155,7 +155,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -187,7 +187,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/ra2l1-cpk/board/Kconfig
+++ b/bsp/renesas/ra2l1-cpk/board/Kconfig
@@ -283,7 +283,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -314,7 +314,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -345,7 +345,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -376,7 +376,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -407,7 +407,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -438,7 +438,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -469,7 +469,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -500,7 +500,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -531,7 +531,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -562,7 +562,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/ra4m2-eco/board/Kconfig
+++ b/bsp/renesas/ra4m2-eco/board/Kconfig
@@ -233,7 +233,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -264,7 +264,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -295,7 +295,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -326,7 +326,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -357,7 +357,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -388,7 +388,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -419,7 +419,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -450,7 +450,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -481,7 +481,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -512,7 +512,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/ra6m3-ek/board/Kconfig
+++ b/bsp/renesas/ra6m3-ek/board/Kconfig
@@ -170,7 +170,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -201,7 +201,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -232,7 +232,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -263,7 +263,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -294,7 +294,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -325,7 +325,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -356,7 +356,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -387,7 +387,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -418,7 +418,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -449,7 +449,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/ra6m3-hmi-board/board/Kconfig
+++ b/bsp/renesas/ra6m3-hmi-board/board/Kconfig
@@ -384,7 +384,7 @@ endmenu
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -415,7 +415,7 @@ endmenu
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -446,7 +446,7 @@ endmenu
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -477,7 +477,7 @@ endmenu
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -508,7 +508,7 @@ endmenu
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -539,7 +539,7 @@ endmenu
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -570,7 +570,7 @@ endmenu
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -601,7 +601,7 @@ endmenu
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -632,7 +632,7 @@ endmenu
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -663,7 +663,7 @@ endmenu
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/ra6m4-cpk/board/Kconfig
+++ b/bsp/renesas/ra6m4-cpk/board/Kconfig
@@ -479,7 +479,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -510,7 +510,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -541,7 +541,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -572,7 +572,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -603,7 +603,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -634,7 +634,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -665,7 +665,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -696,7 +696,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -727,7 +727,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -758,7 +758,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/ra6m4-iot/board/Kconfig
+++ b/bsp/renesas/ra6m4-iot/board/Kconfig
@@ -455,7 +455,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -486,7 +486,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -517,7 +517,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -548,7 +548,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -579,7 +579,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -610,7 +610,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -641,7 +641,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -672,7 +672,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -703,7 +703,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -734,7 +734,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/ra8d1-ek/board/Kconfig
+++ b/bsp/renesas/ra8d1-ek/board/Kconfig
@@ -125,7 +125,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -156,7 +156,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -187,7 +187,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -218,7 +218,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -249,7 +249,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -280,7 +280,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -311,7 +311,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -342,7 +342,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -373,7 +373,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -404,7 +404,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/ra8d1-vision-board/board/Kconfig
+++ b/bsp/renesas/ra8d1-vision-board/board/Kconfig
@@ -182,7 +182,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -213,7 +213,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -244,7 +244,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -275,7 +275,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -306,7 +306,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -337,7 +337,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -368,7 +368,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -399,7 +399,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -430,7 +430,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -461,7 +461,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/ra8m1-ek/board/Kconfig
+++ b/bsp/renesas/ra8m1-ek/board/Kconfig
@@ -109,7 +109,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -140,7 +140,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -171,7 +171,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -202,7 +202,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -233,7 +233,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -264,7 +264,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -295,7 +295,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -326,7 +326,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -357,7 +357,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -388,7 +388,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/ra8p1-titan-board/board/Kconfig
+++ b/bsp/renesas/ra8p1-titan-board/board/Kconfig
@@ -11,7 +11,7 @@ menu "Hardware Drivers Config"
             select BSP_START_SECONDARY_CORE
             select PKG_USING_RPMSG_LITE
             if BSP_USING_RPMSG
-                choice
+                choice BSP_RPMSG_LITE_SEL
                 prompt "choice rpmsg-lite method"
                 default BSP_USING_RPMSG_LITE
                 config BSP_USING_RPMSG_LITE
@@ -248,7 +248,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -279,7 +279,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -310,7 +310,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -341,7 +341,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -372,7 +372,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -403,7 +403,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -434,7 +434,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -465,7 +465,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -496,7 +496,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -527,7 +527,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/rzn2l_etherkit/board/Kconfig
+++ b/bsp/renesas/rzn2l_etherkit/board/Kconfig
@@ -133,7 +133,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -164,7 +164,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -195,7 +195,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -226,7 +226,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -257,7 +257,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -288,7 +288,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -319,7 +319,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -350,7 +350,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -381,7 +381,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -412,7 +412,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/renesas/rzt2m_rsk/board/Kconfig
+++ b/bsp/renesas/rzt2m_rsk/board/Kconfig
@@ -121,7 +121,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI0"
                     default n
                     if BSP_USING_SCI0
-                        choice
+                        choice BSP_SCI0_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI0_SPI
                         config BSP_USING_SCI0_SPI
@@ -152,7 +152,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI1"
                     default n
                     if BSP_USING_SCI1
-                        choice
+                        choice BSP_SCI1_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI1_SPI
                         config BSP_USING_SCI1_SPI
@@ -183,7 +183,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI2"
                     default n
                     if BSP_USING_SCI2
-                        choice
+                        choice BSP_SCI2_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI2_SPI
                         config BSP_USING_SCI2_SPI
@@ -214,7 +214,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI3"
                     default n
                     if BSP_USING_SCI3
-                        choice
+                        choice BSP_SCI3_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI3_SPI
                         config BSP_USING_SCI3_SPI
@@ -245,7 +245,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI4"
                     default n
                     if BSP_USING_SCI4
-                        choice
+                        choice BSP_SCI4_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI4_SPI
                         config BSP_USING_SCI4_SPI
@@ -276,7 +276,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI5"
                     default n
                     if BSP_USING_SCI5
-                        choice
+                        choice BSP_SCI5_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI5_SPI
                         config BSP_USING_SCI5_SPI
@@ -307,7 +307,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI6"
                     default n
                     if BSP_USING_SCI6
-                        choice
+                        choice BSP_SCI6_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI6_SPI
                         config BSP_USING_SCI6_SPI
@@ -338,7 +338,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI7"
                     default n
                     if BSP_USING_SCI7
-                        choice
+                        choice BSP_SCI7_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI7_SPI
                         config BSP_USING_SCI7_SPI
@@ -369,7 +369,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI8"
                     default n
                     if BSP_USING_SCI8
-                        choice
+                        choice BSP_SCI8_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI8_SPI
                         config BSP_USING_SCI8_SPI
@@ -400,7 +400,7 @@ menu "Hardware Drivers Config"
                     bool "Enable SCI9"
                     default n
                     if BSP_USING_SCI9
-                        choice
+                        choice BSP_SCI9_SEL
                         prompt "choice sci mode"
                         default BSP_USING_SCI9_SPI
                         config BSP_USING_SCI9_SPI

--- a/bsp/stm32/libraries/templates/stm32l1xx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32l1xx/board/Kconfig
@@ -210,7 +210,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/libraries/templates/stm32wbxx/board/Kconfig
+++ b/bsp/stm32/libraries/templates/stm32wbxx/board/Kconfig
@@ -144,7 +144,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/libraries/templates/stm32xx_board_Kconfig
+++ b/bsp/stm32/libraries/templates/stm32xx_board_Kconfig
@@ -153,7 +153,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f091-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f091-st-nucleo/board/Kconfig
@@ -188,7 +188,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f103-atk-nano/board/Kconfig
+++ b/bsp/stm32/stm32f103-atk-nano/board/Kconfig
@@ -271,7 +271,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f103-atk-warshipv3/board/Kconfig
+++ b/bsp/stm32/stm32f103-atk-warshipv3/board/Kconfig
@@ -295,7 +295,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f103-blue-pill/board/Kconfig
+++ b/bsp/stm32/stm32f103-blue-pill/board/Kconfig
@@ -234,7 +234,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f103-fire-arbitrary/board/Kconfig
+++ b/bsp/stm32/stm32f103-fire-arbitrary/board/Kconfig
@@ -350,7 +350,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f103-hw100k-ibox/board/Kconfig
+++ b/bsp/stm32/stm32f103-hw100k-ibox/board/Kconfig
@@ -299,7 +299,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f407-armfly-v5/board/Kconfig
+++ b/bsp/stm32/stm32f407-armfly-v5/board/Kconfig
@@ -224,7 +224,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f407-atk-explorer/board/Kconfig
+++ b/bsp/stm32/stm32f407-atk-explorer/board/Kconfig
@@ -627,7 +627,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f407-fk407m2-zgt6/board/Kconfig
+++ b/bsp/stm32/stm32f407-fk407m2-zgt6/board/Kconfig
@@ -455,7 +455,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f407-lckfb-skystar/board/Kconfig
+++ b/bsp/stm32/stm32f407-lckfb-skystar/board/Kconfig
@@ -521,7 +521,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f407-micu/board/Kconfig
+++ b/bsp/stm32/stm32f407-micu/board/Kconfig
@@ -149,7 +149,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f407-rt-spark/board/Kconfig
+++ b/bsp/stm32/stm32f407-rt-spark/board/Kconfig
@@ -862,7 +862,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f411-atk-nano/board/Kconfig
+++ b/bsp/stm32/stm32f411-atk-nano/board/Kconfig
@@ -204,7 +204,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f411-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f411-st-nucleo/board/Kconfig
@@ -237,7 +237,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f413-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f413-st-nucleo/board/Kconfig
@@ -182,7 +182,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f429-armfly-v6/board/Kconfig
+++ b/bsp/stm32/stm32f429-armfly-v6/board/Kconfig
@@ -227,7 +227,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f429-atk-apollo/board/Kconfig
+++ b/bsp/stm32/stm32f429-atk-apollo/board/Kconfig
@@ -342,7 +342,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f429-fire-challenger/board/Kconfig
+++ b/bsp/stm32/stm32f429-fire-challenger/board/Kconfig
@@ -272,7 +272,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f469-st-disco/board/Kconfig
+++ b/bsp/stm32/stm32f469-st-disco/board/Kconfig
@@ -95,7 +95,7 @@ menu "Onboard Peripheral Drivers"
         select BSP_USING_SOFT_I2C
         select BSP_USING_SOFT_I2C1
 
-    choice
+    choice BSP_TOUCH_FT6_SEL
         prompt "Touch IC type"
         depends on BSP_USING_TOUCH
         default BSP_USING_TOUCH_FT6X36

--- a/bsp/stm32/stm32f746-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f746-st-nucleo/board/Kconfig
@@ -13,7 +13,7 @@ menu "Onboard Peripheral Drivers"
         default n
 
         if BSP_USING_ETH
-            choice
+            choice ON_BOARD_PHY_CHIP_SEL
                 prompt "On-board PHY chip"
                 default PHY_USING_LAN8742A
 
@@ -242,7 +242,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f767-atk-apollo/board/Kconfig
+++ b/bsp/stm32/stm32f767-atk-apollo/board/Kconfig
@@ -271,7 +271,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f767-fire-challenger-v1/board/Kconfig
+++ b/bsp/stm32/stm32f767-fire-challenger-v1/board/Kconfig
@@ -242,7 +242,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32f767-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32f767-st-nucleo/board/Kconfig
@@ -13,7 +13,7 @@ menu "Onboard Peripheral Drivers"
         default n
 
         if BSP_USING_ETH
-            choice
+            choice ON_BOARD_PHY_CHIP_SEL
                 prompt "On-board PHY chip"
                 default PHY_USING_LAN8720A
 

--- a/bsp/stm32/stm32f769-st-disco/board/Kconfig
+++ b/bsp/stm32/stm32f769-st-disco/board/Kconfig
@@ -8,7 +8,7 @@ menu "Onboard Peripheral Drivers"
         default n
 
         if BSP_USING_ETH
-            choice
+            choice ON_BOARD_PHY_CHIP_SEL
                 prompt "On-board PHY chip"
                 default PHY_USING_DP83848C
 

--- a/bsp/stm32/stm32g070-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32g070-st-nucleo/board/Kconfig
@@ -242,7 +242,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32g491-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32g491-st-nucleo/board/Kconfig
@@ -279,7 +279,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32h743-atk-apollo/board/Kconfig
+++ b/bsp/stm32/stm32h743-atk-apollo/board/Kconfig
@@ -213,7 +213,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32h750-artpi/board/Kconfig
+++ b/bsp/stm32/stm32h750-artpi/board/Kconfig
@@ -413,7 +413,7 @@ menu "On-chip Peripheral Drivers"
                 default "PA.3"
         endif
         if BSP_USING_ETH_H750
-            choice
+            choice ETH_PHY_SEL
                 prompt "Choose ETH PHY"
                 default PHY_USING_LAN8720A
                         config PHY_USING_LAN8720A

--- a/bsp/stm32/stm32h750-weact-ministm32h7xx/board/Kconfig
+++ b/bsp/stm32/stm32h750-weact-ministm32h7xx/board/Kconfig
@@ -35,7 +35,7 @@ menu "Onboard Peripheral Drivers"
         default n
 
         if BSP_USING_LCD_SPI
-            choice
+            choice LCD_BACKLIGHT_SEL
                 prompt "choice back light"
                 default LCD_BACKLIGHT_USING_GPIO
                 config LCD_BACKLIGHT_USING_PWM

--- a/bsp/stm32/stm32l412-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l412-st-nucleo/board/Kconfig
@@ -68,7 +68,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32l431-tencentos-tiny-EVB_MX+/board/Kconfig
+++ b/bsp/stm32/stm32l431-tencentos-tiny-EVB_MX+/board/Kconfig
@@ -144,7 +144,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32l432-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l432-st-nucleo/board/Kconfig
@@ -68,7 +68,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32l433-ali-startkit/board/Kconfig
+++ b/bsp/stm32/stm32l433-ali-startkit/board/Kconfig
@@ -246,7 +246,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32l433-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l433-st-nucleo/board/Kconfig
@@ -118,7 +118,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32l475-atk-pandora/board/Kconfig
+++ b/bsp/stm32/stm32l475-atk-pandora/board/Kconfig
@@ -51,7 +51,7 @@ menu "Onboard Peripheral Drivers"
             default n
 
         if BSP_USING_ARDUINO_ST7789
-            choice
+            choice BSP_ARDUINO_ST7789_SEL
                 prompt "Arduino GUI Framework"
 
                 config BSP_USING_ARDUINO_ST7789_ADAFRUIT_GFX
@@ -613,7 +613,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32l476-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l476-st-nucleo/board/Kconfig
@@ -281,7 +281,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32l496-ali-developer/board/Kconfig
+++ b/bsp/stm32/stm32l496-ali-developer/board/Kconfig
@@ -254,7 +254,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32l496-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l496-st-nucleo/board/Kconfig
@@ -269,7 +269,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/stm32/stm32l4r5-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32l4r5-st-nucleo/board/Kconfig
@@ -232,7 +232,7 @@ menu "Hardware Drivers Config"
             select RT_USING_RTC
             default n
             if BSP_USING_ONCHIP_RTC
-                choice
+                choice BSP_RTC_LS_SEL
                     prompt "Select clock source"
                     default BSP_RTC_USING_LSE
                     config BSP_RTC_USING_LSE

--- a/bsp/stm32/stm32wb55-st-nucleo/board/Kconfig
+++ b/bsp/stm32/stm32wb55-st-nucleo/board/Kconfig
@@ -137,7 +137,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/tae32f5300/drivers/Kconfig
+++ b/bsp/tae32f5300/drivers/Kconfig
@@ -172,7 +172,7 @@ menu "On-chip Peripheral Drivers"
         default n
 
         if BSP_USING_RTC
-            choice
+            choice CLK_SRC_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LRC
 

--- a/bsp/ti/c28x/tms320f28379d/board/Kconfig
+++ b/bsp/ti/c28x/tms320f28379d/board/Kconfig
@@ -113,7 +113,7 @@ menu "On-chip Peripheral Drivers"
                             bool "Enable phase"
                             default n
                             if BSP_PWM1_PHASE_ENABLE
-                                choice
+                                choice BSP_PWM1_SEL
                                     prompt "Select master or slave"
                                     default BSP_PWM1_MASTER
                                     config BSP_PWM1_MASTER
@@ -140,7 +140,7 @@ menu "On-chip Peripheral Drivers"
                             bool "Enable interrupt service"
                             default n
                             if BSP_PWM1_IT_ENABLE
-                                choice
+                                choice BSP_PWM1_INTSEL_ET_SEL
                                     prompt "Select interrupt time"
                                     default BSP_PWM1_INTSEL_ET_CTR_ZERO
                                     config BSP_PWM1_INTSEL_ET_DCAEVT1SOC
@@ -171,7 +171,7 @@ menu "On-chip Peripheral Drivers"
                                     default 5 if BSP_PWM1_INTSEL_ET_CTRD_CMPA
                                     default 6 if BSP_PWM1_INTSEL_ET_CTRU_CMPB
                                     default 7 if BSP_PWM1_INTSEL_ET_CTRD_CMPB
-                                choice
+                                choice BSP_PWM1_INT_ET_SEL
                                     prompt "Interrupt generation time"
                                     default BSP_PWM1_INT_ET_1ST
                                     config BSP_PWM1_INT_ET_DISABLE
@@ -190,7 +190,7 @@ menu "On-chip Peripheral Drivers"
                                     default 2 if BSP_PWM1_INT_ET_2ND
                                     default 3 if BSP_PWM1_INT_ET_3RD
                             endif
-                        choice
+                        choice BSP_PWM1_HSPCLKDIV_SEL
                             prompt "HSP Clock division"
                             default BSP_PWM1_HSPCLKDIV1
                             config BSP_PWM1_HSPCLKDIV1
@@ -205,7 +205,7 @@ menu "On-chip Peripheral Drivers"
                             default 0 if BSP_PWM1_HSPCLKDIV1
                             default 1 if BSP_PWM1_HSPCLKDIV2
                             default 2 if BSP_PWM1_HSPCLKDIV4
-                        choice
+                        choice BSP_PWM1_CLKDIV_SEL
                             prompt "Clock division"
                             default BSP_PWM1_CLKDIV1
                             config BSP_PWM1_CLKDIV1
@@ -220,7 +220,7 @@ menu "On-chip Peripheral Drivers"
                             default 0 if BSP_PWM1_CLKDIV1
                             default 1 if BSP_PWM1_CLKDIV2
                             default 2 if BSP_PWM1_CLKDIV4
-                        choice
+                        choice BSP_PWM1_CTR_SEL
                             default BSP_PWM1_CTR_MODE_UPDOWN
                             prompt "Select counter mode"
                             config BSP_PWM1_CTR_MODE_UPDOWN
@@ -238,7 +238,7 @@ menu "On-chip Peripheral Drivers"
                             default 1 if BSP_PWM1_CTR_MODE_DOWN
                             default 2 if BSP_PWM1_CTR_MODE_UPDOWN
                             default 3 if BSP_PWM1_CTR_FREEZE
-                        choice
+                        choice BSP_PWM1_CC_SEL
                             prompt "Register load mode"
                             config BSP_PWM1_CC_CTR_ZERO
                                 bool "Load when counter == 0"
@@ -264,7 +264,7 @@ menu "On-chip Peripheral Drivers"
                         menuconfig BSP_PWM1_ADC_TRIGGER
                             bool "Enable ADC trigger from PWM1"
                             if BSP_PWM1_ADC_TRIGGER
-                                choice
+                                choice BSP_PWM1_SOCASEL_ET_SEL
                                     prompt "Select soc triggering time"
                                     default BSP_PWM1_SOCASEL_ET_CTR_ZERO
                                     config BSP_PWM1_SOCASEL_ET_DCAEVT1SOC
@@ -295,7 +295,7 @@ menu "On-chip Peripheral Drivers"
                                     default 5 if BSP_PWM1_SOCASEL_ET_CTRD_CMPA
                                     default 6 if BSP_PWM1_SOCASEL_ET_CTRU_CMPB
                                     default 7 if BSP_PWM1_SOCASEL_ET_CTRD_CMPB
-                                choice
+                                choice BSP_PWM1_SOCA_ET_SEL
                                     prompt "SOCA generation time"
                                     default BSP_PWM1_SOCA_ET_1ST
                                     config BSP_PWM1_SOCA_ET_DISABLE
@@ -333,7 +333,7 @@ menu "On-chip Peripheral Drivers"
                             bool "Enable phase"
                             default n
                             if BSP_PWM2_PHASE_ENABLE
-                                choice
+                                choice BSP_PWM2_SEL
                                     prompt "Select master or slave"
                                     default BSP_PWM2_SLAVE
                                     config BSP_PWM2_MASTER
@@ -360,7 +360,7 @@ menu "On-chip Peripheral Drivers"
                             bool "Enable interrupt service"
                             default n
                             if BSP_PWM2_IT_ENABLE
-                                choice
+                                choice BSP_PWM2_INTSEL_ET_SEL
                                     prompt "Select interrupt time"
                                     default BSP_PWM2_INTSEL_ET_CTR_ZERO
                                     config BSP_PWM2_INTSEL_ET_DCAEVT1SOC
@@ -391,7 +391,7 @@ menu "On-chip Peripheral Drivers"
                                     default 5 if BSP_PWM2_INTSEL_ET_CTRD_CMPA
                                     default 6 if BSP_PWM2_INTSEL_ET_CTRU_CMPB
                                     default 7 if BSP_PWM2_INTSEL_ET_CTRD_CMPB
-                                choice
+                                choice BSP_PWM2_INT_ET_SEL
                                     prompt "Interrupt generation time"
                                     default BSP_PWM2_INT_ET_1ST
                                     config BSP_PWM2_INT_ET_DISABLE
@@ -410,7 +410,7 @@ menu "On-chip Peripheral Drivers"
                                     default 2 if BSP_PWM2_INT_ET_2ND
                                     default 3 if BSP_PWM2_INT_ET_3RD
                             endif
-                        choice
+                        choice BSP_PWM2_HSPCLKDIV_SEL
                             prompt "HSP Clock division"
                             default BSP_PWM2_HSPCLKDIV1
                             config BSP_PWM2_HSPCLKDIV1
@@ -425,7 +425,7 @@ menu "On-chip Peripheral Drivers"
                             default 0 if BSP_PWM2_HSPCLKDIV1
                             default 1 if BSP_PWM2_HSPCLKDIV2
                             default 2 if BSP_PWM2_HSPCLKDIV4
-                        choice
+                        choice BSP_PWM2_CLKDIV_SEL
                             prompt "Clock division"
                             default BSP_PWM2_CLKDIV1
                             config BSP_PWM2_CLKDIV1
@@ -440,7 +440,7 @@ menu "On-chip Peripheral Drivers"
                             default 0 if BSP_PWM2_CLKDIV1
                             default 1 if BSP_PWM2_CLKDIV2
                             default 2 if BSP_PWM2_CLKDIV4
-                        choice
+                        choice BSP_PWM2_CTR_SEL
                             default BSP_PWM2_CTR_MODE_UPDOWN
                             prompt "Select counter mode"
                             config BSP_PWM2_CTR_MODE_UPDOWN
@@ -458,7 +458,7 @@ menu "On-chip Peripheral Drivers"
                             default 1 if BSP_PWM2_CTR_MODE_DOWN
                             default 2 if BSP_PWM2_CTR_MODE_UPDOWN
                             default 3 if BSP_PWM2_CTR_FREEZE
-                        choice
+                        choice BSP_PWM2_CC_SEL
                             prompt "Register load mode"
                             config BSP_PWM2_CC_CTR_ZERO
                                 bool "Load when counter == 0"
@@ -484,7 +484,7 @@ menu "On-chip Peripheral Drivers"
                         menuconfig BSP_PWM2_ADC_TRIGGER
                             bool "Enable ADC trigger from PWM2"
                             if BSP_PWM2_ADC_TRIGGER
-                                choice
+                                choice BSP_PWM2_SOCASEL_ET_SEL
                                     prompt "Select soc triggering time"
                                     default BSP_PWM2_SOCASEL_ET_CTR_ZERO
                                     config BSP_PWM2_SOCASEL_ET_DCAEVT1SOC
@@ -515,7 +515,7 @@ menu "On-chip Peripheral Drivers"
                                     default 5 if BSP_PWM2_SOCASEL_ET_CTRD_CMPA
                                     default 6 if BSP_PWM2_SOCASEL_ET_CTRU_CMPB
                                     default 7 if BSP_PWM2_SOCASEL_ET_CTRD_CMPB
-                                choice
+                                choice BSP_PWM2_SOCA_ET_SEL
                                     prompt "SOCA generation time"
                                     default BSP_PWM2_SOCA_ET_1ST
                                     config BSP_PWM2_SOCA_ET_DISABLE
@@ -553,7 +553,7 @@ menu "On-chip Peripheral Drivers"
                             bool "Enable phase"
                             default n
                             if BSP_PWM3_PHASE_ENABLE
-                                choice
+                                choice BSP_PWM3_SEL
                                     prompt "Select master or slave"
                                     default BSP_PWM3_SLAVE
                                     config BSP_PWM3_MASTER
@@ -580,7 +580,7 @@ menu "On-chip Peripheral Drivers"
                             bool "Enable interrupt service"
                             default n
                             if BSP_PWM3_IT_ENABLE
-                                choice
+                                choice BSP_PWM3_INTSEL_ET_SEL
                                     prompt "Select interrupt time"
                                     default BSP_PWM3_INTSEL_ET_CTR_ZERO
                                     config BSP_PWM3_INTSEL_ET_DCAEVT1SOC
@@ -611,7 +611,7 @@ menu "On-chip Peripheral Drivers"
                                     default 5 if BSP_PWM3_INTSEL_ET_CTRD_CMPA
                                     default 6 if BSP_PWM3_INTSEL_ET_CTRU_CMPB
                                     default 7 if BSP_PWM3_INTSEL_ET_CTRD_CMPB
-                                choice
+                                choice BSP_PWM3_INT_ET_SEL
                                     prompt "Interrupt generation time"
                                     default BSP_PWM3_INT_ET_1ST
                                     config BSP_PWM3_INT_ET_DISABLE
@@ -630,7 +630,7 @@ menu "On-chip Peripheral Drivers"
                                     default 2 if BSP_PWM3_INT_ET_2ND
                                     default 3 if BSP_PWM3_INT_ET_3RD
                             endif
-                        choice
+                        choice BSP_PWM3_HSPCLKDIV_SEL
                             prompt "HSP Clock division"
                             default BSP_PWM3_HSPCLKDIV1
                             config BSP_PWM3_HSPCLKDIV1
@@ -645,7 +645,7 @@ menu "On-chip Peripheral Drivers"
                             default 0 if BSP_PWM3_HSPCLKDIV1
                             default 1 if BSP_PWM3_HSPCLKDIV2
                             default 2 if BSP_PWM3_HSPCLKDIV4
-                        choice
+                        choice BSP_PWM3_CLKDIV_SEL
                             prompt "Clock division"
                             default BSP_PWM3_CLKDIV1
                             config BSP_PWM3_CLKDIV1
@@ -660,7 +660,7 @@ menu "On-chip Peripheral Drivers"
                             default 0 if BSP_PWM3_CLKDIV1
                             default 1 if BSP_PWM3_CLKDIV2
                             default 2 if BSP_PWM3_CLKDIV4
-                        choice
+                        choice BSP_PWM3_CTR_SEL
                             default BSP_PWM3_CTR_MODE_UPDOWN
                             prompt "Select counter mode"
                             config BSP_PWM3_CTR_MODE_UPDOWN
@@ -678,7 +678,7 @@ menu "On-chip Peripheral Drivers"
                             default 1 if BSP_PWM3_CTR_MODE_DOWN
                             default 2 if BSP_PWM3_CTR_MODE_UPDOWN
                             default 3 if BSP_PWM3_CTR_FREEZE
-                        choice
+                        choice BSP_PWM3_CC_SEL
                             prompt "Register load mode"
                             config BSP_PWM3_CC_CTR_ZERO
                                 bool "Load when counter == 0"
@@ -704,7 +704,7 @@ menu "On-chip Peripheral Drivers"
                         menuconfig BSP_PWM3_ADC_TRIGGER
                             bool "Enable ADC trigger from PWM3"
                             if BSP_PWM3_ADC_TRIGGER
-                                choice
+                                choice BSP_PWM3_SOCASEL_ET_SEL
                                     prompt "Select soc triggering time"
                                     default BSP_PWM3_SOCASEL_ET_CTR_ZERO
                                     config BSP_PWM3_SOCASEL_ET_DCAEVT1SOC
@@ -735,7 +735,7 @@ menu "On-chip Peripheral Drivers"
                                     default 5 if BSP_PWM3_SOCASEL_ET_CTRD_CMPA
                                     default 6 if BSP_PWM3_SOCASEL_ET_CTRU_CMPB
                                     default 7 if BSP_PWM3_SOCASEL_ET_CTRD_CMPB
-                                choice
+                                choice BSP_PWM3_SOCA_ET_SEL
                                     prompt "SOCA generation time"
                                     default BSP_PWM3_SOCA_ET_1ST
                                     config BSP_PWM3_SOCA_ET_DISABLE
@@ -773,7 +773,7 @@ menu "On-chip Peripheral Drivers"
                             bool "Enable phase"
                             default n
                             if BSP_PWM4_PHASE_ENABLE
-                                choice
+                                choice BSP_PWM4_SEL
                                     prompt "Select master or slave"
                                     default BSP_PWM4_SLAVE
                                     config BSP_PWM4_MASTER
@@ -800,7 +800,7 @@ menu "On-chip Peripheral Drivers"
                             bool "Enable interrupt service"
                             default n
                             if BSP_PWM4_IT_ENABLE
-                                choice
+                                choice BSP_PWM4_INTSEL_ET_SEL
                                     prompt "Select interrupt time"
                                     default BSP_PWM4_INTSEL_ET_CTR_ZERO
                                     config BSP_PWM4_INTSEL_ET_DCAEVT1SOC
@@ -831,7 +831,7 @@ menu "On-chip Peripheral Drivers"
                                     default 5 if BSP_PWM4_INTSEL_ET_CTRD_CMPA
                                     default 6 if BSP_PWM4_INTSEL_ET_CTRU_CMPB
                                     default 7 if BSP_PWM4_INTSEL_ET_CTRD_CMPB
-                                choice
+                                choice BSP_PWM4_INT_ET_SEL
                                     prompt "Interrupt generation time"
                                     default BSP_PWM4_INT_ET_1ST
                                     config BSP_PWM4_INT_ET_DISABLE
@@ -850,7 +850,7 @@ menu "On-chip Peripheral Drivers"
                                     default 2 if BSP_PWM4_INT_ET_2ND
                                     default 3 if BSP_PWM4_INT_ET_3RD
                             endif
-                        choice
+                        choice BSP_PWM4_HSPCLKDIV_SEL
                             prompt "HSP Clock division"
                             default BSP_PWM4_HSPCLKDIV1
                             config BSP_PWM4_HSPCLKDIV1
@@ -865,7 +865,7 @@ menu "On-chip Peripheral Drivers"
                             default 0 if BSP_PWM4_HSPCLKDIV1
                             default 1 if BSP_PWM4_HSPCLKDIV2
                             default 2 if BSP_PWM4_HSPCLKDIV4
-                        choice
+                        choice BSP_PWM4_CLKDIV_SEL
                             prompt "Clock division"
                             default BSP_PWM4_CLKDIV1
                             config BSP_PWM4_CLKDIV1
@@ -880,7 +880,7 @@ menu "On-chip Peripheral Drivers"
                             default 0 if BSP_PWM4_CLKDIV1
                             default 1 if BSP_PWM4_CLKDIV2
                             default 2 if BSP_PWM4_CLKDIV4
-                        choice
+                        choice BSP_PWM4_CTR_SEL
                             default BSP_PWM4_CTR_MODE_UPDOWN
                             prompt "Select counter mode"
                             config BSP_PWM4_CTR_MODE_UPDOWN
@@ -898,7 +898,7 @@ menu "On-chip Peripheral Drivers"
                             default 1 if BSP_PWM4_CTR_MODE_DOWN
                             default 2 if BSP_PWM4_CTR_MODE_UPDOWN
                             default 3 if BSP_PWM4_CTR_FREEZE
-                        choice
+                        choice BSP_PWM4_CC_SEL
                             prompt "Register load mode"
                             config BSP_PWM4_CC_CTR_ZERO
                                 bool "Load when counter == 0"
@@ -924,7 +924,7 @@ menu "On-chip Peripheral Drivers"
                         menuconfig BSP_PWM4_ADC_TRIGGER
                             bool "Enable ADC trigger from PWM4"
                             if BSP_PWM4_ADC_TRIGGER
-                                choice
+                                choice BSP_PWM4_SOCASEL_ET_SEL
                                     prompt "Select soc triggering time"
                                     default BSP_PWM4_SOCASEL_ET_CTR_ZERO
                                     config BSP_PWM4_SOCASEL_ET_DCAEVT1SOC
@@ -955,7 +955,7 @@ menu "On-chip Peripheral Drivers"
                                     default 5 if BSP_PWM4_SOCASEL_ET_CTRD_CMPA
                                     default 6 if BSP_PWM4_SOCASEL_ET_CTRU_CMPB
                                     default 7 if BSP_PWM4_SOCASEL_ET_CTRD_CMPB
-                                choice
+                                choice BSP_PWM4_SOCA_ET_SEL
                                     prompt "SOCA generation time"
                                     default BSP_PWM4_SOCA_ET_1ST
                                     config BSP_PWM4_SOCA_ET_DISABLE
@@ -987,7 +987,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable ADC1"
                 default n
                 if BSP_USING_ADC1
-                    choice
+                    choice BSP_ADC1_RES_SEL
                         prompt "Select resolution"
                         default BSP_ADC_USING_12BIT
 
@@ -1002,7 +1002,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable ADC2"
                 default n
                 if BSP_USING_ADC2
-                    choice
+                    choice BSP_ADC2_RES_SEL
                         prompt "Select resolution"
                         default BSP_ADC_USING_12BIT
 
@@ -1017,7 +1017,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable ADC3"
                 default n
                 if BSP_USING_ADC3
-                    choice
+                    choice BSP_ADC3_RES_SEL
                         prompt "Select resolution"
                         default BSP_ADC_USING_12BIT
 
@@ -1035,7 +1035,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/tkm32F499/drivers/Kconfig
+++ b/bsp/tkm32F499/drivers/Kconfig
@@ -115,7 +115,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/tm4c123bsp/board/Kconfig
+++ b/bsp/tm4c123bsp/board/Kconfig
@@ -197,7 +197,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable I2C0 BUS"
                 default n
             if BSP_USING_I2C0
-                choice
+                choice BSP_I2C0_CLK_SEL
                     prompt "I2C0 CLK frequency"
                     default BSP_I2C0_CLK_100
 
@@ -213,7 +213,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable I2C1 BUS"
                 default n
             if BSP_USING_I2C1
-                choice
+                choice BSP_I2C1_CLK_SEL
                     prompt "I2C1 CLK frequency"
                     default BSP_I2C1_CLK_100
 
@@ -229,7 +229,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable I2C2 BUS"
                 default n
             if BSP_USING_I2C2
-                choice
+                choice BSP_I2C2_CLK_SEL
                     prompt "I2C2 CLK frequency"
                     default BSP_I2C3_CLK_100
 
@@ -245,7 +245,7 @@ menu "On-chip Peripheral Drivers"
                 bool "Enable I2C3 BUS"
                 default n
             if BSP_USING_I2C3
-                choice
+                choice BSP_I2C3_CLK_SEL
                     prompt "I2C3 CLK frequency"
                     default BSP_I2C4_CLK_100
 
@@ -339,7 +339,7 @@ menu "On-chip Peripheral Drivers"
         select RT_USING_RTC
         default n
         if BSP_USING_ONCHIP_RTC
-            choice
+            choice BSP_RTC_LS_SEL
                 prompt "Select clock source"
                 default BSP_RTC_USING_LSE
 

--- a/bsp/w60x/drivers/Kconfig
+++ b/bsp/w60x/drivers/Kconfig
@@ -5,7 +5,7 @@ config BSP_USING_WM_LIBRARIES
     default y
 
 menu "W60x Device config"
-    choice
+    choice SOC_TYPE_SEL
         prompt "SOC type"
         default SOC_W600_A8xx
         config SOC_W600_A8xx
@@ -14,7 +14,7 @@ menu "W60x Device config"
             bool "W601-A8xx"
     endchoice
 
-    choice
+    choice BOARD_TYPE_SEL
         prompt "Board type"
         if SOC_W600_A8xx
             config W600_EV_BOARD

--- a/bsp/wch/arm/ch32f103c8-core/board/Kconfig
+++ b/bsp/wch/arm/ch32f103c8-core/board/Kconfig
@@ -100,7 +100,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM1
-                        choice
+                        choice BSP_TIM1_SEL
                                 prompt "using TIM1 as clock_timer or PWM mode"
                                 default BSP_USING_TIM1_CLOCK_TIMER
 
@@ -138,7 +138,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM2
-                        choice
+                        choice BSP_TIM2_SEL
                                 prompt "using TIM2 as clock_timer or PWM mode"
                                 default BSP_USING_TIM2_CLOCK_TIMER
 
@@ -176,7 +176,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM3
-                        choice
+                        choice BSP_TIM3_SEL
                                 prompt "using TIM3 as clock_timer or PWM mode"
                                 default BSP_USING_TIM3_CLOCK_TIMER
 
@@ -214,7 +214,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM4
-                        choice
+                        choice BSP_TIM4_SEL
                                 prompt "using TIM4 as clock_timer or PWM mode"
                                 default BSP_USING_TIM4_CLOCK_TIMER
 

--- a/bsp/wch/arm/ch32f203r-evt/board/Kconfig
+++ b/bsp/wch/arm/ch32f203r-evt/board/Kconfig
@@ -124,7 +124,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM1
-                        choice
+                        choice BSP_TIM1_SEL
                                 prompt "using TIM1 as clock_timer or PWM mode"
                                 default BSP_USING_TIM1_CLOCK_TIMER
 
@@ -162,7 +162,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM2
-                        choice
+                        choice BSP_TIM2_SEL
                                 prompt "using TIM2 as clock_timer or PWM mode"
                                 default BSP_USING_TIM2_CLOCK_TIMER
 
@@ -200,7 +200,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM3
-                        choice
+                        choice BSP_TIM3_SEL
                                 prompt "using TIM3 as clock_timer or PWM mode"
                                 default BSP_USING_TIM3_CLOCK_TIMER
 
@@ -238,7 +238,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM4
-                        choice
+                        choice BSP_TIM4_SEL
                                 prompt "using TIM4 as clock_timer or PWM mode"
                                 default BSP_USING_TIM4_CLOCK_TIMER
 
@@ -276,7 +276,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM4
-                        choice
+                        choice BSP_TIM5_SEL
                                 prompt "using TIM5 as clock_timer or PWM mode"
                                 default BSP_USING_TIM5_CLOCK_TIMER
 
@@ -338,7 +338,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM8
-                        choice
+                        choice BSP_TIM8_SEL
                                 prompt "using TIM8 as clock_timer or PWM mode"
                                 default BSP_USING_TIM8_CLOCK_TIMER
 
@@ -376,7 +376,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM9
-                        choice
+                        choice BSP_TIM9_SEL
                                 prompt "using TIM9 as clock_timer or PWM mode"
                                 default BSP_USING_TIM9_CLOCK_TIMER
 
@@ -414,7 +414,7 @@ config BSP_USING_TIM
                         default n
 
                 if BSP_USING_TIM10
-                        choice
+                        choice BSP_TIM10_SEL
                                 prompt "using TIM10 as clock_timer or PWM mode"
                                 default BSP_USING_TIM10_CLOCK_TIMER
 

--- a/bsp/wch/risc-v/ch32v208w-r0/board/Kconfig
+++ b/bsp/wch/risc-v/ch32v208w-r0/board/Kconfig
@@ -313,7 +313,7 @@ menu "On-chip Peripheral Drivers"
                 default n
 
                 if BSP_USING_TIM1
-                    choice
+                    choice BSP_TIM1_SEL
                         prompt "Using TIM1 as clock_timer or PWM mode"
                         default BSP_USING_TIM1_CLOCK_TIMER
 
@@ -349,7 +349,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                 if BSP_USING_TIM2
-                    choice
+                    choice BSP_TIM2_SEL
                         prompt "Using TIM2 as clock_timer or PWM mode"
                         default BSP_USING_TIM2_CLOCK_TIMER
 
@@ -385,7 +385,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                 if BSP_USING_TIM3
-                    choice
+                    choice BSP_TIM3_SEL
                         prompt "Using TIM3 as clock_timer or PWM mode"
                         default BSP_USING_TIM3_CLOCK_TIMER
 
@@ -421,7 +421,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                 if BSP_USING_TIM4
-                    choice
+                    choice BSP_TIM4_SEL
                         prompt "Using TIM4 as clock_timer or PWM mode"
                         default BSP_USING_TIM4_CLOCK_TIMER
 
@@ -457,7 +457,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                 if BSP_USING_TIM5
-                    choice
+                    choice BSP_TIM5_SEL
                         prompt "Using TIM5 as clock_timer or PWM mode"
                         default BSP_USING_TIM5_CLOCK_TIMER
 
@@ -493,7 +493,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                 if BSP_USING_TIM6
-                    choice
+                    choice TIM5_CLK_TMR_PWM_MO_SEL
                         prompt "Using TIM5 as clock_timer (PWM mode not supported)"
                         default BSP_USING_TIM6_CLOCK_TIMER
 
@@ -509,7 +509,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                 if BSP_USING_TIM7
-                    choice
+                    choice TIM7_CLK_TMR_PWM_MO_SEL
                         prompt "Using TIM7 as clock_timer (PWM mode not supported)"
                         default BSP_USING_TIM7_CLOCK_TIMER
 
@@ -525,7 +525,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                 if BSP_USING_TIM8
-                    choice
+                    choice BSP_TIM8_SEL
                         prompt "Using TIM8 as clock_timer or PWM mode"
                         default BSP_USING_TIM8_CLOCK_TIMER
 
@@ -561,7 +561,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                 if BSP_USING_TIM9
-                    choice
+                    choice BSP_TIM9_SEL
                         prompt "Using TIM9 as clock_timer or PWM mode"
                         default BSP_USING_TIM9_CLOCK_TIMER
 
@@ -597,7 +597,7 @@ menu "On-chip Peripheral Drivers"
                     default n
 
                 if BSP_USING_TIM10
-                    choice
+                    choice BSP_TIM10_SEL
                         prompt "Using TIM10 as clock_timer or PWM mode"
                         default BSP_USING_TIM10_CLOCK_TIMER
 

--- a/bsp/wch/risc-v/yd-ch32v307vct6/board/Kconfig
+++ b/bsp/wch/risc-v/yd-ch32v307vct6/board/Kconfig
@@ -241,7 +241,7 @@ menu "On-chip Peripheral Drivers"
         default n
 
         if BSP_USING_RTC
-            choice
+            choice BSP_RTC_SEL
                 prompt "Using clock for RTC"
                 default BSP_USING_RTC_LSI
                 

--- a/bsp/x86/Kconfig
+++ b/bsp/x86/Kconfig
@@ -18,7 +18,7 @@ config IA32
 
 menu "X86 Features"
 
-choice
+choice C_LIB_TYPE_SEL
     prompt "C Library type"
     default X86_BSP_USING_LIBC
 

--- a/bsp/xuantie/smartl/e906/Kconfig
+++ b/bsp/xuantie/smartl/e906/Kconfig
@@ -21,7 +21,7 @@ menu "CPU Architecture Features"
         default y
 
     if ENABLE_FPU
-        choice
+        choice ARCH_RISCV_FPU_SEL
             prompt "FPU Configuration"
             default ARCH_RISCV_FPU_D
 

--- a/bsp/xuantie/smartl/e907/Kconfig
+++ b/bsp/xuantie/smartl/e907/Kconfig
@@ -21,7 +21,7 @@ menu "CPU Architecture Features"
         default y
 
     if ENABLE_FPU
-        choice
+        choice ARCH_RISCV_FPU_SEL
             prompt "FPU Configuration"
             default ARCH_RISCV_FPU_D
 

--- a/components/drivers/graphic/logo/Kconfig
+++ b/components/drivers/graphic/logo/Kconfig
@@ -3,7 +3,7 @@ menuconfig RT_GRAPHIC_LOGO
     select RT_GRAPHIC_FB
     default y
 
-choice
+choice RT_GRAPHIC_LOGO_SEL
     prompt "Rendering image(ppm)"
     default RT_GRAPHIC_LOGO_RT_THREAD_CLUT224
     depends on RT_GRAPHIC_LOGO

--- a/components/drivers/serial/device/virtual/Kconfig
+++ b/components/drivers/serial/device/virtual/Kconfig
@@ -4,7 +4,7 @@ menuconfig RT_SERIAL_VIRTUAL
     depends on RT_INPUT_KEYBOARD
     default n
 
-choice
+choice RT_SERIAL_VIRT_FONT_UNI2_SEL
     prompt "Rendering font(psf)"
     default RT_SERIAL_VIRTUAL_FONT_UNI2_FIXED16
     depends on RT_SERIAL_VIRTUAL


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

PR #10643 已经给部分核心组件中的匿名 choice 增加了显式名称，用于避免 kconfiglib 在解析匿名 choice 时产生对象引用不一致相关 warning。

当前仓库中仍有大量 Kconfig 使用匿名 choice，主要分布在 BSP 目录。继续保留匿名 choice 会让后续 Kconfiglib 检查、菜单配置解析和自动化脚本更容易遇到同类问题。

#### 你的解决方案是什么 (what is your solution)

为仓库中剩余的匿名 choice 增加唯一、可读的显式名称。

命名主要基于 BSP 路径和 choice 内 config 符号公共前缀生成，只修改 choice 声明行，不改变 prompt、default、depends、config 选项或实际配置行为。

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP:
  - 根 Kconfig
  - bsp/stm32/stm32f407-atk-explorer
  - bsp/raspberry-pico/RP2040
  - bsp/hpmicro/hpm6800evk
  - bsp/renesas/ra6m4-cpk
  - bsp/nuvoton/numaker-m467hj
  - bsp/ti/c28x/tms320f28379d
  - bsp/bouffalo_lab/bl808/d0

- .config:
  - 无需修改 .config。本 PR 只为 Kconfig choice 增加显式名称。

- action:
  - 本地验证：
    - 全仓匿名 choice grep 无匹配
    - git diff --check
    - kconfiglib 解析根 Kconfig，warnings 0
    - kconfiglib 解析多个 BSP 样本；部分 BSP 存在既有 select choice symbol/重复定义类 warning，与本次匿名 choice 命名无关

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
