### PR TITLE
usbdevice: clamp OS compatible ID response length

### DIFF
--- a/components/legacy/usb/usbdevice/core/usbdevice_core.c
+++ b/components/legacy/usb/usbdevice/core/usbdevice_core.c
@@ -693,6 +693,7 @@ static rt_err_t _vendor_request(udevice_t device, ureq_t setup)
     usb_os_func_comp_id_desc_t func_comp_id_desc;
     uintf_t intf;
     ufunction_t func;
+    rt_size_t size;
     switch(setup->bRequest)
     {
         case 'A':
@@ -726,7 +727,9 @@ static rt_err_t _vendor_request(udevice_t device, ureq_t setup)
                         pusb_comp_id_desc += sizeof(struct usb_os_function_comp_id_descriptor)-sizeof(rt_list_t);
                     }
                 }
-                rt_usbd_ep0_write(device, (void*)usb_comp_id_desc, setup->wLength);
+                size = (setup->wLength > usb_comp_id_desc_size) ?
+                       usb_comp_id_desc_size : setup->wLength;
+                rt_usbd_ep0_write(device, (void*)usb_comp_id_desc, size);
             break;
             case 0x05:
                 intf = rt_usbd_find_interface(device, setup->wValue & 0xFF, &func);


### PR DESCRIPTION
Closes #11287

## Summary

- Clamp the Microsoft OS Compatible ID descriptor response length to the constructed descriptor size.
- Keep the existing descriptor allocation and caching behavior unchanged.
- Prevent host-controlled `wLength` from making EP0 transmit beyond the allocated descriptor buffer.

## Testing

- `git diff --check origin/master...HEAD`
- Verified the touched file uses CRLF line endings and has no UTF-8 BOM.
- Not run: RT-Thread build or USB device utest, because this Windows host does not have `scons`, a C compiler, or an embedded cross toolchain installed.