### PR TITLE
[bsp][gd32] fix pwm enable channel check

### DIFF
--- a/bsp/gd32/arm/gd32405rg/.ci/attachconfig/ci.attachconfig.yml
+++ b/bsp/gd32/arm/gd32405rg/.ci/attachconfig/ci.attachconfig.yml
@@ -1,0 +1,4 @@
+hw_drv_onchip.pwm0:
+  kconfig:
+    - CONFIG_BSP_USING_PWM=y
+    - CONFIG_BSP_USING_PWM0=y

--- a/bsp/gd32/arm/libraries/gd32_drivers/drv_pwm.c
+++ b/bsp/gd32/arm/libraries/gd32_drivers/drv_pwm.c
@@ -517,6 +517,7 @@ static void timer_config(void)
 static rt_err_t drv_pwm_enable(struct gd32_pwm *pwm, const struct rt_pwm_configuration *configuration,
                                rt_bool_t enable)
 {
+    uint8_t channel_num = configuration->channel;
     if(channel_num == 0)
     {
         LOG_E("GD32 PWM channel starts from 1!\n");


### PR DESCRIPTION
﻿## Summary

- define the PWM channel number before validating it in the GD32 PWM enable path
- keep the enable/disable behavior unchanged and match the existing period/pulse helpers

## Root cause

`drv_pwm_enable()` checks `channel_num`, but the local variable was never initialized in that function after the GD32 PWM refactor. The adjacent period and pulse helpers already derive it from `configuration->channel` before the same validation.

Closes #11331

## Testing

- `git diff --check`
- verified the diff is limited to one insertion in `bsp/gd32/arm/libraries/gd32_drivers/drv_pwm.c`
- verified the file keeps CRLF line endings

Not run: GD32 BSP build. This machine does not have `scons`, `gcc`, `arm-none-eabi-gcc`, or `clang` installed.
