### PR TITLE
fix klibc format and string comparison semantics

### DIFF
--- a/src/klibc/kstring.c
+++ b/src/klibc/kstring.c
@@ -440,15 +440,18 @@ int rt_strncmp(const char *cs, const char *ct, size_t count)
 #ifdef RT_KLIBC_USING_LIBC_STRNCMP
     return strncmp(cs, ct, count);
 #else
-    signed char res = 0;
+    int res = 0;
 
     while (count)
     {
-        if ((res = *cs - *ct++) != 0 || !*cs++)
+        res = (unsigned char)*cs - (unsigned char)*ct;
+        if (res != 0 || *cs == '\0')
         {
             break;
         }
 
+        cs ++;
+        ct ++;
         count --;
     }
 
@@ -482,7 +485,7 @@ int rt_strcmp(const char *cs, const char *ct)
         ct++;
     }
 
-    return (*cs - *ct);
+    return (unsigned char)*cs - (unsigned char)*ct;
 #endif /* RT_KLIBC_USING_LIBC_STRCMP */
 }
 #endif /* RT_KLIBC_USING_USER_STRCMP */

--- a/src/klibc/kstring.c
+++ b/src/klibc/kstring.c
@@ -10,15 +10,15 @@
 
 #include <rtthread.h>
 
-#if defined(RT_KLIBC_USING_LIBC_MEMSET) || \
-    defined(RT_KLIBC_USING_LIBC_MEMCPY) || \
+#if defined(RT_KLIBC_USING_LIBC_MEMSET) ||  \
+    defined(RT_KLIBC_USING_LIBC_MEMCPY) ||  \
     defined(RT_KLIBC_USING_LIBC_MEMMOVE) || \
-    defined(RT_KLIBC_USING_LIBC_MEMCMP) || \
-    defined(RT_KLIBC_USING_LIBC_STRSTR) || \
+    defined(RT_KLIBC_USING_LIBC_MEMCMP) ||  \
+    defined(RT_KLIBC_USING_LIBC_STRSTR) ||  \
     defined(RT_KLIBC_USING_LIBC_STRNCPY) || \
-    defined(RT_KLIBC_USING_LIBC_STRCPY) || \
+    defined(RT_KLIBC_USING_LIBC_STRCPY) ||  \
     defined(RT_KLIBC_USING_LIBC_STRNCMP) || \
-    defined(RT_KLIBC_USING_LIBC_STRCMP) || \
+    defined(RT_KLIBC_USING_LIBC_STRCMP) ||  \
     defined(RT_KLIBC_USING_LIBC_STRLEN)
 #include <string.h>
 #endif
@@ -49,9 +49,9 @@ void *rt_memset(void *s, int c, size_t count)
     return s;
 #else
 
-#define LBLOCKSIZE      (sizeof(rt_ubase_t))
-#define UNALIGNED(X)    ((long)X & (LBLOCKSIZE - 1))
-#define TOO_SMALL(LEN)  ((LEN) < LBLOCKSIZE)
+#define LBLOCKSIZE     (sizeof(rt_ubase_t))
+#define UNALIGNED(X)   ((long)X & (LBLOCKSIZE - 1))
+#define TOO_SMALL(LEN) ((LEN) < LBLOCKSIZE)
 
     unsigned int i = 0;
     char *m = (char *)s;
@@ -72,7 +72,7 @@ void *rt_memset(void *s, int c, size_t count)
          */
         for (i = 0; i < LBLOCKSIZE; i++)
         {
-            *(((unsigned char *)&buffer)+i) = d;
+            *(((unsigned char *)&buffer) + i) = d;
         }
 
         while (count >= LBLOCKSIZE * 4)
@@ -132,11 +132,11 @@ void *rt_memcpy(void *dst, const void *src, size_t count)
     if (tmp <= s || tmp > (s + count))
     {
         while (count--)
-            *tmp ++ = *s ++;
+            *tmp++ = *s++;
     }
     else
     {
-        for (len = count; len > 0; len --)
+        for (len = count; len > 0; len--)
             tmp[len - 1] = s[len - 1];
     }
 
@@ -144,9 +144,9 @@ void *rt_memcpy(void *dst, const void *src, size_t count)
 #else
 
 #define UNALIGNED(X, Y) \
-    (((long)X & (sizeof (long) - 1)) | ((long)Y & (sizeof (long) - 1)))
-#define BIGBLOCKSIZE    (sizeof (long) << 2)
-#define LITTLEBLOCKSIZE (sizeof (long))
+    (((long)X & (sizeof(long) - 1)) | ((long)Y & (sizeof(long) - 1)))
+#define BIGBLOCKSIZE    (sizeof(long) << 2)
+#define LITTLEBLOCKSIZE (sizeof(long))
 #define TOO_SMALL(LEN)  ((LEN) < BIGBLOCKSIZE)
 
     char *dst_ptr = (char *)dst;
@@ -298,13 +298,13 @@ char *rt_strstr(const char *s1, const char *s2)
     l1 = rt_strlen(s1);
     while (l1 >= l2)
     {
-        l1 --;
+        l1--;
         if (!rt_memcmp(s1, s2, l2))
         {
             return (char *)s1;
         }
 
-        s1 ++;
+        s1++;
     }
 
     return RT_NULL;
@@ -338,8 +338,7 @@ int rt_strcasecmp(const char *a, const char *b)
             ca += 'a' - 'A';
         if (cb >= 'A' && cb <= 'Z')
             cb += 'a' - 'A';
-    }
-    while (ca == cb && ca != '\0');
+    } while (ca == cb && ca != '\0');
 
     return ca - cb;
 }
@@ -450,9 +449,9 @@ int rt_strncmp(const char *cs, const char *ct, size_t count)
             break;
         }
 
-        cs ++;
-        ct ++;
-        count --;
+        cs++;
+        ct++;
+        count--;
     }
 
     return res;
@@ -506,7 +505,8 @@ size_t rt_strlen(const char *s)
     return strlen(s);
 #else
     const char *sc = RT_NULL;
-    for (sc = s; *sc != '\0'; ++sc);
+    for (sc = s; *sc != '\0'; ++sc)
+        ;
     return sc - s;
 #endif /* RT_KLIBC_USING_LIBC_STRLEN */
 }
@@ -530,7 +530,8 @@ RTM_EXPORT(rt_strlen);
 size_t rt_strnlen(const char *s, size_t maxlen)
 {
     const char *sc;
-    for (sc = s; *sc != '\0' && (size_t)(sc - s) < maxlen; ++sc);
+    for (sc = s; *sc != '\0' && (size_t)(sc - s) < maxlen; ++sc)
+        ;
     return sc - s;
 }
 #endif /* RT_KLIBC_USING_USER_STRNLEN */

--- a/src/klibc/rt_vsnprintf_tiny.c
+++ b/src/klibc/rt_vsnprintf_tiny.c
@@ -252,15 +252,21 @@ static char *print_number(char *buf,
         ++ buf;
     }
 
-    /* put number in the temporary buffer */
-    while (i-- > 0 && (precision_bak != 0))
+    /* put number in the temporary buffer.
+     * A precision of zero suppresses only the value zero. Non-zero values
+     * must still be emitted, for example "%.0d" with 5 should print "5".
+     */
+    if (!(precision_bak == 0 && i == 1 && tmp[0] == '0'))
     {
-        if (buf < end)
+        while (i-- > 0)
         {
-            *buf = tmp[i];
-        }
+            if (buf < end)
+            {
+                *buf = tmp[i];
+            }
 
-        ++ buf;
+            ++ buf;
+        }
     }
 
     while (size-- > 0)
@@ -451,9 +457,9 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
                 s = "(null)";
             }
 
-            for (len = 0; (len != field_width) && (s[len] != '\0'); len++);
+            for (len = 0; s[len] != '\0'; len++);
 
-            if (precision > 0 && len > precision)
+            if (precision >= 0 && len > precision)
             {
                 len = precision;
             }

--- a/src/klibc/rt_vsnprintf_tiny.c
+++ b/src/klibc/rt_vsnprintf_tiny.c
@@ -10,7 +10,7 @@
 
 #include <rtthread.h>
 
-#define _ISDIGIT(c)  ((unsigned)((c) - '0') < 10)
+#define _ISDIGIT(c) ((unsigned)((c) - '0') < 10)
 
 /**
  * @brief  This function will duplicate a string.
@@ -50,32 +50,32 @@ rt_inline int skip_atoi(const char **s)
     return i;
 }
 
-#define ZEROPAD     (1 << 0)    /* pad with zero */
-#define SIGN        (1 << 1)    /* unsigned/signed long */
-#define PLUS        (1 << 2)    /* show plus */
-#define SPACE       (1 << 3)    /* space if plus */
-#define LEFT        (1 << 4)    /* left justified */
-#define SPECIAL     (1 << 5)    /* 0x */
-#define LARGE       (1 << 6)    /* use 'ABCDEF' instead of 'abcdef' */
+#define ZEROPAD (1 << 0)    /* pad with zero */
+#define SIGN    (1 << 1)    /* unsigned/signed long */
+#define PLUS    (1 << 2)    /* show plus */
+#define SPACE   (1 << 3)    /* space if plus */
+#define LEFT    (1 << 4)    /* left justified */
+#define SPECIAL (1 << 5)    /* 0x */
+#define LARGE   (1 << 6)    /* use 'ABCDEF' instead of 'abcdef' */
 
 static char *print_number(char *buf,
                           char *end,
 #ifdef RT_KLIBC_USING_VSNPRINTF_LONGLONG
-                          unsigned long long  num,
+                          unsigned long long num,
 #else
-                          unsigned long  num,
+                          unsigned long num,
 #endif /* RT_KLIBC_USING_VSNPRINTF_LONGLONG */
-                          int   base,
-                          int   qualifier,
-                          int   s,
-                          int   precision,
-                          int   type)
+                          int base,
+                          int qualifier,
+                          int s,
+                          int precision,
+                          int type)
 {
     char c = 0, sign = 0;
 #ifdef RT_KLIBC_USING_VSNPRINTF_LONGLONG
-    char tmp[64] = {0};
+    char tmp[64] = { 0 };
 #else
-    char tmp[32] = {0};
+    char tmp[32] = { 0 };
 #endif /* RT_KLIBC_USING_VSNPRINTF_LONGLONG */
     int precision_bak = precision;
     const char *digits = RT_NULL;
@@ -181,7 +181,7 @@ static char *print_number(char *buf,
                 *buf = ' ';
             }
 
-            ++ buf;
+            ++buf;
         }
     }
 
@@ -191,8 +191,8 @@ static char *print_number(char *buf,
         {
             *buf = sign;
         }
-        -- size;
-        ++ buf;
+        --size;
+        ++buf;
     }
 
     if (type & SPECIAL)
@@ -201,16 +201,16 @@ static char *print_number(char *buf,
         {
             if (buf < end)
                 *buf = '0';
-            ++ buf;
+            ++buf;
             if (buf < end)
                 *buf = 'b';
-            ++ buf;
+            ++buf;
         }
         else if (base == 8)
         {
             if (buf < end)
                 *buf = '0';
-            ++ buf;
+            ++buf;
         }
         else if (base == 16)
         {
@@ -219,12 +219,12 @@ static char *print_number(char *buf,
                 *buf = '0';
             }
 
-            ++ buf;
+            ++buf;
             if (buf < end)
             {
                 *buf = type & LARGE ? 'X' : 'x';
             }
-            ++ buf;
+            ++buf;
         }
     }
 
@@ -238,7 +238,7 @@ static char *print_number(char *buf,
                 *buf = c;
             }
 
-            ++ buf;
+            ++buf;
         }
     }
 
@@ -249,7 +249,7 @@ static char *print_number(char *buf,
             *buf = '0';
         }
 
-        ++ buf;
+        ++buf;
     }
 
     /* put number in the temporary buffer.
@@ -265,7 +265,7 @@ static char *print_number(char *buf,
                 *buf = tmp[i];
             }
 
-            ++ buf;
+            ++buf;
         }
     }
 
@@ -276,7 +276,7 @@ static char *print_number(char *buf,
             *buf = ' ';
         }
 
-        ++ buf;
+        ++buf;
     }
 
     return buf;
@@ -324,11 +324,11 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
     /* Make sure end is always >= buf */
     if (end < buf)
     {
-        end  = ((char *) - 1);
+        end = ((char *)-1);
         size = end - buf;
     }
 
-    for (; *fmt ; ++fmt)
+    for (; *fmt; ++fmt)
     {
         if (*fmt != '%')
         {
@@ -337,7 +337,7 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
                 *str = *fmt;
             }
 
-            ++ str;
+            ++str;
             continue;
         }
 
@@ -348,12 +348,18 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
         {
             /* skips the first '%' also */
             ++fmt;
-            if (*fmt == '-') flags |= LEFT;
-            else if (*fmt == '+') flags |= PLUS;
-            else if (*fmt == ' ') flags |= SPACE;
-            else if (*fmt == '#') flags |= SPECIAL;
-            else if (*fmt == '0') flags |= ZEROPAD;
-            else break;
+            if (*fmt == '-')
+                flags |= LEFT;
+            else if (*fmt == '+')
+                flags |= PLUS;
+            else if (*fmt == ' ')
+                flags |= SPACE;
+            else if (*fmt == '#')
+                flags |= SPECIAL;
+            else if (*fmt == '0')
+                flags |= ZEROPAD;
+            else
+                break;
         }
 
         /* get field width */
@@ -429,8 +435,9 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
             {
                 while (--field_width > 0)
                 {
-                    if (str < end) *str = ' ';
-                    ++ str;
+                    if (str < end)
+                        *str = ' ';
+                    ++str;
                 }
             }
 
@@ -440,13 +447,14 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
             {
                 *str = c;
             }
-            ++ str;
+            ++str;
 
             /* put width */
             while (--field_width > 0)
             {
-                if (str < end) *str = ' ';
-                ++ str;
+                if (str < end)
+                    *str = ' ';
+                ++str;
             }
             continue;
 
@@ -457,7 +465,8 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
                 s = "(null)";
             }
 
-            for (len = 0; s[len] != '\0'; len++);
+            for (len = 0; s[len] != '\0'; len++)
+                ;
 
             if (precision >= 0 && len > precision)
             {
@@ -468,22 +477,25 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
             {
                 while (len < field_width--)
                 {
-                    if (str < end) *str = ' ';
-                    ++ str;
+                    if (str < end)
+                        *str = ' ';
+                    ++str;
                 }
             }
 
             for (i = 0; i < len; ++i)
             {
-                if (str < end) *str = *s;
-                ++ str;
-                ++ s;
+                if (str < end)
+                    *str = *s;
+                ++str;
+                ++s;
             }
 
             while (len < field_width--)
             {
-                if (str < end) *str = ' ';
-                ++ str;
+                if (str < end)
+                    *str = ' ';
+                ++str;
             }
             continue;
 
@@ -504,7 +516,7 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
             {
                 *str = '%';
             }
-            ++ str;
+            ++str;
             continue;
 
         /* integer number formats - set up the flags and "break" */
@@ -539,7 +551,7 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
             {
                 *str = '%';
             }
-            ++ str;
+            ++str;
 
             if (*fmt)
             {
@@ -547,11 +559,11 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
                 {
                     *str = *fmt;
                 }
-                ++ str;
+                ++str;
             }
             else
             {
-                -- fmt;
+                --fmt;
             }
             continue;
         }

--- a/src/klibc/utest/TC_rt_sprintf.c
+++ b/src/klibc/utest/TC_rt_sprintf.c
@@ -985,6 +985,29 @@ SPRINTF_TEST_CASE(string_length)
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
 }
 
+
+SPRINTF_TEST_CASE(string_precision_zero_and_width)
+{
+    char buffer[base_buffer_size];
+
+    /* Width specifies the minimum field width and must not truncate strings. */
+    SPRINTF_CHECK("abcdefgh",                buffer, "%5s", "abcdefgh");
+
+    /* A string precision of zero means no characters are written. */
+    SPRINTF_CHECK("",                        buffer, "%.0s", "abc");
+    SPRINTF_CHECK("",                        buffer, "%.s", "abc");
+}
+
+SPRINTF_TEST_CASE(integer_precision_zero_nonzero)
+{
+    char buffer[base_buffer_size];
+
+    /* Precision zero suppresses only the zero value; non-zero values are printed. */
+    SPRINTF_CHECK("",                        buffer, "%.0d", 0);
+    SPRINTF_CHECK("5",                       buffer, "%.0d", 5);
+    SPRINTF_CHECK("-5",                      buffer, "%.0d", -5);
+}
+
 SPRINTF_TEST_CASE(misc)
 {
     char buffer[base_buffer_size];
@@ -1059,6 +1082,8 @@ static void utest_do_tc(void)
     UTEST_UNIT_RUN(SPRINTF_TEST_CASE_NAME(types__non_standard_format));
     UTEST_UNIT_RUN(SPRINTF_TEST_CASE_NAME(pointer));
     UTEST_UNIT_RUN(SPRINTF_TEST_CASE_NAME(string_length));
+    UTEST_UNIT_RUN(SPRINTF_TEST_CASE_NAME(string_precision_zero_and_width));
+    UTEST_UNIT_RUN(SPRINTF_TEST_CASE_NAME(integer_precision_zero_nonzero));
     UTEST_UNIT_RUN(SPRINTF_TEST_CASE_NAME(misc));
 }
 

--- a/src/klibc/utest/TC_rt_sprintf.c
+++ b/src/klibc/utest/TC_rt_sprintf.c
@@ -60,156 +60,157 @@ extremal_unsigned_integer_values
 
 #define base_buffer_size 100
 
-#define SPRINTF_CHECK(expected, buffer, format, ...)  \
-do {                                                  \
-    rt_memset(buffer, 0xCC, base_buffer_size);        \
-    rt_sprintf(buffer, format, ##__VA_ARGS__);        \
-    uassert_str_equal(expected, buffer);              \
-} while (0)
+#define SPRINTF_CHECK(expected, buffer, format, ...) \
+    do                                               \
+    {                                                \
+        rt_memset(buffer, 0xCC, base_buffer_size);   \
+        rt_sprintf(buffer, format, ##__VA_ARGS__);   \
+        uassert_str_equal(expected, buffer);         \
+    } while (0)
 
 #define SPRINTF_TEST_CASE_NAME(testname) TC_##testname
-#define SPRINTF_TEST_CASE(testname) static void SPRINTF_TEST_CASE_NAME(testname)(void)
+#define SPRINTF_TEST_CASE(testname)      static void SPRINTF_TEST_CASE_NAME(testname)(void)
 
 SPRINTF_TEST_CASE(space_flag)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK(" 42",                     buffer, "% d", 42);
-    SPRINTF_CHECK("-42",                     buffer, "% d", -42);
-    SPRINTF_CHECK("   42",                   buffer, "% 5d", 42);
-    SPRINTF_CHECK("  -42",                   buffer, "% 5d", -42);
-    SPRINTF_CHECK("             42",         buffer, "% 15d", 42);
-    SPRINTF_CHECK("            -42",         buffer, "% 15d", -42);
-    SPRINTF_CHECK("            -42",         buffer, "% 15d", -42);
+    SPRINTF_CHECK(" 42", buffer, "% d", 42);
+    SPRINTF_CHECK("-42", buffer, "% d", -42);
+    SPRINTF_CHECK("   42", buffer, "% 5d", 42);
+    SPRINTF_CHECK("  -42", buffer, "% 5d", -42);
+    SPRINTF_CHECK("             42", buffer, "% 15d", 42);
+    SPRINTF_CHECK("            -42", buffer, "% 15d", -42);
+    SPRINTF_CHECK("            -42", buffer, "% 15d", -42);
 #ifdef RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS
-    SPRINTF_CHECK("        -42.987",         buffer, "% 15.3f", -42.987);
-    SPRINTF_CHECK("         42.987",         buffer, "% 15.3f", 42.987);
+    SPRINTF_CHECK("        -42.987", buffer, "% 15.3f", -42.987);
+    SPRINTF_CHECK("         42.987", buffer, "% 15.3f", 42.987);
 #endif
-    SPRINTF_CHECK(" 1024",                   buffer, "% d", 1024);
-    SPRINTF_CHECK("-1024",                   buffer, "% d", -1024);
-    SPRINTF_CHECK(" 1024",                   buffer, "% i", 1024);
-    SPRINTF_CHECK("-1024",                   buffer, "% i", -1024);
+    SPRINTF_CHECK(" 1024", buffer, "% d", 1024);
+    SPRINTF_CHECK("-1024", buffer, "% d", -1024);
+    SPRINTF_CHECK(" 1024", buffer, "% i", 1024);
+    SPRINTF_CHECK("-1024", buffer, "% i", -1024);
 }
 
 SPRINTF_TEST_CASE(space_flag__non_standard_format)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("Hello testing",           buffer, "% s", "Hello testing");
-    SPRINTF_CHECK("1024",                    buffer, "% u", 1024);
+    SPRINTF_CHECK("Hello testing", buffer, "% s", "Hello testing");
+    SPRINTF_CHECK("1024", buffer, "% u", 1024);
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("1024",                    buffer, "% I16u", (uint16_t) 1024);
-    SPRINTF_CHECK("1024",                    buffer, "% I32u", (uint32_t) 1024);
-    SPRINTF_CHECK("1024",                    buffer, "% I64u", (uint64_t) 1024);
+    SPRINTF_CHECK("1024", buffer, "% I16u", (uint16_t)1024);
+    SPRINTF_CHECK("1024", buffer, "% I32u", (uint32_t)1024);
+    SPRINTF_CHECK("1024", buffer, "% I64u", (uint64_t)1024);
 #endif
-    SPRINTF_CHECK("4294966272",              buffer, "% u", 4294966272U);
+    SPRINTF_CHECK("4294966272", buffer, "% u", 4294966272U);
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("4294966272",              buffer, "% I32u", (uint32_t) 4294966272U);
-    SPRINTF_CHECK("4294966272",              buffer, "% I64u", (uint64_t) 4294966272U);
+    SPRINTF_CHECK("4294966272", buffer, "% I32u", (uint32_t)4294966272U);
+    SPRINTF_CHECK("4294966272", buffer, "% I64u", (uint64_t)4294966272U);
 #endif
-    SPRINTF_CHECK("777",                     buffer, "% o", 511);
-    SPRINTF_CHECK("37777777001",             buffer, "% o", 4294966785U);
-    SPRINTF_CHECK("1234abcd",                buffer, "% x", 305441741);
-    SPRINTF_CHECK("edcb5433",                buffer, "% x", 3989525555U);
-    SPRINTF_CHECK("1234ABCD",                buffer, "% X", 305441741);
-    SPRINTF_CHECK("EDCB5433",                buffer, "% X", 3989525555U);
-    SPRINTF_CHECK("x",                       buffer, "% c", 'x');
+    SPRINTF_CHECK("777", buffer, "% o", 511);
+    SPRINTF_CHECK("37777777001", buffer, "% o", 4294966785U);
+    SPRINTF_CHECK("1234abcd", buffer, "% x", 305441741);
+    SPRINTF_CHECK("edcb5433", buffer, "% x", 3989525555U);
+    SPRINTF_CHECK("1234ABCD", buffer, "% X", 305441741);
+    SPRINTF_CHECK("EDCB5433", buffer, "% X", 3989525555U);
+    SPRINTF_CHECK("x", buffer, "% c", 'x');
 }
 
 SPRINTF_TEST_CASE(plus_flag)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("+42",                     buffer, "%+d", 42);
-    SPRINTF_CHECK("-42",                     buffer, "%+d", -42);
-    SPRINTF_CHECK("  +42",                   buffer, "%+5d", 42);
-    SPRINTF_CHECK("  -42",                   buffer, "%+5d", -42);
-    SPRINTF_CHECK("            +42",         buffer, "%+15d", 42);
-    SPRINTF_CHECK("            -42",         buffer, "%+15d", -42);
-    SPRINTF_CHECK("+1024",                   buffer, "%+d", 1024);
-    SPRINTF_CHECK("-1024",                   buffer, "%+d", -1024);
-    SPRINTF_CHECK("+1024",                   buffer, "%+i", 1024);
-    SPRINTF_CHECK("-1024",                   buffer, "%+i", -1024);
+    SPRINTF_CHECK("+42", buffer, "%+d", 42);
+    SPRINTF_CHECK("-42", buffer, "%+d", -42);
+    SPRINTF_CHECK("  +42", buffer, "%+5d", 42);
+    SPRINTF_CHECK("  -42", buffer, "%+5d", -42);
+    SPRINTF_CHECK("            +42", buffer, "%+15d", 42);
+    SPRINTF_CHECK("            -42", buffer, "%+15d", -42);
+    SPRINTF_CHECK("+1024", buffer, "%+d", 1024);
+    SPRINTF_CHECK("-1024", buffer, "%+d", -1024);
+    SPRINTF_CHECK("+1024", buffer, "%+i", 1024);
+    SPRINTF_CHECK("-1024", buffer, "%+i", -1024);
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("+1024",                   buffer, "%+I16d", (int16_t) 1024);
-    SPRINTF_CHECK("-1024",                   buffer, "%+I16d", (int16_t) -1024);
-    SPRINTF_CHECK("+1024",                   buffer, "%+I32d", (int32_t) 1024);
-    SPRINTF_CHECK("-1024",                   buffer, "%+I32d", (int32_t) -1024);
-    SPRINTF_CHECK("+1024",                   buffer, "%+I64d", (int64_t) 1024);
-    SPRINTF_CHECK("-1024",                   buffer, "%+I64d", (int64_t) -1024);
+    SPRINTF_CHECK("+1024", buffer, "%+I16d", (int16_t)1024);
+    SPRINTF_CHECK("-1024", buffer, "%+I16d", (int16_t)-1024);
+    SPRINTF_CHECK("+1024", buffer, "%+I32d", (int32_t)1024);
+    SPRINTF_CHECK("-1024", buffer, "%+I32d", (int32_t)-1024);
+    SPRINTF_CHECK("+1024", buffer, "%+I64d", (int64_t)1024);
+    SPRINTF_CHECK("-1024", buffer, "%+I64d", (int64_t)-1024);
 #endif
-    SPRINTF_CHECK("+",                       buffer, "%+.0d", 0);
+    SPRINTF_CHECK("+", buffer, "%+.0d", 0);
 }
 
 SPRINTF_TEST_CASE(plus_flag__non_standard_format)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("Hello testing",           buffer, "%+s", "Hello testing");
-    SPRINTF_CHECK("1024",                    buffer, "%+u", 1024);
+    SPRINTF_CHECK("Hello testing", buffer, "%+s", "Hello testing");
+    SPRINTF_CHECK("1024", buffer, "%+u", 1024);
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("1024",                    buffer, "%+I32u", (uint32_t) 1024);
+    SPRINTF_CHECK("1024", buffer, "%+I32u", (uint32_t)1024);
 #endif
-    SPRINTF_CHECK("4294966272",              buffer, "%+u", 4294966272U);
+    SPRINTF_CHECK("4294966272", buffer, "%+u", 4294966272U);
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("4294966272",              buffer, "%+I32u", (uint32_t) 4294966272U);
+    SPRINTF_CHECK("4294966272", buffer, "%+I32u", (uint32_t)4294966272U);
 #endif
-    SPRINTF_CHECK("777",                     buffer, "%+o", 511);
-    SPRINTF_CHECK("37777777001",             buffer, "%+o", 4294966785U);
-    SPRINTF_CHECK("1234abcd",                buffer, "%+x", 305441741);
-    SPRINTF_CHECK("edcb5433",                buffer, "%+x", 3989525555U);
-    SPRINTF_CHECK("1234ABCD",                buffer, "%+X", 305441741);
-    SPRINTF_CHECK("EDCB5433",                buffer, "%+X", 3989525555U);
-    SPRINTF_CHECK("x",                       buffer, "%+c", 'x');
+    SPRINTF_CHECK("777", buffer, "%+o", 511);
+    SPRINTF_CHECK("37777777001", buffer, "%+o", 4294966785U);
+    SPRINTF_CHECK("1234abcd", buffer, "%+x", 305441741);
+    SPRINTF_CHECK("edcb5433", buffer, "%+x", 3989525555U);
+    SPRINTF_CHECK("1234ABCD", buffer, "%+X", 305441741);
+    SPRINTF_CHECK("EDCB5433", buffer, "%+X", 3989525555U);
+    SPRINTF_CHECK("x", buffer, "%+c", 'x');
 }
 
 SPRINTF_TEST_CASE(zero_flag)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("42",                      buffer, "%0d", 42);
-    SPRINTF_CHECK("42",                      buffer, "%0ld", 42L);
-    SPRINTF_CHECK("-42",                     buffer, "%0d", -42);
-    SPRINTF_CHECK("00042",                   buffer, "%05d", 42);
-    SPRINTF_CHECK("-0042",                   buffer, "%05d", -42);
-    SPRINTF_CHECK("000000000000042",         buffer, "%015d", 42);
-    SPRINTF_CHECK("-00000000000042",         buffer, "%015d", -42);
+    SPRINTF_CHECK("42", buffer, "%0d", 42);
+    SPRINTF_CHECK("42", buffer, "%0ld", 42L);
+    SPRINTF_CHECK("-42", buffer, "%0d", -42);
+    SPRINTF_CHECK("00042", buffer, "%05d", 42);
+    SPRINTF_CHECK("-0042", buffer, "%05d", -42);
+    SPRINTF_CHECK("000000000000042", buffer, "%015d", 42);
+    SPRINTF_CHECK("-00000000000042", buffer, "%015d", -42);
 #ifdef RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS
-    SPRINTF_CHECK("000000000042.12",         buffer, "%015.2f", 42.1234);
-    SPRINTF_CHECK("00000000042.988",         buffer, "%015.3f", 42.9876);
-    SPRINTF_CHECK("-00000042.98760",         buffer, "%015.5f", -42.9876);
+    SPRINTF_CHECK("000000000042.12", buffer, "%015.2f", 42.1234);
+    SPRINTF_CHECK("00000000042.988", buffer, "%015.3f", 42.9876);
+    SPRINTF_CHECK("-00000042.98760", buffer, "%015.5f", -42.9876);
 #endif
 }
 
 SPRINTF_TEST_CASE(minus_flag)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("42",                      buffer, "%-d", 42);
-    SPRINTF_CHECK("-42",                     buffer, "%-d", -42);
-    SPRINTF_CHECK("42   ",                   buffer, "%-5d", 42);
-    SPRINTF_CHECK("-42  ",                   buffer, "%-5d", -42);
-    SPRINTF_CHECK("42             ",         buffer, "%-15d", 42);
-    SPRINTF_CHECK("-42            ",         buffer, "%-15d", -42);
+    SPRINTF_CHECK("42", buffer, "%-d", 42);
+    SPRINTF_CHECK("-42", buffer, "%-d", -42);
+    SPRINTF_CHECK("42   ", buffer, "%-5d", 42);
+    SPRINTF_CHECK("-42  ", buffer, "%-5d", -42);
+    SPRINTF_CHECK("42             ", buffer, "%-15d", 42);
+    SPRINTF_CHECK("-42            ", buffer, "%-15d", -42);
 }
 
 SPRINTF_TEST_CASE(minus_flag_and_non_standard_zero_modifier_for_integers)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("42",                      buffer, "%-0d", 42);
-    SPRINTF_CHECK("-42",                     buffer, "%-0d", -42);
-    SPRINTF_CHECK("42   ",                   buffer, "%-05d", 42);
-    SPRINTF_CHECK("-42  ",                   buffer, "%-05d", -42);
-    SPRINTF_CHECK("42             ",         buffer, "%-015d", 42);
-    SPRINTF_CHECK("-42            ",         buffer, "%-015d", -42);
-    SPRINTF_CHECK("42",                      buffer, "%0-d", 42);
-    SPRINTF_CHECK("-42",                     buffer, "%0-d", -42);
-    SPRINTF_CHECK("42   ",                   buffer, "%0-5d", 42);
-    SPRINTF_CHECK("-42  ",                   buffer, "%0-5d", -42);
-    SPRINTF_CHECK("42             ",         buffer, "%0-15d", 42);
-    SPRINTF_CHECK("-42            ",         buffer, "%0-15d", -42);
+    SPRINTF_CHECK("42", buffer, "%-0d", 42);
+    SPRINTF_CHECK("-42", buffer, "%-0d", -42);
+    SPRINTF_CHECK("42   ", buffer, "%-05d", 42);
+    SPRINTF_CHECK("-42  ", buffer, "%-05d", -42);
+    SPRINTF_CHECK("42             ", buffer, "%-015d", 42);
+    SPRINTF_CHECK("-42            ", buffer, "%-015d", -42);
+    SPRINTF_CHECK("42", buffer, "%0-d", 42);
+    SPRINTF_CHECK("-42", buffer, "%0-d", -42);
+    SPRINTF_CHECK("42   ", buffer, "%0-5d", 42);
+    SPRINTF_CHECK("-42  ", buffer, "%0-5d", -42);
+    SPRINTF_CHECK("42             ", buffer, "%0-15d", 42);
+    SPRINTF_CHECK("-42            ", buffer, "%0-15d", -42);
 
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
 #ifdef RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS
-    SPRINTF_CHECK("-4.200e+01     ",         buffer, "%0-15.3e", -42.);
-    SPRINTF_CHECK("-42            ",         buffer, "%0-15.3g", -42.);
+    SPRINTF_CHECK("-4.200e+01     ", buffer, "%0-15.3e", -42.);
+    SPRINTF_CHECK("-42            ", buffer, "%0-15.3g", -42.);
 #else
-    SPRINTF_CHECK("e",                       buffer, "%0-15.3e", -42.);
-    SPRINTF_CHECK("g",                       buffer,  "%0-15.3g", -42.);
+    SPRINTF_CHECK("e", buffer, "%0-15.3e", -42.);
+    SPRINTF_CHECK("g", buffer, "%0-15.3g", -42.);
 #endif /* RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS */
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
 }
@@ -218,41 +219,41 @@ SPRINTF_TEST_CASE(sharp_flag)
 {
     char buffer[base_buffer_size];
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("0",                       buffer, "%#o",   0);
-    SPRINTF_CHECK("0",                       buffer, "%#0o",  0);
+    SPRINTF_CHECK("0", buffer, "%#o", 0);
+    SPRINTF_CHECK("0", buffer, "%#0o", 0);
 #endif
-    SPRINTF_CHECK("0",                       buffer, "%#.0o", 0);
+    SPRINTF_CHECK("0", buffer, "%#.0o", 0);
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("0",                       buffer, "%#.1o", 0);
-    SPRINTF_CHECK("   0",                    buffer, "%#4o",  0);
-    SPRINTF_CHECK("0000",                    buffer, "%#.4o", 0);
+    SPRINTF_CHECK("0", buffer, "%#.1o", 0);
+    SPRINTF_CHECK("   0", buffer, "%#4o", 0);
+    SPRINTF_CHECK("0000", buffer, "%#.4o", 0);
 #endif
-    SPRINTF_CHECK("01",                      buffer, "%#o",   1);
-    SPRINTF_CHECK("01",                      buffer, "%#0o",  1);
+    SPRINTF_CHECK("01", buffer, "%#o", 1);
+    SPRINTF_CHECK("01", buffer, "%#0o", 1);
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("01",                      buffer, "%#.0o", 1);
+    SPRINTF_CHECK("01", buffer, "%#.0o", 1);
 #endif
-    SPRINTF_CHECK("01",                      buffer, "%#.1o", 1);
-    SPRINTF_CHECK("  01",                    buffer, "%#4o",  1);
+    SPRINTF_CHECK("01", buffer, "%#.1o", 1);
+    SPRINTF_CHECK("  01", buffer, "%#4o", 1);
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("0001",                    buffer, "%#.4o", 1);
+    SPRINTF_CHECK("0001", buffer, "%#.4o", 1);
 #endif
-    SPRINTF_CHECK("0x1001",                  buffer, "%#04x", 0x1001);
-    SPRINTF_CHECK("01001",                   buffer, "%#04o", 01001);
+    SPRINTF_CHECK("0x1001", buffer, "%#04x", 0x1001);
+    SPRINTF_CHECK("01001", buffer, "%#04o", 01001);
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("",                        buffer, "%#.0x", 0);
+    SPRINTF_CHECK("", buffer, "%#.0x", 0);
 #endif
-    SPRINTF_CHECK("0x0000614e",              buffer, "%#.8x", 0x614e);
+    SPRINTF_CHECK("0x0000614e", buffer, "%#.8x", 0x614e);
 }
 
 SPRINTF_TEST_CASE(sharp_flag__non_standard_format)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("0b110",                   buffer, "%#b",    6);
-    SPRINTF_CHECK("0b11111111",              buffer, "%#010b", 0xff);
-    SPRINTF_CHECK("0b011111111",             buffer, "%#011b", 0xff);
-    SPRINTF_CHECK("077",                     buffer, "%#03o",  077);
-    SPRINTF_CHECK("0077",                    buffer, "%#04o",  077);
+    SPRINTF_CHECK("0b110", buffer, "%#b", 6);
+    SPRINTF_CHECK("0b11111111", buffer, "%#010b", 0xff);
+    SPRINTF_CHECK("0b011111111", buffer, "%#011b", 0xff);
+    SPRINTF_CHECK("077", buffer, "%#03o", 077);
+    SPRINTF_CHECK("0077", buffer, "%#04o", 077);
 }
 
 #ifdef RT_KLIBC_USING_VSNPRINTF_LONGLONG
@@ -260,72 +261,72 @@ SPRINTF_TEST_CASE(sharp_flag_with_long_long)
 {
     char buffer[base_buffer_size];
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("0",                       buffer, "%#llo",   (long long) 0);
-    SPRINTF_CHECK("0",                       buffer, "%#0llo",  (long long) 0);
+    SPRINTF_CHECK("0", buffer, "%#llo", (long long)0);
+    SPRINTF_CHECK("0", buffer, "%#0llo", (long long)0);
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
-    SPRINTF_CHECK("0",                       buffer, "%#.0llo", (long long) 0);
+    SPRINTF_CHECK("0", buffer, "%#.0llo", (long long)0);
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("0",                       buffer, "%#.1llo", (long long) 0);
-    SPRINTF_CHECK("   0",                    buffer, "%#4llo",  (long long) 0);
-    SPRINTF_CHECK("0000",                    buffer, "%#.4llo", (long long) 0);
+    SPRINTF_CHECK("0", buffer, "%#.1llo", (long long)0);
+    SPRINTF_CHECK("   0", buffer, "%#4llo", (long long)0);
+    SPRINTF_CHECK("0000", buffer, "%#.4llo", (long long)0);
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
-    SPRINTF_CHECK("01",                      buffer, "%#llo",   (long long) 1);
-    SPRINTF_CHECK("01",                      buffer, "%#0llo",  (long long) 1);
+    SPRINTF_CHECK("01", buffer, "%#llo", (long long)1);
+    SPRINTF_CHECK("01", buffer, "%#0llo", (long long)1);
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("01",                      buffer, "%#.0llo", (long long) 1);
+    SPRINTF_CHECK("01", buffer, "%#.0llo", (long long)1);
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
-    SPRINTF_CHECK("01",                      buffer, "%#.1llo", (long long) 1);
-    SPRINTF_CHECK("  01",                    buffer, "%#4llo",  (long long) 1);
+    SPRINTF_CHECK("01", buffer, "%#.1llo", (long long)1);
+    SPRINTF_CHECK("  01", buffer, "%#4llo", (long long)1);
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("0001",                    buffer, "%#.4llo", (long long) 1);
+    SPRINTF_CHECK("0001", buffer, "%#.4llo", (long long)1);
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
-    SPRINTF_CHECK("0x1001",                  buffer, "%#04llx", (long long) 0x1001);
-    SPRINTF_CHECK("01001",                   buffer, "%#04llo", (long long) 01001);
+    SPRINTF_CHECK("0x1001", buffer, "%#04llx", (long long)0x1001);
+    SPRINTF_CHECK("01001", buffer, "%#04llo", (long long)01001);
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("",                        buffer, "%#.0llx", (long long) 0);
+    SPRINTF_CHECK("", buffer, "%#.0llx", (long long)0);
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
-    SPRINTF_CHECK("0x0000614e",              buffer, "%#.8llx", (long long) 0x614e);
+    SPRINTF_CHECK("0x0000614e", buffer, "%#.8llx", (long long)0x614e);
 }
 
 SPRINTF_TEST_CASE(sharp_flag_with_long_long__non_standard_format)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("0b110",                   buffer, "%#llb", (long long) 6);
+    SPRINTF_CHECK("0b110", buffer, "%#llb", (long long)6);
 }
 #endif /* RT_KLIBC_USING_VSNPRINTF_LONGLONG */
 
 SPRINTF_TEST_CASE(specifier)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("Hello testing",           buffer, "Hello testing");
-    SPRINTF_CHECK("Hello testing",           buffer, "%s", "Hello testing");
-    SPRINTF_CHECK("(null)",                  buffer, "%s", (const char *) RT_NULL);
-    SPRINTF_CHECK("1024",                    buffer, "%d", 1024);
+    SPRINTF_CHECK("Hello testing", buffer, "Hello testing");
+    SPRINTF_CHECK("Hello testing", buffer, "%s", "Hello testing");
+    SPRINTF_CHECK("(null)", buffer, "%s", (const char *)RT_NULL);
+    SPRINTF_CHECK("1024", buffer, "%d", 1024);
 #if INT_MAX >= 2147483647LL
-    SPRINTF_CHECK("2147483647",              buffer, "%d", 2147483647);
-    SPRINTF_CHECK("4294966272",              buffer, "%u", 4294966272U);
-    SPRINTF_CHECK("37777777001",             buffer, "%o", 4294966785U);
-    SPRINTF_CHECK("1234abcd",                buffer, "%x", 305441741);
-    SPRINTF_CHECK("edcb5433",                buffer, "%x", 3989525555U);
-    SPRINTF_CHECK("1234ABCD",                buffer, "%X", 305441741);
-    SPRINTF_CHECK("EDCB5433",                buffer, "%X", 3989525555U);
+    SPRINTF_CHECK("2147483647", buffer, "%d", 2147483647);
+    SPRINTF_CHECK("4294966272", buffer, "%u", 4294966272U);
+    SPRINTF_CHECK("37777777001", buffer, "%o", 4294966785U);
+    SPRINTF_CHECK("1234abcd", buffer, "%x", 305441741);
+    SPRINTF_CHECK("edcb5433", buffer, "%x", 3989525555U);
+    SPRINTF_CHECK("1234ABCD", buffer, "%X", 305441741);
+    SPRINTF_CHECK("EDCB5433", buffer, "%X", 3989525555U);
 #endif
-    SPRINTF_CHECK("-1024",                   buffer, "%d", -1024);
-    SPRINTF_CHECK("1024",                    buffer, "%i", 1024);
-    SPRINTF_CHECK("-1024",                   buffer, "%i", -1024);
-    SPRINTF_CHECK("1024",                    buffer, "%u", 1024);
-    SPRINTF_CHECK("777",                     buffer, "%o", 511);
-    SPRINTF_CHECK("%",                       buffer, "%%");
+    SPRINTF_CHECK("-1024", buffer, "%d", -1024);
+    SPRINTF_CHECK("1024", buffer, "%i", 1024);
+    SPRINTF_CHECK("-1024", buffer, "%i", -1024);
+    SPRINTF_CHECK("1024", buffer, "%u", 1024);
+    SPRINTF_CHECK("777", buffer, "%o", 511);
+    SPRINTF_CHECK("%", buffer, "%%");
 
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("127",                     buffer, "%I8d", (int8_t) 127LL);
+    SPRINTF_CHECK("127", buffer, "%I8d", (int8_t)127LL);
 #if (SHRT_MAX >= 32767)
-    SPRINTF_CHECK("32767",                   buffer, "%I16d", (int16_t) 32767LL);
+    SPRINTF_CHECK("32767", buffer, "%I16d", (int16_t)32767LL);
 #endif
 #if (LLONG_MAX >= 2147483647)
-    SPRINTF_CHECK("2147483647",              buffer, "%I32d", (int32_t) 2147483647LL);
+    SPRINTF_CHECK("2147483647", buffer, "%I32d", (int32_t)2147483647LL);
 #if (LLONG_MAX >= 9223372036854775807LL)
-    SPRINTF_CHECK("9223372036854775807",     buffer, "%I64d", (int64_t) 9223372036854775807LL);
+    SPRINTF_CHECK("9223372036854775807", buffer, "%I64d", (int64_t)9223372036854775807LL);
 #endif
 #endif
 #endif /* RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS */
@@ -335,116 +336,116 @@ SPRINTF_TEST_CASE(width)
 {
     char buffer[base_buffer_size];
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("Hello testing",           buffer, "%1s", "Hello testing");
+    SPRINTF_CHECK("Hello testing", buffer, "%1s", "Hello testing");
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
-    SPRINTF_CHECK("1024",                    buffer, "%1d", 1024);
-    SPRINTF_CHECK("-1024",                   buffer, "%1d", -1024);
-    SPRINTF_CHECK("1024",                    buffer, "%1i", 1024);
-    SPRINTF_CHECK("-1024",                   buffer, "%1i", -1024);
-    SPRINTF_CHECK("1024",                    buffer, "%1u", 1024);
+    SPRINTF_CHECK("1024", buffer, "%1d", 1024);
+    SPRINTF_CHECK("-1024", buffer, "%1d", -1024);
+    SPRINTF_CHECK("1024", buffer, "%1i", 1024);
+    SPRINTF_CHECK("-1024", buffer, "%1i", -1024);
+    SPRINTF_CHECK("1024", buffer, "%1u", 1024);
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("1024",                    buffer, "%1I16u", (uint16_t) 1024);
-    SPRINTF_CHECK("1024",                    buffer, "%1I32u", (uint32_t) 1024);
-    SPRINTF_CHECK("1024",                    buffer, "%1I64u", (uint64_t) 1024);
+    SPRINTF_CHECK("1024", buffer, "%1I16u", (uint16_t)1024);
+    SPRINTF_CHECK("1024", buffer, "%1I32u", (uint32_t)1024);
+    SPRINTF_CHECK("1024", buffer, "%1I64u", (uint64_t)1024);
 #endif /* RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS */
-    SPRINTF_CHECK("4294966272",              buffer, "%1u", 4294966272U);
+    SPRINTF_CHECK("4294966272", buffer, "%1u", 4294966272U);
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("4294966272",              buffer, "%1I32u", (uint32_t) 4294966272U);
-    SPRINTF_CHECK("4294966272",              buffer, "%1I64u", (uint64_t) 4294966272U);
+    SPRINTF_CHECK("4294966272", buffer, "%1I32u", (uint32_t)4294966272U);
+    SPRINTF_CHECK("4294966272", buffer, "%1I64u", (uint64_t)4294966272U);
 #endif /* RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS */
-    SPRINTF_CHECK("777",                     buffer, "%1o", 511);
-    SPRINTF_CHECK("37777777001",             buffer, "%1o", 4294966785U);
-    SPRINTF_CHECK("1234abcd",                buffer, "%1x", 305441741);
-    SPRINTF_CHECK("edcb5433",                buffer, "%1x", 3989525555U);
-    SPRINTF_CHECK("1234ABCD",                buffer, "%1X", 305441741);
-    SPRINTF_CHECK("EDCB5433",                buffer, "%1X", 3989525555U);
-    SPRINTF_CHECK("x",                       buffer, "%1c", 'x');
+    SPRINTF_CHECK("777", buffer, "%1o", 511);
+    SPRINTF_CHECK("37777777001", buffer, "%1o", 4294966785U);
+    SPRINTF_CHECK("1234abcd", buffer, "%1x", 305441741);
+    SPRINTF_CHECK("edcb5433", buffer, "%1x", 3989525555U);
+    SPRINTF_CHECK("1234ABCD", buffer, "%1X", 305441741);
+    SPRINTF_CHECK("EDCB5433", buffer, "%1X", 3989525555U);
+    SPRINTF_CHECK("x", buffer, "%1c", 'x');
 }
 
 SPRINTF_TEST_CASE(width_20)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("               Hello",    buffer, "%20s", "Hello");
-    SPRINTF_CHECK("                1024",    buffer, "%20d", 1024);
-    SPRINTF_CHECK("               -1024",    buffer, "%20d", -1024);
-    SPRINTF_CHECK("                1024",    buffer, "%20i", 1024);
-    SPRINTF_CHECK("               -1024",    buffer, "%20i", -1024);
-    SPRINTF_CHECK("                   0",    buffer, "%20i", 0);
-    SPRINTF_CHECK("                1024",    buffer, "%20u", 1024);
+    SPRINTF_CHECK("               Hello", buffer, "%20s", "Hello");
+    SPRINTF_CHECK("                1024", buffer, "%20d", 1024);
+    SPRINTF_CHECK("               -1024", buffer, "%20d", -1024);
+    SPRINTF_CHECK("                1024", buffer, "%20i", 1024);
+    SPRINTF_CHECK("               -1024", buffer, "%20i", -1024);
+    SPRINTF_CHECK("                   0", buffer, "%20i", 0);
+    SPRINTF_CHECK("                1024", buffer, "%20u", 1024);
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("                1024",    buffer, "%20I16u", (uint16_t) 1024);
-    SPRINTF_CHECK("                1024",    buffer, "%20I32u", (uint32_t) 1024);
-    SPRINTF_CHECK("                1024",    buffer, "%20I64u", (uint64_t) 1024);
+    SPRINTF_CHECK("                1024", buffer, "%20I16u", (uint16_t)1024);
+    SPRINTF_CHECK("                1024", buffer, "%20I32u", (uint32_t)1024);
+    SPRINTF_CHECK("                1024", buffer, "%20I64u", (uint64_t)1024);
 #endif /* RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS */
-    SPRINTF_CHECK("          4294966272",    buffer, "%20u", 4294966272U);
+    SPRINTF_CHECK("          4294966272", buffer, "%20u", 4294966272U);
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("          4294966272",    buffer, "%20I32u", (uint32_t) 4294966272U);
-    SPRINTF_CHECK("          4294966272",    buffer, "%20I64u", (uint64_t) 4294966272U);
+    SPRINTF_CHECK("          4294966272", buffer, "%20I32u", (uint32_t)4294966272U);
+    SPRINTF_CHECK("          4294966272", buffer, "%20I64u", (uint64_t)4294966272U);
 #endif /* RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS */
-    SPRINTF_CHECK("                 777",    buffer, "%20o", 511);
-    SPRINTF_CHECK("         37777777001",    buffer, "%20o", 4294966785U);
-    SPRINTF_CHECK("            1234abcd",    buffer, "%20x", 305441741);
-    SPRINTF_CHECK("            edcb5433",    buffer, "%20x", 3989525555U);
-    SPRINTF_CHECK("            1234ABCD",    buffer, "%20X", 305441741);
-    SPRINTF_CHECK("            EDCB5433",    buffer, "%20X", 3989525555U);
-    SPRINTF_CHECK("                   0",    buffer, "%20X", 0);
-    SPRINTF_CHECK("                   0",    buffer, "%20X", 0U);
+    SPRINTF_CHECK("                 777", buffer, "%20o", 511);
+    SPRINTF_CHECK("         37777777001", buffer, "%20o", 4294966785U);
+    SPRINTF_CHECK("            1234abcd", buffer, "%20x", 305441741);
+    SPRINTF_CHECK("            edcb5433", buffer, "%20x", 3989525555U);
+    SPRINTF_CHECK("            1234ABCD", buffer, "%20X", 305441741);
+    SPRINTF_CHECK("            EDCB5433", buffer, "%20X", 3989525555U);
+    SPRINTF_CHECK("                   0", buffer, "%20X", 0);
+    SPRINTF_CHECK("                   0", buffer, "%20X", 0U);
 #ifdef RT_KLIBC_USING_VSNPRINTF_LONGLONG
-    SPRINTF_CHECK("                   0",    buffer, "%20llX", 0ULL);
+    SPRINTF_CHECK("                   0", buffer, "%20llX", 0ULL);
 #endif /* RT_KLIBC_USING_VSNPRINTF_LONGLONG */
-    SPRINTF_CHECK("                   x",    buffer, "%20c", 'x');
+    SPRINTF_CHECK("                   x", buffer, "%20c", 'x');
 }
 
 SPRINTF_TEST_CASE(width_asterisk_20)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("               Hello",    buffer, "%*s", 20, "Hello");
-    SPRINTF_CHECK("                1024",    buffer, "%*d", 20, 1024);
-    SPRINTF_CHECK("               -1024",    buffer, "%*d", 20, -1024);
-    SPRINTF_CHECK("                1024",    buffer, "%*i", 20, 1024);
-    SPRINTF_CHECK("               -1024",    buffer, "%*i", 20, -1024);
-    SPRINTF_CHECK("                1024",    buffer, "%*u", 20, 1024);
+    SPRINTF_CHECK("               Hello", buffer, "%*s", 20, "Hello");
+    SPRINTF_CHECK("                1024", buffer, "%*d", 20, 1024);
+    SPRINTF_CHECK("               -1024", buffer, "%*d", 20, -1024);
+    SPRINTF_CHECK("                1024", buffer, "%*i", 20, 1024);
+    SPRINTF_CHECK("               -1024", buffer, "%*i", 20, -1024);
+    SPRINTF_CHECK("                1024", buffer, "%*u", 20, 1024);
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("                1024",    buffer, "%*I16u", 20, (uint16_t) 1024);
-    SPRINTF_CHECK("                1024",    buffer, "%*I32u", 20, (uint32_t) 1024);
-    SPRINTF_CHECK("                1024",    buffer, "%*I64u", 20, (uint64_t) 1024);
+    SPRINTF_CHECK("                1024", buffer, "%*I16u", 20, (uint16_t)1024);
+    SPRINTF_CHECK("                1024", buffer, "%*I32u", 20, (uint32_t)1024);
+    SPRINTF_CHECK("                1024", buffer, "%*I64u", 20, (uint64_t)1024);
 #endif /* RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS */
-    SPRINTF_CHECK("          4294966272",    buffer, "%*u", 20, 4294966272U);
+    SPRINTF_CHECK("          4294966272", buffer, "%*u", 20, 4294966272U);
 #ifdef RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS
-    SPRINTF_CHECK("          4294966272",    buffer, "%*I32u", 20, (uint32_t) 4294966272U);
-    SPRINTF_CHECK("          4294966272",    buffer, "%*I64u", 20, (uint64_t) 4294966272U);
+    SPRINTF_CHECK("          4294966272", buffer, "%*I32u", 20, (uint32_t)4294966272U);
+    SPRINTF_CHECK("          4294966272", buffer, "%*I64u", 20, (uint64_t)4294966272U);
 #endif /* RT_KLIBC_USING_VSNPRINTF_MSVC_STYLE_INTEGER_SPECIFIERS */
-    SPRINTF_CHECK("                 777",    buffer, "%*o", 20, 511);
-    SPRINTF_CHECK("         37777777001",    buffer, "%*o", 20, 4294966785U);
-    SPRINTF_CHECK("            1234abcd",    buffer, "%*x", 20, 305441741);
-    SPRINTF_CHECK("            edcb5433",    buffer, "%*x", 20, 3989525555U);
-    SPRINTF_CHECK("            1234ABCD",    buffer, "%*X", 20, 305441741);
-    SPRINTF_CHECK("            EDCB5433",    buffer, "%*X", 20, 3989525555U);
-    SPRINTF_CHECK("                   x",    buffer, "%*c", 20, 'x');
+    SPRINTF_CHECK("                 777", buffer, "%*o", 20, 511);
+    SPRINTF_CHECK("         37777777001", buffer, "%*o", 20, 4294966785U);
+    SPRINTF_CHECK("            1234abcd", buffer, "%*x", 20, 305441741);
+    SPRINTF_CHECK("            edcb5433", buffer, "%*x", 20, 3989525555U);
+    SPRINTF_CHECK("            1234ABCD", buffer, "%*X", 20, 305441741);
+    SPRINTF_CHECK("            EDCB5433", buffer, "%*X", 20, 3989525555U);
+    SPRINTF_CHECK("                   x", buffer, "%*c", 20, 'x');
 }
 
 SPRINTF_TEST_CASE(width_minus_20)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("Hello               ",    buffer, "%-20s", "Hello");
-    SPRINTF_CHECK("1024                ",    buffer, "%-20d", 1024);
-    SPRINTF_CHECK("-1024               ",    buffer, "%-20d", -1024);
-    SPRINTF_CHECK("1024                ",    buffer, "%-20i", 1024);
-    SPRINTF_CHECK("-1024               ",    buffer, "%-20i", -1024);
-    SPRINTF_CHECK("1024                ",    buffer, "%-20u", 1024);
+    SPRINTF_CHECK("Hello               ", buffer, "%-20s", "Hello");
+    SPRINTF_CHECK("1024                ", buffer, "%-20d", 1024);
+    SPRINTF_CHECK("-1024               ", buffer, "%-20d", -1024);
+    SPRINTF_CHECK("1024                ", buffer, "%-20i", 1024);
+    SPRINTF_CHECK("-1024               ", buffer, "%-20i", -1024);
+    SPRINTF_CHECK("1024                ", buffer, "%-20u", 1024);
 #ifdef RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS
-    SPRINTF_CHECK("1024.1234           ",    buffer, "%-20.4f", 1024.1234);
+    SPRINTF_CHECK("1024.1234           ", buffer, "%-20.4f", 1024.1234);
 #endif /* RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS */
-    SPRINTF_CHECK("4294966272          ",    buffer, "%-20u", 4294966272U);
-    SPRINTF_CHECK("777                 ",    buffer, "%-20o", 511);
-    SPRINTF_CHECK("37777777001         ",    buffer, "%-20o", 4294966785U);
-    SPRINTF_CHECK("1234abcd            ",    buffer, "%-20x", 305441741);
-    SPRINTF_CHECK("edcb5433            ",    buffer, "%-20x", 3989525555U);
-    SPRINTF_CHECK("1234ABCD            ",    buffer, "%-20X", 305441741);
-    SPRINTF_CHECK("EDCB5433            ",    buffer, "%-20X", 3989525555U);
-    SPRINTF_CHECK("x                   ",    buffer, "%-20c", 'x');
-    SPRINTF_CHECK("|    9| |9 | |    9|",    buffer, "|%5d| |%-2d| |%5d|", 9, 9, 9);
-    SPRINTF_CHECK("|   10| |10| |   10|",    buffer, "|%5d| |%-2d| |%5d|", 10, 10, 10);
+    SPRINTF_CHECK("4294966272          ", buffer, "%-20u", 4294966272U);
+    SPRINTF_CHECK("777                 ", buffer, "%-20o", 511);
+    SPRINTF_CHECK("37777777001         ", buffer, "%-20o", 4294966785U);
+    SPRINTF_CHECK("1234abcd            ", buffer, "%-20x", 305441741);
+    SPRINTF_CHECK("edcb5433            ", buffer, "%-20x", 3989525555U);
+    SPRINTF_CHECK("1234ABCD            ", buffer, "%-20X", 305441741);
+    SPRINTF_CHECK("EDCB5433            ", buffer, "%-20X", 3989525555U);
+    SPRINTF_CHECK("x                   ", buffer, "%-20c", 'x');
+    SPRINTF_CHECK("|    9| |9 | |    9|", buffer, "|%5d| |%-2d| |%5d|", 9, 9, 9);
+    SPRINTF_CHECK("|   10| |10| |   10|", buffer, "|%5d| |%-2d| |%5d|", 10, 10, 10);
     SPRINTF_CHECK("|    9| |9           | |    9|", buffer, "|%5d| |%-12d| |%5d|", 9, 9, 9);
     SPRINTF_CHECK("|   10| |10          | |   10|", buffer, "|%5d| |%-12d| |%5d|", 10, 10, 10);
 }
@@ -452,115 +453,115 @@ SPRINTF_TEST_CASE(width_minus_20)
 SPRINTF_TEST_CASE(width_0_minus_20)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("Hello               ",    buffer, "%0-20s", "Hello");
-    SPRINTF_CHECK("1024                ",    buffer, "%0-20d", 1024);
-    SPRINTF_CHECK("-1024               ",    buffer, "%0-20d", -1024);
-    SPRINTF_CHECK("1024                ",    buffer, "%0-20i", 1024);
-    SPRINTF_CHECK("-1024               ",    buffer, "%0-20i", -1024);
-    SPRINTF_CHECK("1024                ",    buffer, "%0-20u", 1024);
-    SPRINTF_CHECK("4294966272          ",    buffer, "%0-20u", 4294966272U);
-    SPRINTF_CHECK("777                 ",    buffer, "%0-20o", 511);
-    SPRINTF_CHECK("37777777001         ",    buffer, "%0-20o", 4294966785U);
-    SPRINTF_CHECK("1234abcd            ",    buffer, "%0-20x", 305441741);
-    SPRINTF_CHECK("edcb5433            ",    buffer, "%0-20x", 3989525555U);
-    SPRINTF_CHECK("1234ABCD            ",    buffer, "%0-20X", 305441741);
-    SPRINTF_CHECK("EDCB5433            ",    buffer, "%0-20X", 3989525555U);
-    SPRINTF_CHECK("x                   ",    buffer, "%0-20c", 'x');
+    SPRINTF_CHECK("Hello               ", buffer, "%0-20s", "Hello");
+    SPRINTF_CHECK("1024                ", buffer, "%0-20d", 1024);
+    SPRINTF_CHECK("-1024               ", buffer, "%0-20d", -1024);
+    SPRINTF_CHECK("1024                ", buffer, "%0-20i", 1024);
+    SPRINTF_CHECK("-1024               ", buffer, "%0-20i", -1024);
+    SPRINTF_CHECK("1024                ", buffer, "%0-20u", 1024);
+    SPRINTF_CHECK("4294966272          ", buffer, "%0-20u", 4294966272U);
+    SPRINTF_CHECK("777                 ", buffer, "%0-20o", 511);
+    SPRINTF_CHECK("37777777001         ", buffer, "%0-20o", 4294966785U);
+    SPRINTF_CHECK("1234abcd            ", buffer, "%0-20x", 305441741);
+    SPRINTF_CHECK("edcb5433            ", buffer, "%0-20x", 3989525555U);
+    SPRINTF_CHECK("1234ABCD            ", buffer, "%0-20X", 305441741);
+    SPRINTF_CHECK("EDCB5433            ", buffer, "%0-20X", 3989525555U);
+    SPRINTF_CHECK("x                   ", buffer, "%0-20c", 'x');
 }
 
 SPRINTF_TEST_CASE(padding_20)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("00000000000000001024",    buffer, "%020d", 1024);
-    SPRINTF_CHECK("-0000000000000001024",    buffer, "%020d", -1024);
-    SPRINTF_CHECK("00000000000000001024",    buffer, "%020i", 1024);
-    SPRINTF_CHECK("-0000000000000001024",    buffer, "%020i", -1024);
-    SPRINTF_CHECK("00000000000000001024",    buffer, "%020u", 1024);
-    SPRINTF_CHECK("00000000004294966272",    buffer, "%020u", 4294966272U);
-    SPRINTF_CHECK("00000000000000000777",    buffer, "%020o", 511);
-    SPRINTF_CHECK("00000000037777777001",    buffer, "%020o", 4294966785U);
-    SPRINTF_CHECK("0000000000001234abcd",    buffer, "%020x", 305441741);
-    SPRINTF_CHECK("000000000000edcb5433",    buffer, "%020x", 3989525555U);
-    SPRINTF_CHECK("0000000000001234ABCD",    buffer, "%020X", 305441741);
-    SPRINTF_CHECK("000000000000EDCB5433",    buffer, "%020X", 3989525555U);
+    SPRINTF_CHECK("00000000000000001024", buffer, "%020d", 1024);
+    SPRINTF_CHECK("-0000000000000001024", buffer, "%020d", -1024);
+    SPRINTF_CHECK("00000000000000001024", buffer, "%020i", 1024);
+    SPRINTF_CHECK("-0000000000000001024", buffer, "%020i", -1024);
+    SPRINTF_CHECK("00000000000000001024", buffer, "%020u", 1024);
+    SPRINTF_CHECK("00000000004294966272", buffer, "%020u", 4294966272U);
+    SPRINTF_CHECK("00000000000000000777", buffer, "%020o", 511);
+    SPRINTF_CHECK("00000000037777777001", buffer, "%020o", 4294966785U);
+    SPRINTF_CHECK("0000000000001234abcd", buffer, "%020x", 305441741);
+    SPRINTF_CHECK("000000000000edcb5433", buffer, "%020x", 3989525555U);
+    SPRINTF_CHECK("0000000000001234ABCD", buffer, "%020X", 305441741);
+    SPRINTF_CHECK("000000000000EDCB5433", buffer, "%020X", 3989525555U);
 }
 
 SPRINTF_TEST_CASE(padding_dot_20)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("00000000000000001024",    buffer, "%.20d", 1024);
-    SPRINTF_CHECK("-00000000000000001024",   buffer, "%.20d", -1024);
-    SPRINTF_CHECK("00000000000000001024",    buffer, "%.20i", 1024);
-    SPRINTF_CHECK("-00000000000000001024",   buffer, "%.20i", -1024);
-    SPRINTF_CHECK("00000000000000001024",    buffer, "%.20u", 1024);
-    SPRINTF_CHECK("00000000004294966272",    buffer, "%.20u", 4294966272U);
-    SPRINTF_CHECK("00000000000000000777",    buffer, "%.20o", 511);
-    SPRINTF_CHECK("00000000037777777001",    buffer, "%.20o", 4294966785U);
-    SPRINTF_CHECK("0000000000001234abcd",    buffer, "%.20x", 305441741);
-    SPRINTF_CHECK("000000000000edcb5433",    buffer, "%.20x", 3989525555U);
-    SPRINTF_CHECK("0000000000001234ABCD",    buffer, "%.20X", 305441741);
-    SPRINTF_CHECK("000000000000EDCB5433",    buffer, "%.20X", 3989525555U);
+    SPRINTF_CHECK("00000000000000001024", buffer, "%.20d", 1024);
+    SPRINTF_CHECK("-00000000000000001024", buffer, "%.20d", -1024);
+    SPRINTF_CHECK("00000000000000001024", buffer, "%.20i", 1024);
+    SPRINTF_CHECK("-00000000000000001024", buffer, "%.20i", -1024);
+    SPRINTF_CHECK("00000000000000001024", buffer, "%.20u", 1024);
+    SPRINTF_CHECK("00000000004294966272", buffer, "%.20u", 4294966272U);
+    SPRINTF_CHECK("00000000000000000777", buffer, "%.20o", 511);
+    SPRINTF_CHECK("00000000037777777001", buffer, "%.20o", 4294966785U);
+    SPRINTF_CHECK("0000000000001234abcd", buffer, "%.20x", 305441741);
+    SPRINTF_CHECK("000000000000edcb5433", buffer, "%.20x", 3989525555U);
+    SPRINTF_CHECK("0000000000001234ABCD", buffer, "%.20X", 305441741);
+    SPRINTF_CHECK("000000000000EDCB5433", buffer, "%.20X", 3989525555U);
 }
 
 SPRINTF_TEST_CASE(padding_sharp_020__non_standard_format)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("00000000000000001024",    buffer, "%#020d", 1024);
-    SPRINTF_CHECK("-0000000000000001024",    buffer, "%#020d", -1024);
-    SPRINTF_CHECK("00000000000000001024",    buffer, "%#020i", 1024);
-    SPRINTF_CHECK("-0000000000000001024",    buffer, "%#020i", -1024);
-    SPRINTF_CHECK("00000000000000001024",    buffer, "%#020u", 1024);
-    SPRINTF_CHECK("00000000004294966272",    buffer, "%#020u", 4294966272U);
+    SPRINTF_CHECK("00000000000000001024", buffer, "%#020d", 1024);
+    SPRINTF_CHECK("-0000000000000001024", buffer, "%#020d", -1024);
+    SPRINTF_CHECK("00000000000000001024", buffer, "%#020i", 1024);
+    SPRINTF_CHECK("-0000000000000001024", buffer, "%#020i", -1024);
+    SPRINTF_CHECK("00000000000000001024", buffer, "%#020u", 1024);
+    SPRINTF_CHECK("00000000004294966272", buffer, "%#020u", 4294966272U);
 }
 
 SPRINTF_TEST_CASE(padding_sharp_020)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("00000000000000000777",    buffer, "%#020o", 511);
-    SPRINTF_CHECK("00000000037777777001",    buffer, "%#020o", 4294966785U);
-    SPRINTF_CHECK("0x00000000001234abcd",    buffer, "%#020x", 305441741);
-    SPRINTF_CHECK("0x0000000000edcb5433",    buffer, "%#020x", 3989525555U);
-    SPRINTF_CHECK("0X00000000001234ABCD",    buffer, "%#020X", 305441741);
-    SPRINTF_CHECK("0X0000000000EDCB5433",    buffer, "%#020X", 3989525555U);
+    SPRINTF_CHECK("00000000000000000777", buffer, "%#020o", 511);
+    SPRINTF_CHECK("00000000037777777001", buffer, "%#020o", 4294966785U);
+    SPRINTF_CHECK("0x00000000001234abcd", buffer, "%#020x", 305441741);
+    SPRINTF_CHECK("0x0000000000edcb5433", buffer, "%#020x", 3989525555U);
+    SPRINTF_CHECK("0X00000000001234ABCD", buffer, "%#020X", 305441741);
+    SPRINTF_CHECK("0X0000000000EDCB5433", buffer, "%#020X", 3989525555U);
 }
 
 SPRINTF_TEST_CASE(padding_sharp_20__non_standard_format)
 {
-  char buffer[base_buffer_size];
-  SPRINTF_CHECK("                1024",      buffer, "%#20d", 1024);
-  SPRINTF_CHECK("               -1024",      buffer, "%#20d", -1024);
-  SPRINTF_CHECK("                1024",      buffer, "%#20i", 1024);
-  SPRINTF_CHECK("               -1024",      buffer, "%#20i", -1024);
-  SPRINTF_CHECK("                1024",      buffer, "%#20u", 1024);
-  SPRINTF_CHECK("          4294966272",      buffer, "%#20u", 4294966272U);
+    char buffer[base_buffer_size];
+    SPRINTF_CHECK("                1024", buffer, "%#20d", 1024);
+    SPRINTF_CHECK("               -1024", buffer, "%#20d", -1024);
+    SPRINTF_CHECK("                1024", buffer, "%#20i", 1024);
+    SPRINTF_CHECK("               -1024", buffer, "%#20i", -1024);
+    SPRINTF_CHECK("                1024", buffer, "%#20u", 1024);
+    SPRINTF_CHECK("          4294966272", buffer, "%#20u", 4294966272U);
 }
 
 SPRINTF_TEST_CASE(padding_sharp_20)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("                0777",    buffer, "%#20o", 511);
-    SPRINTF_CHECK("        037777777001",    buffer, "%#20o", 4294966785U);
-    SPRINTF_CHECK("          0x1234abcd",    buffer, "%#20x", 305441741);
-    SPRINTF_CHECK("          0xedcb5433",    buffer, "%#20x", 3989525555U);
-    SPRINTF_CHECK("          0X1234ABCD",    buffer, "%#20X", 305441741);
-    SPRINTF_CHECK("          0XEDCB5433",    buffer, "%#20X", 3989525555U);
+    SPRINTF_CHECK("                0777", buffer, "%#20o", 511);
+    SPRINTF_CHECK("        037777777001", buffer, "%#20o", 4294966785U);
+    SPRINTF_CHECK("          0x1234abcd", buffer, "%#20x", 305441741);
+    SPRINTF_CHECK("          0xedcb5433", buffer, "%#20x", 3989525555U);
+    SPRINTF_CHECK("          0X1234ABCD", buffer, "%#20X", 305441741);
+    SPRINTF_CHECK("          0XEDCB5433", buffer, "%#20X", 3989525555U);
 }
 
 SPRINTF_TEST_CASE(padding_20_point_5)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("               01024",    buffer, "%20.5d", 1024);
-    SPRINTF_CHECK("              -01024",    buffer, "%20.5d", -1024);
-    SPRINTF_CHECK("               01024",    buffer, "%20.5i", 1024);
-    SPRINTF_CHECK("              -01024",    buffer, "%20.5i", -1024);
-    SPRINTF_CHECK("               01024",    buffer, "%20.5u", 1024);
-    SPRINTF_CHECK("          4294966272",    buffer, "%20.5u", 4294966272U);
-    SPRINTF_CHECK("               00777",    buffer, "%20.5o", 511);
-    SPRINTF_CHECK("         37777777001",    buffer, "%20.5o", 4294966785U);
-    SPRINTF_CHECK("            1234abcd",    buffer, "%20.5x", 305441741);
-    SPRINTF_CHECK("          00edcb5433",    buffer, "%20.10x", 3989525555U);
-    SPRINTF_CHECK("            1234ABCD",    buffer, "%20.5X", 305441741);
-    SPRINTF_CHECK("          00EDCB5433",    buffer, "%20.10X", 3989525555U);
+    SPRINTF_CHECK("               01024", buffer, "%20.5d", 1024);
+    SPRINTF_CHECK("              -01024", buffer, "%20.5d", -1024);
+    SPRINTF_CHECK("               01024", buffer, "%20.5i", 1024);
+    SPRINTF_CHECK("              -01024", buffer, "%20.5i", -1024);
+    SPRINTF_CHECK("               01024", buffer, "%20.5u", 1024);
+    SPRINTF_CHECK("          4294966272", buffer, "%20.5u", 4294966272U);
+    SPRINTF_CHECK("               00777", buffer, "%20.5o", 511);
+    SPRINTF_CHECK("         37777777001", buffer, "%20.5o", 4294966785U);
+    SPRINTF_CHECK("            1234abcd", buffer, "%20.5x", 305441741);
+    SPRINTF_CHECK("          00edcb5433", buffer, "%20.10x", 3989525555U);
+    SPRINTF_CHECK("            1234ABCD", buffer, "%20.5X", 305441741);
+    SPRINTF_CHECK("          00EDCB5433", buffer, "%20.10X", 3989525555U);
 }
 
 SPRINTF_TEST_CASE(padding_negative_numbers)
@@ -568,16 +569,16 @@ SPRINTF_TEST_CASE(padding_negative_numbers)
     char buffer[base_buffer_size];
 
     /* space padding */
-    SPRINTF_CHECK("-5",                      buffer, "% 1d", -5);
-    SPRINTF_CHECK("-5",                      buffer, "% 2d", -5);
-    SPRINTF_CHECK(" -5",                     buffer, "% 3d", -5);
-    SPRINTF_CHECK("  -5",                    buffer, "% 4d", -5);
+    SPRINTF_CHECK("-5", buffer, "% 1d", -5);
+    SPRINTF_CHECK("-5", buffer, "% 2d", -5);
+    SPRINTF_CHECK(" -5", buffer, "% 3d", -5);
+    SPRINTF_CHECK("  -5", buffer, "% 4d", -5);
 
     /* zero padding */
-    SPRINTF_CHECK("-5",                      buffer, "%01d", -5);
-    SPRINTF_CHECK("-5",                      buffer, "%02d", -5);
-    SPRINTF_CHECK("-05",                     buffer, "%03d", -5);
-    SPRINTF_CHECK("-005",                    buffer, "%04d", -5);
+    SPRINTF_CHECK("-5", buffer, "%01d", -5);
+    SPRINTF_CHECK("-5", buffer, "%02d", -5);
+    SPRINTF_CHECK("-05", buffer, "%03d", -5);
+    SPRINTF_CHECK("-005", buffer, "%04d", -5);
 }
 
 #if defined(RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS) || \
@@ -588,33 +589,33 @@ SPRINTF_TEST_CASE(float_padding_negative_numbers)
 
     /* space padding */
 #ifdef RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS
-    SPRINTF_CHECK("-5.0",                    buffer, "% 3.1f", -5.);
-    SPRINTF_CHECK("-5.0",                    buffer, "% 4.1f", -5.);
-    SPRINTF_CHECK(" -5.0",                   buffer, "% 5.1f", -5.);
+    SPRINTF_CHECK("-5.0", buffer, "% 3.1f", -5.);
+    SPRINTF_CHECK("-5.0", buffer, "% 4.1f", -5.);
+    SPRINTF_CHECK(" -5.0", buffer, "% 5.1f", -5.);
 #endif
 
 #ifdef RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS
-    SPRINTF_CHECK("    -5",                  buffer, "% 6.1g", -5.);
-    SPRINTF_CHECK("-5.0e+00",                buffer, "% 6.1e", -5.);
-    SPRINTF_CHECK("  -5.0e+00",              buffer, "% 10.1e", -5.);
+    SPRINTF_CHECK("    -5", buffer, "% 6.1g", -5.);
+    SPRINTF_CHECK("-5.0e+00", buffer, "% 6.1e", -5.);
+    SPRINTF_CHECK("  -5.0e+00", buffer, "% 10.1e", -5.);
 #endif
 
     /* zero padding */
 #ifdef RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS
-    SPRINTF_CHECK("-5.0",                    buffer, "%03.1f", -5.);
-    SPRINTF_CHECK("-5.0",                    buffer, "%04.1f", -5.);
-    SPRINTF_CHECK("-05.0",                   buffer, "%05.1f", -5.);
+    SPRINTF_CHECK("-5.0", buffer, "%03.1f", -5.);
+    SPRINTF_CHECK("-5.0", buffer, "%04.1f", -5.);
+    SPRINTF_CHECK("-05.0", buffer, "%05.1f", -5.);
 
     /* zero padding no decimal point */
-    SPRINTF_CHECK("-5",                      buffer, "%01.0f", -5.);
-    SPRINTF_CHECK("-5",                      buffer, "%02.0f", -5.);
-    SPRINTF_CHECK("-05",                     buffer, "%03.0f", -5.);
+    SPRINTF_CHECK("-5", buffer, "%01.0f", -5.);
+    SPRINTF_CHECK("-5", buffer, "%02.0f", -5.);
+    SPRINTF_CHECK("-05", buffer, "%03.0f", -5.);
 #endif
 
 #ifdef RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS
-    SPRINTF_CHECK("-005.0e+00",              buffer, "%010.1e", -5.);
-    SPRINTF_CHECK("-05E+00",                 buffer, "%07.0E", -5.);
-    SPRINTF_CHECK("-05",                     buffer, "%03.0g", -5.);
+    SPRINTF_CHECK("-005.0e+00", buffer, "%010.1e", -5.);
+    SPRINTF_CHECK("-05E+00", buffer, "%07.0E", -5.);
+    SPRINTF_CHECK("-05", buffer, "%03.0g", -5.);
 #endif
 }
 
@@ -625,13 +626,13 @@ SPRINTF_TEST_CASE(infinity_and_not_a_number_values)
     /* test special-case floats using math.h macros */
 #ifdef RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS
     // SPRINTF_CHECK("     nan",                buffer, "%8f", (double) NAN);
-    SPRINTF_CHECK("     inf",                buffer, "%8f", (double) INFINITY);
-    SPRINTF_CHECK("-inf    ",                buffer, "%-8f", (double) -INFINITY);
+    SPRINTF_CHECK("     inf", buffer, "%8f", (double)INFINITY);
+    SPRINTF_CHECK("-inf    ", buffer, "%-8f", (double)-INFINITY);
 #endif /* RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS */
 #ifdef RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS
     // SPRINTF_CHECK("     nan",                buffer, "%8e", (double) NAN);
-    SPRINTF_CHECK("     inf",                buffer, "%8e", (double) INFINITY);
-    SPRINTF_CHECK("-inf    ",                buffer, "%-8e", (double) -INFINITY);
+    SPRINTF_CHECK("     inf", buffer, "%8e", (double)INFINITY);
+    SPRINTF_CHECK("-inf    ", buffer, "%-8e", (double)-INFINITY);
 #endif /* RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS */
 }
 
@@ -639,39 +640,39 @@ SPRINTF_TEST_CASE(floating_point_specifiers_precision_and_flags)
 {
     char buffer[base_buffer_size];
 #ifdef RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS
-    SPRINTF_CHECK("3.1415",                  buffer, "%.4f", 3.1415354);
-    SPRINTF_CHECK("30343.142",               buffer, "%.3f", 30343.1415354);
-    SPRINTF_CHECK("34",                      buffer, "%.0f", 34.1415354);
-    SPRINTF_CHECK("1",                       buffer, "%.0f", 1.3);
-    SPRINTF_CHECK("2",                       buffer, "%.0f", 1.55);
-    SPRINTF_CHECK("1.6",                     buffer, "%.1f", 1.64);
-    SPRINTF_CHECK("42.90",                   buffer, "%.2f", 42.8952);
-    SPRINTF_CHECK("42.895200000",            buffer, "%.9f", 42.8952);
-    SPRINTF_CHECK("42.8952230000",           buffer, "%.10f", 42.895223);
-    SPRINTF_CHECK("42.895223123457",         buffer, "%.12f", 42.89522312345678);
-    SPRINTF_CHECK("42477.371093750000000",   buffer, "%020.15f", 42477.37109375);
-    SPRINTF_CHECK("42.895223876543",         buffer, "%.12f", 42.89522387654321);
-    SPRINTF_CHECK(" 42.90",                  buffer, "%6.2f", 42.8952);
-    SPRINTF_CHECK("+42.90",                  buffer, "%+6.2f", 42.8952);
-    SPRINTF_CHECK("+42.9",                   buffer, "%+5.1f", 42.9252);
-    SPRINTF_CHECK("42.500000",               buffer, "%f", 42.5);
-    SPRINTF_CHECK("42.5",                    buffer, "%.1f", 42.5);
-    SPRINTF_CHECK("42167.000000",            buffer, "%f", 42167.0);
-    SPRINTF_CHECK("-12345.987654321",        buffer, "%.9f", -12345.987654321);
-    SPRINTF_CHECK("4.0",                     buffer, "%.1f", 3.999);
-    SPRINTF_CHECK("4",                       buffer, "%.0f", 3.5);
-    SPRINTF_CHECK("4",                       buffer, "%.0f", 4.5);
-    SPRINTF_CHECK("3",                       buffer, "%.0f", 3.49);
-    SPRINTF_CHECK("3.5",                     buffer, "%.1f", 3.49);
-    SPRINTF_CHECK("a0.5  ",                  buffer, "a%-5.1f", 0.5);
-    SPRINTF_CHECK("a0.5  end",               buffer, "a%-5.1fend", 0.5);
+    SPRINTF_CHECK("3.1415", buffer, "%.4f", 3.1415354);
+    SPRINTF_CHECK("30343.142", buffer, "%.3f", 30343.1415354);
+    SPRINTF_CHECK("34", buffer, "%.0f", 34.1415354);
+    SPRINTF_CHECK("1", buffer, "%.0f", 1.3);
+    SPRINTF_CHECK("2", buffer, "%.0f", 1.55);
+    SPRINTF_CHECK("1.6", buffer, "%.1f", 1.64);
+    SPRINTF_CHECK("42.90", buffer, "%.2f", 42.8952);
+    SPRINTF_CHECK("42.895200000", buffer, "%.9f", 42.8952);
+    SPRINTF_CHECK("42.8952230000", buffer, "%.10f", 42.895223);
+    SPRINTF_CHECK("42.895223123457", buffer, "%.12f", 42.89522312345678);
+    SPRINTF_CHECK("42477.371093750000000", buffer, "%020.15f", 42477.37109375);
+    SPRINTF_CHECK("42.895223876543", buffer, "%.12f", 42.89522387654321);
+    SPRINTF_CHECK(" 42.90", buffer, "%6.2f", 42.8952);
+    SPRINTF_CHECK("+42.90", buffer, "%+6.2f", 42.8952);
+    SPRINTF_CHECK("+42.9", buffer, "%+5.1f", 42.9252);
+    SPRINTF_CHECK("42.500000", buffer, "%f", 42.5);
+    SPRINTF_CHECK("42.5", buffer, "%.1f", 42.5);
+    SPRINTF_CHECK("42167.000000", buffer, "%f", 42167.0);
+    SPRINTF_CHECK("-12345.987654321", buffer, "%.9f", -12345.987654321);
+    SPRINTF_CHECK("4.0", buffer, "%.1f", 3.999);
+    SPRINTF_CHECK("4", buffer, "%.0f", 3.5);
+    SPRINTF_CHECK("4", buffer, "%.0f", 4.5);
+    SPRINTF_CHECK("3", buffer, "%.0f", 3.49);
+    SPRINTF_CHECK("3.5", buffer, "%.1f", 3.49);
+    SPRINTF_CHECK("a0.5  ", buffer, "a%-5.1f", 0.5);
+    SPRINTF_CHECK("a0.5  end", buffer, "a%-5.1fend", 0.5);
 
     /* %f for double */
-    SPRINTF_CHECK("42.895223123457",         buffer, "%.12f", 42.89522312345678);
+    SPRINTF_CHECK("42.895223123457", buffer, "%.12f", 42.89522312345678);
     /* %F for double */
-    SPRINTF_CHECK("42.895223123457",         buffer, "%.12F", 42.89522312345678);
+    SPRINTF_CHECK("42.895223123457", buffer, "%.12F", 42.89522312345678);
     /* %lf for double */
-    SPRINTF_CHECK("42.895223123457",         buffer, "%.12lf", 42.89522312345678);
+    SPRINTF_CHECK("42.895223123457", buffer, "%.12lf", 42.89522312345678);
     /* %Lf for long double */
     // TODO: fix me
     // SPRINTF_CHECK("42.895223123457",         buffer, "%.12Lf", 42.89522312345678l);
@@ -679,55 +680,55 @@ SPRINTF_TEST_CASE(floating_point_specifiers_precision_and_flags)
 #endif /* RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS */
 
 #ifdef RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS
-    SPRINTF_CHECK("0.5",                     buffer, "%.4g", 0.5);
-    SPRINTF_CHECK("1",                       buffer, "%.4g", 1.0);
-    SPRINTF_CHECK("12345.7",                 buffer, "%G", 12345.678);
-    SPRINTF_CHECK("12345.68",                buffer, "%.7G", 12345.678);
-    SPRINTF_CHECK("1.2346E+08",              buffer, "%.5G", 123456789.);
-    SPRINTF_CHECK("12345",                   buffer, "%.6G", 12345.);
-    SPRINTF_CHECK("  +1.235e+08",            buffer, "%+12.4g", 123456789.);
-    SPRINTF_CHECK("0.0012",                  buffer, "%.2G", 0.001234);
-    SPRINTF_CHECK(" +0.001234",              buffer, "%+10.4G", 0.001234);
-    SPRINTF_CHECK("+001.234e-05",            buffer, "%+012.4g", 0.00001234);
+    SPRINTF_CHECK("0.5", buffer, "%.4g", 0.5);
+    SPRINTF_CHECK("1", buffer, "%.4g", 1.0);
+    SPRINTF_CHECK("12345.7", buffer, "%G", 12345.678);
+    SPRINTF_CHECK("12345.68", buffer, "%.7G", 12345.678);
+    SPRINTF_CHECK("1.2346E+08", buffer, "%.5G", 123456789.);
+    SPRINTF_CHECK("12345", buffer, "%.6G", 12345.);
+    SPRINTF_CHECK("  +1.235e+08", buffer, "%+12.4g", 123456789.);
+    SPRINTF_CHECK("0.0012", buffer, "%.2G", 0.001234);
+    SPRINTF_CHECK(" +0.001234", buffer, "%+10.4G", 0.001234);
+    SPRINTF_CHECK("+001.234e-05", buffer, "%+012.4g", 0.00001234);
     /* Note: The following two values are _barely_ normal;
     make their mantissa 1.1 and they lose their normality. */
-    SPRINTF_CHECK("-1.23e-308",              buffer, "%.3g", -1.2345e-308);
-    SPRINTF_CHECK("+1.230E+308",             buffer, "%+.3E", 1.23e+308);
-    SPRINTF_CHECK("1.000e+01",               buffer, "%.3e", 9.9996);
-    SPRINTF_CHECK("0",                       buffer, "%g", 0.);
+    SPRINTF_CHECK("-1.23e-308", buffer, "%.3g", -1.2345e-308);
+    SPRINTF_CHECK("+1.230E+308", buffer, "%+.3E", 1.23e+308);
+    SPRINTF_CHECK("1.000e+01", buffer, "%.3e", 9.9996);
+    SPRINTF_CHECK("0", buffer, "%g", 0.);
     // SPRINTF_CHECK("-0",                      buffer, "%g", -0.);
-    SPRINTF_CHECK("+0",                      buffer, "%+g", 0.);
+    SPRINTF_CHECK("+0", buffer, "%+g", 0.);
     // SPRINTF_CHECK("-0",                      buffer, "%+g", -0.);
-    SPRINTF_CHECK("-4e+04",                  buffer, "%.1g", -40661.5);
-    SPRINTF_CHECK("-4.e+04",                 buffer, "%#.1g", -40661.5);
-    SPRINTF_CHECK("100.",                    buffer, "%#.3g", 99.998580932617187500);
+    SPRINTF_CHECK("-4e+04", buffer, "%.1g", -40661.5);
+    SPRINTF_CHECK("-4.e+04", buffer, "%#.1g", -40661.5);
+    SPRINTF_CHECK("100.", buffer, "%#.3g", 99.998580932617187500);
     // TODO: fix me
     // SPRINTF_CHECK("1.e01",                   buffer, "%# 01.1g", 9.8);
     /* Note: The following value is _barely_ normal;
     make the mantissa 1.1 and it loses its normality. */
-    SPRINTF_CHECK("1.2345678901e-308",       buffer, "%.10e", 1.2345678901e-308);
+    SPRINTF_CHECK("1.2345678901e-308", buffer, "%.10e", 1.2345678901e-308);
     /* Rounding-focused checks */
-    SPRINTF_CHECK("4.895512e+04",            buffer, "%e", 48955.125);
-    SPRINTF_CHECK("9.2524e+04",              buffer, "%.4e", 92523.5);
-    SPRINTF_CHECK("-8.380923438e+04",        buffer, "%.9e", -83809.234375);
+    SPRINTF_CHECK("4.895512e+04", buffer, "%e", 48955.125);
+    SPRINTF_CHECK("9.2524e+04", buffer, "%.4e", 92523.5);
+    SPRINTF_CHECK("-8.380923438e+04", buffer, "%.9e", -83809.234375);
 
     /* %g for double */
-    SPRINTF_CHECK("100.",                    buffer, "%#.3g", 99.998580932617187500);
+    SPRINTF_CHECK("100.", buffer, "%#.3g", 99.998580932617187500);
     /* %G for double */
-    SPRINTF_CHECK("100.",                    buffer, "%#.3G", 99.998580932617187500);
+    SPRINTF_CHECK("100.", buffer, "%#.3G", 99.998580932617187500);
     /* %lg for double */
-    SPRINTF_CHECK("100.",                    buffer, "%#.3lg", 99.998580932617187500);
+    SPRINTF_CHECK("100.", buffer, "%#.3lg", 99.998580932617187500);
     /* %Lg for long double */
     // TODO: fix me
     // SPRINTF_CHECK("100.",                    buffer, "%#.3Lg", 99.998580932617187500l);
     // SPRINTF_CHECK("100.",                    buffer, "%#.3Lg", 99.998580932617187500L);
 
     /* %e for double */
-    SPRINTF_CHECK("-8.380923438e+04",        buffer, "%.9e", -83809.234375);
+    SPRINTF_CHECK("-8.380923438e+04", buffer, "%.9e", -83809.234375);
     /* %E for double */
-    SPRINTF_CHECK("-8.380923438E+04",        buffer, "%.9E", -83809.234375);
+    SPRINTF_CHECK("-8.380923438E+04", buffer, "%.9E", -83809.234375);
     /* %le for double */
-    SPRINTF_CHECK("-8.380923438e+04",        buffer, "%.9le", -83809.234375);
+    SPRINTF_CHECK("-8.380923438e+04", buffer, "%.9le", -83809.234375);
     /* %Le for long double */
     // TODO: fix me
     // SPRINTF_CHECK("-8.380923438e+04",        buffer, "%.9Le", -83809.234375l);
@@ -740,20 +741,20 @@ SPRINTF_TEST_CASE(floating_point_specifiers_with_31_to_32_bit_integer_values)
 {
     char buffer[base_buffer_size];
 #if RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL >= 10
-    SPRINTF_CHECK("2147483647",              buffer, "%.10f", 2147483647.0); /* 2^31 - 1 */
-    SPRINTF_CHECK("2147483648",              buffer, "%.10f", 2147483648.0); /* 2^31 */
-    SPRINTF_CHECK("4294967295",              buffer, "%.10f", 4294967295.0); /* 2^32 - 1 */
-    SPRINTF_CHECK("4294967296",              buffer, "%.10f", 4294967296.0); /* 2^32 */
+    SPRINTF_CHECK("2147483647", buffer, "%.10f", 2147483647.0); /* 2^31 - 1 */
+    SPRINTF_CHECK("2147483648", buffer, "%.10f", 2147483648.0); /* 2^31 */
+    SPRINTF_CHECK("4294967295", buffer, "%.10f", 4294967295.0); /* 2^32 - 1 */
+    SPRINTF_CHECK("4294967296", buffer, "%.10f", 4294967296.0); /* 2^32 */
 #else
-    SPRINTF_CHECK("2.1474836470e+09",        buffer, "%.10f", 2147483647.0); /* 2^31 - 1 */
-    SPRINTF_CHECK("2.1474836480e+09",        buffer, "%.10f", 2147483648.0); /* 2^31 */
-    SPRINTF_CHECK("4.2949672950e+09",        buffer, "%.10f", 4294967295.0); /* 2^32 - 1 */
-    SPRINTF_CHECK("4.2949672960e+09",        buffer, "%.10f", 4294967296.0); /* 2^32 */
+    SPRINTF_CHECK("2.1474836470e+09", buffer, "%.10f", 2147483647.0); /* 2^31 - 1 */
+    SPRINTF_CHECK("2.1474836480e+09", buffer, "%.10f", 2147483648.0); /* 2^31 */
+    SPRINTF_CHECK("4.2949672950e+09", buffer, "%.10f", 4294967295.0); /* 2^32 - 1 */
+    SPRINTF_CHECK("4.2949672960e+09", buffer, "%.10f", 4294967296.0); /* 2^32 */
 #endif /* RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL */
-    SPRINTF_CHECK("2147483647",              buffer, "%.10g", 2147483647.0); /* 2^31 - 1 */
-    SPRINTF_CHECK("2147483648",              buffer, "%.10g", 2147483648.0); /* 2^31 */
-    SPRINTF_CHECK("4294967295",              buffer, "%.10g", 4294967295.0); /* 2^32 - 1 */
-    SPRINTF_CHECK("4294967296",              buffer, "%.10g", 4294967296.0); /* 2^32 */
+    SPRINTF_CHECK("2147483647", buffer, "%.10g", 2147483647.0); /* 2^31 - 1 */
+    SPRINTF_CHECK("2147483648", buffer, "%.10g", 2147483648.0); /* 2^31 */
+    SPRINTF_CHECK("4294967295", buffer, "%.10g", 4294967295.0); /* 2^32 - 1 */
+    SPRINTF_CHECK("4294967296", buffer, "%.10g", 4294967296.0); /* 2^32 */
 }
 
 SPRINTF_TEST_CASE(fallback_from_decimal_to_exponential)
@@ -761,46 +762,61 @@ SPRINTF_TEST_CASE(fallback_from_decimal_to_exponential)
     char buffer[base_buffer_size];
 
     /* Check for 1 * 1000 */
-    if (RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL < 3) {
-        SPRINTF_CHECK("1e+3", buffer, "%.0f", (double) ((int64_t) 1 * 1000));
-    } else {
-        SPRINTF_CHECK("1000", buffer, "%.0f", (double) ((int64_t) 1 * 1000));
+    if (RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL < 3)
+    {
+        SPRINTF_CHECK("1e+3", buffer, "%.0f", (double)((int64_t)1 * 1000));
+    }
+    else
+    {
+        SPRINTF_CHECK("1000", buffer, "%.0f", (double)((int64_t)1 * 1000));
     }
 
     /* Check for 1 * 1000 * 1000 */
-    if (RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL < 6) {
-        SPRINTF_CHECK("1e+6", buffer, "%.0f", (double) ((int64_t) 1 * 1000 * 1000));
-    } else {
-        SPRINTF_CHECK("1000000", buffer, "%.0f", (double) ((int64_t) 1 * 1000 * 1000));
+    if (RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL < 6)
+    {
+        SPRINTF_CHECK("1e+6", buffer, "%.0f", (double)((int64_t)1 * 1000 * 1000));
+    }
+    else
+    {
+        SPRINTF_CHECK("1000000", buffer, "%.0f", (double)((int64_t)1 * 1000 * 1000));
     }
 
     /* Check for 1 * 1000 * 1000 * 1000 */
-    if (RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL < 9) {
-        SPRINTF_CHECK("1e+9", buffer, "%.0f", (double) ((int64_t) 1 * 1000 * 1000 * 1000));
-    } else {
-        SPRINTF_CHECK("1000000000", buffer, "%.0f", (double) ((int64_t) 1 * 1000 * 1000 * 1000));
+    if (RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL < 9)
+    {
+        SPRINTF_CHECK("1e+9", buffer, "%.0f", (double)((int64_t)1 * 1000 * 1000 * 1000));
+    }
+    else
+    {
+        SPRINTF_CHECK("1000000000", buffer, "%.0f", (double)((int64_t)1 * 1000 * 1000 * 1000));
     }
 
     /* Check for 1 * 1000 * 1000 * 1000 * 1000 */
-    if (RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL < 12) {
+    if (RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL < 12)
+    {
 #ifdef RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS
-        SPRINTF_CHECK("1e+12", buffer, "%.0f", (double) ((int64_t) 1 * 1000 * 1000 * 1000 * 1000));
+        SPRINTF_CHECK("1e+12", buffer, "%.0f", (double)((int64_t)1 * 1000 * 1000 * 1000 * 1000));
 #else
-        SPRINTF_CHECK("", buffer, "%.0f", (double) ((int64_t) 1 * 1000 * 1000 * 1000 * 1000));
+        SPRINTF_CHECK("", buffer, "%.0f", (double)((int64_t)1 * 1000 * 1000 * 1000 * 1000));
 #endif
-    } else {
-        SPRINTF_CHECK("1000000000000", buffer, "%.0f", (double) ((int64_t) 1 * 1000 * 1000 * 1000 * 1000));
+    }
+    else
+    {
+        SPRINTF_CHECK("1000000000000", buffer, "%.0f", (double)((int64_t)1 * 1000 * 1000 * 1000 * 1000));
     }
 
     /* Check for 1 * 1000 * 1000 * 1000 * 1000 * 1000 */
-    if (RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL < 15) {
+    if (RT_KLIBC_USING_VSNPRINTF_MAX_INTEGRAL_DIGITS_FOR_DECIMAL < 15)
+    {
 #ifdef RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS
-        SPRINTF_CHECK("1e+15", buffer, "%.0f", (double) ((int64_t) 1 * 1000 * 1000 * 1000 * 1000 * 1000));
+        SPRINTF_CHECK("1e+15", buffer, "%.0f", (double)((int64_t)1 * 1000 * 1000 * 1000 * 1000 * 1000));
 #else
-        SPRINTF_CHECK("", buffer, "%.0f", (double) ((int64_t) 1 * 1000 * 1000 * 1000 * 1000 * 1000));
+        SPRINTF_CHECK("", buffer, "%.0f", (double)((int64_t)1 * 1000 * 1000 * 1000 * 1000 * 1000));
 #endif
-    } else {
-        SPRINTF_CHECK("1000000000000000", buffer, "%.0f", (double) ((int64_t) 1 * 1000 * 1000 * 1000 * 1000 * 1000));
+    }
+    else
+    {
+        SPRINTF_CHECK("1000000000000000", buffer, "%.0f", (double)((int64_t)1 * 1000 * 1000 * 1000 * 1000 * 1000));
     }
 
     /* Check for a value which should definitely be out of range for float */
@@ -817,18 +833,18 @@ SPRINTF_TEST_CASE(tiny_floating_point_values)
 {
     char buffer[base_buffer_size];
 
-    SPRINTF_CHECK("1e-23",                   buffer, "%.0e",  1.380651569e-23);
-    SPRINTF_CHECK("1.4e-23",                 buffer, "%.1e",  1.380651569e-23);
-    SPRINTF_CHECK("1.38e-23",                buffer, "%.2e",  1.380651569e-23);
-    SPRINTF_CHECK("1.381e-23",               buffer, "%.3e",  1.380651569e-23);
-    SPRINTF_CHECK("1.3807e-23",              buffer, "%.4e",  1.380651569e-23);
-    SPRINTF_CHECK("1.38065e-23",             buffer, "%.5e",  1.380651569e-23);
-    SPRINTF_CHECK("1.380652e-23",            buffer, "%.6e",  1.380651569e-23);
-    SPRINTF_CHECK("1.3806516e-23",           buffer, "%.7e",  1.380651569e-23);
-    SPRINTF_CHECK("1.38065157e-23",          buffer, "%.8e",  1.380651569e-23);
-    SPRINTF_CHECK("1.380651569e-23",         buffer, "%.9e",  1.380651569e-23);
-    SPRINTF_CHECK("1.3806515690e-23",        buffer, "%.10e", 1.380651569e-23);
-    SPRINTF_CHECK("1.38065156900e-23",       buffer, "%.11e", 1.380651569e-23);
+    SPRINTF_CHECK("1e-23", buffer, "%.0e", 1.380651569e-23);
+    SPRINTF_CHECK("1.4e-23", buffer, "%.1e", 1.380651569e-23);
+    SPRINTF_CHECK("1.38e-23", buffer, "%.2e", 1.380651569e-23);
+    SPRINTF_CHECK("1.381e-23", buffer, "%.3e", 1.380651569e-23);
+    SPRINTF_CHECK("1.3807e-23", buffer, "%.4e", 1.380651569e-23);
+    SPRINTF_CHECK("1.38065e-23", buffer, "%.5e", 1.380651569e-23);
+    SPRINTF_CHECK("1.380652e-23", buffer, "%.6e", 1.380651569e-23);
+    SPRINTF_CHECK("1.3806516e-23", buffer, "%.7e", 1.380651569e-23);
+    SPRINTF_CHECK("1.38065157e-23", buffer, "%.8e", 1.380651569e-23);
+    SPRINTF_CHECK("1.380651569e-23", buffer, "%.9e", 1.380651569e-23);
+    SPRINTF_CHECK("1.3806515690e-23", buffer, "%.10e", 1.380651569e-23);
+    SPRINTF_CHECK("1.38065156900e-23", buffer, "%.11e", 1.380651569e-23);
 }
 #endif /* RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS */
 #endif /* RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS || RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS */
@@ -837,106 +853,106 @@ SPRINTF_TEST_CASE(tiny_floating_point_values)
 SPRINTF_TEST_CASE(length)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("",                        buffer, "%.0s", "Hello testing");
-    SPRINTF_CHECK("                    ",    buffer, "%20.0s", "Hello testing");
-    SPRINTF_CHECK("",                        buffer, "%.s", "Hello testing");
-    SPRINTF_CHECK("                    ",    buffer, "%20.s", "Hello testing");
-    SPRINTF_CHECK("                1024",    buffer, "%20.0d", 1024);
-    SPRINTF_CHECK("               -1024",    buffer, "%20.0d", -1024);
-    SPRINTF_CHECK("                    ",    buffer, "%20.d", 0);
-    SPRINTF_CHECK("                1024",    buffer, "%20.0i", 1024);
-    SPRINTF_CHECK("               -1024",    buffer, "%20.i", -1024);
-    SPRINTF_CHECK("                    ",    buffer, "%20.i", 0);
-    SPRINTF_CHECK("                1024",    buffer, "%20.u", 1024);
-    SPRINTF_CHECK("          4294966272",    buffer, "%20.0u", 4294966272U);
-    SPRINTF_CHECK("                    ",    buffer, "%20.u", 0U);
-    SPRINTF_CHECK("                 777",    buffer, "%20.o", 511);
-    SPRINTF_CHECK("         37777777001",    buffer, "%20.0o", 4294966785U);
-    SPRINTF_CHECK("                    ",    buffer, "%20.o", 0U);
-    SPRINTF_CHECK("            1234abcd",    buffer, "%20.x", 305441741);
+    SPRINTF_CHECK("", buffer, "%.0s", "Hello testing");
+    SPRINTF_CHECK("                    ", buffer, "%20.0s", "Hello testing");
+    SPRINTF_CHECK("", buffer, "%.s", "Hello testing");
+    SPRINTF_CHECK("                    ", buffer, "%20.s", "Hello testing");
+    SPRINTF_CHECK("                1024", buffer, "%20.0d", 1024);
+    SPRINTF_CHECK("               -1024", buffer, "%20.0d", -1024);
+    SPRINTF_CHECK("                    ", buffer, "%20.d", 0);
+    SPRINTF_CHECK("                1024", buffer, "%20.0i", 1024);
+    SPRINTF_CHECK("               -1024", buffer, "%20.i", -1024);
+    SPRINTF_CHECK("                    ", buffer, "%20.i", 0);
+    SPRINTF_CHECK("                1024", buffer, "%20.u", 1024);
+    SPRINTF_CHECK("          4294966272", buffer, "%20.0u", 4294966272U);
+    SPRINTF_CHECK("                    ", buffer, "%20.u", 0U);
+    SPRINTF_CHECK("                 777", buffer, "%20.o", 511);
+    SPRINTF_CHECK("         37777777001", buffer, "%20.0o", 4294966785U);
+    SPRINTF_CHECK("                    ", buffer, "%20.o", 0U);
+    SPRINTF_CHECK("            1234abcd", buffer, "%20.x", 305441741);
     SPRINTF_CHECK("                                          1234abcd",
-                                              buffer, "%50.x", 305441741);
+                  buffer, "%50.x", 305441741);
     SPRINTF_CHECK("                                          1234abcd     12345",
-                                              buffer, "%50.x%10.u", 305441741, 12345);
-    SPRINTF_CHECK("            edcb5433",    buffer, "%20.0x", 3989525555U);
-    SPRINTF_CHECK("                    ",    buffer, "%20.x", 0U);
-    SPRINTF_CHECK("            1234ABCD",    buffer, "%20.X", 305441741);
-    SPRINTF_CHECK("            EDCB5433",    buffer, "%20.0X", 3989525555U);
-    SPRINTF_CHECK("                    ",    buffer, "%20.X", 0U);
+                  buffer, "%50.x%10.u", 305441741, 12345);
+    SPRINTF_CHECK("            edcb5433", buffer, "%20.0x", 3989525555U);
+    SPRINTF_CHECK("                    ", buffer, "%20.x", 0U);
+    SPRINTF_CHECK("            1234ABCD", buffer, "%20.X", 305441741);
+    SPRINTF_CHECK("            EDCB5433", buffer, "%20.0X", 3989525555U);
+    SPRINTF_CHECK("                    ", buffer, "%20.X", 0U);
 }
 
 SPRINTF_TEST_CASE(length__non_standard_format)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("  ",                      buffer, "%02.0u", 0U);
-    SPRINTF_CHECK("  ",                      buffer, "%02.0d", 0);
+    SPRINTF_CHECK("  ", buffer, "%02.0u", 0U);
+    SPRINTF_CHECK("  ", buffer, "%02.0d", 0);
 }
 
 SPRINTF_TEST_CASE(unknown_flag__non_standard_format)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("kmarco",                  buffer, "%kmarco", 42, 37);
+    SPRINTF_CHECK("kmarco", buffer, "%kmarco", 42, 37);
 }
 
 SPRINTF_TEST_CASE(string_length__non_standard_format)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK(".2s",                     buffer, "%.4.2s", "123456");
+    SPRINTF_CHECK(".2s", buffer, "%.4.2s", "123456");
 }
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
 
 SPRINTF_TEST_CASE(integer_types)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("0",                       buffer, "%i", 0);
-    SPRINTF_CHECK("1234",                    buffer, "%i", 1234);
-    SPRINTF_CHECK("32767",                   buffer, "%i", 32767);
-    SPRINTF_CHECK("-32767",                  buffer, "%i", -32767);
-    SPRINTF_CHECK("30",                      buffer, "%li", 30L);
-    SPRINTF_CHECK("-2147483647",             buffer, "%li", -2147483647L);
-    SPRINTF_CHECK("2147483647",              buffer, "%li", 2147483647L);
+    SPRINTF_CHECK("0", buffer, "%i", 0);
+    SPRINTF_CHECK("1234", buffer, "%i", 1234);
+    SPRINTF_CHECK("32767", buffer, "%i", 32767);
+    SPRINTF_CHECK("-32767", buffer, "%i", -32767);
+    SPRINTF_CHECK("30", buffer, "%li", 30L);
+    SPRINTF_CHECK("-2147483647", buffer, "%li", -2147483647L);
+    SPRINTF_CHECK("2147483647", buffer, "%li", 2147483647L);
 #ifdef RT_KLIBC_USING_VSNPRINTF_LONGLONG
-    SPRINTF_CHECK("30",                      buffer, "%lli", 30LL);
+    SPRINTF_CHECK("30", buffer, "%lli", 30LL);
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("-9223372036854775807",    buffer, "%lli", -9223372036854775807LL);
-    SPRINTF_CHECK("9223372036854775807",     buffer, "%lli", 9223372036854775807LL);
+    SPRINTF_CHECK("-9223372036854775807", buffer, "%lli", -9223372036854775807LL);
+    SPRINTF_CHECK("9223372036854775807", buffer, "%lli", 9223372036854775807LL);
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
 #endif /* RT_KLIBC_USING_VSNPRINTF_LONGLONG */
-    SPRINTF_CHECK("100000",                  buffer, "%lu", 100000L);
-    SPRINTF_CHECK("4294967295",              buffer, "%lu", 0xFFFFFFFFL);
+    SPRINTF_CHECK("100000", buffer, "%lu", 100000L);
+    SPRINTF_CHECK("4294967295", buffer, "%lu", 0xFFFFFFFFL);
 #ifdef RT_KLIBC_USING_VSNPRINTF_LONGLONG
-    SPRINTF_CHECK("281474976710656",         buffer, "%llu", 281474976710656LLU);
-    SPRINTF_CHECK("18446744073709551615",    buffer, "%llu", 18446744073709551615LLU);
+    SPRINTF_CHECK("281474976710656", buffer, "%llu", 281474976710656LLU);
+    SPRINTF_CHECK("18446744073709551615", buffer, "%llu", 18446744073709551615LLU);
 #endif /* RT_KLIBC_USING_VSNPRINTF_LONGLONG */
-    SPRINTF_CHECK("2147483647",              buffer, "%zu", (size_t) 2147483647UL);
-    SPRINTF_CHECK("2147483647",              buffer, "%zd", (size_t) 2147483647UL);
-    SPRINTF_CHECK("-2147483647",             buffer, "%zi", (ssize_t) -2147483647L);
-    SPRINTF_CHECK("165140",                  buffer, "%o", 60000);
-    SPRINTF_CHECK("57060516",                buffer, "%lo", 12345678L);
-    SPRINTF_CHECK("12345678",                buffer, "%lx", 0x12345678L);
+    SPRINTF_CHECK("2147483647", buffer, "%zu", (size_t)2147483647UL);
+    SPRINTF_CHECK("2147483647", buffer, "%zd", (size_t)2147483647UL);
+    SPRINTF_CHECK("-2147483647", buffer, "%zi", (ssize_t)-2147483647L);
+    SPRINTF_CHECK("165140", buffer, "%o", 60000);
+    SPRINTF_CHECK("57060516", buffer, "%lo", 12345678L);
+    SPRINTF_CHECK("12345678", buffer, "%lx", 0x12345678L);
 #ifdef RT_KLIBC_USING_VSNPRINTF_LONGLONG
-    SPRINTF_CHECK("1234567891234567",        buffer, "%llx", 0x1234567891234567LLU);
+    SPRINTF_CHECK("1234567891234567", buffer, "%llx", 0x1234567891234567LLU);
 #endif /* RT_KLIBC_USING_VSNPRINTF_LONGLONG */
-    SPRINTF_CHECK("abcdefab",                buffer, "%lx", 0xabcdefabL);
-    SPRINTF_CHECK("ABCDEFAB",                buffer, "%lX", 0xabcdefabL);
-    SPRINTF_CHECK("v",                       buffer, "%c", 'v');
-    SPRINTF_CHECK("wv",                      buffer, "%cv", 'w');
-    SPRINTF_CHECK("A Test",                  buffer, "%s", "A Test");
+    SPRINTF_CHECK("abcdefab", buffer, "%lx", 0xabcdefabL);
+    SPRINTF_CHECK("ABCDEFAB", buffer, "%lX", 0xabcdefabL);
+    SPRINTF_CHECK("v", buffer, "%c", 'v');
+    SPRINTF_CHECK("wv", buffer, "%cv", 'w');
+    SPRINTF_CHECK("A Test", buffer, "%s", "A Test");
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("255",                     buffer, "%hhu", (unsigned char) 0xFFU);
+    SPRINTF_CHECK("255", buffer, "%hhu", (unsigned char)0xFFU);
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
-    SPRINTF_CHECK("4660",                    buffer, "%hu", (unsigned short) 0x1234u);
-    SPRINTF_CHECK("Test100 65535",           buffer, "%s%hhi %hu", "Test", (char) 100, (unsigned short) 0xFFFF);
+    SPRINTF_CHECK("4660", buffer, "%hu", (unsigned short)0x1234u);
+    SPRINTF_CHECK("Test100 65535", buffer, "%s%hhi %hu", "Test", (char)100, (unsigned short)0xFFFF);
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("a",                       buffer, "%tx", &buffer[10] - &buffer[0]);
-    SPRINTF_CHECK("-2147483647",             buffer, "%ji", (intmax_t) -2147483647L);
+    SPRINTF_CHECK("a", buffer, "%tx", &buffer[10] - &buffer[0]);
+    SPRINTF_CHECK("-2147483647", buffer, "%ji", (intmax_t)-2147483647L);
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
 }
 
 SPRINTF_TEST_CASE(types__non_standard_format)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("1110101001100000",        buffer, "%b", 60000);
+    SPRINTF_CHECK("1110101001100000", buffer, "%b", 60000);
     SPRINTF_CHECK("101111000110000101001110", buffer, "%lb", 12345678L);
 }
 
@@ -946,21 +962,24 @@ SPRINTF_TEST_CASE(pointer)
 
     /* Test for pointer value 0x1234U */
     SPRINTF_CHECK((sizeof(void *) == 4U) ? "0x00001234" : "0x0000000000001234",
-                  buffer, "%p", (void *) 0x1234U);
+                  buffer, "%p", (void *)0x1234U);
 
     /* Test for pointer value 0x12345678U */
     SPRINTF_CHECK((sizeof(void *) == 4U) ? "0x12345678" : "0x0000000012345678",
-                  buffer, "%p", (void *) 0x12345678U);
+                  buffer, "%p", (void *)0x12345678U);
 
     /* Test for pointer range 0x12345678U to 0x7EDCBA98U */
     SPRINTF_CHECK((sizeof(void *) == 4U) ? "0x12345678-0x7edcba98" : "0x0000000012345678-0x000000007edcba98",
-                  buffer, "%p-%p", (void *) 0x12345678U, (void *) 0x7EDCBA98U);
+                  buffer, "%p-%p", (void *)0x12345678U, (void *)0x7EDCBA98U);
 
     /* Test for maximum uintptr_t value 0xFFFFFFFFU */
-    if (sizeof(uintptr_t) == sizeof(uint64_t)) {
-        SPRINTF_CHECK("0x00000000ffffffff", buffer, "%p", (void *) (uintptr_t) 0xFFFFFFFFU);
-    } else {
-        SPRINTF_CHECK("0xffffffff", buffer, "%p", (void *) (uintptr_t) 0xFFFFFFFFU);
+    if (sizeof(uintptr_t) == sizeof(uint64_t))
+    {
+        SPRINTF_CHECK("0x00000000ffffffff", buffer, "%p", (void *)(uintptr_t)0xFFFFFFFFU);
+    }
+    else
+    {
+        SPRINTF_CHECK("0xffffffff", buffer, "%p", (void *)(uintptr_t)0xFFFFFFFFU);
     }
 
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
@@ -972,16 +991,16 @@ SPRINTF_TEST_CASE(pointer)
 SPRINTF_TEST_CASE(string_length)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("This",                    buffer, "%.4s", "This is a test");
-    SPRINTF_CHECK("test",                    buffer, "%.4s", "test");
-    SPRINTF_CHECK("123",                     buffer, "%.7s", "123");
-    SPRINTF_CHECK("",                        buffer, "%.7s", "");
-    SPRINTF_CHECK("1234ab",                  buffer, "%.4s%.2s", "123456", "abcdef");
-    SPRINTF_CHECK("123",                     buffer, "%.*s", 3, "123456");
+    SPRINTF_CHECK("This", buffer, "%.4s", "This is a test");
+    SPRINTF_CHECK("test", buffer, "%.4s", "test");
+    SPRINTF_CHECK("123", buffer, "%.7s", "123");
+    SPRINTF_CHECK("", buffer, "%.7s", "");
+    SPRINTF_CHECK("1234ab", buffer, "%.4s%.2s", "123456", "abcdef");
+    SPRINTF_CHECK("123", buffer, "%.*s", 3, "123456");
 #ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
-    SPRINTF_CHECK("(null)",                  buffer, "%.*s", 3, (const char *) RT_NULL);
+    SPRINTF_CHECK("(null)", buffer, "%.*s", 3, (const char *)RT_NULL);
 #else
-    SPRINTF_CHECK("(nu",                  buffer, "%.*s", 3, (const char *) RT_NULL);
+    SPRINTF_CHECK("(nu", buffer, "%.*s", 3, (const char *)RT_NULL);
 #endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
 }
 
@@ -991,11 +1010,11 @@ SPRINTF_TEST_CASE(string_precision_zero_and_width)
     char buffer[base_buffer_size];
 
     /* Width specifies the minimum field width and must not truncate strings. */
-    SPRINTF_CHECK("abcdefgh",                buffer, "%5s", "abcdefgh");
+    SPRINTF_CHECK("abcdefgh", buffer, "%5s", "abcdefgh");
 
     /* A string precision of zero means no characters are written. */
-    SPRINTF_CHECK("",                        buffer, "%.0s", "abc");
-    SPRINTF_CHECK("",                        buffer, "%.s", "abc");
+    SPRINTF_CHECK("", buffer, "%.0s", "abc");
+    SPRINTF_CHECK("", buffer, "%.s", "abc");
 }
 
 SPRINTF_TEST_CASE(integer_precision_zero_nonzero)
@@ -1003,29 +1022,29 @@ SPRINTF_TEST_CASE(integer_precision_zero_nonzero)
     char buffer[base_buffer_size];
 
     /* Precision zero suppresses only the zero value; non-zero values are printed. */
-    SPRINTF_CHECK("",                        buffer, "%.0d", 0);
-    SPRINTF_CHECK("5",                       buffer, "%.0d", 5);
-    SPRINTF_CHECK("-5",                      buffer, "%.0d", -5);
+    SPRINTF_CHECK("", buffer, "%.0d", 0);
+    SPRINTF_CHECK("5", buffer, "%.0d", 5);
+    SPRINTF_CHECK("-5", buffer, "%.0d", -5);
 }
 
 SPRINTF_TEST_CASE(misc)
 {
     char buffer[base_buffer_size];
-    SPRINTF_CHECK("53000atest-20 bit",       buffer, "%u%u%ctest%d %s", 5, 3000, 'a', -20, "bit");
+    SPRINTF_CHECK("53000atest-20 bit", buffer, "%u%u%ctest%d %s", 5, 3000, 'a', -20, "bit");
 #ifdef RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS
-    SPRINTF_CHECK("0.33",                    buffer, "%.*f", 2, 0.33333333);
-    SPRINTF_CHECK("1",                       buffer, "%.*d", -1, 1);
-    SPRINTF_CHECK("foo",                     buffer, "%.3s", "foobar");
-    SPRINTF_CHECK(" ",                       buffer, "% .0d", 0);
-    SPRINTF_CHECK("     00004",              buffer, "%10.5d", 4);
-    SPRINTF_CHECK("hi x",                    buffer, "%*sx", -3, "hi");
-    SPRINTF_CHECK("00123               ",    buffer, "%-20.5i", 123);
+    SPRINTF_CHECK("0.33", buffer, "%.*f", 2, 0.33333333);
+    SPRINTF_CHECK("1", buffer, "%.*d", -1, 1);
+    SPRINTF_CHECK("foo", buffer, "%.3s", "foobar");
+    SPRINTF_CHECK(" ", buffer, "% .0d", 0);
+    SPRINTF_CHECK("     00004", buffer, "%10.5d", 4);
+    SPRINTF_CHECK("hi x", buffer, "%*sx", -3, "hi");
+    SPRINTF_CHECK("00123               ", buffer, "%-20.5i", 123);
     SPRINTF_CHECK("-67224.546875000000000000", buffer, "%.18f", -67224.546875);
 #endif /* RT_KLIBC_USING_VSNPRINTF_DECIMAL_SPECIFIERS */
 #ifdef RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS
-    SPRINTF_CHECK("0.33",                    buffer, "%.*g", 2, 0.33333333);
-    SPRINTF_CHECK("3.33e-01",                buffer, "%.*e", 2, 0.33333333);
-    SPRINTF_CHECK("0.000000e+00",            buffer, "%e", 0.0);
+    SPRINTF_CHECK("0.33", buffer, "%.*g", 2, 0.33333333);
+    SPRINTF_CHECK("3.33e-01", buffer, "%.*e", 2, 0.33333333);
+    SPRINTF_CHECK("0.000000e+00", buffer, "%e", 0.0);
     // SPRINTF_CHECK("-0.000000e+00",           buffer, "%e", -0.0);
 #endif /* RT_KLIBC_USING_VSNPRINTF_EXPONENTIAL_SPECIFIERS */
 }

--- a/src/klibc/utest/TC_rt_strcmp.c
+++ b/src/klibc/utest/TC_rt_strcmp.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2006-2024, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author             Notes
+ * 2026-07-03     Geek_simple        add rt_strcmp and rt_strncmp regression tests
+ */
+
+#include <rtklibc.h>
+#include <utest.h>
+
+static void TC_rt_strcmp_unsigned_char_order(void)
+{
+    const char high[] = {(char)0x80, '\0'};
+    const char low[] = {(char)0x01, '\0'};
+    const char max_byte[] = {(char)0xFF, '\0'};
+    const char ascii_high[] = {(char)0x7F, '\0'};
+
+    /* strcmp compares bytes as unsigned char, so 0x80 and 0xFF are greater. */
+    uassert_value_greater(rt_strcmp(high, low), 0);
+    uassert_value_less(rt_strcmp(low, high), 0);
+    uassert_value_greater(rt_strcmp(max_byte, ascii_high), 0);
+}
+
+static void TC_rt_strncmp_unsigned_char_order(void)
+{
+    const char high_first[] = {(char)0xC8, 'Z', '\0'};
+    const char low_first[] = {(char)0x01, 'Z', '\0'};
+    const char max_byte[] = {(char)0xFF, '\0'};
+    const char ascii_high[] = {(char)0x7F, '\0'};
+
+    /* strncmp also compares the first different byte as unsigned char. */
+    uassert_value_greater(rt_strncmp(high_first, low_first, 2), 0);
+    uassert_value_less(rt_strncmp(low_first, high_first, 2), 0);
+    uassert_value_greater(rt_strncmp(max_byte, ascii_high, 1), 0);
+}
+
+static void TC_rt_strncmp_count_zero(void)
+{
+    const char high[] = {(char)0x80, '\0'};
+    const char low[] = {(char)0x01, '\0'};
+
+    uassert_int_equal(rt_strncmp(high, low, 0), 0);
+}
+
+static void utest_do_tc(void)
+{
+    UTEST_UNIT_RUN(TC_rt_strcmp_unsigned_char_order);
+    UTEST_UNIT_RUN(TC_rt_strncmp_unsigned_char_order);
+    UTEST_UNIT_RUN(TC_rt_strncmp_count_zero);
+}
+
+UTEST_TC_EXPORT(utest_do_tc, "core.klibc.rt_strcmp", RT_NULL, RT_NULL, 1000);

--- a/src/klibc/utest/TC_rt_strcmp.c
+++ b/src/klibc/utest/TC_rt_strcmp.c
@@ -13,10 +13,10 @@
 
 static void TC_rt_strcmp_unsigned_char_order(void)
 {
-    const char high[] = {(char)0x80, '\0'};
-    const char low[] = {(char)0x01, '\0'};
-    const char max_byte[] = {(char)0xFF, '\0'};
-    const char ascii_high[] = {(char)0x7F, '\0'};
+    const char high[] = { (char)0x80, '\0' };
+    const char low[] = { (char)0x01, '\0' };
+    const char max_byte[] = { (char)0xFF, '\0' };
+    const char ascii_high[] = { (char)0x7F, '\0' };
 
     /* strcmp compares bytes as unsigned char, so 0x80 and 0xFF are greater. */
     uassert_value_greater(rt_strcmp(high, low), 0);
@@ -26,10 +26,10 @@ static void TC_rt_strcmp_unsigned_char_order(void)
 
 static void TC_rt_strncmp_unsigned_char_order(void)
 {
-    const char high_first[] = {(char)0xC8, 'Z', '\0'};
-    const char low_first[] = {(char)0x01, 'Z', '\0'};
-    const char max_byte[] = {(char)0xFF, '\0'};
-    const char ascii_high[] = {(char)0x7F, '\0'};
+    const char high_first[] = { (char)0xC8, 'Z', '\0' };
+    const char low_first[] = { (char)0x01, 'Z', '\0' };
+    const char max_byte[] = { (char)0xFF, '\0' };
+    const char ascii_high[] = { (char)0x7F, '\0' };
 
     /* strncmp also compares the first different byte as unsigned char. */
     uassert_value_greater(rt_strncmp(high_first, low_first, 2), 0);
@@ -39,8 +39,8 @@ static void TC_rt_strncmp_unsigned_char_order(void)
 
 static void TC_rt_strncmp_count_zero(void)
 {
-    const char high[] = {(char)0x80, '\0'};
-    const char low[] = {(char)0x01, '\0'};
+    const char high[] = { (char)0x80, '\0' };
+    const char low[] = { (char)0x01, '\0' };
 
     uassert_int_equal(rt_strncmp(high, low, 0), 0);
 }


### PR DESCRIPTION
#### 为什么提交这份PR (why to submit this PR)

本 PR 用于修复 RT-Thread `klibc` 中若干格式化输出与字符串比较行为不符合标准语义的问题。相关问题均属于纯软件逻辑缺陷，不依赖具体开发板、外设或硬件环境。

当前实现中主要存在以下问题：

1. `rt_vsnprintf_tiny` 在处理 `%s` 时错误地将字段宽度 `field width` 当作最大输出长度使用。例如使用 `%5s` 格式化字符串 `"abcdefgh"` 时，当前实现会错误输出 `"abcde"`。按照标准 `printf` 语义，字段宽度只表示最小宽度，不能截断字符串；字符串截断只能由精度控制。

2. `rt_vsnprintf_tiny` 对字符串精度为 0 的情况处理不正确。`%.0s` 和 `%.s` 应该输出空字符串，但当前实现仍会输出原字符串内容。

3. `rt_vsnprintf_tiny` 在处理整数零精度格式时错误抑制了非零整数输出。例如 `%.0d` 格式化数值 `5` 时应输出 `"5"`，只有数值为 `0` 且精度为 `0` 时才应输出空字符串。

4. `rt_strcmp` 和 `rt_strncmp` 当前使用有符号 `char` 参与字节比较。当字符串中包含 `0x80`、`0xC8`、`0xFF` 等高位字节时，比较结果的正负号可能与标准 `strcmp` / `strncmp` 语义不一致。标准字符串比较应按 `unsigned char` 进行字节比较。

因此，本 PR 对上述边界情况进行修复，并补充对应回归测试，避免后续再次引入相同行为缺陷。

#### 你的解决方案是什么 (what is your solution)

本 PR 主要进行了以下修改：

1. 修复 `rt_vsnprintf_tiny` 中 `%s` 的字段宽度处理逻辑

* 先按字符串实际内容计算完整长度；
* 字段宽度只用于补空格对齐；
* 字符串是否截断仅由精度控制；
* 正确支持 `%.0s` 和 `%.s` 输出空字符串。

2. 修复 `rt_vsnprintf_tiny` 中整数零精度格式化逻辑

* 仅在“数值为 0 且精度为 0”时抑制数字输出；
* 对 `%.0d` 格式化 `5`、`-5` 等非零数值时，仍正常输出对应数字。

3. 修复 `rt_strcmp` 和 `rt_strncmp` 的高位字节比较逻辑

* 比较前将字符转换为 `unsigned char`；
* `rt_strncmp` 使用 `int` 保存比较结果，避免 `signed char` 截断或符号反转；
* 保证包含高位字节的字符串比较结果与标准 `strcmp` / `strncmp` 语义一致。

4. 补充回归测试

新增和补充了以下测试覆盖：

* `%5s` 不应截断字符串；
* `%.0s` 和 `%.s` 应输出空字符串；
* `%.0d` 对 `0` 应输出空字符串；
* `%.0d` 对 `5`、`-5` 应正常输出数字；
* `rt_strcmp` / `rt_strncmp` 应按 `unsigned char` 比较 `0x80`、`0xC8`、`0xFF` 等高位字节。

#### 请提供验证的bsp和config (provide the config and bsp)

* BSP:

`bsp/simulator`

本次修改位于 `klibc` 纯软件逻辑层，不依赖具体硬件外设，因此使用 `bsp/simulator` 进行构建验证。

* .config:

未修改 `.config`。

验证时使用 `bsp/simulator` 目录下已有的默认 `.config`。

额外进行了主机侧行为对比验证，将修复后的 RT-Thread 实现与本机 libc 行为进行对比，覆盖以下场景：

* `%5s` 格式化 `"abcdefgh"`；
* `%.0s` 格式化 `"abc"`；
* `%.s` 格式化 `"abc"`；
* `%.0d` 格式化 `0`；
* `%.0d` 格式化 `5`；
* `%.0d` 格式化 `-5`；
* `rt_strcmp("\x80", "\x01")`；
* `rt_strncmp("\xC8Z", "\x01Z", 2)`；
* `rt_strncmp("\xFF", "\x7F", 1)`。

同时，对新增和修改的 utest 文件进行了本地语法检查：

* `src/klibc/utest/TC_rt_sprintf.c`
* `src/klibc/utest/TC_rt_strcmp.c`

使用 `bsp/simulator` 完成构建验证：

```sh
cd bsp/simulator
scons -j$(nproc)
```
构建结果：

```text
scons_exit_code=0
```

* action:

Fork 分支：

`https://github.com/yanhu7150-tech/rt-thread/tree/bugfix-klibc-format-string`

当前分支 action 页面：

`https://github.com/yanhu7150-tech/rt-thread/actions?query=branch%3Abugfix-klibc-format-string`

如果 GitHub Action 尚未触发或尚未完成，我会在 action 成功后补充对应的成功链接。

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json) 详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)