### PR TITLE
fix dist-strip compile_commands path parsing

### DIFF
--- a/tools/compile_commands.py
+++ b/tools/compile_commands.py
@@ -24,6 +24,7 @@
 import os
 import json
 import re
+import shlex
 from SCons.Script import *
 
 def collect_compile_info(env):
@@ -115,6 +116,87 @@ def generate_compile_commands(env):
     print("=> Adding post-build action for compile_commands generation")
     env.AddPostAction(None, write_compile_commands)
 
+def _normalize_compile_path(path, base_dir=None):
+    """Normalize a path from compile_commands.json."""
+    if not path:
+        return None
+
+    path = os.path.expanduser(path)
+    if not os.path.isabs(path) and base_dir:
+        path = os.path.join(base_dir, path)
+
+    return os.path.abspath(os.path.normpath(path))
+
+
+def _is_path_under(path, root):
+    """Check whether path is under root after normalization."""
+    if not path or not root:
+        return False
+
+    try:
+        path = os.path.abspath(os.path.normpath(path))
+        root = os.path.abspath(os.path.normpath(root))
+        return os.path.commonpath([path, root]) == root
+    except ValueError:
+        return False
+
+
+def _strip_argument_quotes(arg):
+    """Strip quotes kept by non-POSIX shlex parsing."""
+    if len(arg) >= 2 and arg[0] == arg[-1] and arg[0] in ('"', "'"):
+        return arg[1:-1]
+
+    return arg
+
+
+def _get_entry_arguments(entry):
+    """Return compiler arguments from a compile database entry."""
+    arguments = entry.get('arguments')
+    if isinstance(arguments, list):
+        return [str(arg) for arg in arguments]
+
+    command = entry.get('command', '')
+    if not command:
+        return []
+
+    try:
+        return shlex.split(command, posix=False)
+    except ValueError:
+        return command.split()
+
+
+def _extract_include_paths(args):
+    """Extract include paths from compiler arguments."""
+    include_paths = []
+    index = 0
+
+    separated_options = {
+        '-I',
+        '-isystem',
+        '-iquote',
+        '-idirafter',
+        '/I',
+    }
+
+    while index < len(args):
+        arg = args[index]
+
+        if arg in separated_options:
+            if index + 1 < len(args):
+                include_paths.append(_strip_argument_quotes(args[index + 1]))
+                index += 2
+                continue
+
+        if arg.startswith('-I') and len(arg) > 2:
+            include_paths.append(_strip_argument_quotes(arg[2:]))
+        elif arg.startswith('/I') and len(arg) > 2:
+            include_paths.append(_strip_argument_quotes(arg[2:]))
+
+        index += 1
+
+    return include_paths
+
+
 def parse_compile_paths(json_path, rt_thread_root=None):
     """解析compile_commands.json并提取RT-Thread相关的包含路径
     
@@ -132,7 +214,7 @@ def parse_compile_paths(json_path, rt_thread_root=None):
         if not rt_thread_root:
             raise ValueError("RT-Thread根目录未指定")
     
-    rt_thread_root = os.path.abspath(rt_thread_root)
+    rt_thread_root = os.path.abspath(os.path.normpath(rt_thread_root))
     result = {
         'sources': set(),
         'includes': set()
@@ -141,20 +223,32 @@ def parse_compile_paths(json_path, rt_thread_root=None):
     try:
         with open(json_path, 'r') as f:
             compile_commands = json.load(f)
+
+        if not isinstance(compile_commands, list):
+            raise ValueError("compile_commands.json should contain a list")
             
         for entry in compile_commands:
+            if not isinstance(entry, dict):
+                continue
+
+            entry_dir = _normalize_compile_path(
+                entry.get('directory', ''),
+                os.path.dirname(os.path.abspath(json_path))
+            )
+
             # 处理源文件
-            src_file = entry.get('file', '')
-            if src_file.startswith(rt_thread_root):
+            src_file = _normalize_compile_path(entry.get('file', ''), entry_dir)
+            if _is_path_under(src_file, rt_thread_root):
                 rel_path = os.path.relpath(src_file, rt_thread_root)
                 result['sources'].add(os.path.dirname(rel_path))
             
-            # 处理包含路径 
-            command = entry.get('command', '')
-            include_paths = [p[2:] for p in command.split() if p.startswith('-I')]
+            # 处理包含路径
+            args = _get_entry_arguments(entry)
+            include_paths = _extract_include_paths(args)
             
             for inc_path in include_paths:
-                if inc_path.startswith(rt_thread_root):
+                inc_path = _normalize_compile_path(inc_path, entry_dir)
+                if _is_path_under(inc_path, rt_thread_root):
                     rel_path = os.path.relpath(inc_path, rt_thread_root)
                     result['includes'].add(rel_path)
         

--- a/tools/mkdist.py
+++ b/tools/mkdist.py
@@ -279,6 +279,15 @@ def MkDist_Strip(program, BSP_ROOT, RTT_ROOT, env, project_name, project_path=No
         RTT_ROOT
     )
 
+    if not used_paths:
+        print("Warning: No source paths found from compile_commands.json")
+        print("Skip source cleanup to avoid removing required files")
+        if project_path is None:
+            zip_dist(dist_dir, project_name)
+            print("Distribution package created: {}.zip".format(dist_dir))
+        print('=> Distribution strip skipped')
+        return
+
     # Clean up RT-Thread directory except tools and build files
     rt_thread_dir = os.path.join(dist_dir, 'rt-thread')
     source_extensions = ('.c', '.cpp', '.cxx', '.cc', '.s', '.S')

--- a/tools/testcases/test_compile_commands_paths.py
+++ b/tools/testcases/test_compile_commands_paths.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+TOOLS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, TOOLS_DIR)
+
+from compile_commands import get_minimal_dist_paths
+from compile_commands import _get_entry_arguments
+from compile_commands import _extract_include_paths
+import mkdist
+
+
+def test_arguments_and_relative_paths():
+    tmp = tempfile.mkdtemp(prefix="rtthread_ccdb_test_")
+    try:
+        rt_root = os.path.join(tmp, "rt-thread")
+        src_dir = os.path.join(rt_root, "components", "foo")
+        inc_dir = os.path.join(src_dir, "include")
+        os.makedirs(inc_dir, exist_ok=True)
+
+        with open(os.path.join(src_dir, "foo.c"), "w", encoding="utf-8") as f:
+            f.write("int foo(void) { return 0; }\n")
+
+        with open(os.path.join(inc_dir, "foo.h"), "w", encoding="utf-8") as f:
+            f.write("#define FOO 1\n")
+
+        ccdb = os.path.join(tmp, "compile_commands.json")
+        with open(ccdb, "w", encoding="utf-8") as f:
+            json.dump([
+                {
+                    "directory": rt_root,
+                    "arguments": [
+                        "gcc",
+                        "-I",
+                        "components/foo/include",
+                        "-c",
+                        "components/foo/foo.c"
+                    ],
+                    "file": "components/foo/foo.c"
+                }
+            ], f)
+
+        paths = get_minimal_dist_paths(ccdb, rt_root)
+
+        expected = [
+            os.path.join("components", "foo"),
+            os.path.join("components", "foo", "include")
+        ]
+
+        missing = [path for path in expected if path not in paths]
+        if missing:
+            print("FAILED: missing expected paths:", missing)
+            print("actual paths:", paths)
+            return False
+
+        print("PASSED: arguments and relative paths are handled")
+        return True
+    finally:
+        shutil.rmtree(tmp)
+
+
+def test_mkdist_strip_keeps_sources_when_used_paths_empty():
+    tmp = tempfile.mkdtemp(prefix="rtthread_mkdist_strip_test_")
+    old_mkdist = mkdist.MkDist
+    old_zip_dist = mkdist.zip_dist
+
+    try:
+        bsp_root = os.path.join(tmp, "bsp")
+        rt_root = os.path.join(tmp, "rt-thread")
+        dist_dir = os.path.join(tmp, "dist_project")
+        source_dir = os.path.join(dist_dir, "rt-thread", "components", "foo")
+        source_file = os.path.join(source_dir, "foo.c")
+
+        os.makedirs(bsp_root, exist_ok=True)
+        os.makedirs(rt_root, exist_ok=True)
+
+        def fake_mkdist(program, BSP_ROOT, RTT_ROOT, env, project_name, project_path=None):
+            os.makedirs(source_dir, exist_ok=True)
+            with open(source_file, "w", encoding="utf-8") as f:
+                f.write("int foo(void) { return 0; }\n")
+
+        def fake_zip_dist(dist_dir, project_name):
+            return None
+
+        mkdist.MkDist = fake_mkdist
+        mkdist.zip_dist = fake_zip_dist
+
+        mkdist.MkDist_Strip(None, bsp_root, rt_root, None, "dist_project", dist_dir)
+
+        if not os.path.exists(source_file):
+            print("FAILED: MkDist_Strip removed sources when used_paths is empty")
+            return False
+
+        print("PASSED: MkDist_Strip keeps sources when used_paths is empty")
+        return True
+    finally:
+        mkdist.MkDist = old_mkdist
+        mkdist.zip_dist = old_zip_dist
+        shutil.rmtree(tmp)
+
+
+def test_command_string_keeps_windows_backslashes():
+    command = r"gcc -IC:\rt-thread\components\foo\include -c C:\rt-thread\components\foo\foo.c"
+    args = _get_entry_arguments({"command": command})
+    include_paths = _extract_include_paths(args)
+    expected = r"C:\rt-thread\components\foo\include"
+
+    if expected not in include_paths:
+        print("FAILED: Windows include path was not preserved")
+        print("args:", args)
+        print("include_paths:", include_paths)
+        return False
+
+    print("PASSED: Windows include path is preserved")
+    return True
+
+
+def main():
+    success = True
+
+    if not test_arguments_and_relative_paths():
+        success = False
+
+    if not test_mkdist_strip_keeps_sources_when_used_paths_empty():
+        success = False
+
+    if not test_command_string_keeps_windows_backslashes():
+        success = False
+
+    if success:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
#### 为什么提交这份PR (why to submit this PR)

本 PR 用于修复 RT-Thread `tools/` 中 `--dist-strip` 依赖 `compile_commands.json` 推导最小发布包保留路径时的路径解析问题，以及解析结果为空时仍继续执行源码清理的问题。

该问题属于普通构建/发布工具的软件逻辑缺陷

`--dist-strip` 的目标是根据 `compile_commands.json` 中记录的实际编译路径，生成只保留必要源码的最小发布包。当前实现对 compile database 的解析不完整，在部分标准输入格式和跨平台路径场景下，可能漏掉实际需要保留的源码目录或 include 目录，进而影响最小发布包的正确性。

主要问题如下：

1. `tools/compile_commands.py` 只解析 `command` 字符串，未支持 compile database 标准允许的 `arguments` 数组；
2. 原实现使用 `command.split()` 解析编译命令，无法正确处理 `-I path` 分离写法、带引号路径以及 Windows 反斜杠路径；
3. 相对 `file` 路径和相对 include 路径没有基于 compile database entry 的 `directory` 字段进行归一化，导致标准格式的 `compile_commands.json` 中有效源码路径和 include 路径可能被漏掉；
4. `tools/mkdist.py` 中 `MkDist_Strip()` 在 `compile_commands.json` 缺失、解析失败或解析结果为空时，仍继续执行源码清理，可能删除 dist 包中实际需要保留的源码文件。

修复前，使用如下标准 compile database entry 时，`get_minimal_dist_paths()` 无法正确识别相对源码目录和 include 目录：

```json
[
  {
    "directory": "/tmp/rt-thread",
    "arguments": [
      "gcc",
      "-I",
      "components/foo/include",
      "-c",
      "components/foo/foo.c"
    ],
    "file": "components/foo/foo.c"
  }
]
```

修复前实际行为：

```text
returned_paths: []
has_src_dir: False
has_inc_dir: False
```

这会导致 `--dist-strip` 后续清理逻辑缺少可靠的保留路径依据。


#### 你的解决方案是什么 (what is your solution)

本 PR 的解决方案主要包括以下几个部分：

1. 增强 `compile_commands.json` entry 解析逻辑

   - 优先支持 compile database 标准中的 `arguments` 数组；
   - 对 `command` 字符串使用 `shlex.split(..., posix=False)` 解析，避免 Windows 反斜杠路径被错误转义；
   - 支持常见 include 参数形式：
     - `-Ifoo`
     - `-I foo`
     - `/Ifoo`
     - `/I foo`
     - `-isystem path`
     - `-iquote path`
     - `-idirafter path`
   - 对非 POSIX shlex 解析后保留的外层引号进行必要剥离，保证带引号路径能够继续参与路径归一化。

2. 增强路径归一化逻辑

   - 将相对 `file` 路径基于 compile database entry 的 `directory` 字段归一化；
   - 将相对 include 路径基于 entry 的 `directory` 字段归一化；
   - 使用规范化后的路径判断其是否位于 RT-Thread 根目录下，避免简单字符串前缀判断带来的误判；
   - 对异常路径场景进行保护，避免路径比较时抛出未处理异常。

3. 修复 `MkDist_Strip()` 的空结果处理

   - 当 `compile_commands.json` 缺失、解析失败或没有解析到任何使用路径时，跳过源码清理；
   - 避免在路径信息不足时删除可能仍然需要保留的源码文件；
   - 保持完整 dist 产物可用，避免生成被错误裁剪的最小发布包。

4. 新增回归测试

   新增 `tools/testcases/test_compile_commands_paths.py`，覆盖以下场景：

   - `arguments` 数组和相对路径解析；
   - `used_paths` 为空时，`MkDist_Strip()` 不应删除源码；
   - Windows command 字符串中的反斜杠 include 路径应被正确保留。


#### 请提供验证的bsp和config (provide the config and bsp)

- BSP:

本 PR 修改的是 `tools/` 下的构建/发布辅助脚本，不依赖具体 BSP 或真实开发板。

Host-side verification was used for this tools-only change.

- .config:

未修改 `.config`。

本 PR 不涉及 BSP 配置项变更。

- action:

Fork branch:

https://github.com/yanhu7150-tech/rt-thread/tree/bugfix-dist-strip-compile-commands

Action page:

https://github.com/yanhu7150-tech/rt-thread/actions?query=branch%3Abugfix-dist-strip-compile-commands

本地验证环境：

```text
OS: Windows
Python: 3.10.11
SCons: 4.10.1
```

本地验证命令：

```powershell
python -m py_compile tools\compile_commands.py tools\mkdist.py tools\testcases\test_compile_commands_paths.py
python tools\testcases\test_compile_commands_paths.py
echo "test_exit_code=$LASTEXITCODE"
```

验证结果：

```text
PASSED: arguments and relative paths are handled
PASSED: MkDist_Strip keeps sources when used_paths is empty
PASSED: Windows include path is preserved
test_exit_code=0
```

变更范围：

```text
tools/compile_commands.py
tools/mkdist.py
tools/testcases/test_compile_commands_paths.py
```

提交分支：

```text
bugfix-dist-strip-compile-commands
```

提交信息：

```text
fix dist strip compile command path parsing
```
### 代码质量 Code Quality： 我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用 formatting 等源码格式化工具确保格式符合 RT-Thread 代码规范