### PR TITLE
tools: fix mkromfs C generation for special filenames

### DIFF
--- a/tools/mkromfs.py
+++ b/tools/mkromfs.py
@@ -7,6 +7,56 @@ import struct
 from collections import namedtuple
 import io
 
+
+def _make_c_identifier(name):
+    encoded = os.fsencode(name)
+    chars = []
+    for byte in encoded:
+        is_digit = ord('0') <= byte <= ord('9')
+        is_upper = ord('A') <= byte <= ord('Z')
+        is_lower = ord('a') <= byte <= ord('z')
+        if is_digit or is_upper or is_lower or byte == ord('_'):
+            chars.append(chr(byte))
+        else:
+            chars.append('_%02x' % byte)
+
+    if not chars:
+        chars.append('empty')
+    if chars[0].isdigit():
+        chars.insert(0, '_')
+    return '_' + ''.join(chars)
+
+
+def _unique_c_identifier(name, used):
+    base = _make_c_identifier(name)
+    candidate = base
+    index = 1
+    while candidate in used:
+        candidate = '%s_%d' % (base, index)
+        index += 1
+    used.add(candidate)
+    return candidate
+
+
+def _c_string_literal(value):
+    escaped = []
+    for byte in os.fsencode(value):
+        if byte == ord('\\'):
+            escaped.append('\\\\')
+        elif byte == ord('"'):
+            escaped.append('\\\"')
+        elif byte == ord('\n'):
+            escaped.append('\\n')
+        elif byte == ord('\r'):
+            escaped.append('\\r')
+        elif byte == ord('\t'):
+            escaped.append('\\t')
+        elif 0x20 <= byte <= 0x7e:
+            escaped.append(chr(byte))
+        else:
+            escaped.append('\\%03o' % byte)
+    return '"' + ''.join(escaped) + '"'
+
 import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('rootdir', type=str, help='the path to rootfs')
@@ -16,9 +66,11 @@ parser.add_argument('--binary', action='store_true', help='output binary file')
 parser.add_argument('--addr', default='0', help='set the base address of the binary file, default to 0.')
 
 class File(object):
-    def __init__(self, name):
+    def __init__(self, name, path=None):
         self._name = name
-        self._data = open(name, 'rb').read()
+        self._path = path if path is not None else name
+        self._data = open(self._path, 'rb').read()
+        self._c_name = None
 
     @property
     def name(self):
@@ -26,7 +78,12 @@ class File(object):
 
     @property
     def c_name(self):
-        return '_' + self._name.replace('.', '_')
+        if self._c_name is not None:
+            return self._c_name
+        return _make_c_identifier(self._name)
+
+    def set_c_name(self, c_name):
+        self._c_name = c_name
 
     @property
     def bin_name(self):
@@ -62,9 +119,11 @@ class Folder(object):
     bin_fmt = struct.Struct('IIII')
     bin_item = namedtuple('dirent', 'type, name, data, size')
 
-    def __init__(self, name):
+    def __init__(self, name, path=None):
         self._name = name
+        self._path = path
         self._children = []
+        self._c_name = None
 
     @property
     def name(self):
@@ -72,8 +131,12 @@ class Folder(object):
 
     @property
     def c_name(self):
-        # add _ to avoid conflict with C key words.
-        return '_' + self._name
+        if self._c_name is not None:
+            return self._c_name
+        return _make_c_identifier(self._name)
+
+    def set_c_name(self, c_name):
+        self._c_name = c_name
 
     @property
     def bin_name(self):
@@ -83,20 +146,15 @@ class Folder(object):
         return bn
 
     def walk(self):
-        # os.listdir will return unicode list if the argument is unicode.
-        # TODO: take care of the unicode names
-        for ent in os.listdir(u'.'):
-            if os.path.isdir(ent):
-                cwd = os.getcwd()
-                d = Folder(ent)
-                # depth-first
-                os.chdir(os.path.join(cwd, ent))
+        root = self._path if self._path is not None else u'.'
+        for ent in os.listdir(root):
+            path = os.path.join(root, ent)
+            if os.path.isdir(path):
+                d = Folder(ent, path)
                 d.walk()
-                # restore the cwd
-                os.chdir(cwd)
                 self._children.append(d)
             else:
-                self._children.append(File(ent))
+                self._children.append(File(ent, path))
 
     def sort(self):
         def _sort(x, y):
@@ -114,6 +172,18 @@ class Folder(object):
             if isinstance(c, Folder):
                 c.sort()
 
+    def assign_c_names(self):
+        if self._c_name is None:
+            self._c_name = _make_c_identifier(self._name)
+
+        used = set()
+        for c in self._children:
+            c.set_c_name(_unique_c_identifier(c.name, used))
+
+        for c in self._children:
+            if isinstance(c, Folder):
+                c.assign_c_names()
+
     def dump(self, indent=0):
         print('%s%s' % (' ' * indent, self._name))
         for c in self._children:
@@ -130,8 +200,8 @@ class Folder(object):
 
         dhead = 'static const struct romfs_dirent %s[] = {\n' % (prefix + self.c_name)
         dtail = '\n};'
-        body_fmt = '    {{{type}, "{name}", (rt_uint8_t *){data}, sizeof({data})/sizeof({data}[0])}}'
-        body_fmt0= '    {{{type}, "{name}", RT_NULL, 0}}'
+        body_fmt = '    {{{type}, {name}, (rt_uint8_t *){data}, sizeof({data})/sizeof({data}[0])}}'
+        body_fmt0= '    {{{type}, {name}, RT_NULL, 0}}'
         # prefix of children
         cpf = prefix+self.c_name
         body_li = []
@@ -145,10 +215,11 @@ class Folder(object):
             else:
                 assert False, 'Unkown instance:%s' % str(c)
             if entry_size == 0:
-                body_li.append(body_fmt0.format(type=tp, name = c.name))
+                body_li.append(body_fmt0.format(type=tp,
+                                                name=_c_string_literal(c.name)))
             else:
                 body_li.append(body_fmt.format(type=tp,
-                                            name=c.name,
+                                            name=_c_string_literal(c.name),
                                             data=cpf+c.c_name))
             payload_li.append(c.c_data(prefix=cpf))
 
@@ -246,11 +317,10 @@ def get_bin_data(tree, base_addr):
 if __name__ == '__main__':
     args = parser.parse_args()
 
-    os.chdir(args.rootdir)
-
-    tree = Folder('romfs_root')
+    tree = Folder('romfs_root', args.rootdir)
     tree.walk()
     tree.sort()
+    tree.assign_c_names()
 
     if args.dump:
         tree.dump()
@@ -261,7 +331,9 @@ if __name__ == '__main__':
         data = get_c_data(tree).encode()
 
     output = args.output
-    if not output:
-        output = sys.stdout
-
-    output.write(data)
+    if output:
+        output.write(data)
+    elif args.binary:
+        sys.stdout.buffer.write(data)
+    else:
+        sys.stdout.write(data.decode())

--- a/tools/testcases/test_mkromfs.py
+++ b/tools/testcases/test_mkromfs.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -54,6 +55,8 @@ class MkromfsCodeGenerationTestCase(unittest.TestCase):
         )
 
     def compile_c_file(self, source):
+        if shutil.which("gcc") is None:
+            self.skipTest("gcc is not available")
         return subprocess.run(
             [
                 "gcc",
@@ -72,9 +75,15 @@ class MkromfsCodeGenerationTestCase(unittest.TestCase):
         test_files = {
             "foo-bar.txt": "hyphen\n",
             "a b.txt": "space\n",
-            'a"b.txt': "quote\n",
-            r"a\b.txt": "backslash\n",
         }
+        if os.name != "nt":
+            test_files.update(
+                {
+                    'a"b.txt': "quote\n",
+                    r"a\b.txt": "backslash\n",
+                }
+            )
+
         for name, content in test_files.items():
             (self.rootdir / name).write_text(content, encoding="utf-8")
 
@@ -86,18 +95,19 @@ class MkromfsCodeGenerationTestCase(unittest.TestCase):
             msg=mkromfs_result.stderr,
         )
 
+        generated = output.read_text(encoding="utf-8")
+        self.assertIn('"foo-bar.txt"', generated)
+        self.assertIn('"a b.txt"', generated)
+        if os.name != "nt":
+            self.assertIn(r'"a\"b.txt"', generated)
+            self.assertIn(r'"a\\b.txt"', generated)
+
         compile_result = self.compile_c_file(output)
         self.assertEqual(
             compile_result.returncode,
             0,
             msg=compile_result.stderr,
         )
-
-        generated = output.read_text(encoding="utf-8")
-        self.assertIn('"foo-bar.txt"', generated)
-        self.assertIn('"a b.txt"', generated)
-        self.assertIn(r'"a\"b.txt"', generated)
-        self.assertIn(r'"a\\b.txt"', generated)
 
     def test_empty_file_with_special_name_generates_valid_null_entry(self):
         (self.rootdir / "empty-file.txt").write_bytes(b"")
@@ -110,16 +120,16 @@ class MkromfsCodeGenerationTestCase(unittest.TestCase):
             msg=mkromfs_result.stderr,
         )
 
+        generated = output.read_text(encoding="utf-8")
+        self.assertIn('"empty-file.txt"', generated)
+        self.assertIn("RT_NULL, 0", generated)
+
         compile_result = self.compile_c_file(output)
         self.assertEqual(
             compile_result.returncode,
             0,
             msg=compile_result.stderr,
         )
-
-        generated = output.read_text(encoding="utf-8")
-        self.assertIn('"empty-file.txt"', generated)
-        self.assertIn("RT_NULL, 0", generated)
 
 
 if __name__ == "__main__":

--- a/tools/testcases/test_mkromfs.py
+++ b/tools/testcases/test_mkromfs.py
@@ -1,0 +1,126 @@
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+class MkromfsCodeGenerationTestCase(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = Path(__file__).resolve().parents[2]
+        self.mkromfs = self.repo_root / "tools" / "mkromfs.py"
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.workdir = Path(self.tempdir.name)
+        self.rootdir = self.workdir / "root"
+        self.include_dir = self.workdir / "include"
+        self.rootdir.mkdir()
+        self.include_dir.mkdir()
+
+        (self.include_dir / "rtthread.h").write_text(
+            "typedef unsigned char rt_uint8_t;\n",
+            encoding="utf-8",
+        )
+        (self.include_dir / "dfs_romfs.h").write_text(
+            textwrap.dedent(
+                """\
+                #define ROMFS_DIRENT_FILE 0
+                #define ROMFS_DIRENT_DIR 1
+                #define RT_NULL ((void *)0)
+                struct romfs_dirent
+                {
+                    int type;
+                    const char *name;
+                    rt_uint8_t *data;
+                    unsigned int size;
+                };
+                """
+            ),
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def run_mkromfs(self, output):
+        return subprocess.run(
+            [sys.executable, str(self.mkromfs), str(self.rootdir), str(output)],
+            cwd=str(self.repo_root),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def compile_c_file(self, source):
+        return subprocess.run(
+            [
+                "gcc",
+                "-fsyntax-only",
+                "-I",
+                str(self.include_dir),
+                str(source),
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def test_special_file_names_generate_valid_c_code(self):
+        test_files = {
+            "foo-bar.txt": "hyphen\n",
+            "a b.txt": "space\n",
+            'a"b.txt': "quote\n",
+            r"a\b.txt": "backslash\n",
+        }
+        for name, content in test_files.items():
+            (self.rootdir / name).write_text(content, encoding="utf-8")
+
+        output = self.workdir / "romfs.c"
+        mkromfs_result = self.run_mkromfs(output)
+        self.assertEqual(
+            mkromfs_result.returncode,
+            0,
+            msg=mkromfs_result.stderr,
+        )
+
+        compile_result = self.compile_c_file(output)
+        self.assertEqual(
+            compile_result.returncode,
+            0,
+            msg=compile_result.stderr,
+        )
+
+        generated = output.read_text(encoding="utf-8")
+        self.assertIn('"foo-bar.txt"', generated)
+        self.assertIn('"a b.txt"', generated)
+        self.assertIn(r'"a\"b.txt"', generated)
+        self.assertIn(r'"a\\b.txt"', generated)
+
+    def test_empty_file_with_special_name_generates_valid_null_entry(self):
+        (self.rootdir / "empty-file.txt").write_bytes(b"")
+
+        output = self.workdir / "romfs.c"
+        mkromfs_result = self.run_mkromfs(output)
+        self.assertEqual(
+            mkromfs_result.returncode,
+            0,
+            msg=mkromfs_result.stderr,
+        )
+
+        compile_result = self.compile_c_file(output)
+        self.assertEqual(
+            compile_result.returncode,
+            0,
+            msg=compile_result.stderr,
+        )
+
+        generated = output.read_text(encoding="utf-8")
+        self.assertIn('"empty-file.txt"', generated)
+        self.assertIn("RT_NULL, 0", generated)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

This PR fixes a ROMFS C code generation bug in `tools/mkromfs.py`.

Before this change, `mkromfs.py` directly used source file names when generating C identifiers and C string literals. However, some file names that are valid on the host file system are not valid C identifiers or need escaping when emitted as C string literals.

For example, a ROMFS source file named `foo-bar.txt` could generate invalid C code like:

```c
static const rt_uint8_t _romfs_root_foo-bar_txt[] = {
```

The `-` character is not valid inside a C identifier, so the generated `romfs.c` fails C syntax checking.

Other valid file names can also break the generated C source:

- `a b.txt` generates a C identifier containing a space;
- `a"b.txt` generates an unescaped quote inside a C string literal;
- `a\b.txt` generates an unescaped backslash inside generated C code.

This causes `mkromfs.py` to fail when users generate ROMFS resources from ordinary files with special characters in their names. This is a normal host-side tool bug, not a security vulnerability.

#### 你的解决方案是什么 (what is your solution)

This PR updates `tools/mkromfs.py` to generate valid C code for ROMFS entries whose file names contain special characters.

The main changes are:

1. Sanitize generated C identifiers.

   - ASCII letters, digits and `_` are kept when valid;
   - other bytes are encoded as `_xx` hexadecimal fragments;
   - identifiers are kept valid even when the original name starts with a digit.

2. Keep generated C identifiers unique among sibling ROMFS entries.

   This avoids symbol collisions when different file names would otherwise normalize to the same C identifier.

3. Escape ROMFS file names correctly when emitting C string literals.

   - `"` is emitted as `\"`;
   - `\` is emitted as `\\`;
   - newline, carriage return and tab are escaped;
   - other non-printable bytes are emitted with octal escape sequences.

4. Avoid changing the process working directory while walking the ROMFS input tree.

   The tree walker now tracks entry paths explicitly instead of relying on global `os.chdir()` side effects.

5. Handle stdout output correctly.

   - binary output is written to `sys.stdout.buffer`;
   - generated C source output is written as text.

6. Add regression tests in `tools/testcases/test_mkromfs.py`.

   The tests cover:

   - file names with hyphens and spaces;
   - quote and backslash file names on non-Windows platforms;
   - empty files with special names;
   - generated C syntax checking with `gcc -fsyntax-only` when `gcc` is available.

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP:

N/A. This is a host-side tool fix for `tools/mkromfs.py`. It does not depend on a specific BSP or board.

- .config:

N/A. No `.config` option is required to verify this PR.

- action:

N/A / pending. This PR was verified locally with host-side Python tests. If the RT-Thread PR bot requires a workflow run after the PR is opened, the corresponding action link can be added in the PR discussion.

Local verification on Linux:

```bash
python3 -m py_compile tools/mkromfs.py tools/testcases/test_mkromfs.py
python3 tools/testcases/test_mkromfs.py
```

Additional Linux manual verification:

```bash
python3 tools/mkromfs.py <romfs_root> romfs.c
gcc -fsyntax-only -I <stub_include_dir> romfs.c
```

Before this fix, the generated `romfs.c` failed syntax checking for special file names.  
After this fix, the generated `romfs.c` passes syntax checking.

Local verification on Windows:

```powershell
python -m py_compile tools\mkromfs.py tools\testcases\test_mkromfs.py
python tools\testcases\test_mkromfs.py
```

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json) 详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)