### PR TITLE
tools: fix CI git diff path parsing

### DIFF
--- a/tools/ci/compile_bsp_with_drivers.py
+++ b/tools/ci/compile_bsp_with_drivers.py
@@ -8,10 +8,14 @@
 # 2023-06-27     dejavudwh    the first version
 #
 
-import subprocess
 import logging
 import os
 import sys
+
+try:
+    from git_utils import get_changed_files
+except ImportError:
+    from tools.ci.git_utils import get_changed_files
 
 CONFIG_BSP_USING_X = ["CONFIG_BSP_USING_UART", "CONFIG_BSP_USING_I2C", "CONFIG_BSP_USING_SPI", "CONFIG_BSP_USING_ADC", "CONFIG_BSP_USING_DAC"]
 
@@ -24,25 +28,35 @@ def init_logger():
                         )
 
 def diff():
-    result = subprocess.run(['git', 'diff', '--name-only', 'HEAD', 'origin/master', '--diff-filter=ACMR', '--no-renames', '--full-index'], stdout = subprocess.PIPE)
-    file_list = result.stdout.decode().strip().split('\n')
+    try:
+        file_list = get_changed_files(
+            "HEAD",
+            "origin/master",
+            diff_filter="ACMR",
+            no_renames=True,
+            full_index=True,
+        )
+    except RuntimeError as e:
+        logging.error(e)
+        return set()
+
     logging.info(file_list)
     bsp_paths = set()
     for file in file_list:
         if "bsp/" in file:
             logging.info("Modifed file: {}".format(file))
             bsp_paths.add(file)
-    
+
     dirs = set()
     for dir in bsp_paths:
-        dir = os.path.dirname(dir)    
+        dir = os.path.dirname(dir)
         while "bsp/" in dir:
             files = os.listdir(dir)
             if ".config" in files and "rt-thread.elf" not in files and not dir.endswith("bsp"):
                 logging.info("Found bsp path: {}".format(dir))
                 dirs.add(dir)
                 break
-            new_dir = os.path.dirname(dir)    
+            new_dir = os.path.dirname(dir)
             dir = new_dir
 
     return dirs

--- a/tools/ci/format_ignore.py
+++ b/tools/ci/format_ignore.py
@@ -11,7 +11,11 @@
 import yaml
 import logging
 import os
-import subprocess
+
+try:
+    from git_utils import get_changed_files
+except ImportError:
+    from tools.ci.git_utils import get_changed_files
 
 def init_logger():
     log_format = "[%(filename)s %(lineno)d %(levelname)s] %(message)s "
@@ -72,13 +76,23 @@ class CheckOut:
         return 1
     
     def get_new_file(self):
-        result = subprocess.run(['git', 'diff', '--name-only', 'HEAD', 'origin/master', '--diff-filter=ACMR', '--no-renames', '--full-index'], stdout = subprocess.PIPE)
-        file_list = result.stdout.decode().strip().split('\n')
+        try:
+            file_list = get_changed_files(
+                "HEAD",
+                "origin/master",
+                diff_filter="ACMR",
+                no_renames=True,
+                full_index=True,
+            )
+        except RuntimeError as e:
+            logging.error(e)
+            return []
+
         new_files = []
         for line in file_list:
             logging.info("modified file -> {}".format(line))
             result = self.__exclude_file(line)
             if result != 0:
                 new_files.append(line)
-        
+
         return new_files

--- a/tools/ci/git_diff_show.py
+++ b/tools/ci/git_diff_show.py
@@ -17,6 +17,16 @@ from typing import List, Dict
 
 import json
 from typing import List
+
+try:
+    from git_utils import get_blob_size
+    from git_utils import get_merge_base as git_get_merge_base
+    from git_utils import get_name_status_lines
+except ImportError:
+    from tools.ci.git_utils import get_blob_size
+    from tools.ci.git_utils import get_merge_base as git_get_merge_base
+    from tools.ci.git_utils import get_name_status_lines
+
 class FileDiff:
     def __init__(self, path: str, status: str, size_change: int = 0, old_size: int = 0, new_size: int = 0):
         self.path = path
@@ -49,14 +59,13 @@ class GitDiffAnalyzer:
             sys.exit(1)
             
         # 获取差异文件列表
-        diff_cmd = f"git diff --name-status {merge_base} HEAD"
-        print(diff_cmd)
+        print("git diff --name-status {} HEAD".format(merge_base))
         try:
-            output = subprocess.check_output(diff_cmd.split(), stderr=subprocess.STDOUT)
-            output = output.decode(self.encoding).strip()
+            lines = get_name_status_lines(merge_base, "HEAD", self.encoding)
+            output = "\n".join(lines)
             print(output)
-        except subprocess.CalledProcessError as e:
-            print(f"Error executing git diff: {e.output.decode(self.encoding)}")
+        except RuntimeError as e:
+            print("Error executing git diff: {}".format(e))
             sys.exit(1)
             
         if not output:
@@ -110,24 +119,15 @@ class GitDiffAnalyzer:
     def get_merge_base(self) -> str:
         """获取当前分支和目标分支的最近共同祖先"""
         try:
-            cmd = f"git merge-base {self.target_branch} HEAD"
-            print(cmd)
-            output = subprocess.check_output(cmd.split(), stderr=subprocess.STDOUT)
-            return output.decode(self.encoding).strip()
-        except subprocess.CalledProcessError as e:
-            print(f"Error executing git merge-base: {e.output.decode(self.encoding)}")
+            print("git merge-base {} HEAD".format(self.target_branch))
+            return git_get_merge_base(self.target_branch, "HEAD", self.encoding)
+        except RuntimeError as e:
+            print("Error executing git merge-base: {}".format(e))
             return None
 
     def get_file_size(self, path: str, ref: str) -> int:
-        """获取指定分支上文件的大小"""
-        try:
-            # 使用 git cat-file 来获取文件内容，然后计算其大小
-            cmd = f"git cat-file blob {ref}:{path}"
-            output = subprocess.check_output(cmd.split(), stderr=subprocess.STDOUT)
-            return len(output)
-        except subprocess.CalledProcessError:
-            # 如果文件不存在或无法获取，返回0
-            return 0
+        """Get the size of a file at the specified git ref."""
+        return get_blob_size(ref, path, self.encoding)
 
 def format_size(size: int) -> str:
     """将字节大小转换为人类可读的格式"""

--- a/tools/ci/git_utils.py
+++ b/tools/ci/git_utils.py
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2006-2026, RT-Thread Development Team
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import locale
+import subprocess
+
+
+def _default_encoding():
+    return locale.getpreferredencoding()
+
+
+def _decode_output(data, encoding=None):
+    if data is None:
+        return ""
+
+    if encoding is None:
+        encoding = _default_encoding()
+
+    return data.decode(encoding, errors="replace")
+
+
+def _run_git(args, encoding=None):
+    result = subprocess.run(
+        ["git"] + args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    stdout = _decode_output(getattr(result, "stdout", b""), encoding)
+    stderr = _decode_output(getattr(result, "stderr", b""), encoding)
+    returncode = getattr(result, "returncode", 0)
+
+    if returncode != 0:
+        raise RuntimeError(
+            "git {} failed with code {}: {}".format(
+                " ".join(args),
+                returncode,
+                stderr.strip(),
+            )
+        )
+
+    return stdout
+
+
+def split_nonempty_lines(output):
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def get_changed_files(base, head, diff_filter="ACMR", no_renames=True, full_index=True, encoding=None):
+    args = [
+        "diff",
+        "--name-only",
+        base,
+        head,
+        "--diff-filter={}".format(diff_filter),
+    ]
+
+    if no_renames:
+        args.append("--no-renames")
+    if full_index:
+        args.append("--full-index")
+
+    output = _run_git(args, encoding=encoding)
+    return split_nonempty_lines(output)
+
+
+def get_name_status_lines(base, head="HEAD", encoding=None):
+    output = _run_git(
+        ["diff", "--name-status", base, head],
+        encoding=encoding,
+    )
+    return split_nonempty_lines(output)
+
+
+def get_merge_base(target_branch, head="HEAD", encoding=None):
+    output = _run_git(
+        ["merge-base", target_branch, head],
+        encoding=encoding,
+    )
+    return output.strip()
+
+
+def _parse_ls_tree_size(output, encoding=None):
+    text = _decode_output(output, encoding).strip()
+    if not text:
+        return 0
+
+    fields = text.split(None, 4)
+    if len(fields) < 4:
+        return 0
+
+    try:
+        return int(fields[3])
+    except ValueError:
+        return 0
+
+
+def get_blob_size(ref, path, encoding=None):
+    result = subprocess.run(
+        ["git", "ls-tree", "-l", ref, "--", path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        return 0
+
+    return _parse_ls_tree_size(result.stdout, encoding)

--- a/tools/testcases/test_ci_diff_paths.py
+++ b/tools/testcases/test_ci_diff_paths.py
@@ -1,0 +1,176 @@
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+def load_module(module_name, path):
+    path = Path(path)
+    repo_root = path.parents[2]
+    module_dir = path.parent
+
+    for item in (str(repo_root), str(module_dir)):
+        if item not in sys.path:
+            sys.path.insert(0, item)
+
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CIDiffPathParsingTestCase(unittest.TestCase):
+    def setUp(self):
+        self.repo_root = Path(__file__).resolve().parents[2]
+        self.old_cwd = os.getcwd()
+
+    def tearDown(self):
+        os.chdir(self.old_cwd)
+
+    def test_git_utils_splits_empty_diff_output(self):
+        module = load_module(
+            "git_utils",
+            self.repo_root / "tools" / "ci" / "git_utils.py",
+        )
+
+        self.assertEqual(module.split_nonempty_lines(""), [])
+        self.assertEqual(module.split_nonempty_lines("\n\r\n"), [])
+        self.assertEqual(module.split_nonempty_lines("a.c\n\n b.c \n"), ["a.c", "b.c"])
+
+    def test_format_ignore_returns_empty_list_for_empty_diff(self):
+        module = load_module(
+            "format_ignore",
+            self.repo_root / "tools" / "ci" / "format_ignore.py",
+        )
+
+        if hasattr(module, "get_changed_files"):
+            patcher = mock.patch.object(module, "get_changed_files", return_value=[])
+        else:
+            class FakeResult:
+                returncode = 0
+                stdout = b""
+                stderr = b""
+
+            patcher = mock.patch.object(module.subprocess, "run", return_value=FakeResult())
+
+        with patcher:
+            files = module.CheckOut().get_new_file()
+
+        self.assertEqual(files, [])
+
+    def test_compile_bsp_diff_returns_empty_set_for_empty_diff(self):
+        module = load_module(
+            "compile_bsp_with_drivers",
+            self.repo_root / "tools" / "ci" / "compile_bsp_with_drivers.py",
+        )
+
+        if hasattr(module, "get_changed_files"):
+            patcher = mock.patch.object(module, "get_changed_files", return_value=[])
+        else:
+            class FakeResult:
+                returncode = 0
+                stdout = b""
+                stderr = b""
+
+            patcher = mock.patch.object(module.subprocess, "run", return_value=FakeResult())
+
+        with patcher:
+            dirs = module.diff()
+
+        self.assertEqual(dirs, set())
+
+    def test_git_diff_show_handles_paths_with_spaces(self):
+        if shutil.which("git") is None:
+            self.skipTest("git is not available")
+
+        module = load_module(
+            "git_diff_show",
+            self.repo_root / "tools" / "ci" / "git_diff_show.py",
+        )
+
+        tempdir = tempfile.mkdtemp()
+        workdir = Path(tempdir)
+
+        try:
+            def run(cmd):
+                result = subprocess.run(
+                    cmd,
+                    cwd=str(workdir),
+                    text=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    check=False,
+                )
+                self.assertEqual(
+                    result.returncode,
+                    0,
+                    msg="command failed: {}\nstdout:\n{}\nstderr:\n{}".format(
+                        " ".join(cmd),
+                        result.stdout,
+                        result.stderr,
+                    ),
+                )
+                return result
+
+            run(["git", "init"])
+            run(["git", "checkout", "-b", "master"])
+
+            space_dir = workdir / "dir with space"
+            space_dir.mkdir()
+            file_path = space_dir / "file with space.txt"
+            file_path.write_text("old\n", encoding="utf-8")
+
+            run(["git", "add", "."])
+            run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=Test",
+                    "-c",
+                    "user.email=test@example.com",
+                    "commit",
+                    "-m",
+                    "base",
+                ]
+            )
+
+            run(["git", "checkout", "-b", "feature"])
+            file_path.write_text("old\nnew content\n", encoding="utf-8")
+            run(["git", "add", "."])
+            run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=Test",
+                    "-c",
+                    "user.email=test@example.com",
+                    "commit",
+                    "-m",
+                    "modify space path",
+                ]
+            )
+
+            os.chdir(workdir)
+            diffs = module.GitDiffAnalyzer("master").get_diff_files()
+        finally:
+            os.chdir(self.old_cwd)
+            shutil.rmtree(workdir, ignore_errors=True)
+
+        self.assertEqual(len(diffs), 1)
+        self.assertEqual(diffs[0].path, "dir with space/file with space.txt")
+        self.assertEqual(diffs[0].status, "M")
+        self.assertEqual(diffs[0].old_size, len("old\n".encode("utf-8")))
+        self.assertEqual(diffs[0].new_size, len("old\nnew content\n".encode("utf-8")))
+        self.assertEqual(
+            diffs[0].size_change,
+            len("old\nnew content\n".encode("utf-8")) - len("old\n".encode("utf-8")),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

本 PR 用于修复 `tools/ci` 目录下多个 CI 辅助脚本在解析 Git diff 输出和处理特殊文件路径时存在的不一致问题。

在修复前，部分脚本直接使用如下方式解析 `git diff --name-only` 的输出：

```python
result.stdout.decode().strip().split('\n')
```

这种写法在 diff 输出为空时会得到 `['']`，而不是预期的空列表 `[]`。因此，在没有变更文件的情况下，CI 辅助脚本仍可能继续处理一个空字符串路径，导致后续路径过滤、BSP 目录判断或格式检查逻辑出现不必要的误判风险。

此外，`tools/ci/git_diff_show.py` 中部分 Git 命令先拼接成字符串，再通过 `.split()` 拆分后执行。例如，当文件路径中包含空格时：

```text
dir with space/file with space.txt
```

该路径会被错误拆分成多个命令参数，导致 Git 无法正确识别原始路径。实际表现为：`git_diff_show.py` 在统计该类文件的 old size / new size / size change 时，可能错误返回 `0`，从而导致差异统计结果不准确。

这些问题虽然位于 CI 工具脚本中，不直接影响 RT-Thread 内核、组件或 BSP 运行逻辑，但会影响 CI 辅助脚本对变更文件的识别、BSP 构建范围筛选以及 PR 差异信息统计的准确性。因此需要进行统一修复。

#### 你的解决方案是什么 (what is your solution)

本 PR 新增了一个公共 Git 工具模块，并将相关 CI 脚本中重复且不够稳健的 Git diff/path 解析逻辑统一迁移到该模块中。

新增文件：

```text
tools/ci/git_utils.py
```

该模块主要提供以下能力：

- `split_nonempty_lines()`
  - 统一处理 Git 命令输出中的空行；
  - 确保空 diff 输出被解析为 `[]`，而不是 `['']`。

- `get_changed_files()`
  - 统一封装 `git diff --name-only`；
  - 用于获取变更文件列表；
  - 保持原有 `--diff-filter=ACMR`、`--no-renames`、`--full-index` 等行为。

- `get_name_status_lines()`
  - 统一封装 `git diff --name-status`；
  - 用于 `git_diff_show.py` 中获取文件状态和路径。

- `get_merge_base()`
  - 统一封装 `git merge-base`；
  - 避免不同脚本中重复拼接 Git 命令。

- `get_blob_size()`
  - 使用 pathspec 安全的 Git 调用方式获取指定 ref 下文件大小；
  - 避免通过字符串拼接加 `.split()` 执行命令；
  - 对包含空格的路径能够正确处理。

其中，文件大小查询使用如下参数列表形式：

```python
["git", "ls-tree", "-l", ref, "--", path]
```

这种方式将 Git 参数和文件路径明确分离，可以避免路径中包含空格时被错误拆分。

本 PR 修改的脚本包括：

1. `tools/ci/format_ignore.py`

   修改前，空 diff 输出会被解析成 `['']`。

   修改后：

   - 使用 `get_changed_files()` 获取变更文件列表；
   - 当没有变更文件时返回空列表 `[]`；
   - 避免继续处理空字符串路径；
   - 在 Git 命令执行失败时记录错误日志并返回空列表。

2. `tools/ci/compile_bsp_with_drivers.py`

   修改前，该脚本也使用相同的 `strip().split('\n')` 方式解析 diff 输出，存在同类空路径解析隐患。

   修改后：

   - 使用 `get_changed_files()` 统一获取变更文件列表；
   - 保持原有 BSP 路径筛选逻辑不变；
   - 当没有变更文件时返回空集合 `set()`；
   - 在 Git 命令执行失败时记录错误日志并返回空集合。

3. `tools/ci/git_diff_show.py`

   修改前，该脚本使用字符串拼接 Git 命令，并通过 `.split()` 执行，导致带空格路径无法正确处理。

   修改后：

   - 使用 `get_merge_base()` 获取当前分支与目标分支的共同祖先；
   - 使用 `get_name_status_lines()` 获取文件状态列表；
   - 使用 `get_blob_size()` 计算指定 ref 下的文件大小；
   - 避免因路径中包含空格导致 size 统计错误；
   - 保留原有差异展示和后续 BSP 过滤逻辑。

同时，本 PR 新增回归测试文件：

```text
tools/testcases/test_ci_diff_paths.py
```

测试覆盖以下场景：

- 空 diff 输出应被解析为空列表；
- `format_ignore.py` 在空 diff 场景下应返回 `[]`；
- `compile_bsp_with_drivers.py` 在空 diff 场景下应返回 `set()`；
- `git_diff_show.py` 在路径包含空格时，应正确计算 old size、new size 和 size change。

通过这些修改，CI 工具脚本中的 Git diff/path 解析逻辑更加集中、清晰和一致，也避免了多个脚本中重复维护类似逻辑。

#### 请提供验证的bsp和config (provide the config and bsp)

本 PR 仅修改 CI Python 辅助脚本，不涉及任何 BSP 源码、驱动配置或 `.config` 配置项变更。

- BSP: N/A，本 PR 不涉及具体 BSP。

- .config: N/A，本 PR 不修改 `.config` 配置。

- action: N/A，本 PR 不涉及特定 BSP 编译验证。该修改已完成本地 Python 语法检查、单元测试和 diff 检查；提交 PR 后以 GitHub PR CI 运行结果为准。

本地验证环境：

```text
Windows PowerShell
Python 3.10
Git for Windows
```

已执行语法检查：

```powershell
python -m py_compile tools\ci\git_utils.py tools\ci\format_ignore.py tools\ci\compile_bsp_with_drivers.py tools\ci\git_diff_show.py tools\testcases\test_ci_diff_paths.py
```

结果：通过，无语法错误。

已执行新增回归测试：

```powershell
python tools\testcases\test_ci_diff_paths.py
```

结果：

```text
Ran 4 tests in 0.739s

OK
```

已执行 unittest discover 验证：

```powershell
python -m unittest discover -s tools\testcases -p "test_ci_diff_paths.py"
```

结果：

```text
Ran 4 tests in 0.657s

OK
```

已执行 diff 检查：

```powershell
git diff --check
```

结果：未发现 whitespace error。Windows 环境下仅出现 LF/CRLF 提示，不影响代码内容和测试结果。

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)