### PR TITLE
tools: harden attachconfig handling

### DIFF
--- a/tools/attachconfig.py
+++ b/tools/attachconfig.py
@@ -16,6 +16,9 @@ def GenAttachConfigProject(program = None):
         attachconfig=[]
         GetAttachConfig("get",attachconfig,0)
         print("\033[32m✅ AttachConfig has: \033[0m")
+        if attachconfig==[]:
+            print("No AttachConfig found.")
+            return
         prefix=attachconfig[0]
         for line in attachconfig:
             temp_prefix=line.split(".", 1)

--- a/tools/ci/bsp_buildings.py
+++ b/tools/ci/bsp_buildings.py
@@ -115,6 +115,30 @@ def is_env_enabled(name, default=False):
 
     return value.lower() not in ('', '0', 'false', 'no', 'off')
 
+def parse_csv_env(name, required=False):
+    value = os.getenv(name)
+    if value is None or value.strip() == '':
+        if required:
+            print(f"::error::{name} is not set or empty")
+            sys.exit(1)
+        return None
+
+    items = [item.strip() for item in value.split(',') if item.strip()]
+    if required and items == []:
+        print(f"::error::{name} is not set or empty")
+        sys.exit(1)
+
+    return items
+
+def split_config_commands(value):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value.splitlines()
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
 def run_dist_build_check(bsp, scons_args=''):
     """
     build BSP distribution and verify that the generated project can compile.
@@ -381,15 +405,10 @@ if __name__ == "__main__":
     qemu_timeout_second = 50
 
     rtt_root = os.getcwd()
-    srtt_bsp = os.getenv('SRTT_BSP').split(',')
-    attachconfig_rtt_bsp_env = os.getenv('ATTACHCONFIG_RTT_BSP')
-    attachconfig_rtt_bsp = None
-    if attachconfig_rtt_bsp_env:
-        attachconfig_rtt_bsp = {
-            bsp.strip()
-            for bsp in attachconfig_rtt_bsp_env.split(',')
-            if bsp.strip()
-        }
+    srtt_bsp = parse_csv_env('SRTT_BSP', required=True)
+    attachconfig_rtt_bsp = parse_csv_env('ATTACHCONFIG_RTT_BSP')
+    if attachconfig_rtt_bsp is not None:
+        attachconfig_rtt_bsp = set(attachconfig_rtt_bsp)
     print(srtt_bsp)
     for bsp in srtt_bsp:
         count += 1
@@ -444,9 +463,9 @@ if __name__ == "__main__":
                 # 如果是bsp_board_info，读取基本的信息
                 if(name == 'bsp_board_info'):
                     print(details)
-                    pre_build_commands = details.get("pre_build").splitlines()
-                    build_command = details.get("build_cmd").splitlines()
-                    post_build_command = details.get("post_build").splitlines()
+                    pre_build_commands = split_config_commands(details.get("pre_build"))
+                    build_command = split_config_commands(details.get("build_cmd"))
+                    post_build_command = split_config_commands(details.get("post_build"))
                     qemu_command = details.get("run_cmd")
                 
                 if details.get("kconfig") is not None:
@@ -455,7 +474,7 @@ if __name__ == "__main__":
                     else:
                         build_check_result = None
                     if details.get("msh_cmd") is not None:
-                        commands = details.get("msh_cmd").splitlines()
+                        commands = split_config_commands(details.get("msh_cmd"))
                     else:
                         msh_cmd = None
                     if details.get("checkresult") is not None:
@@ -467,54 +486,55 @@ if __name__ == "__main__":
                     else:
                         ci_build_run_flag = None
                     if details.get("pre_build") is not None:
-                        pre_build_commands = details.get("pre_build").splitlines()
+                        pre_build_commands = split_config_commands(details.get("pre_build"))
                     if details.get("env") is not None:
                         bsp_build_env = details.get("env")
                     else:
                         bsp_build_env = None
                     if details.get("build_cmd") is not None:
-                        build_command = details.get("build_cmd").splitlines()
+                        build_command = split_config_commands(details.get("build_cmd"))
                     else:
                         build_command = None
                     if details.get("post_build") is not None:
-                        post_build_command = details.get("post_build").splitlines()
+                        post_build_command = split_config_commands(details.get("post_build"))
                     if details.get("run_cmd") is not None:
                         qemu_command = details.get("run_cmd")
                     else:
                         qemu_command = None
+                if details.get("kconfig") is None:
+                    continue
                 count += 1
                 config_bacakup = config_file+'.origin'
                 shutil.copyfile(config_file, config_bacakup)
-                #加载yml中的配置放到.config文件
-                with open(config_file, 'a') as destination:
-                    if details.get("kconfig") is None:
-                        #如果没有Kconfig，读取下一个配置
-                        continue
-                    if(projects.get(name) is not None):
-                        # 获取Kconfig中所有的信息
-                        detail_list=get_details_and_dependencies([name],projects)
-                        for line in detail_list:
-                            destination.write(line + '\n')
-                scons_arg=[]
-                #如果配置中有scons_arg
-                if details.get('scons_arg') is not None:
-                    for line in details.get('scons_arg'):
-                        scons_arg.append(line)
-                scons_arg_str=' '.join(scons_arg) if scons_arg else ' '
-                print(f"::group::\tCompiling yml project: =={count}==={name}=scons_arg={scons_arg_str}==")
-                # #开始编译bsp
-                res = build_bsp(bsp, scons_arg_str,name=name,pre_build_commands=pre_build_commands,post_build_command=post_build_command,build_check_result=build_check_result,bsp_build_env =bsp_build_env)
-                if not res:
-                    print(f"::error::build {bsp} {name} failed.")
-                    add_summary(f'\t- ❌ build {bsp} {name} failed.')
-                    failed += 1
-                else:
-                    add_summary(f'\t- ✅ build {bsp} {name} success.')
-                print("::endgroup::")
+                try:
+                    #加载yml中的配置放到.config文件
+                    with open(config_file, 'a') as destination:
+                        if(projects.get(name) is not None):
+                            # 获取Kconfig中所有的信息
+                            detail_list=get_details_and_dependencies([name],projects)
+                            for line in detail_list:
+                                destination.write(line + '\n')
+                    scons_arg=[]
+                    #如果配置中有scons_arg
+                    if details.get('scons_arg') is not None:
+                        for line in details.get('scons_arg'):
+                            scons_arg.append(line)
+                    scons_arg_str=' '.join(scons_arg) if scons_arg else ' '
+                    print(f"::group::\tCompiling yml project: =={count}==={name}=scons_arg={scons_arg_str}==")
+                    # #开始编译bsp
+                    res = build_bsp(bsp, scons_arg_str,name=name,pre_build_commands=pre_build_commands,post_build_command=post_build_command,build_check_result=build_check_result,bsp_build_env =bsp_build_env)
+                    if not res:
+                        print(f"::error::build {bsp} {name} failed.")
+                        add_summary(f'\t- ❌ build {bsp} {name} failed.')
+                        failed += 1
+                    else:
+                        add_summary(f'\t- ✅ build {bsp} {name} success.')
+                    print("::endgroup::")
 
 
-                shutil.copyfile(config_bacakup, config_file)
-                os.remove(config_bacakup)
+                finally:
+                    shutil.copyfile(config_bacakup, config_file)
+                    os.remove(config_bacakup)
 
 
 

--- a/tools/testcases/test_attachconfig_robustness.py
+++ b/tools/testcases/test_attachconfig_robustness.py
@@ -1,0 +1,156 @@
+﻿import contextlib
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from io import StringIO
+
+
+RTT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def load_attachconfig_module():
+    scons_mod = types.ModuleType("SCons")
+    script_mod = types.ModuleType("SCons.Script")
+    script_mod.GetOption = lambda name: None
+
+    old_scons = sys.modules.get("SCons")
+    old_script = sys.modules.get("SCons.Script")
+    sys.modules["SCons"] = scons_mod
+    sys.modules["SCons.Script"] = script_mod
+
+    try:
+        path = os.path.join(RTT_ROOT, "tools", "attachconfig.py")
+        spec = importlib.util.spec_from_file_location("attachconfig_under_test", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if old_scons is None:
+            sys.modules.pop("SCons", None)
+        else:
+            sys.modules["SCons"] = old_scons
+        if old_script is None:
+            sys.modules.pop("SCons.Script", None)
+        else:
+            sys.modules["SCons.Script"] = old_script
+
+
+class AttachConfigRobustnessTest(unittest.TestCase):
+
+    def test_attach_query_handles_empty_attachconfig_list(self):
+        module = load_attachconfig_module()
+        module.GetOption = lambda name: "?" if name == "attach" else None
+        module.GetAttachConfig = lambda action, attachconfig, result: None
+
+        output = StringIO()
+        with contextlib.redirect_stdout(output):
+            module.GenAttachConfigProject()
+
+        self.assertIn("AttachConfig", output.getvalue())
+
+    def test_bsp_buildings_reports_missing_srtt_bsp_without_traceback(self):
+        env = os.environ.copy()
+        env.pop("SRTT_BSP", None)
+
+        result = subprocess.run(
+            [sys.executable, os.path.join("tools", "ci", "bsp_buildings.py")],
+            cwd=RTT_ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        combined_output = result.stdout + result.stderr
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("SRTT_BSP", combined_output)
+        self.assertNotIn("Traceback", combined_output)
+    def test_bsp_board_info_allows_missing_optional_commands(self):
+        bsp_name = "tmp_attachconfig_board_info_test"
+        bsp_dir = os.path.join(RTT_ROOT, "bsp", bsp_name)
+        attach_dir = os.path.join(bsp_dir, ".ci", "attachconfig")
+
+        shutil.rmtree(bsp_dir, ignore_errors=True)
+        os.makedirs(attach_dir, exist_ok=True)
+
+        try:
+            config_file = os.path.join(bsp_dir, ".config")
+            backup_file = config_file + ".origin"
+            with open(config_file, "w", encoding="utf-8") as f:
+                f.write("CONFIG_BASE=y\n")
+
+            with open(os.path.join(attach_dir, "board_attachconfig.yml"), "w", encoding="utf-8") as f:
+                f.write(
+                    "bsp_board_info:\n"
+                    "  run_cmd: \"echo run\"\n"
+                    "board_project:\n"
+                    "  kconfig:\n"
+                    "    - CONFIG_BOARD_PROJECT=y\n"
+                )
+
+            env = os.environ.copy()
+            env["SRTT_BSP"] = bsp_name
+
+            result = subprocess.run(
+                [sys.executable, os.path.join("tools", "ci", "bsp_buildings.py")],
+                cwd=RTT_ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            combined_output = result.stdout + result.stderr
+            self.assertNotIn("AttributeError", combined_output)
+            self.assertNotIn("Traceback", combined_output)
+            self.assertFalse(os.path.exists(backup_file))
+        finally:
+            shutil.rmtree(bsp_dir, ignore_errors=True)
+    def test_attachconfig_without_kconfig_does_not_leave_backup(self):
+        bsp_name = "tmp_attachconfig_test"
+        bsp_dir = os.path.join(RTT_ROOT, "bsp", bsp_name)
+        attach_dir = os.path.join(bsp_dir, ".ci", "attachconfig")
+
+        shutil.rmtree(bsp_dir, ignore_errors=True)
+        os.makedirs(attach_dir, exist_ok=True)
+
+        try:
+            config_file = os.path.join(bsp_dir, ".config")
+            backup_file = config_file + ".origin"
+            with open(config_file, "w", encoding="utf-8") as f:
+                f.write("CONFIG_BASE=y\n")
+
+            with open(os.path.join(attach_dir, "bad_attachconfig.yml"), "w", encoding="utf-8") as f:
+                f.write(
+                    "no_kconfig_project:\n"
+                    "  pre_build: \"echo pre\"\n"
+                    "  build_cmd: \"echo build\"\n"
+                    "  post_build: \"echo post\"\n"
+                )
+
+            env = os.environ.copy()
+            env["SRTT_BSP"] = bsp_name
+
+            subprocess.run(
+                [sys.executable, os.path.join("tools", "ci", "bsp_buildings.py")],
+                cwd=RTT_ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+            self.assertFalse(os.path.exists(backup_file))
+            with open(config_file, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read(), "CONFIG_BASE=y\n")
+        finally:
+            shutil.rmtree(bsp_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

本 PR 修复 RT-Thread Python 构建工具和 CI 脚本中 attachconfig 处理流程的若干健壮性问题。

修复前，在一些正常的 attachconfig 异常输入或缺省配置场景下，脚本可能直接抛出 Python 异常，或者在 BSP 目录中残留临时备份文件，影响后续构建流程的稳定性。具体问题包括：

1. `tools/ci/bsp_buildings.py` 中直接使用 `os.getenv('SRTT_BSP').split(',')` 解析环境变量。当 `SRTT_BSP` 未设置或为空时，脚本会触发 `AttributeError`，并输出 Python traceback，而不是给出明确的 CI 配置错误提示。

2. `tools/attachconfig.py` 在执行 attachconfig 查询模式时，会直接访问 `attachconfig[0]`。当当前 BSP 没有任何 attachconfig 配置项时，会触发 `IndexError: list index out of range`。

3. 在 YAML attachconfig 构建流程中，如果某个 project 缺少 `kconfig` 字段，旧逻辑可能已经创建 `.config.origin` 备份文件后直接 `continue`，导致 `.config.origin` 残留在 BSP 目录中，并跳过正常的 `.config` 恢复流程。

4. 一些 YAML 可选命令字段，例如 `pre_build`、`build_cmd`、`post_build`、`msh_cmd`，旧代码在未检查字段是否存在的情况下直接调用 `.splitlines()`。当这些可选字段缺失时，可能触发非预期异常。

以上问题属于普通构建工具健壮性缺陷，不涉及安全漏洞。

#### 你的解决方案是什么 (what is your solution)

本 PR 对 attachconfig 处理流程进行了以下改进：

1. 增加逗号分隔环境变量的安全解析逻辑：

   * 在使用 `SRTT_BSP` 前先检查环境变量是否存在且非空；
   * 当 `SRTT_BSP` 缺失或为空时，输出明确错误信息：`::error::SRTT_BSP is not set or empty`；
   * 对逗号分隔后的 BSP 名称执行 `strip`，并过滤空字符串；
   * 保持 `ATTACHCONFIG_RTT_BSP` 对 attachconfig BSP 过滤的原有行为。

2. 修复 attachconfig 查询结果为空时的异常：

   * 当 `scons --attach=?` 没有找到任何 attachconfig 项时，输出 `No AttachConfig found.`；
   * 正常返回，不再访问空列表；
   * 避免 `IndexError`。

3. 增强 YAML 可选命令字段处理：

   * 当字段缺失时，不再对 `None` 调用 `.splitlines()`；
   * 字符串字段仍保持按行拆分的原有行为；
   * 对 list 或 tuple 类型字段，直接转换为命令列表处理。

4. 改进 `.config` 备份和恢复流程：

   * 对缺少 `kconfig` 的 YAML project，在创建 `.config.origin` 前直接跳过；
   * 对已经创建 `.config.origin` 的构建流程使用 `try/finally` 保护；
   * 确保构建流程结束后总是恢复 `.config`，并删除 `.config.origin`；
   * 避免异常或跳过路径导致 BSP 目录残留临时备份文件。

5. 新增回归测试，覆盖以下场景：

   * attachconfig 查询结果为空；
   * `SRTT_BSP` 未设置；
   * YAML project 缺少 `kconfig`；
   * `bsp_board_info` 缺少可选命令字段。

#### 请提供验证的bsp和config (provide the config and bsp)

* BSP: N/A

本 PR 只修改 Python 构建/CI 辅助脚本，并新增对应回归测试，不涉及具体 BSP 源码修改。

* .config: N/A

本 PR 不需要修改任何 BSP `.config` 选项。

* action: N/A

本 PR 已在本地完成 Python 语法检查和回归测试。提交 PR 后，可继续以 GitHub Actions 的结果为准。

本地验证命令如下：

```powershell
python -m py_compile tools\attachconfig.py tools\ci\bsp_buildings.py tools\testcases\test_attachconfig_robustness.py
python tools\testcases\test_attachconfig_robustness.py
python -m unittest discover -s tools\testcases -p "test_attachconfig_robustness.py"
git diff --check
```

本地测试结果如下：

```text
Ran 4 tests

OK
```

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

* [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
* [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

* [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
* [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
* [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
* [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
* [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
* [x] 代码是高质量的 Code in this PR is of high quality
* [ ] 已经使用[[formatting](https://github.com/mysterywolf/formatting)](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [[RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
* [ ] 如果是新增bsp, 已经添加ci检查到[[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)