### PR TITLE
drivers: fix CFI MTD array bounds checks

### DIFF
--- a/components/drivers/mtd/mtd-cfi.c
+++ b/components/drivers/mtd/mtd-cfi.c
@@ -1070,8 +1070,8 @@ static rt_err_t cfi_flash_dev_probe(struct rt_device *dev, struct cfi_flash_devi
     {
         LOG_E("Too many %d (> %d) erase regions found",
                num_erase_regions, RT_ARRAY_SIZE(query->erase_region_info));
-        num_erase_regions = RT_ARRAY_SIZE(query->erase_region_info);
-        query->num_erase_regions = num_erase_regions;
+        err = -RT_EINVAL;
+        goto _fail;
     }
 
     if (fdev->ext_addr)

--- a/components/drivers/mtd/mtd-cfi.c
+++ b/components/drivers/mtd/mtd-cfi.c
@@ -1066,6 +1066,13 @@ static rt_err_t cfi_flash_dev_probe(struct rt_device *dev, struct cfi_flash_devi
     fdev->vendor = rt_le16_to_cpu(get_unaligned(&query->primary_id));
     fdev->ext_addr = rt_le16_to_cpu(get_unaligned(&query->primary_address));
     num_erase_regions = query->num_erase_regions;
+    if (num_erase_regions > RT_ARRAY_SIZE(query->erase_region_info))
+    {
+        LOG_E("Too many %d (> %d) erase regions found",
+               num_erase_regions, RT_ARRAY_SIZE(query->erase_region_info));
+        num_erase_regions = RT_ARRAY_SIZE(query->erase_region_info);
+        query->num_erase_regions = num_erase_regions;
+    }
 
     if (fdev->ext_addr)
     {
@@ -1138,13 +1145,6 @@ static rt_err_t cfi_flash_dev_probe(struct rt_device *dev, struct cfi_flash_devi
 
     for (int i = 0; i < num_erase_regions; ++i)
     {
-        if (i > RT_ARRAY_SIZE(query->erase_region_info))
-        {
-            LOG_E("Too many %d (> %d) erase regions found",
-                   num_erase_regions, RT_ARRAY_SIZE(query->erase_region_info));
-            break;
-        }
-
         value = rt_le32_to_cpu(get_unaligned(&query->erase_region_info[i]));
 
         erase_region_count = (value & 0xffff) + 1;
@@ -1158,7 +1158,7 @@ static rt_err_t cfi_flash_dev_probe(struct rt_device *dev, struct cfi_flash_devi
                 break;
             }
 
-            if (sect_count > RT_ARRAY_SIZE(fdev->sect))
+            if (sect_count >= RT_ARRAY_SIZE(fdev->sect))
             {
                 LOG_E("Too many %d (> %d) sector found",
                        sect_count, RT_ARRAY_SIZE(fdev->sect));

--- a/components/drivers/mtd/mtd-cfi.c
+++ b/components/drivers/mtd/mtd-cfi.c
@@ -1069,7 +1069,7 @@ static rt_err_t cfi_flash_dev_probe(struct rt_device *dev, struct cfi_flash_devi
     if (num_erase_regions > RT_ARRAY_SIZE(query->erase_region_info))
     {
         LOG_E("Too many %d (> %d) erase regions found",
-               num_erase_regions, RT_ARRAY_SIZE(query->erase_region_info));
+              num_erase_regions, RT_ARRAY_SIZE(query->erase_region_info));
         err = -RT_EINVAL;
         goto _fail;
     }


### PR DESCRIPTION
## Summary

- Reject CFI erase-region counts that exceed the local `erase_region_info` table before fixup/reverse logic consumes them.
- Treat `sect_count == RT_ARRAY_SIZE(fdev->sect)` as full before writing `fdev->sect[sect_count]` and `fdev->protect[sect_count]`.

## Details

`query->num_erase_regions` comes from the CFI query data, but the local `erase_region_info` array can be configured with `CFI_QUERY_ERASE_REGIONS_MAX`. Check the count immediately after detection so later fixup/reverse helpers cannot index beyond the table.

The probe now fails when the reported geometry cannot fit. Truncating would leave `fdev->size` describing the full flash while `sect[]` and `sect_count` describe only the retained regions, allowing erase address lookup to select an incorrect sector.

The sector table check currently allows `sect_count == RT_ARRAY_SIZE(fdev->sect)`, then writes through that index. This changes the guard to `>=` so the arrays are treated as full before the out-of-bounds write.

## Testing

- `git diff --check`
- Reviewed the probe failure cleanup and device registration path.
- Current head `b63da3b16` passed format/license, static analysis, package tests, the full unit-test and BSP matrices, memory reports, and CLA; only expected helper jobs were skipped.