### PR TITLE
bsp: Use raw regex strings in upgrade tools

### DIFF
--- a/bsp/Infineon/tools/upgrade.py
+++ b/bsp/Infineon/tools/upgrade.py
@@ -77,7 +77,7 @@ def heap2zero(path):
                         if line == '':
                             break
 
-                        re_result = re.match('\s*Heap_Size\s+EQU\s+0[xX][0-9a-fA-F]+', line) #MDK的表示方法
+                        re_result = re.match(r'\s*Heap_Size\s+EQU\s+0[xX][0-9a-fA-F]+', line) #MDK的表示方法
                         if re_result != None:
                             oldline = line
                             newline = re.sub('0[xX][0-9a-fA-F]+','0x00000000', oldline)
@@ -100,7 +100,7 @@ def heap2zero(path):
                         if line == '':
                             break
 
-                        re_result = re.match('\s*define\s+symbol\s+__ICFEDIT_size_heap__\s*=\s*0[xX][0-9a-fA-F]+', line) #IAR的表示方法
+                        re_result = re.match(r'\s*define\s+symbol\s+__ICFEDIT_size_heap__\s*=\s*0[xX][0-9a-fA-F]+', line) #IAR的表示方法
                         if re_result != None:
                             oldline = line
                             newline = re.sub('0[xX][0-9a-fA-F]+','0x000', oldline)
@@ -123,7 +123,7 @@ def heap2zero(path):
                         if line == '':
                             break
 
-                        re_result = re.match('\s*_system_stack_size\s*=\s*0[xX][0-9a-fA-F]+', line) #GCC的表示方法, 将默认的栈大小增加到0x400
+                        re_result = re.match(r'\s*_system_stack_size\s*=\s*0[xX][0-9a-fA-F]+', line) #GCC的表示方法, 将默认的栈大小增加到0x400
                         if re_result != None:
                             oldline = line
                             newline = re.sub('0[xX][0-9a-fA-F]+','0x400', oldline)

--- a/bsp/ft32/tools/upgrade.py
+++ b/bsp/ft32/tools/upgrade.py
@@ -77,7 +77,7 @@ def heap2zero(path):
                         if line == '':
                             break
 
-                        re_result = re.match('\s*Heap_Size\s+EQU\s+0[xX][0-9a-fA-F]+', line) #MDK的表示方法
+                        re_result = re.match(r'\s*Heap_Size\s+EQU\s+0[xX][0-9a-fA-F]+', line) #MDK的表示方法
                         if re_result != None:
                             oldline = line
                             newline = re.sub('0[xX][0-9a-fA-F]+','0x00000000', oldline)
@@ -100,7 +100,7 @@ def heap2zero(path):
                         if line == '':
                             break
 
-                        re_result = re.match('\s*define\s+symbol\s+__ICFEDIT_size_heap__\s*=\s*0[xX][0-9a-fA-F]+', line) #IAR的表示方法
+                        re_result = re.match(r'\s*define\s+symbol\s+__ICFEDIT_size_heap__\s*=\s*0[xX][0-9a-fA-F]+', line) #IAR的表示方法
                         if re_result != None:
                             oldline = line
                             newline = re.sub('0[xX][0-9a-fA-F]+','0x000', oldline)
@@ -123,7 +123,7 @@ def heap2zero(path):
                         if line == '':
                             break
 
-                        re_result = re.match('\s*_system_stack_size\s*=\s*0[xX][0-9a-fA-F]+', line) #GCC的表示方法, 将默认的栈大小增加到0x400
+                        re_result = re.match(r'\s*_system_stack_size\s*=\s*0[xX][0-9a-fA-F]+', line) #GCC的表示方法, 将默认的栈大小增加到0x400
                         if re_result != None:
                             oldline = line
                             newline = re.sub('0[xX][0-9a-fA-F]+','0x400', oldline)

--- a/bsp/mm32/tools/upgrade.py
+++ b/bsp/mm32/tools/upgrade.py
@@ -79,7 +79,7 @@ def heap2zero(path):
                         if line == '':
                             break
 
-                        re_result = re.match('\s*Heap_Size\s+EQU\s+0[xX][0-9a-fA-F]+', line) #MDK的表示方法
+                        re_result = re.match(r'\s*Heap_Size\s+EQU\s+0[xX][0-9a-fA-F]+', line) #MDK的表示方法
                         if re_result != None:
                             oldline = line
                             newline = re.sub('0[xX][0-9a-fA-F]+','0x00000000', oldline)
@@ -102,7 +102,7 @@ def heap2zero(path):
                         if line == '':
                             break
 
-                        re_result = re.match('\s*define\s+symbol\s+__ICFEDIT_size_heap__\s*=\s*0[xX][0-9a-fA-F]+', line) #IAR的表示方法
+                        re_result = re.match(r'\s*define\s+symbol\s+__ICFEDIT_size_heap__\s*=\s*0[xX][0-9a-fA-F]+', line) #IAR的表示方法
                         if re_result != None:
                             oldline = line
                             newline = re.sub('0[xX][0-9a-fA-F]+','0x000', oldline)
@@ -125,7 +125,7 @@ def heap2zero(path):
                         if line == '':
                             break
 
-                        re_result = re.match('\s*_system_stack_size\s*=\s*0[xX][0-9a-fA-F]+', line) #GCC的表示方法, 将默认的栈大小增加到0x400
+                        re_result = re.match(r'\s*_system_stack_size\s*=\s*0[xX][0-9a-fA-F]+', line) #GCC的表示方法, 将默认的栈大小增加到0x400
                         if re_result != None:
                             oldline = line
                             newline = re.sub('0[xX][0-9a-fA-F]+','0x400', oldline)


### PR DESCRIPTION
## Summary
- mark heap update regex patterns as raw strings in the FT32, Infineon, and MM32 BSP upgrade tools
- keep the parsed Python AST unchanged while removing invalid escape warnings

## Verification
- SyntaxWarning scan for the three changed files reports `TOTAL 0`
- AST comparison against `origin/master` reports `AST_EQUAL True` for all three changed files
- `git diff --check`
- `git ls-files --eol bsp/ft32/tools/upgrade.py bsp/Infineon/tools/upgrade.py bsp/mm32/tools/upgrade.py`

I also checked for open duplicate PRs/issues mentioning `upgrade.py`, `invalid escape`, `SyntaxWarning`, and the changed BSP tool paths, and found no matches.
