### PR TITLE
drivers: pci: fix endpoint MSI setup

### DIFF
--- a/components/drivers/pci/endpoint/endpoint.c
+++ b/components/drivers/pci/endpoint/endpoint.c
@@ -182,7 +182,7 @@ rt_err_t rt_pci_ep_set_msi(struct rt_pci_ep *ep, rt_uint8_t func_no,
 
     if (ep && ep->ops && func_no < ep->max_functions)
     {
-        if (ep->ops->set_msix)
+        if (ep->ops->set_msi)
         {
             err = -RT_EINVAL;
 
@@ -193,6 +193,7 @@ rt_err_t rt_pci_ep_set_msi(struct rt_pci_ep *ep, rt_uint8_t func_no,
                     rt_mutex_take(&ep->lock, RT_WAITING_FOREVER);
                     err = ep->ops->set_msi(ep, func_no, log2);
                     rt_mutex_release(&ep->lock);
+                    break;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fix the MSI endpoint callback guard in `rt_pci_ep_set_msi()`
- stop after the first log2 MSI vector count that satisfies the requested interrupt count

## Why
The MSI setup path tested `ep->ops->set_msix` before calling `ep->ops->set_msi`. That can reject controllers that support MSI without MSI-X, and can call a NULL `set_msi` callback if only MSI-X is implemented.

The same loop converts a requested MSI vector count into the log2 encoding passed to the controller. Without a `break`, a request for a smaller count continues through later iterations and is widened to the largest supported value.

## Testing
- `git diff --check origin/master...HEAD`
- `git show --stat --check --format=fuller HEAD`
- Not run: local RT-Thread build, because this Windows workstation does not have the required C build toolchain installed.