### PR TITLE
drivers: dac: fix disable callback check

### DIFF
--- a/components/drivers/misc/dac.c
+++ b/components/drivers/misc/dac.c
@@ -46,7 +46,7 @@ static rt_err_t _dac_control(rt_device_t dev, int cmd, void *args)
     {
         result = dac->ops->enabled(dac, (rt_uint32_t)args);
     }
-    else if (cmd == RT_DAC_CMD_DISABLE && dac->ops->enabled)
+    else if (cmd == RT_DAC_CMD_DISABLE && dac->ops->disabled)
     {
         result = dac->ops->disabled(dac, (rt_uint32_t)args);
     }


### PR DESCRIPTION
## Summary
- fix the DAC disable command callback guard in `_dac_control()`
- check `ops->disabled` before dispatching `RT_DAC_CMD_DISABLE`

## Why
The disable path currently checks `ops->enabled` and then calls `ops->disabled`. This can reject DAC drivers that provide a disable callback without enable, and can call a NULL `disabled` callback when only enable is implemented.

## Testing
- `git diff --check origin/master...HEAD`
- `git show --stat --check --format=fuller HEAD`
- Not run: local RT-Thread build, because this Windows workstation does not have the required C build toolchain installed.