### PR TITLE
drivers: fix fan53555 slew rate bounds check

### DIFF
--- a/components/drivers/regulator/regulator-fan53555.c
+++ b/components/drivers/regulator/regulator-fan53555.c
@@ -550,7 +550,7 @@ static rt_err_t fan53555_regulator_probe(struct rt_i2c_client *client)
         {
             int slew_idx = freg->slew_rate;
 
-            if (slew_idx > RT_ARRAY_SIZE(slew_rates))
+            if (slew_idx >= RT_ARRAY_SIZE(slew_rates))
             {
                 LOG_E("Invalid slew rate");
 


### PR DESCRIPTION
## Summary
- reject slew_idx == RT_ARRAY_SIZE(slew_rates) before indexing the slew_rates table
- keep the fix at the fan53555 probe-time validation layer

## Testing
- git diff --check origin/master...HEAD
- git show --stat --check --format=fuller HEAD