### PR TITLE
components: finsh: check token bounds before access

### DIFF
--- a/components/finsh/msh.c
+++ b/components/finsh/msh.c
@@ -262,7 +262,7 @@ int msh_exec_module(const char *cmd_line, int size)
     if (size == 0)
         return -RT_ERROR;
     /* get the length of command0 */
-    while ((cmd_line[cmd_length] != ' ' && cmd_line[cmd_length] != '\t') && cmd_length < size)
+    while (cmd_length < size && cmd_line[cmd_length] != ' ' && cmd_line[cmd_length] != '\t')
         cmd_length ++;
 
     /* get name length */
@@ -487,7 +487,7 @@ int _msh_exec_lwp(int debug, char *cmd, rt_size_t length)
     int ret;
 
     /* find the size of first command */
-    while ((cmd[cmd0_size] != ' ' && cmd[cmd0_size] != '\t') && cmd0_size < length)
+    while (cmd0_size < length && cmd[cmd0_size] != ' ' && cmd[cmd0_size] != '\t')
         cmd0_size ++;
     if (cmd0_size == 0)
         return -1;

--- a/components/finsh/msh_file.c
+++ b/components/finsh/msh_file.c
@@ -76,7 +76,7 @@ int msh_exec_script(const char *cmd_line, int size)
     if (size == 0) return -RT_ERROR;
 
     /* get the length of command0 */
-    while ((cmd_line[cmd_length] != ' ' && cmd_line[cmd_length] != '\t') && cmd_length < size)
+    while (cmd_length < size && cmd_line[cmd_length] != ' ' && cmd_line[cmd_length] != '\t')
         cmd_length ++;
 
     /* get name length */


### PR DESCRIPTION
## Summary\n- check command buffer bounds before reading the current character in module command parsing\n- apply the same ordering to script and LWP command parsing, matching the safer pattern already used by msh_exec_cmd()\n\n## Verification\n- git diff --check HEAD^ HEAD -- components/finsh/msh.c components/finsh/msh_file.c\n- git show --stat --check --format=fuller HEAD\n- git ls-files --eol -- components/finsh/msh.c components/finsh/msh_file.c\n- git grep -n -P -e 'while \\(\\([^)]*cmd(?:_line)?\\[[^]]+\\].*&& [^)]*< (?:length|size)\\)' -- '*.c' '*.h'