### PR TITLE
bsp: zynqmp-r5: Fix IGMP multicast range check

### DIFF
--- a/bsp/zynqmp-r5-axu4ev/drivers/Zynq_HAL_Driver/xemacpsif/xemacpsif.c
+++ b/bsp/zynqmp-r5-axu4ev/drivers/Zynq_HAL_Driver/xemacpsif/xemacpsif.c
@@ -632,7 +632,7 @@ static err_t xemacpsif_mac_filter_update (struct netif *netif, ip_addr_t *group,
     unsigned int i;
     u8_t * ip_addr = (u8_t *) group;
 
-    if ((ip_addr[0] < 224) && (ip_addr[0] > 239)) {
+    if ((ip_addr[0] < 224) || (ip_addr[0] > 239)) {
         LWIP_DEBUGF(NETIF_DEBUG,
                 ("%s: The requested MAC address is not a multicast address.\r\n", __func__));
         LWIP_DEBUGF(NETIF_DEBUG,


### PR DESCRIPTION
## Summary
- reject IPv4 addresses outside the 224.0.0.0/4 multicast range in the ZynqMP IGMP MAC filter callback
- replace the impossible AND condition with the intended range-outside OR check

## Testing
- git diff --check -- bsp/zynqmp-r5-axu4ev/drivers/Zynq_HAL_Driver/xemacpsif/xemacpsif.c
- git show --stat --check --format=fuller HEAD