### PR TITLE
bsp: renesas: Fix RA pin name digit checks

### DIFF
--- a/bsp/renesas/libraries/HAL_Drivers/drivers/drv_gpio.c
+++ b/bsp/renesas/libraries/HAL_Drivers/drivers/drv_gpio.c
@@ -374,8 +374,8 @@ static rt_base_t ra_pin_get(const char *name)
     if ((rt_strlen(name) == 4) &&
         (name[0] == 'P' || name[0] == 'p') &&
         (name[1] >= '0' && name[1] <= '9') &&
-        (name[2] >= '0' && name[1] <= '9') &&
-        (name[3] >= '0' && name[1] <= '9'))
+        (name[2] >= '0' && name[2] <= '9') &&
+        (name[3] >= '0' && name[3] <= '9'))
     {
         return (name[1] - '0') * 0x100 + (name[2] - '0') * 10 + (name[3] - '0');
     }


### PR DESCRIPTION
## Summary
- validate the second and third digits in RA \PXXX\ pin names against \
ame[2]\ and \
ame[3]\
- stop non-digit suffix characters from passing only because \
ame[1]\ is a digit

## Testing
- git diff --check -- bsp/renesas/libraries/HAL_Drivers/drivers/drv_gpio.c
- git show --stat --check --format=fuller HEAD