### PR TITLE
bsp: ft2004: Clear full QSPI command pack

### DIFF
--- a/bsp/ft2004/drivers/drv_qspi.c
+++ b/bsp/ft2004/drivers/drv_qspi.c
@@ -324,7 +324,7 @@ static void cmd05_check(void)
     cmd_pack.cmd = 0x6;
     FQSpi_CmdOperation(&_ft2004_qspi_bus.fqspi, &cmd_pack);
 
-    rt_memset(&cmd_pack, 0, sizeof(&cmd_pack));
+    rt_memset(&cmd_pack, 0, sizeof(cmd_pack));
     cmd_pack.cmd = 0x5;
     cmd_pack.flags = FQSPI_CMD_NEED_GET_MASK;
     cmd_pack.rxBuf = rx_buffer;
@@ -337,11 +337,11 @@ static void cmd05_check(void)
         LOG_I("cnt %d, 0x%x ", i, rx_buffer[i]);
     }
 
-    rt_memset(&cmd_pack, 0, sizeof(&cmd_pack));
+    rt_memset(&cmd_pack, 0, sizeof(cmd_pack));
     cmd_pack.cmd = 0x4;
     FQSpi_CmdOperation(&_ft2004_qspi_bus.fqspi, &cmd_pack);
 
-    rt_memset(&cmd_pack, 0, sizeof(&cmd_pack));
+    rt_memset(&cmd_pack, 0, sizeof(cmd_pack));
     cmd_pack.cmd = 0x5;
     cmd_pack.flags = FQSPI_CMD_NEED_GET_MASK;
     cmd_pack.rxBuf = rx_buffer;
@@ -366,7 +366,7 @@ static void cmd35_check(void)
     cmd_pack.cmd = 0x6;
     FQSpi_CmdOperation(&_ft2004_qspi_bus.fqspi, &cmd_pack);
 
-    rt_memset(&cmd_pack, 0, sizeof(&cmd_pack));
+    rt_memset(&cmd_pack, 0, sizeof(cmd_pack));
     cmd_pack.cmd = 0x5;
     cmd_pack.flags = FQSPI_CMD_NEED_GET_MASK;
     cmd_pack.rxBuf = rx_buffer;
@@ -382,7 +382,7 @@ static void cmd35_check(void)
     cmd_pack.cmd = 0xB7;
     FQSpi_CmdOperation(&_ft2004_qspi_bus.fqspi, &cmd_pack);
 
-    rt_memset(&cmd_pack, 0, sizeof(&cmd_pack));
+    rt_memset(&cmd_pack, 0, sizeof(cmd_pack));
     cmd_pack.cmd = 0x35;
     cmd_pack.flags = FQSPI_CMD_NEED_GET_MASK;
     cmd_pack.rxBuf = rx_buffer;
@@ -406,7 +406,7 @@ static void cmd15_check(void)
     // cmd_pack.cmd = 0xB7;
     // FQSpi_CmdOperation(&_ft2004_qspi_bus.fqspi, &cmd_pack);
 
-    rt_memset(&cmd_pack, 0, sizeof(&cmd_pack));
+    rt_memset(&cmd_pack, 0, sizeof(cmd_pack));
     cmd_pack.cmd = 0x15;
     cmd_pack.flags = FQSPI_CMD_NEED_GET_MASK;
     cmd_pack.rxBuf = rx_buffer;


### PR DESCRIPTION
## Summary
- clear the full FQSpi_CmdPack object before QSPI debug command reuse
- replace pointer-size sizeof(&cmd_pack) with object-size sizeof(cmd_pack)

## Rationale
cmd_pack is a stack struct FQSpi_CmdPack. Clearing it with sizeof(&cmd_pack) only resets the pointer-sized prefix, so fields from the previous command can remain set when the debug helpers reuse the object.

## Testing
- git diff --check
- git show --stat --check --format=fuller HEAD
- git ls-files --eol -- bsp\\ft2004\\drivers\\drv_qspi.c