### PR TITLE
bsp: rockchip: fix CAN-FD bit timing copy size

### DIFF
--- a/bsp/rockchip/dm/can/canfd-rockchip.c
+++ b/bsp/rockchip/dm/can/canfd-rockchip.c
@@ -534,13 +534,13 @@ static rt_err_t rockchip_canfd_control(struct rt_can_device *can, int cmd, void 
         if (timing->count)
         {
             rt_memcpy(&can->config.can_timing, &timing->items[0],
-                    sizeof(&timing->items[0]));
+                    sizeof(timing->items[0]));
         }
 
         if (timing->count == 2)
         {
             rt_memcpy(&can->config.canfd_timing, &timing->items[1],
-                    sizeof(&timing->items[1]));
+                    sizeof(timing->items[1]));
         }
         break;
 


### PR DESCRIPTION
## What this PR does

Fixes the Rockchip CAN-FD `RT_CAN_CMD_SET_BITTIMING` handler to copy the full `struct rt_can_bit_timing` entries from `timing->items`.

The current code uses `sizeof(&timing->items[n])`, which is the size of a pointer, when copying into `can->config.can_timing` and `can->config.canfd_timing`. That can leave part of each timing structure unchanged. Other CAN drivers copy the full `items[n]` entry.

## Verification

- `git diff --check`
- `git show --stat --check --format=fuller HEAD`
- `git ls-files --eol -- bsp/rockchip/dm/can/canfd-rockchip.c`
- `rg -n sizeof\s*\(&timing->items bsp/rockchip/dm/can/canfd-rockchip.c` returns no matches

I could not run an RT-Thread build locally because this Windows environment does not have `scons`, `gcc`, or `arm-none-eabi-gcc` installed.

Generated-by: OpenAI Codex