### PR TITLE
bsp: renesas: fix LCD framebuffer bounds

### DIFF
--- a/bsp/renesas/libraries/HAL_Drivers/drivers/drv_lcd.c
+++ b/bsp/renesas/libraries/HAL_Drivers/drivers/drv_lcd.c
@@ -88,7 +88,7 @@ static void turn_on_lcd_backlight(void)
 
 static void ra_bsp_lcd_clear(uint16_t color)
 {
-    for (uint32_t i = 0; i <= LCD_BUF_SIZE / sizeof(uint16_t); i++)
+    for (uint32_t i = 0; i < LCD_BUF_SIZE / sizeof(uint16_t); i++)
     {
         lcd_current_working_buffer[i] = color;
     }
@@ -97,7 +97,7 @@ static void ra_bsp_lcd_clear(uint16_t color)
 void lcd_draw_pixel(uint32_t x, uint32_t y, uint16_t color)
 {
     // Verify pixel is within LCD range
-    if ((x <= LCD_WIDTH) && (y <= LCD_HEIGHT))
+    if ((x < LCD_WIDTH) && (y < LCD_HEIGHT))
     {
         switch (screen_rotation)
         {
@@ -108,7 +108,7 @@ void lcd_draw_pixel(uint32_t x, uint32_t y, uint16_t color)
         }
         case ROTATION_180:
         {
-            lcd_current_working_buffer[((LCD_HEIGHT - y) * LCD_WIDTH) + (LCD_WIDTH - x)] = color;
+            lcd_current_working_buffer[(((LCD_HEIGHT - 1) - y) * LCD_WIDTH) + ((LCD_WIDTH - 1) - x)] = color;
             break;
         }
         default:


### PR DESCRIPTION
## What this PR does

Fixes off-by-one framebuffer writes in the Renesas LCD helper.

`LCD_WIDTH` and `LCD_HEIGHT` are pixel counts, so valid framebuffer coordinates are `0..LCD_WIDTH - 1` and `0..LCD_HEIGHT - 1`.

This updates:

- the clear loop to stop before `LCD_BUF_SIZE / sizeof(uint16_t)`
- `lcd_draw_pixel()` bounds to reject `x == LCD_WIDTH` and `y == LCD_HEIGHT`
- the 180-degree rotation mapping to use the last valid row and column

## Verification

- `git diff --check`
- `git show --stat --check --format=fuller HEAD`
- `git ls-files --eol -- bsp/renesas/libraries/HAL_Drivers/drivers/drv_lcd.c`
- `rg -n "i <= LCD_BUF_SIZE / sizeof\(uint16_t\)|x <= LCD_WIDTH|y <= LCD_HEIGHT|LCD_HEIGHT - y|LCD_WIDTH - x" bsp/renesas/libraries/HAL_Drivers/drivers/drv_lcd.c` returns no matches

I could not run an RT-Thread build locally because this Windows environment does not have `scons`, `gcc`, or `arm-none-eabi-gcc` installed.

Generated-by: OpenAI Codex
