### PR TITLE
drivers: pic: fix PIRQ lookup upper bound

### DIFF
--- a/components/drivers/pic/pic.c
+++ b/components/drivers/pic/pic.c
@@ -280,7 +280,7 @@ struct rt_pic_irq *rt_pic_find_ipi(struct rt_pic *pic, int ipi_index)
 
 struct rt_pic_irq *rt_pic_find_pirq(struct rt_pic *pic, int irq)
 {
-    if (pic && irq >= pic->irq_start && irq <= pic->irq_start + pic->irq_nr)
+    if (pic && irq >= pic->irq_start && irq < pic->irq_start + pic->irq_nr)
     {
         return &pic->pirqs[irq - pic->irq_start];
     }


### PR DESCRIPTION
## What this PR does

Fixes the upper-bound check in `rt_pic_find_pirq()`.

`rt_pic_linear_irq()` stores `irq_nr` as a count and sets `pic->pirqs` to the first entry in that range. The valid IRQ range is therefore `[irq_start, irq_start + irq_nr)`. The current inclusive check can return `pic->pirqs[irq_nr]` when `irq == irq_start + irq_nr`, which is one entry past the range.

## Verification

- `git diff --check`
- `git show --stat --check --format=fuller HEAD`
- `git ls-files --eol -- components/drivers/pic/pic.c`

I could not run an RT-Thread build locally because this Windows environment does not have `scons`, `gcc`, or `arm-none-eabi-gcc` installed.

Generated-by: OpenAI Codex
