### PR TITLE
net: lwip: fix mDNS test buffer fill size

### DIFF
--- a/components/net/lwip/lwip-2.0.3/test/unit/mdns/test_mdns.c
+++ b/components/net/lwip/lwip-2.0.3/test/unit/mdns/test_mdns.c
@@ -572,14 +572,14 @@ START_TEST(domain_eq_length)
   LWIP_UNUSED_ARG(_i);
 
   memset(&domain1, 0, sizeof(domain1));
-  memset(domain1.name, 0xAA, sizeof(MDNS_DOMAIN_MAXLEN));
+  memset(domain1.name, 0xAA, sizeof(domain1.name));
   res = mdns_domain_add_label(&domain1, "multi", 5);
   fail_unless(res == ERR_OK);
   res = mdns_domain_add_label(&domain1, "cast", 4);
   fail_unless(res == ERR_OK);
 
   memset(&domain2, 0, sizeof(domain2));
-  memset(domain2.name, 0xBB, sizeof(MDNS_DOMAIN_MAXLEN));
+  memset(domain2.name, 0xBB, sizeof(domain2.name));
   res = mdns_domain_add_label(&domain2, "multi", 5);
   fail_unless(res == ERR_OK);
   res = mdns_domain_add_label(&domain2, "cast", 4);

--- a/components/net/lwip/lwip-2.1.2/test/unit/mdns/test_mdns.c
+++ b/components/net/lwip/lwip-2.1.2/test/unit/mdns/test_mdns.c
@@ -572,14 +572,14 @@ START_TEST(domain_eq_length)
   LWIP_UNUSED_ARG(_i);
 
   memset(&domain1, 0, sizeof(domain1));
-  memset(domain1.name, 0xAA, sizeof(MDNS_DOMAIN_MAXLEN));
+  memset(domain1.name, 0xAA, sizeof(domain1.name));
   res = mdns_domain_add_label(&domain1, "multi", 5);
   fail_unless(res == ERR_OK);
   res = mdns_domain_add_label(&domain1, "cast", 4);
   fail_unless(res == ERR_OK);
 
   memset(&domain2, 0, sizeof(domain2));
-  memset(domain2.name, 0xBB, sizeof(MDNS_DOMAIN_MAXLEN));
+  memset(domain2.name, 0xBB, sizeof(domain2.name));
   res = mdns_domain_add_label(&domain2, "multi", 5);
   fail_unless(res == ERR_OK);
   res = mdns_domain_add_label(&domain2, "cast", 4);


### PR DESCRIPTION
## Summary
- fill the mDNS domain test buffers using the actual `name` array size
- apply the same test fix to the vendored lwIP 2.0.3 and 2.1.2 copies

## Root cause
`MDNS_DOMAIN_MAXLEN` is an integer constant, so `sizeof(MDNS_DOMAIN_MAXLEN)` only covers the size of that constant. The `domain_eq_length` test is intended to leave different trailing bytes after equal names are encoded, so it should initialize the whole `name` array.

## Testing
- `git diff --check HEAD~1 HEAD`
- `git show --stat --check --format=fuller HEAD`
- `rg -n sizeof\(MDNS_DOMAIN_MAXLEN\)|sizeof\(domain[12]\.name\) components/net/lwip/lwip-2.0.3/test/unit/mdns/test_mdns.c components/net/lwip/lwip-2.1.2/test/unit/mdns/test_mdns.c`

Not run locally:
- build/tests: local `scons`, `make`, `gcc`, `arm-none-eabi-gcc`, and `clang` are not installed