### PR TITLE
ci: report skipped membrowse targets as identical

### DIFF
--- a/.github/workflows/membrowse-report.yml
+++ b/.github/workflows/membrowse-report.yml
@@ -42,6 +42,8 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       target_count: ${{ steps.set-matrix.outputs.target_count }}
+      skipped_matrix: ${{ steps.set-matrix.outputs.skipped_matrix }}
+      skipped_count: ${{ steps.set-matrix.outputs.skipped_count }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -177,3 +179,38 @@ jobs:
           verbose: INFO
           # Uncomment to allow CI to pass even when memory budgets are exceeded
           # dont_fail_on_alerts: true
+
+  # Targets not affected by this push are not rebuilt, but their binaries are
+  # unchanged. Report them as identical (metadata-only, no build) so every
+  # target keeps an unbroken per-commit chain instead of a hole on each commit
+  # that only touched other BSPs. Only runs on push to master; PRs are transient
+  # and keep the build-affected-only behavior above.
+  mark-identical:
+    needs: load-targets
+    if: ${{ github.event_name == 'push' && needs.load-targets.outputs.skipped_count != '0' }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.skipped_matrix) }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Mark MemBrowse report identical
+        # Non-fatal: an identical upload needs the parent commit to already have
+        # a report for this target. Right after adoption some parents predate
+        # this job and the upload is rejected; it self-heals once the target is
+        # next built (a full report needs no parent) and every later commit is
+        # covered. Don't fail the run over that transient window.
+        continue-on-error: true
+        uses: membrowse/membrowse-action@v1
+        with:
+          target_name: ${{ matrix.target_name }}
+          identical: true
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}
+          verbose: INFO

--- a/tools/ci/membrowse_filter_targets.py
+++ b/tools/ci/membrowse_filter_targets.py
@@ -79,13 +79,20 @@ def select_targets(targets, changed_files):
     return selected
 
 
-def write_github_output(matrix, output_path):
+def skipped_targets(targets, selected_targets):
+    selected_names = {target["target_name"] for target in selected_targets}
+    return [target for target in targets if target["target_name"] not in selected_names]
+
+
+def write_github_output(selected, skipped, output_path):
     if not output_path:
         return
 
     with open(output_path, "a", encoding="utf-8") as output:
-        output.write("matrix={}\n".format(json.dumps(matrix, separators=(",", ":"))))
-        output.write("target_count={}\n".format(len(matrix)))
+        output.write("matrix={}\n".format(json.dumps(selected, separators=(",", ":"))))
+        output.write("target_count={}\n".format(len(selected)))
+        output.write("skipped_matrix={}\n".format(json.dumps(skipped, separators=(",", ":"))))
+        output.write("skipped_count={}\n".format(len(skipped)))
 
 
 def main():
@@ -99,6 +106,10 @@ def main():
 
     changed_files = read_changed_files(args.changed_files)
     selected_targets = select_targets(targets, changed_files)
+    # Targets not affected by this change are built by nobody, but their
+    # binaries are unchanged, so they are reported as identical (metadata-only)
+    # to keep every target's per-commit chain unbroken. See membrowse-report.yml.
+    unselected_targets = skipped_targets(targets, selected_targets)
 
     print("Changed files:")
     for changed_file in changed_files:
@@ -108,8 +119,12 @@ def main():
     for target in selected_targets:
         print("  {}".format(target["target_name"]))
 
+    print("Skipped MemBrowse targets (reported as identical):")
+    for target in unselected_targets:
+        print("  {}".format(target["target_name"]))
+
     print("Selected {}/{} MemBrowse targets".format(len(selected_targets), len(targets)))
-    write_github_output(selected_targets, os.getenv("GITHUB_OUTPUT"))
+    write_github_output(selected_targets, unselected_targets, os.getenv("GITHUB_OUTPUT"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
拉取/合并请求描述：(PR description)

  [

  为什么提交这份PR (why to submit this PR)

  The MemBrowse target filter (added in #11518) only builds targets whose watched paths changed. A
  commit touching a single BSP is uploaded for that one target and skipped for the rest, so it becomes
  a hole in every other target's per-commit chain: the next commit built for a target records a
  parent_sha that was never uploaded, breaking the chain shown on the dashboard.

  你的解决方案是什么 (what is your solution)

  Keep the invariant that every push produces a report for every target: affected targets are built as
  before, and unaffected targets get a metadata-only identical report (no build, no ELF).

  - membrowse_filter_targets.py: emit the complement of the selected set as skipped_matrix /
  skipped_count.
  - membrowse-report.yml: a new push-only mark-identical job uploads identical: true for each skipped
  target. It is continue-on-error because an identical upload needs the parent's report to exist; the
  rare gaps right after adoption self-heal at the next real build. PR behavior is unchanged.

  请提供验证的bsp和config (provide the config and bsp)

CI-only change — no BSP source, driver, or .config is touched.

  - BSP: N/A
  - .config: N/A
  - action: https://github.com/michael-membrowse/rt-thread/actions/workflows/membrowse-report.yml

  ]

  当前拉取/合并请求的状态 Intent for your PR

  必须选择一项 Choose one (Mandatory):

  - [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
  - [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

  代码质量 Code Quality：

  我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

  - [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
  - [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing,
  naming and other styles
  - [x] 没有垃圾代码，代码尽量精简，不包含#if 0代码，不包含已经被注释了的代码 All redundant code is
  removed and cleaned up
  - [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified
  and not affect other components or BSP
  - [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
  - [x] 代码是高质量的 Code in this PR is of high quality
  - [x] 已经使用formatting (https://github.com/mysterywolf/formatting)
  等源码格式化工具确保格式符合RT-Thread代码规范 (https://github.com/RT-Thread/rt-thread/blob/master/do
  cumentation/contribution_guide/coding_style_cn.md) This PR complies with RT-Thread code
  specification (https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/c
  oding_style_en.md)
  - [ ] 如果是新增bsp, 已经添加ci检查到.github/ALL_BSP_COMPILE.json
  (https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)
  详细请参考链接BSP自查 (https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standar
  d/development-guide/bsp-selfcheck/bsp_selfcheck)