### PR TITLE
bsp: add CAN-FD and loopback support

### DIFF
--- a/bsp/nxp/mcx/mcxa/Libraries/drivers/drv_can.c
+++ b/bsp/nxp/mcx/mcxa/Libraries/drivers/drv_can.c
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2025-12-23     CYFS         the first version.
+ * 2026-07-05     WANGYU       add CAN-FD and loopback support.
  */
 
 #include <rtdevice.h>
@@ -13,12 +14,13 @@
 #ifdef RT_USING_CAN
 
 #include "fsl_common.h"
+#include "fsl_clock.h"
 #include "fsl_flexcan.h"
 
-#define TX_MB_IDX       (6)
+#define TX_MB_IDX       (0)
+#define RX_MB_IDX       (1)
 #define RX_MB_COUNT     (1)
-static flexcan_frame_t frame[RX_MB_COUNT];    /* one frame buffer per RX MB */
-static rt_uint32_t filter_mask = 0;
+#define CAN_POLL_TIMEOUT (10000000U)
 
 enum
 {
@@ -40,7 +42,123 @@ struct imxrt_can
     clock_attach_id_t       clock_attach_id;
     flexcan_handle_t        handle;
     struct rt_can_device    can_dev;
+    flexcan_frame_t         frame[RX_MB_COUNT];
+#ifdef RT_CAN_USING_CANFD
+    flexcan_fd_frame_t      framefd[RX_MB_COUNT];
+    rt_bool_t               fd_enabled;
+#endif
+    rt_uint32_t             filter_mask;
 };
+
+static void _can_dump_err(struct imxrt_can *can, const char *stage)
+{
+    rt_kprintf("%s: %s, MCR=0x%08x ESR1=0x%08x IFLAG1=0x%08x\n",
+               can->name, stage, can->base->MCR, can->base->ESR1, can->base->IFLAG1);
+}
+
+static void _can_setup_loopback_mb(struct imxrt_can *can)
+{
+    flexcan_rx_mb_config_t mb_config;
+
+    mb_config.format = kFLEXCAN_FrameFormatStandard;
+    mb_config.type = kFLEXCAN_FrameTypeData;
+    mb_config.id = FLEXCAN_ID_STD(0);
+
+    FLEXCAN_SetRxMbGlobalMask(can->base, 0U);
+    FLEXCAN_SetRxIndividualMask(can->base, RX_MB_IDX, 0U);
+
+#ifdef RT_CAN_USING_CANFD
+    if (can->fd_enabled)
+    {
+        FLEXCAN_SetFDRxMbConfig(can->base, RX_MB_IDX, &mb_config, true);
+    }
+    else
+#endif
+    {
+        FLEXCAN_SetRxMbConfig(can->base, RX_MB_IDX, &mb_config, true);
+    }
+}
+
+#ifdef RT_CAN_USING_CANFD
+static rt_uint8_t _can_dlc2len(rt_uint8_t dlc)
+{
+    return (rt_uint8_t)DLC_LENGTH_DECODE(dlc);
+}
+
+static rt_uint8_t _can_len2dlc(rt_uint8_t len)
+{
+    static const rt_uint8_t table[] =
+    {
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+        9, 9, 9, 9,
+        10, 10, 10, 10,
+        11, 11, 11, 11,
+        12, 12, 12, 12,
+        13, 13, 13, 13, 13, 13, 13, 13,
+        14, 14, 14, 14, 14, 14, 14, 14,
+        14, 14, 14, 14, 14, 14, 14, 14,
+        15, 15, 15, 15, 15, 15, 15, 15,
+        15, 15, 15, 15, 15, 15, 15, 15,
+    };
+
+    if (len <= 64)
+    {
+        return table[len];
+    }
+
+    return 15;
+}
+#endif
+
+static void _can_fill_classic_frame(flexcan_frame_t *frame, const struct rt_can_msg *msg)
+{
+    if (RT_CAN_STDID == msg->ide)
+    {
+        frame->id = FLEXCAN_ID_STD(msg->id);
+        frame->format = kFLEXCAN_FrameFormatStandard;
+    }
+    else
+    {
+        frame->id = FLEXCAN_ID_EXT(msg->id);
+        frame->format = kFLEXCAN_FrameFormatExtend;
+    }
+
+    frame->type = (RT_CAN_DTR == msg->rtr) ? kFLEXCAN_FrameTypeData : kFLEXCAN_FrameTypeRemote;
+    frame->length = msg->len;
+    frame->dataByte0 = msg->data[0];
+    frame->dataByte1 = msg->data[1];
+    frame->dataByte2 = msg->data[2];
+    frame->dataByte3 = msg->data[3];
+    frame->dataByte4 = msg->data[4];
+    frame->dataByte5 = msg->data[5];
+    frame->dataByte6 = msg->data[6];
+    frame->dataByte7 = msg->data[7];
+}
+
+static void _can_parse_classic_frame(struct rt_can_msg *msg, const flexcan_frame_t *frame)
+{
+    if (frame->format == kFLEXCAN_FrameFormatStandard)
+    {
+        msg->ide = RT_CAN_STDID;
+        msg->id = frame->id >> CAN_ID_STD_SHIFT;
+    }
+    else
+    {
+        msg->ide = RT_CAN_EXTID;
+        msg->id = frame->id >> CAN_ID_EXT_SHIFT;
+    }
+
+    msg->rtr = (frame->type == kFLEXCAN_FrameTypeData) ? RT_CAN_DTR : RT_CAN_RTR;
+    msg->len = frame->length;
+    msg->data[0] = frame->dataByte0;
+    msg->data[1] = frame->dataByte1;
+    msg->data[2] = frame->dataByte2;
+    msg->data[3] = frame->dataByte3;
+    msg->data[4] = frame->dataByte4;
+    msg->data[5] = frame->dataByte5;
+    msg->data[6] = frame->dataByte6;
+    msg->data[7] = frame->dataByte7;
+}
 
 struct imxrt_can flexcans[] =
 {
@@ -66,91 +184,304 @@ struct imxrt_can flexcans[] =
 #endif
 };
 
+static rt_bool_t _can_is_loopback(const struct can_configure *cfg)
+{
+    return (cfg->mode == RT_CAN_MODE_LOOPBACK) ||
+           (cfg->mode == RT_CAN_MODE_LOOPBACKANLISTEN);
+}
+
+static void _can_abort_rx(struct imxrt_can *can)
+{
+#ifdef RT_CAN_USING_CANFD
+    if (can->fd_enabled)
+    {
+        FLEXCAN_TransferFDAbortReceive(can->base, &can->handle, RX_MB_IDX);
+    }
+    else
+#endif
+    {
+        FLEXCAN_TransferAbortReceive(can->base, &can->handle, RX_MB_IDX);
+    }
+}
+
+static void _can_enable_periph_clock(struct imxrt_can *can)
+{
+    clock_ip_name_t can_clocks[] = FLEXCAN_CLOCKS;
+
+    CLOCK_EnableClock(can_clocks[can->instance]);
+    CLOCK_SetClockDiv(can->clock_div_name, 2u);
+    CLOCK_AttachClk(can->clock_attach_id);
+}
+
+static void _can_safe_deinit(struct imxrt_can *can)
+{
+    CAN_Type *base = can->base;
+
+    _can_enable_periph_clock(can);
+
+    /* FLEXCAN_Reset() inside FLEXCAN_Deinit() requires MDIS cleared. */
+    if (0U != (base->MCR & CAN_MCR_MDIS_MASK))
+    {
+        (void)FLEXCAN_Enable(base, true);
+    }
+
+    FLEXCAN_Deinit(base);
+}
+
+static status_t _can_wait_mb_tx_done(struct imxrt_can *can, uint8_t mb_idx)
+{
+    CAN_Type *base = can->base;
+    uint32_t timeout = CAN_POLL_TIMEOUT;
+
+    while (0U == FLEXCAN_GetMbStatusFlags(base, (uint64_t)1U << mb_idx))
+    {
+        if (--timeout == 0U)
+        {
+            return kStatus_Timeout;
+        }
+    }
+
+    FLEXCAN_ClearMbStatusFlags(base, (uint64_t)1U << mb_idx);
+    return kStatus_Success;
+}
+
+static status_t _can_wait_mb_rx_done(CAN_Type *base, uint8_t mb_idx)
+{
+    uint32_t timeout = CAN_POLL_TIMEOUT;
+
+    while (0U == FLEXCAN_GetMbStatusFlags(base, (uint64_t)1U << mb_idx))
+    {
+        if (--timeout == 0U)
+        {
+            return kStatus_Timeout;
+        }
+    }
+
+    FLEXCAN_ClearMbStatusFlags(base, (uint64_t)1U << mb_idx);
+    return kStatus_Success;
+}
+
+static void _can_loopback_post_rx(struct imxrt_can *can)
+{
+    rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_RX_IND | RX_MB_IDX << 8);
+}
+
+static void _can_setup_mode(flexcan_config_t *config, const struct can_configure *cfg)
+{
+    switch (cfg->mode)
+    {
+    case RT_CAN_MODE_NORMAL:
+        break;
+    case RT_CAN_MODE_LISTEN:
+        config->enableListenOnlyMode = true;
+        break;
+    case RT_CAN_MODE_LOOPBACK:
+        config->enableLoopBack = true;
+        config->disableSelfReception = false;
+        config->enableIndividMask = false;
+        break;
+    case RT_CAN_MODE_LOOPBACKANLISTEN:
+        config->enableLoopBack = true;
+        config->enableListenOnlyMode = true;
+        config->disableSelfReception = false;
+        config->enableIndividMask = false;
+        break;
+    default:
+        break;
+    }
+}
+
+static void _can_start_rx(struct imxrt_can *can)
+{
+    flexcan_rx_mb_config_t mbConfig;
+    flexcan_mb_transfer_t rxXfer;
+    rt_uint8_t i, mailbox;
+
+    mbConfig.format = kFLEXCAN_FrameFormatStandard;
+    mbConfig.type = kFLEXCAN_FrameTypeData;
+    mbConfig.id = FLEXCAN_ID_STD(0);
+
+    for (i = 0; i < RX_MB_COUNT; i++)
+    {
+        mailbox = RX_MB_IDX + i;
+        FLEXCAN_SetRxIndividualMask(can->base, mailbox, FLEXCAN_RX_MB_STD_MASK(0, 0, 0));
+
+#ifdef RT_CAN_USING_CANFD
+        if (can->fd_enabled)
+        {
+            FLEXCAN_SetFDRxMbConfig(can->base, mailbox, &mbConfig, true);
+            rxXfer.framefd = &can->framefd[i];
+            rxXfer.frame = RT_NULL;
+            rxXfer.mbIdx = mailbox;
+            FLEXCAN_TransferFDReceiveNonBlocking(can->base, &can->handle, &rxXfer);
+        }
+        else
+#endif
+        {
+            FLEXCAN_SetRxMbConfig(can->base, mailbox, &mbConfig, true);
+            rxXfer.frame = &can->frame[i];
+#ifdef RT_CAN_USING_CANFD
+            rxXfer.framefd = RT_NULL;
+#endif
+            rxXfer.mbIdx = mailbox;
+            FLEXCAN_TransferReceiveNonBlocking(can->base, &can->handle, &rxXfer);
+        }
+    }
+}
+
+static void _can_enable_controller_irq(struct imxrt_can *can)
+{
+    FLEXCAN_EnableInterrupts(can->base, (uint32_t)kFLEXCAN_BusOffInterruptEnable |
+                                         (uint32_t)kFLEXCAN_ErrorInterruptEnable |
+                                         (uint32_t)kFLEXCAN_RxWarningInterruptEnable |
+                                         (uint32_t)kFLEXCAN_TxWarningInterruptEnable);
+    EnableIRQ(can->irqn);
+}
+
+#ifdef BSP_USING_CAN0
+void CAN0_IRQHandler(void)
+{
+    rt_interrupt_enter();
+    FLEXCAN_TransferHandleIRQ(CAN0, &flexcans[CAN0_INDEX].handle);
+    rt_interrupt_leave();
+}
+#endif
+
+#ifdef BSP_USING_CAN1
+void CAN1_IRQHandler(void)
+{
+    rt_interrupt_enter();
+    FLEXCAN_TransferHandleIRQ(CAN1, &flexcans[CAN1_INDEX].handle);
+    rt_interrupt_leave();
+}
+#endif
+
 static void flexcan_callback(CAN_Type *base, flexcan_handle_t *handle, status_t status, uint64_t result, void *userData)
 {
     struct imxrt_can *can;
     flexcan_mb_transfer_t rxXfer;
+    rt_uint8_t mb_idx;
 
     can = (struct imxrt_can *)userData;
 
     switch (status)
     {
-        case kStatus_FLEXCAN_RxIdle:
-            rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_RX_IND | result << 8);
-            rxXfer.frame = &frame[result - 1];
-            rxXfer.mbIdx = result;
-            FLEXCAN_TransferReceiveNonBlocking(can->base, &can->handle, &rxXfer);
-            break;
+    case kStatus_FLEXCAN_RxIdle:
+        mb_idx = (rt_uint8_t)result;
+        rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_RX_IND | mb_idx << 8);
 
-        case kStatus_FLEXCAN_TxIdle:
-            rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_TX_DONE | result << 8);
-            break;
-        default:
-            break;
+#ifdef RT_CAN_USING_CANFD
+        if (can->fd_enabled)
+        {
+            rxXfer.framefd = &can->framefd[mb_idx - RX_MB_IDX];
+            rxXfer.frame = RT_NULL;
+            rxXfer.mbIdx = mb_idx;
+            FLEXCAN_TransferFDReceiveNonBlocking(can->base, &can->handle, &rxXfer);
+        }
+        else
+#endif
+        {
+            rxXfer.frame = &can->frame[mb_idx - RX_MB_IDX];
+#ifdef RT_CAN_USING_CANFD
+            rxXfer.framefd = RT_NULL;
+#endif
+            rxXfer.mbIdx = mb_idx;
+            FLEXCAN_TransferReceiveNonBlocking(can->base, &can->handle, &rxXfer);
+        }
+        break;
+
+    case kStatus_FLEXCAN_TxIdle:
+        rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_TX_DONE | result << 8);
+        break;
+    default:
+        break;
     }
 }
 
 static rt_err_t _can_config(struct rt_can_device *can_dev, struct can_configure *cfg)
 {
-    struct imxrt_can *can =  (struct imxrt_can *)can_dev->parent.user_data;
+    struct imxrt_can *can = (struct imxrt_can *)can_dev->parent.user_data;
     flexcan_config_t config;
-    rt_uint32_t res = RT_EOK;
-    flexcan_rx_mb_config_t mbConfig;
-    flexcan_mb_transfer_t rxXfer;
-    rt_uint8_t i, mailbox;
+    flexcan_timing_config_t timing_config;
+    rt_uint32_t clk_freq;
+    rt_err_t res = RT_EOK;
+
+    can_dev->config = *cfg;
+    _can_enable_periph_clock(can);
+    clk_freq = CLOCK_GetFlexcanClkFreq(can->instance);
+    if (clk_freq == 0U)
+    {
+        rt_kprintf("%s: flexcan clock is 0\n", can->name);
+        return -RT_ERROR;
+    }
+
+    _can_safe_deinit(can);
 
     FLEXCAN_GetDefaultConfig(&config);
     config.baudRate = cfg->baud_rate;
-    config.enableIndividMask = true;    /* one filter per MB */
-    config.disableSelfReception = true;
+    config.maxMbNum = 8;
+    config.enableIndividMask = true;
+    config.enableSupervisorMode = false;
+    config.disableSelfReception = !_can_is_loopback(cfg);
+    _can_setup_mode(&config, cfg);
 
-    switch (cfg->mode)
+    if (_can_is_loopback(cfg))
     {
-    case RT_CAN_MODE_NORMAL:
-        /* default mode */
-        break;
-    case RT_CAN_MODE_LISTEN:
-        break;
-    case RT_CAN_MODE_LOOPBACK:
-        config.enableLoopBack = true;
-        break;
-    case RT_CAN_MODE_LOOPBACKANLISTEN:
-        break;
+        config.enableTransceiverDelayMeasure = false;
     }
 
-    flexcan_timing_config_t timing_config;
     rt_memset(&timing_config, 0, sizeof(flexcan_timing_config_t));
 
-    if(FLEXCAN_CalculateImprovedTimingValues(can->base, config.baudRate, CLOCK_GetFlexcanClkFreq(can->instance), &timing_config))
+#ifdef RT_CAN_USING_CANFD
+    can->fd_enabled = (cfg->enable_canfd != 0) ? RT_TRUE : RT_FALSE;
+
+    if (can->fd_enabled)
     {
-        /* Update the improved timing configuration*/
-        rt_memcpy(&(config.timingConfig), &timing_config, sizeof(flexcan_timing_config_t));
+        bool brs_enable = _can_is_loopback(cfg) ? false : true;
+        bool timing_ok;
+
+        config.bitRateFD = _can_is_loopback(cfg) ? config.baudRate :
+                           (cfg->baud_rate_fd ? cfg->baud_rate_fd : 2000000U);
+
+        timing_ok = FLEXCAN_FDCalculateImprovedTimingValues(can->base, config.baudRate,
+                                                            config.bitRateFD, clk_freq, &timing_config);
+        if (timing_ok)
+        {
+            rt_memcpy(&(config.timingConfig), &timing_config, sizeof(flexcan_timing_config_t));
+        }
+
+        FLEXCAN_FDInit(can->base, &config, clk_freq, kFLEXCAN_16BperMB, brs_enable);
+        if (!timing_ok)
+        {
+            if (FLEXCAN_SetFDBitRate(can->base, clk_freq, config.baudRate, config.bitRateFD) != kStatus_Success)
+            {
+                rt_kprintf("%s: CAN FD timing setup failed, clk=%u\n", can->name, clk_freq);
+                return -RT_ERROR;
+            }
+        }
+    }
+    else
+#endif
+    {
+        if (FLEXCAN_CalculateImprovedTimingValues(can->base, config.baudRate, clk_freq, &timing_config))
+        {
+            rt_memcpy(&(config.timingConfig), &timing_config, sizeof(flexcan_timing_config_t));
+        }
+
+        FLEXCAN_Init(can->base, &config, clk_freq);
+    }
+
+    can->filter_mask = 0;
+    FLEXCAN_TransferCreateHandle(can->base, &can->handle, flexcan_callback, can);
+    if (_can_is_loopback(cfg))
+    {
+        _can_setup_loopback_mb(can);
     }
     else
     {
-        //rt_kprintf("No found Improved Timing Configuration. Just used default configuration\n");
+        _can_start_rx(can);
     }
-
-    FLEXCAN_Init(can->base, &config, CLOCK_GetFlexcanClkFreq(can->instance));
-    FLEXCAN_TransferCreateHandle(can->base, &can->handle, flexcan_callback, can);
-
-    /* init RX_MB_COUNT RX MB to default status */
-    mbConfig.format = kFLEXCAN_FrameFormatStandard;  /* standard ID */
-    mbConfig.type = kFLEXCAN_FrameTypeData;          /* data frame */
-    mbConfig.id = FLEXCAN_ID_STD(0);                 /* default ID is 0 */
-    for (i = 0; i < RX_MB_COUNT; i++)
-    {
-        /* the used MB index from 1 to RX_MB_COUNT */
-        mailbox = i + 1;
-
-        /* all ID bit in the filter is "don't care" */
-        FLEXCAN_SetRxIndividualMask(can->base, mailbox, FLEXCAN_RX_MB_STD_MASK(0, 0, 0));
-        FLEXCAN_SetRxMbConfig(can->base, mailbox, &mbConfig, true);
-        /* one frame buffer per MB */
-        rxXfer.frame = &frame[i];
-        rxXfer.mbIdx = mailbox;
-        FLEXCAN_TransferReceiveNonBlocking(can->base, &can->handle, &rxXfer);
-    }
+    _can_enable_controller_irq(can);
 
     return res;
 }
@@ -159,9 +490,9 @@ static rt_err_t _can_control(struct rt_can_device *can_dev, int cmd, void *arg)
 {
     struct imxrt_can *can;
     rt_uint32_t argval, mask;
-    rt_uint32_t res = RT_EOK;
+    rt_err_t res = RT_EOK;
     flexcan_rx_mb_config_t mbConfig;
-    struct rt_can_filter_config  *cfg;
+    struct rt_can_filter_config *cfg;
     struct rt_can_filter_item *item;
     rt_uint8_t i, count, index;
 
@@ -173,24 +504,18 @@ static rt_err_t _can_control(struct rt_can_device *can_dev, int cmd, void *arg)
     switch (cmd)
     {
     case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t) arg;
-        if (argval == RT_DEVICE_FLAG_INT_RX)
+        argval = (rt_uint32_t)arg;
+        if (argval == RT_DEVICE_FLAG_INT_RX || argval == RT_DEVICE_FLAG_INT_TX ||
+            argval == RT_DEVICE_CAN_INT_ERR)
         {
-            mask = kFLEXCAN_RxWarningInterruptEnable;
+            _can_enable_controller_irq(can);
         }
-        else if (argval == RT_DEVICE_FLAG_INT_TX)
+        else
         {
-            mask = kFLEXCAN_TxWarningInterruptEnable;
+            res = -RT_ERROR;
         }
-        else if (argval == RT_DEVICE_CAN_INT_ERR)
-        {
-            mask = kFLEXCAN_ErrorInterruptEnable;
-        }
-        FLEXCAN_EnableInterrupts(can->base, mask);
-        EnableIRQ(can->irqn);
         break;
     case RT_DEVICE_CTRL_CLR_INT:
-        /* each CAN device have one IRQ number. */
         DisableIRQ(can->irqn);
         break;
     case RT_CAN_CMD_SET_FILTER:
@@ -198,18 +523,26 @@ static rt_err_t _can_control(struct rt_can_device *can_dev, int cmd, void *arg)
         item = cfg->items;
         count = cfg->count;
 
-        if (filter_mask == 0xffffffff)
+        if (can->filter_mask == 0xffffffff)
         {
             rt_kprintf("%s filter is full!\n", can->name);
             res = -RT_ERROR;
             break;
         }
-        else if (filter_mask == 0)
+        else if (can->filter_mask == 0)
         {
-            /* deinit all init RX MB */
             for (i = 0; i < RX_MB_COUNT; i++)
             {
-                FLEXCAN_SetRxMbConfig(can->base, i + 1, RT_NULL, false);
+#ifdef RT_CAN_USING_CANFD
+                if (can->fd_enabled)
+                {
+                    FLEXCAN_SetFDRxMbConfig(can->base, i + 1, RT_NULL, false);
+                }
+                else
+#endif
+                {
+                    FLEXCAN_SetRxMbConfig(can->base, i + 1, RT_NULL, false);
+                }
             }
         }
 
@@ -228,81 +561,96 @@ static rt_err_t _can_control(struct rt_can_device *can_dev, int cmd, void *arg)
                 mask = FLEXCAN_RX_MB_STD_MASK(item->mask, 0, 0);
             }
 
-            if (item->rtr)
-            {
-                mbConfig.type = kFLEXCAN_FrameTypeRemote;
-            }
-            else
-            {
-                mbConfig.type = kFLEXCAN_FrameTypeData;
-            }
+            mbConfig.type = item->rtr ? kFLEXCAN_FrameTypeRemote : kFLEXCAN_FrameTypeData;
 
-            /* user does not specify hdr index,set hdr_bank from RX MB 1 */
             if (item->hdr_bank == -1)
             {
-
                 for (i = 0; i < 32; i++)
                 {
-                    if (!(filter_mask & (1 << i)))
+                    if (!(can->filter_mask & (1 << i)))
                     {
                         index = i;
                         break;
                     }
                 }
             }
-            else    /* use user specified hdr_bank */
+            else
             {
-                if (filter_mask & (1 << item->hdr_bank))
+                if (can->filter_mask & (1 << item->hdr_bank))
                 {
                     res = -RT_ERROR;
                     rt_kprintf("%s hdr%d filter already set!\n", can->name, item->hdr_bank);
                     break;
                 }
-                else
-                {
-                    index = item->hdr_bank;
-                }
+                index = item->hdr_bank;
             }
 
-            /* RX MB index from 1 to 32,hdr index 0~31 map RX MB index 1~32. */
             FLEXCAN_SetRxIndividualMask(can->base, index + 1, mask);
-            FLEXCAN_SetRxMbConfig(can->base, index + 1, &mbConfig, true);
-            filter_mask |= 1 << index;
+#ifdef RT_CAN_USING_CANFD
+            if (can->fd_enabled)
+            {
+                FLEXCAN_SetFDRxMbConfig(can->base, index + 1, &mbConfig, true);
+            }
+            else
+#endif
+            {
+                FLEXCAN_SetRxMbConfig(can->base, index + 1, &mbConfig, true);
+            }
+            can->filter_mask |= 1 << index;
 
             item++;
             count--;
         }
-
         break;
 
     case RT_CAN_CMD_SET_BAUD:
+        if (arg != RT_NULL)
         {
-            struct can_configure *cfg = (struct can_configure *)arg;
-            if (cfg != RT_NULL)
-            {
-                can->can_dev.config = *cfg;
-                _can_config(can_dev, cfg);
-                res = RT_EOK;
-            }
-            else
-            {
-                res = -RT_ERROR;
-            }
+            can->can_dev.config.baud_rate = *(rt_uint32_t *)arg;
+            res = _can_config(can_dev, &can->can_dev.config);
+        }
+        else
+        {
+            res = -RT_ERROR;
+        }
+        break;
+    case RT_CAN_CMD_SET_MODE:
+        argval = (rt_uint32_t)arg;
+        if (argval > RT_CAN_MODE_LOOPBACKANLISTEN)
+        {
+            res = -RT_ERROR;
             break;
         }
-    case RT_CAN_CMD_SET_MODE:
-        res = -RT_ERROR;
+        can->can_dev.config.mode = argval;
+        res = _can_config(can_dev, &can->can_dev.config);
         break;
-
+#ifdef RT_CAN_USING_CANFD
+    case RT_CAN_CMD_SET_CANFD:
+        argval = (rt_uint32_t)arg;
+        can->can_dev.config.enable_canfd = argval ? 1 : 0;
+        res = _can_config(can_dev, &can->can_dev.config);
+        break;
+    case RT_CAN_CMD_SET_BAUD_FD:
+        if (arg != RT_NULL)
+        {
+            can->can_dev.config.baud_rate_fd = *(rt_uint32_t *)arg;
+            res = _can_config(can_dev, &can->can_dev.config);
+        }
+        else
+        {
+            res = -RT_ERROR;
+        }
+        break;
+#endif
     case RT_CAN_CMD_SET_PRIV:
         res = -RT_ERROR;
         break;
     case RT_CAN_CMD_GET_STATUS:
-        FLEXCAN_GetBusErrCount(can->base, (rt_uint8_t *)(&can->can_dev.status.snderrcnt), (rt_uint8_t *)(&can->can_dev.status.rcverrcnt));
+        FLEXCAN_GetBusErrCount(can->base, (rt_uint8_t *)(&can->can_dev.status.snderrcnt),
+                               (rt_uint8_t *)(&can->can_dev.status.rcverrcnt));
         rt_memcpy(arg, &can->can_dev.status, sizeof(can->can_dev.status));
         break;
     case RT_CAN_CMD_START:
-        /* already started in can_cfg */
         break;
     default:
         res = -RT_ERROR;
@@ -312,70 +660,157 @@ static rt_err_t _can_control(struct rt_can_device *can_dev, int cmd, void *arg)
     return res;
 }
 
+#ifdef RT_CAN_USING_CANFD
+static void _can_fill_fd_frame(flexcan_fd_frame_t *frame, const struct rt_can_msg *msg)
+{
+    rt_uint8_t dlc;
+    rt_uint8_t data_len;
+
+    rt_memset(frame, 0, sizeof(*frame));
+
+    if (RT_CAN_STDID == msg->ide)
+    {
+        frame->id = FLEXCAN_ID_STD(msg->id);
+        frame->format = kFLEXCAN_FrameFormatStandard;
+    }
+    else
+    {
+        frame->id = FLEXCAN_ID_EXT(msg->id);
+        frame->format = kFLEXCAN_FrameFormatExtend;
+    }
+
+    frame->type = (RT_CAN_DTR == msg->rtr) ? kFLEXCAN_FrameTypeData : kFLEXCAN_FrameTypeRemote;
+    frame->edl = 1;
+    frame->brs = msg->brs ? 1 : 0;
+
+    dlc = (msg->len <= 15) ? msg->len : _can_len2dlc((rt_uint8_t)msg->len);
+    frame->length = dlc;
+    data_len = _can_dlc2len(dlc);
+    rt_memcpy(frame->dataWord, msg->data, data_len);
+}
+
+static void _can_parse_fd_frame(struct rt_can_msg *msg, const flexcan_fd_frame_t *frame)
+{
+    rt_uint8_t data_len;
+
+    if (frame->format == kFLEXCAN_FrameFormatStandard)
+    {
+        msg->ide = RT_CAN_STDID;
+        msg->id = frame->id >> CAN_ID_STD_SHIFT;
+    }
+    else
+    {
+        msg->ide = RT_CAN_EXTID;
+        msg->id = frame->id >> CAN_ID_EXT_SHIFT;
+    }
+
+    msg->rtr = (frame->type == kFLEXCAN_FrameTypeData) ? RT_CAN_DTR : RT_CAN_RTR;
+    msg->fd_frame = frame->edl ? 1 : 0;
+    msg->brs = frame->brs ? 1 : 0;
+    msg->len = frame->length;
+    data_len = _can_dlc2len(frame->length);
+    rt_memcpy(msg->data, frame->dataWord, data_len);
+}
+#endif
+
 static rt_ssize_t _can_sendmsg(struct rt_can_device *can_dev, const void *buf, rt_uint32_t boxno)
 {
     struct imxrt_can *can;
     struct rt_can_msg *msg;
-    status_t ret;
-    flexcan_frame_t frame;
-    flexcan_mb_transfer_t txXfer;
+    status_t ret = kStatus_Fail;
+    rt_uint8_t hw_mb = TX_MB_IDX;
 
     RT_ASSERT(can_dev != RT_NULL);
     RT_ASSERT(buf != RT_NULL);
 
     can = (struct imxrt_can *)can_dev->parent.user_data;
-    msg = (struct rt_can_msg *) buf;
+    msg = (struct rt_can_msg *)buf;
+    RT_UNUSED(boxno);
 
-    RT_ASSERT(can != RT_NULL);
-    RT_ASSERT(msg != RT_NULL);
-
-    FLEXCAN_SetTxMbConfig(can->base, boxno, true);
-
-    if (RT_CAN_STDID == msg->ide)
+    if (!_can_is_loopback(&can_dev->config))
     {
-        frame.id = FLEXCAN_ID_STD(msg->id);
-        frame.format = kFLEXCAN_FrameFormatStandard;
+        _can_abort_rx(can);
     }
-    else if (RT_CAN_EXTID == msg->ide)
+    else
     {
-        frame.id = FLEXCAN_ID_EXT(msg->id);
-        frame.format = kFLEXCAN_FrameFormatExtend;
+        _can_setup_loopback_mb(can);
     }
 
-    if (RT_CAN_DTR == msg->rtr)
+#ifdef RT_CAN_USING_CANFD
+    if (can->fd_enabled && msg->fd_frame)
     {
-        frame.type = kFLEXCAN_FrameTypeData;
+        flexcan_fd_frame_t tx_frame;
+
+        FLEXCAN_ClearMbStatusFlags(can->base, ((uint64_t)1U << hw_mb) | ((uint64_t)1U << RX_MB_IDX));
+        FLEXCAN_SetFDTxMbConfig(can->base, hw_mb, true);
+        _can_fill_fd_frame(&tx_frame, msg);
+
+        if (FLEXCAN_WriteFDTxMb(can->base, hw_mb, &tx_frame) != kStatus_Success)
+        {
+            ret = kStatus_Fail;
+        }
+        else
+        {
+            ret = _can_wait_mb_tx_done(can, hw_mb);
+        }
+
+        if (ret == kStatus_Success && _can_is_loopback(&can_dev->config))
+        {
+            ret = _can_wait_mb_rx_done(can->base, RX_MB_IDX);
+            if (ret == kStatus_Success)
+            {
+                ret = FLEXCAN_ReadFDRxMb(can->base, RX_MB_IDX, &can->framefd[0]);
+                if (ret == kStatus_Success)
+                {
+                    _can_loopback_post_rx(can);
+                }
+            }
+        }
     }
-    else if (RT_CAN_RTR == msg->rtr)
+    else
+#endif
     {
-        frame.type = kFLEXCAN_FrameTypeRemote;
+        flexcan_frame_t tx_frame;
+
+        FLEXCAN_ClearMbStatusFlags(can->base, ((uint64_t)1U << hw_mb) | ((uint64_t)1U << RX_MB_IDX));
+        FLEXCAN_SetTxMbConfig(can->base, hw_mb, true);
+        _can_fill_classic_frame(&tx_frame, msg);
+
+        if (FLEXCAN_WriteTxMb(can->base, hw_mb, &tx_frame) != kStatus_Success)
+        {
+            ret = kStatus_Fail;
+        }
+        else
+        {
+            ret = _can_wait_mb_tx_done(can, hw_mb);
+        }
+
+        if (ret == kStatus_Success && _can_is_loopback(&can_dev->config))
+        {
+            ret = _can_wait_mb_rx_done(can->base, RX_MB_IDX);
+            if (ret == kStatus_Success)
+            {
+                ret = FLEXCAN_ReadRxMb(can->base, RX_MB_IDX, &can->frame[0]);
+                if (ret == kStatus_Success)
+                {
+                    _can_loopback_post_rx(can);
+                }
+            }
+        }
     }
 
-    frame.length = msg->len;
-    frame.dataByte0 = msg->data[0];
-    frame.dataByte1 = msg->data[1];
-    frame.dataByte2 = msg->data[2];
-    frame.dataByte3 = msg->data[3];
-    frame.dataByte4 = msg->data[4];
-    frame.dataByte5 = msg->data[5];
-    frame.dataByte6 = msg->data[6];
-    frame.dataByte7 = msg->data[7];
-
-    txXfer.mbIdx = boxno;
-    txXfer.frame = &frame;
-    ret = FLEXCAN_TransferSendBlocking(can->base, boxno, txXfer.frame);
-    switch (ret)
+    if (ret == kStatus_Success)
     {
-    case kStatus_Success:
-        ret = RT_EOK;
         rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_TX_DONE | boxno << 8);
-        break;
-    case kStatus_Fail:
-        ret = -RT_ERROR;
-        break;
+        return RT_EOK;
     }
 
-    return (rt_ssize_t)ret;
+    if (ret == kStatus_Timeout)
+    {
+        _can_dump_err(can, "loopback timeout");
+    }
+
+    return -RT_ERROR;
 }
 
 static rt_ssize_t _can_recvmsg(struct rt_can_device *can_dev, void *buf, rt_uint32_t boxno)
@@ -387,40 +822,27 @@ static rt_ssize_t _can_recvmsg(struct rt_can_device *can_dev, void *buf, rt_uint
     RT_ASSERT(can_dev != RT_NULL);
 
     can = (struct imxrt_can *)can_dev->parent.user_data;
-    pmsg = (struct rt_can_msg *) buf;
-    RT_ASSERT(can != RT_NULL);
+    pmsg = (struct rt_can_msg *)buf;
+    index = (boxno >= RX_MB_IDX) ? (boxno - RX_MB_IDX) : 0;
 
-    index = boxno - 1;
-
-    if (frame[index].format == kFLEXCAN_FrameFormatStandard)
+#ifdef RT_CAN_USING_CANFD
+    if (can->fd_enabled && can->framefd[index].edl)
     {
-        pmsg->ide = RT_CAN_STDID;
-        pmsg->id = frame[index].id >> CAN_ID_STD_SHIFT;
+        _can_parse_fd_frame(pmsg, &can->framefd[index]);
+    }
+    else if (can->fd_enabled)
+    {
+        _can_parse_classic_frame(pmsg, (const flexcan_frame_t *)&can->framefd[index]);
+        pmsg->fd_frame = 0;
+        pmsg->brs = 0;
     }
     else
+#endif
     {
-        pmsg->ide = RT_CAN_EXTID;
-        pmsg->id = frame[index].id >> CAN_ID_EXT_SHIFT;
+        _can_parse_classic_frame(pmsg, &can->frame[index]);
     }
 
-    if (frame[index].type == kFLEXCAN_FrameTypeData)
-    {
-        pmsg->rtr = RT_CAN_DTR;
-    }
-    else if (frame[index].type == kFLEXCAN_FrameTypeRemote)
-    {
-        pmsg->rtr = RT_CAN_RTR;
-    }
-    pmsg->hdr_index = index;      /* one hdr filter per MB */
-    pmsg->len = frame[index].length;
-    pmsg->data[0] = frame[index].dataByte0;
-    pmsg->data[1] = frame[index].dataByte1;
-    pmsg->data[2] = frame[index].dataByte2;
-    pmsg->data[3] = frame[index].dataByte3;
-    pmsg->data[4] = frame[index].dataByte4;
-    pmsg->data[5] = frame[index].dataByte5;
-    pmsg->data[6] = frame[index].dataByte6;
-    pmsg->data[7] = frame[index].dataByte7;
+    pmsg->hdr_index = index;
 
     return 0;
 }
@@ -442,23 +864,18 @@ static uint8_t FLEXCAN_GetFirstValidMb(CAN_Type *base)
     return firstValidMbNum;
 }
 
-rt_ssize_t _can_sendmsg_nonblocking(struct rt_can_device *can_dev, const void *buf)
+static rt_ssize_t _can_sendmsg_nonblocking(struct rt_can_device *can_dev, const void *buf)
 {
     struct imxrt_can *can;
     struct rt_can_msg *msg;
     status_t ret;
-    flexcan_frame_t frame;
-    flexcan_mb_transfer_t txXfer;
     rt_uint32_t boxno;
+
     RT_ASSERT(can_dev != RT_NULL);
     RT_ASSERT(buf != RT_NULL);
 
     can = (struct imxrt_can *)can_dev->parent.user_data;
-    msg = (struct rt_can_msg *) buf;
-
-    RT_ASSERT(can != RT_NULL);
-    RT_ASSERT(msg != RT_NULL);
-
+    msg = (struct rt_can_msg *)buf;
     boxno = FLEXCAN_GetFirstValidMb(can->base);
 
     if (boxno == 0xFF)
@@ -466,50 +883,35 @@ rt_ssize_t _can_sendmsg_nonblocking(struct rt_can_device *can_dev, const void *b
         return -RT_EBUSY;
     }
 
-    if (RT_CAN_STDID == msg->ide)
+#ifdef RT_CAN_USING_CANFD
+    if (can->fd_enabled && msg->fd_frame)
     {
-        frame.id = FLEXCAN_ID_STD(msg->id);
-        frame.format = kFLEXCAN_FrameFormatStandard;
+        flexcan_mb_transfer_t txXfer;
+        flexcan_fd_frame_t tx_frame;
+
+        FLEXCAN_SetFDTxMbConfig(can->base, boxno, true);
+        _can_fill_fd_frame(&tx_frame, msg);
+        txXfer.mbIdx = boxno;
+        txXfer.framefd = &tx_frame;
+        txXfer.frame = RT_NULL;
+        ret = FLEXCAN_TransferFDSendNonBlocking(can->base, &can->handle, &txXfer);
     }
-    else if (RT_CAN_EXTID == msg->ide)
+    else
+#endif
     {
-        frame.id = FLEXCAN_ID_EXT(msg->id);
-        frame.format = kFLEXCAN_FrameFormatExtend;
+        flexcan_mb_transfer_t txXfer;
+        flexcan_frame_t tx_frame;
+
+        _can_fill_classic_frame(&tx_frame, msg);
+        txXfer.mbIdx = boxno;
+        txXfer.frame = &tx_frame;
+#ifdef RT_CAN_USING_CANFD
+        txXfer.framefd = RT_NULL;
+#endif
+        ret = FLEXCAN_TransferSendNonBlocking(can->base, &can->handle, &txXfer);
     }
 
-    if (RT_CAN_DTR == msg->rtr)
-    {
-        frame.type = kFLEXCAN_FrameTypeData;
-    }
-    else if (RT_CAN_RTR == msg->rtr)
-    {
-        frame.type = kFLEXCAN_FrameTypeRemote;
-    }
-
-    frame.length = msg->len;
-    frame.dataByte0 = msg->data[0];
-    frame.dataByte1 = msg->data[1];
-    frame.dataByte2 = msg->data[2];
-    frame.dataByte3 = msg->data[3];
-    frame.dataByte4 = msg->data[4];
-    frame.dataByte5 = msg->data[5];
-    frame.dataByte6 = msg->data[6];
-    frame.dataByte7 = msg->data[7];
-
-    txXfer.mbIdx = boxno;
-    txXfer.frame = &frame;
-    ret = FLEXCAN_TransferSendNonBlocking(can->base, &can->handle, &txXfer);
-    switch (ret)
-    {
-    case kStatus_Success:
-        ret = RT_EOK;
-        break;
-    case kStatus_Fail:
-        ret = -RT_ERROR;
-        break;
-    }
-
-    return (rt_ssize_t)ret;
+    return (ret == kStatus_Success) ? RT_EOK : -RT_ERROR;
 }
 
 static struct rt_can_ops imxrt_can_ops =
@@ -532,14 +934,18 @@ int rt_hw_can_init(void)
     config.sndboxnumber = 1;
     config.msgboxsz = RX_MB_COUNT;
 #ifdef RT_CAN_USING_HDR
-    config.maxhdr = RX_MB_COUNT;          /* filter count,one filter per MB */
+    config.maxhdr = RX_MB_COUNT;
+#endif
+#ifdef RT_CAN_USING_CANFD
+    config.enable_canfd = 1;
+    config.baud_rate_fd = 2000000;
 #endif
 
     for (i = 0; i < sizeof(flexcans) / sizeof(flexcans[0]); i++)
     {
         flexcans[i].can_dev.config = config;
-        CLOCK_SetClockDiv(flexcans[i].clock_div_name, 1u);
-        CLOCK_AttachClk(flexcans[i].clock_attach_id);
+        flexcans[i].filter_mask = 0;
+        _can_enable_periph_clock(&flexcans[i]);
 
         ret = rt_hw_can_register(&flexcans[i].can_dev, flexcans[i].name, &imxrt_can_ops, &flexcans[i]);
     }
@@ -548,4 +954,4 @@ int rt_hw_can_init(void)
 }
 INIT_BOARD_EXPORT(rt_hw_can_init);
 
-#endif /*RT_USING_CAN */
+#endif /* RT_USING_CAN */

--- a/bsp/nxp/mcx/mcxa/frdm-mcxa366/board/board.c
+++ b/bsp/nxp/mcx/mcxa/frdm-mcxa366/board/board.c
@@ -105,3 +105,25 @@ void MemManage_Handler(void)
     rt_kprintf("Memory Fault!\n");
     HardFault_Handler();
 }
+
+#ifndef NDEBUG
+#if defined(__ARMCC_VERSION) || defined(__ICCARM__)
+void __aeabi_assert(const char *failedExpr, const char *file, int line)
+{
+    rt_kprintf("ASSERT ERROR \" %s \": file \"%s\" Line \"%d\" \n", failedExpr, file, line);
+    for (;;)
+    {
+        __BKPT(0);
+    }
+}
+#elif defined(__GNUC__)
+void __assert_func(const char *file, int line, const char *func, const char *failedExpr)
+{
+    rt_kprintf("ASSERT ERROR \" %s \": file \"%s\" Line \"%d\" function \"%s\" \n", failedExpr, file, line, func);
+    for (;;)
+    {
+        __BKPT(0);
+    }
+}
+#endif /* __ARMCC_VERSION || __ICCARM__ */
+#endif /* NDEBUG */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

    add CAN-FD and loopback support

    - Extend flexcan driver with CAN-FD TX/RX and FD frame parsing
    - Add loopback and loopback+listen-only mode handling
    - Fix mailbox layout, clock init, and safe controller deinit
    - Add debug assert handlers for frdm-mcxa366 board

#### 为什么提交这份PR (why to submit this PR)

MCXA BSP 的 FlexCAN 驱动原先仅支持经典 CAN 的基本收发，缺少 CAN-FD、回环（loopback）和只听（listen-only）模式支持，无法满足 CAN-FD 应用及驱动自测需求。同时 `frdm-mcxa366` 在 Debug 构建下缺少标准 assert 处理函数，断言失败时无法输出有效调试信息。

#### 你的解决方案是什么 (what is your solution)

1. **增强 `drv_can.c` FlexCAN 驱动：**
   - 增加 CAN-FD 支持：FD 帧收发、DLC 编解码，以及 `RT_CAN_CMD_SET_CANFD` / `RT_CAN_CMD_SET_BAUD_FD` 控制命令
   - 增加回环模式（`RT_CAN_MODE_LOOPBACK`）和回环+只听模式（`RT_CAN_MODE_LOOPBACKANLISTEN`），回环模式下通过轮询完成 TX/RX 自测
   - 增加只听模式（`RT_CAN_MODE_LISTEN`）支持
   - 重构驱动：抽取帧填充/解析、时钟使能、安全反初始化、RX 启动等辅助函数
   - 修正邮箱布局（`TX_MB_IDX=0`，`RX_MB_IDX=1`），完善时钟初始化与控制器复位流程

2. **在 `frdm-mcxa366/board/board.c` 中增加 Debug 断言处理函数**（`__assert_func` / `__aeabi_assert`），断言失败时通过 `rt_kprintf` 输出信息并触发断点，便于调试。

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP:
  - `bsp/nxp/mcx/mcxa/frdm-mcxa366`

- .config:
  ```
  CONFIG_BSP_USING_CAN=y
  CONFIG_BSP_USING_CAN0=y
  CONFIG_RT_CAN_USING_CANFD=y        # 验证 CAN-FD 时启用
  CONFIG_RT_CAN_USING_HDR=y          # 可选，验证硬件过滤器时启用
  ```

  验证方式：
  - 经典 CAN：在 `can` 设备上设置 loopback 模式，执行 `can_sample` 或 MSH 命令收发，确认 TX/RX 正常
  - CAN-FD：启用 `CONFIG_RT_CAN_USING_CANFD`，设置 FD 波特率（默认 2 Mbps），在 loopback 模式下收发 FD 帧，确认数据长度与内容正确

- action:
  - （推送分支后，在此填写您 fork 仓库触发的 CI 编译成功链接，例如：`https://github.com/<your-username>/rt-thread/actions/workflows/manual_dist.yml`）

### CAN0 引脚复用

| 信号 | MCU 引脚 | 复用 | 配置要点 |
|------|----------|------|----------|
| CAN0_RXD | **PORT1_11** | Alt11 | 输入使能，无上下拉 |
| CAN0_TXD | **PORT1_2** | Alt11 | 输入使能，无上下拉 |


### FlexCAN 外设时钟（驱动层）

**入口：**  
- 第一次：`rt_hw_can_init()`（板级组件自动导出）  
- 之后：每次 `_can_config()` 也会调用  

**文件：** `Libraries/drivers/drv_can.c`

#### CAN0 静态配置

```165:173:Libraries/drivers/drv_can.c
    {
        .name = "can0",
        .base = CAN0,
        .instance = 0,
        .irqn = CAN0_IRQn,
        .clock_div_name = kCLOCK_DivFLEXCAN0,
        .clock_attach_id = kFRO_HF_DIV_to_FLEXCAN0,
    },
```

#### `_can_enable_periph_clock()` 做了什么

```207:214:Libraries/drivers/drv_can.c
static void _can_enable_periph_clock(struct imxrt_can *can)
{
    clock_ip_name_t can_clocks[] = FLEXCAN_CLOCKS;

    CLOCK_EnableClock(can_clocks[can->instance]);   // ① 打开 FLEXCAN0 时钟门控
    CLOCK_SetClockDiv(can->clock_div_name, 2u);     // ② 分频 /2
    CLOCK_AttachClk(can->clock_attach_id);          // ③ 时钟源 = FRO_HF_DIV
}
```

| 步骤 | API | 作用 |
|------|-----|------|
| ① | `CLOCK_EnableClock(kCLOCK_GateFLEXCAN0)` | 打开 FlexCAN0 时钟门控（早期 bug 就是漏了这步，导致 clk=0） |
| ② | `CLOCK_SetClockDiv(kCLOCK_DivFLEXCAN0, 2)` | FlexCAN 模块时钟再 ÷2 |
| ③ | `CLOCK_AttachClk(kFRO_HF_DIV_to_FLEXCAN0)` | 时钟源接 FRO_HF_DIV |

**频率估算：**  
Boot 后 FRO HF = 180 MHz，FRO_HF_DIV 通常也为 180 MHz（÷1），再经 FlexCAN 分频 ÷2 → **FlexCAN 模块时钟约 90 MHz**。

配置/发送前会调用 `CLOCK_GetFlexcanClkFreq(0)` 读实际频率，用于 500 kbps 位时序计算；若为 0 则报错退出。

### 验证截图

截图为 CAN FD 内部环回测试验证

<img width="625" height="609" alt="8661e50e-f8fc-4069-80a4-0b525aa3378f" src="https://github.com/user-attachments/assets/f3dcee06-19f9-47aa-a757-dcf55e032fe2" />



### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
