### PR TITLE
rt-link: reject frame offset at frame limit

### DIFF
--- a/components/utilities/rt-link/src/rtlink.c
+++ b/components/utilities/rt-link/src/rtlink.c
@@ -767,7 +767,7 @@ static void rt_link_frame_check(void)
             {
                 /* Check the receive sequence */
                 offset = rt_link_check_seq(receive_frame.head.sequence, rt_link_scb->rx_record.rx_seq) - 1;
-                if (offset > RT_LINK_FRAMES_MAX)
+                if (offset >= RT_LINK_FRAMES_MAX)
                 {
                     /* exceptional frame, ignore it */
                     LOG_D("seq (%d) failed, rx_seq (%d) offset=(%d) attr= (%d) status (%d)", receive_frame.head.sequence, rt_link_scb->rx_record.rx_seq, offset, receive_frame.attribute, rt_link_scb->state);


### PR DESCRIPTION
## What

Reject receive sequence offsets that are equal to `RT_LINK_FRAMES_MAX` in the rt-link frame parser.

## Why

`RT_LINK_FRAMES_MAX` is documented as the maximum number of split frames for a long package. `rt_link_send()` rejects `total > RT_LINK_FRAMES_MAX`, so with the current value of 3 the valid zero-based receive offsets are 0, 1, and 2.

The parser maps incoming data-frame sequence numbers to a zero-based `offset` before frame handling. The existing `offset > RT_LINK_FRAMES_MAX` check still accepts `offset == RT_LINK_FRAMES_MAX`, which is outside the valid split-frame offset range.

## Testing

- `git diff --check`
- `git diff --check HEAD~1 HEAD`
- `git show --stat --check --format=fuller HEAD`
- `git ls-files --eol -- components/utilities/rt-link/src/rtlink.c`
- Confirmed duplicate PR/issue searches returned `total_count: 0` for:
  - `repo:RT-Thread/rt-thread RT_LINK_FRAMES_MAX rt-link is:pr`
  - `repo:RT-Thread/rt-thread RT_LINK_FRAMES_MAX rt-link is:issue`
  - `repo:RT-Thread/rt-thread rt_link_frame_check offset is:pr`
  - `repo:RT-Thread/rt-thread rt_link_frame_check offset is:issue`

Not run locally:

- build/tests: local `make`, `scons`, `gcc`, `arm-none-eabi-gcc`, and `clang` are not installed
