### PR TITLE
[rust][tools] Fix Rust build example configuration handling

### DIFF
--- a/bsp/stm32/stm32f407-rt-spark/.ci/attachconfig/ci.attachconfig.yml
+++ b/bsp/stm32/stm32f407-rt-spark/.ci/attachconfig/ci.attachconfig.yml
@@ -246,6 +246,26 @@ component.cherryusb_cdc:
       - CONFIG_RT_CHERRYUSB_DEVICE_DWC2_ST=y
       - CONFIG_RT_CHERRYUSB_DEVICE_CDC_ACM=y
       - CONFIG_RT_CHERRYUSB_DEVICE_TEMPLATE_CDC_ACM=y
+# ------ rust CI ------
+rust:
+    <<: *scons
+    pre_build: |
+      python3 -m pip install --user toml
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly --profile minimal
+      sudo ln -sf "$HOME/.cargo/bin/cargo" /usr/local/bin/cargo
+      sudo ln -sf "$HOME/.cargo/bin/rustc" /usr/local/bin/rustc
+      sudo ln -sf "$HOME/.cargo/bin/rustup" /usr/local/bin/rustup
+      rustup target add thumbv7em-none-eabihf
+      rustup component add rust-src
+      rustc --version
+      cargo --version
+    kconfig:
+      - CONFIG_RT_USING_RUST=y
+      - CONFIG_RT_RUST_CORE=y
+      - CONFIG_RT_USING_RUST_EXAMPLES=y
+      - CONFIG_RT_RUST_BUILD_APPLICATIONS=y
+      - CONFIG_RT_RUST_BUILD_COMPONENTS=y
+      - CONFIG_RUST_LOG_COMPONENT=y
 
 devices.soft_i2c:
   <<: *scons

--- a/components/rust/README.md
+++ b/components/rust/README.md
@@ -84,6 +84,14 @@ rustup target add thumbv7em-none-eabi
 # Add other targets that match your toolchain/ABI as needed
 ```
 
+For ARM targets whose C toolchain uses `-fshort-wchar`, RT-Thread uses the nightly-only `build-std` feature to rebuild Rust `core` and `alloc` from source, keeping the Rust ARM EABI wchar size aligned with the C toolchain. Install `rust-src` and the corresponding target for the same nightly toolchain. From the RT-Thread repository root, set a directory-local nightly override so that the plain `cargo` and `rustc` commands invoked by SCons use this toolchain throughout the repository:
+
+```bash
+rustup toolchain install nightly --profile minimal --component rust-src
+rustup target add --toolchain nightly <target-name>
+rustup override set nightly
+```
+
 ### Build
 
 ```bash

--- a/components/rust/README_zh.md
+++ b/components/rust/README_zh.md
@@ -84,6 +84,14 @@ rustup target add thumbv7em-none-eabi
 # 其他目标请根据实际工具链/ABI 添加对应的 Rust target
 ```
 
+对于 C 工具链使用 `-fshort-wchar` 的 ARM 目标，RT-Thread 会使用仅 nightly 支持的 `build-std` 从源码重新构建 Rust `core` 和 `alloc`，使 Rust ARM EABI wchar 大小与 C 工具链保持一致。请为同一个 nightly 工具链安装 `rust-src` 和对应 target，并在 RT-Thread 仓库根目录设置目录级 nightly override，使 SCons 在整个仓库目录树中调用的普通 `cargo` 和 `rustc` 命令使用该工具链：
+
+```bash
+rustup toolchain install nightly --profile minimal --component rust-src
+rustup target add --toolchain nightly <target-name>
+rustup override set nightly
+```
+
 ### 构建
 
 ```bash

--- a/components/rust/SConscript
+++ b/components/rust/SConscript
@@ -10,7 +10,7 @@ def _has(sym: str) -> bool:
     except Exception:
         return bool(GetDepend(sym))
 
-if not _has('RT_USING_RUST'):
+if not _has('RT_USING_RUST') and not GetOption('clean'):
     Return('objs')
 
 cwd = GetCurrentDir()

--- a/components/rust/core/Cargo.toml
+++ b/components/rust/core/Cargo.toml
@@ -10,6 +10,17 @@ crate-type = ["rlib", "staticlib"]
 [features]
 default = []
 smp = []
+fs = []
+libdl = []
+
+[package.metadata.rt-thread.features.smp]
+all = ["RT_USING_SMP"]
+
+[package.metadata.rt-thread.features.fs]
+all = ["RT_USING_DFS", "DFS_USING_POSIX"]
+
+[package.metadata.rt-thread.features.libdl]
+all = ["RT_USING_MODULE"]
 
 [profile.dev]
 panic = "abort"

--- a/components/rust/core/SConscript
+++ b/components/rust/core/SConscript
@@ -1,5 +1,7 @@
 import os
+import sys
 from building import *
+from SCons.Subst import quote_spaces
 
 cwd = GetCurrentDir()
 
@@ -7,10 +9,12 @@ sys.path.append(os.path.join(cwd, '../tools'))
 from build_support import (
     detect_rust_target,
     make_rustflags,
+    make_cargo_build_std_args,
     collect_features,
     verify_rust_toolchain,
     ensure_rust_target_installed,
     cargo_build_staticlib,
+    get_staticlib_link_name,
     clean_rust_build,
 )
 def _has(sym: str) -> bool:
@@ -20,10 +24,28 @@ def _has(sym: str) -> bool:
         return bool(GetDepend(sym))
 
 
-# Source files – MSH command glue
-src = ['rust_cmd.c']
+group = []
+if not _has('RT_RUST_CORE') and not GetOption('clean'):
+    Return('group')
+
+
+def get_staticlib_link_name_from_artifact(lib_path):
+    """Derive the link name from the actual staticlib artifact file name."""
+    artifact_name = os.path.basename(os.fspath(lib_path))
+    if artifact_name.startswith("lib") and artifact_name.endswith(".a"):
+        return artifact_name[3:-2]
+    return None
+
+
+# Source files – MSH command glue.
+# rust_cmd.c references rust_init(), which is only provided by the Rust core
+# static library. It must only enter the build when that library is actually
+# produced; otherwise the C link stage fails with 'undefined reference to
+# rust_init' instead of failing/skipping cleanly at the Rust build step.
 LIBS = []
 LIBPATH = []
+LINKFLAGS = ""
+include_rust_cmd = False
 
 if GetOption('clean'):
     # Register Rust artifacts for cleaning
@@ -33,39 +55,65 @@ if GetOption('clean'):
         Clean('.', rust_build_dir)
     else:
         print('No rust build artifacts to clean')
+    # Keep rust_cmd.c in the group during clean so its object is cleaned too.
+    include_rust_cmd = True
 else:
     if verify_rust_toolchain():
         import rtconfig
+        rust_build_dir = clean_rust_build(Dir('#').abspath)
 
         target = detect_rust_target(_has, rtconfig)
         if not target:
             print('Error: Unable to detect Rust target; please check configuration')
+            sys.exit(1)
         else:
             print(f'Detected Rust target: {target}')
 
             # Optional hint if target missing
-            ensure_rust_target_installed(target)
-
-            # Build mode and features
-            debug = bool(_has('RUST_DEBUG_BUILD'))
-            features = collect_features(_has)
-
-            rustflags = make_rustflags(rtconfig, target)
-            rust_lib = cargo_build_staticlib(
-                rust_dir=cwd, target=target, features=features, debug=debug, rustflags=rustflags
-            )
-
-            if rust_lib:
-                LIBS = ['rt_rust']
-                LIBPATH = [os.path.dirname(rust_lib)]
-                print('Rust library linked successfully')
+            if not ensure_rust_target_installed(target):
+                print('Error: Rust target is not installed; Rust library build failed')
+                sys.exit(1)
             else:
-                print('Warning: Failed to build Rust library')
-    else:
-        print('Warning: Rust toolchain not found')
-        print('Please install Rust from https://rustup.rs')
+                # Build mode and features
+                debug = bool(_has('RUST_DEBUG_BUILD'))
+                features = collect_features(_has)
 
-# Define component group for SCons
-group = DefineGroup('rust', src, depend=['RT_USING_RUST'], LIBS=LIBS, LIBPATH=LIBPATH)
+                rustflags = make_rustflags(rtconfig, target)
+                cargo_extra_args = make_cargo_build_std_args(rtconfig, target)
+                rust_lib = cargo_build_staticlib(
+                    rust_dir=cwd, target=target, features=features, debug=debug, rustflags=rustflags, build_root=rust_build_dir, cargo_extra_args=cargo_extra_args
+                )
+
+                if rust_lib:
+                    # Derive the link name from the actual artifact so it always
+                    # matches the file that was built. Only fall back to
+                    # re-parsing Cargo.toml when the artifact name does not
+                    # follow the lib<name>.a convention.
+                    link_lib_name = get_staticlib_link_name_from_artifact(rust_lib)
+                    if not link_lib_name:
+                        link_lib_name = get_staticlib_link_name(cwd)
+                    LIBS = [link_lib_name]
+                    LIBPATH = [os.path.dirname(rust_lib)]
+                    if rtconfig.PLATFORM == 'armclang':
+                        if not (os.path.isfile(rust_lib) and os.path.getsize(rust_lib) > 0):
+                            print(f'Error: ArmClang Rust core link requires a non-empty archive, but got: {rust_lib}')
+                            sys.exit(1)
+                        LINKFLAGS = " " + quote_spaces(os.fspath(rust_lib))
+                        LIBS = []
+                        LIBPATH = []
+                    include_rust_cmd = True
+                    print('Rust library linked successfully')
+                else:
+                    print('Error: Failed to build Rust library')
+                    sys.exit(1)
+    else:
+        print('Error: Rust toolchain not found')
+        print('Please install Rust from https://rustup.rs')
+        sys.exit(1)
+
+# Only define the component group (with rust_cmd.c) when the Rust core static
+# library was actually produced, so its rust_init() reference always resolves.
+if include_rust_cmd:
+    group = DefineGroup('rust', ['rust_cmd.c'], depend=['RT_USING_RUST', 'RT_RUST_CORE'], LIBS=LIBS, LIBPATH=LIBPATH, LINKFLAGS=LINKFLAGS)
 
 Return('group')

--- a/components/rust/core/src/api/mod.rs
+++ b/components/rust/core/src/api/mod.rs
@@ -14,6 +14,7 @@ pub mod thread;
 pub mod mutex;
 pub mod sem;
 pub mod queue;
+#[cfg(feature = "libdl")]
 pub mod libloading;
 
 
@@ -24,4 +25,5 @@ pub use thread::*;
 pub use mutex::*;
 pub use sem::*;
 pub use queue::*;
+#[cfg(feature = "libdl")]
 pub use libloading::*;

--- a/components/rust/core/src/api/queue.rs
+++ b/components/rust/core/src/api/queue.rs
@@ -20,7 +20,7 @@ pub type APIRawQueue = rt_mq_t;
 pub(crate) fn queue_create(name: &str, len: u64, message_size: u64) -> Option<APIRawQueue> {
     let s = CString::new(name).unwrap();
     let raw;
-    unsafe { raw = rt_mq_create(s.as_ptr(), message_size, len, 0) }
+    unsafe { raw = rt_mq_create(s.as_ptr(), message_size as rt_size_t, len as rt_size_t, 0) }
     if raw == ptr::null_mut() {
         None
     } else {
@@ -35,7 +35,7 @@ pub(crate) fn queue_send_wait(
     msg_size: u64,
     tick: i32,
 ) -> RttCResult {
-    unsafe { rt_mq_send_wait(handle, msg, msg_size, tick).into() }
+    unsafe { rt_mq_send_wait(handle, msg, msg_size as rt_size_t, tick).into() }
 }
 
 #[inline]
@@ -45,7 +45,12 @@ pub(crate) fn queue_receive_wait(
     msg_size: u64,
     tick: i32,
 ) -> RttCResult {
-    unsafe { rt_mq_recv(handle, msg, msg_size, tick).into() }
+    let ret = unsafe { rt_mq_recv(handle, msg, msg_size as rt_size_t, tick) };
+    if ret >= 0 {
+        RttCResult::Ok
+    } else {
+        ret.into()
+    }
 }
 
 #[inline]

--- a/components/rust/core/src/bindings/librt.rs
+++ b/components/rust/core/src/bindings/librt.rs
@@ -26,6 +26,7 @@ pub type rt_int32_t = c_int;
 pub type rt_uint8_t  = c_uchar;
 pub type rt_tick_t = rt_uint32_t;
 pub type rt_size_t = rt_ubase_t;
+pub type rt_ssize_t = rt_base_t;
 
 pub type rt_thread_t = *mut c_void;
 pub type rt_sem_t = *mut c_void;
@@ -94,7 +95,7 @@ unsafe extern "C" {
     pub fn rt_mq_create(name: *const c_char, msg_size: rt_size_t, max_msgs: rt_size_t, flag: rt_uint8_t) -> rt_mq_t;
     pub fn rt_mq_send(mq: rt_mq_t, buffer: *const c_void, size: rt_size_t) -> rt_err_t;
     pub fn rt_mq_send_wait(mq: rt_mq_t, buffer: *const c_void, size: rt_size_t, timeout: rt_int32_t) -> rt_err_t;
-    pub fn rt_mq_recv(mq: rt_mq_t, buffer: *mut c_void, size: rt_size_t, timeout: rt_int32_t) -> rt_base_t;
+    pub fn rt_mq_recv(mq: rt_mq_t, buffer: *mut c_void, size: rt_size_t, timeout: rt_int32_t) -> rt_ssize_t;
     pub fn rt_mq_delete(mq: rt_mq_t) -> rt_err_t;
     pub fn rt_mq_detach(mq: rt_mq_t) -> rt_err_t;
 }

--- a/components/rust/core/src/bindings/mod.rs
+++ b/components/rust/core/src/bindings/mod.rs
@@ -46,8 +46,7 @@ pub use librt::{
 
 /* Memory management functions */
 pub use librt::{
-    rt_malloc, rt_free, rt_realloc, rt_calloc, rt_malloc_align, rt_free_align,
-    rt_safe_malloc, rt_safe_free
+    rt_malloc, rt_free, rt_realloc, rt_calloc, rt_malloc_align, rt_free_align
 };
 
 /* Device management functions */

--- a/components/rust/core/src/fs.rs
+++ b/components/rust/core/src/fs.rs
@@ -98,7 +98,7 @@ impl File {
 
     pub fn seek(&self, offset: i64) -> RTResult<i64> {
         let n = unsafe { libc::lseek(self.fd, offset as libc::off_t, libc::SEEK_SET) };
-        if n < 0 { Err(FileSeekErr) } else { Ok(n) }
+        if n < 0 { Err(FileSeekErr) } else { Ok(n.into()) }
     }
 
     pub fn flush(&self) -> RTResult<()> {

--- a/components/rust/core/src/lib.rs
+++ b/components/rust/core/src/lib.rs
@@ -17,7 +17,6 @@ and device interfaces. Designed for embedded devices running RT-Thread.
 */
 
 #![no_std]
-#![feature(alloc_error_handler)]
 #![feature(linkage)]
 #![allow(dead_code)]
 
@@ -33,6 +32,7 @@ pub mod init;
 pub mod allocator;
 pub mod mutex;
 pub mod out;
+#[cfg(feature = "fs")]
 pub mod fs;
 pub mod panic;
 pub mod param;
@@ -40,6 +40,7 @@ pub mod queue;
 pub mod sem;
 pub mod thread;
 pub mod time;
+#[cfg(feature = "libdl")]
 pub mod libloader;
 
 mod prelude;

--- a/components/rust/examples/application/SConscript
+++ b/components/rust/examples/application/SConscript
@@ -6,7 +6,7 @@ cwd = GetCurrentDir()
 
 # Import usrapp build module and build support
 sys.path.append(os.path.join(cwd, '../../tools'))
-from build_usrapp import build_example_usrapp
+from build_usrapp import UserAppBuildError, build_example_usrapp
 from build_support import clean_rust_build
 
 
@@ -31,7 +31,7 @@ def load_extended_feature_configs():
 
 group = []
 
-if not _has('RT_RUST_BUILD_APPLICATIONS'):
+if not (_has('RT_RUST_BUILD_APPLICATIONS') or _has('RT_RUST_BUILD_ALL_EXAMPLES')) and not GetOption('clean'):
     Return('group')
 
 # Load extended feature configurations
@@ -51,12 +51,16 @@ if GetOption('clean'):
         print('No example_usrapp build artifacts to clean')
 else:
     import rtconfig
-    LIBS, LIBPATH, LINKFLAGS = build_example_usrapp(
-        cwd=cwd,
-        has_func=_has,
-        rtconfig=rtconfig,
-        build_root=os.path.join(Dir('#').abspath, "build", "example_usrapp")
-    )
+    try:
+        LIBS, LIBPATH, LINKFLAGS = build_example_usrapp(
+            cwd=cwd,
+            has_func=_has,
+            rtconfig=rtconfig,
+            build_root=os.path.join(Dir('#').abspath, "build", "example_usrapp")
+        )
+    except UserAppBuildError as e:
+        print(f'Error: {e}')
+        sys.exit(1)
 
 group = DefineGroup(
     'example_usrapp', 

--- a/components/rust/examples/application/fs/Cargo.toml
+++ b/components/rust/examples/application/fs/Cargo.toml
@@ -12,6 +12,6 @@ default = []
 enable-log = ["em_component_log/enable-log"]
 
 [dependencies]
-rt-rust = { path = "../../../core" }
+rt-rust = { path = "../../../core", features = ["fs"] }
 rt_macros = { path = "../../../rt_macros" }
 em_component_log = { path = "../../component/log"}

--- a/components/rust/examples/application/loadlib/Cargo.toml
+++ b/components/rust/examples/application/loadlib/Cargo.toml
@@ -8,5 +8,5 @@ name = "em_loadlib"
 crate-type = ["staticlib"]
 
 [dependencies]
-rt-rust = { path = "../../../core" }
+rt-rust = { path = "../../../core", features = ["libdl"] }
 rt_macros = { path = "../../../rt_macros" }

--- a/components/rust/examples/component/SConscript
+++ b/components/rust/examples/component/SConscript
@@ -6,7 +6,7 @@ cwd = GetCurrentDir()
 
 # Import component build module and build support
 sys.path.append(os.path.join(cwd, '../../tools'))
-from build_component import build_example_component
+from build_component import ComponentBuildError, build_example_component
 from build_support import clean_rust_build
 
 # Load feature configurations
@@ -25,12 +25,11 @@ def _has(sym: str) -> bool:
         return bool(GetDepend(sym))
 
 
-# Early return if Rust or log component is not enabled
-if not _has('RT_USING_RUST'):
+if not _has('RT_USING_RUST') and not GetOption('clean'):
     group = []
     Return('group')
 
-if not _has('RUST_LOG_COMPONENT'):
+if not (_has('RT_RUST_BUILD_COMPONENTS') or _has('RT_RUST_BUILD_ALL_EXAMPLES')) and not GetOption('clean'):
     group = []
     Return('group')
 
@@ -51,12 +50,16 @@ if GetOption('clean'):
 else:
     # Build the component using the extracted build module
     import rtconfig
-    LIBS, LIBPATH, LINKFLAGS = build_example_component(
-        cwd=cwd,
-        has_func=_has,
-        rtconfig=rtconfig,
-        build_root=os.path.join(Dir('#').abspath, "build", "example_component")
-    )
+    try:
+        LIBS, LIBPATH, LINKFLAGS = build_example_component(
+            cwd=cwd,
+            has_func=_has,
+            rtconfig=rtconfig,
+            build_root=os.path.join(Dir('#').abspath, "build", "example_component")
+        )
+    except ComponentBuildError as e:
+        print(f'Error: {e}')
+        sys.exit(1)
 
 # Define component group for SCons
 group = DefineGroup(

--- a/components/rust/examples/modules/SConscript
+++ b/components/rust/examples/modules/SConscript
@@ -32,6 +32,20 @@ def _has(sym: str) -> bool:
     except Exception:
         return bool(GetDepend(sym))
 
+
+MODULE_CONFIG_MAP = {
+    'example_lib': 'RT_RUST_MODULE_SIMPLE_MODULE',
+}
+
+
+def should_build_module(module_dir: str) -> bool:
+    if _has('RT_RUST_BUILD_ALL_EXAMPLES'):
+        return True
+
+    config = MODULE_CONFIG_MAP.get(os.path.basename(module_dir))
+    return bool(config and _has(config))
+
+
 def detect_target_for_dynamic_modules():
     """
     Detect the appropriate Rust target for dynamic modules.
@@ -68,7 +82,7 @@ def build_rust_module(module_dir, build_root):
         cargo_config = toml.load(f)
     
     module_name = cargo_config['package']['name']
-    
+
     # Detect target automatically based on the current configuration
     target = detect_target_for_dynamic_modules()
     print(f"Building Rust module '{module_name}' for target: {target}")
@@ -121,7 +135,12 @@ def build_rust_module(module_dir, build_root):
         return [], [], ""
 
 # Check dependencies
-if not _has('RT_RUST_BUILD_MODULES'):
+if not _has('RT_USING_MODULE') and not GetOption('clean'):
+    Return([])
+
+if not (
+    _has('RT_RUST_BUILD_MODULES') or _has('RT_RUST_BUILD_ALL_EXAMPLES')
+) and not GetOption('clean'):
     Return([])
 
 build_root = os.path.join(Dir('#').abspath, "build", "rust_modules")
@@ -142,7 +161,11 @@ else:
     modules_built = []
     for item in os.listdir(cwd):
         item_path = os.path.join(cwd, item)
-        if os.path.isdir(item_path) and os.path.exists(os.path.join(item_path, 'Cargo.toml')):
+        if (
+            os.path.isdir(item_path)
+            and os.path.exists(os.path.join(item_path, 'Cargo.toml'))
+            and should_build_module(item_path)
+        ):
             result = build_rust_module(item_path, build_root)
             if result[0]:
                 modules_built.extend(result[0])
@@ -151,9 +174,9 @@ else:
         print(f"Successfully built {len(modules_built)} Rust dynamic module(s): {', '.join(modules_built)}")
 
 group = DefineGroup(
-    'rust_modules', 
-    [], 
-    depend=['RT_RUST_BUILD_MODULES']
+    'rust_modules',
+    [],
+    depend=['RT_USING_RUST']
 )
 
 Return('group')

--- a/components/rust/examples/modules/example_lib/Cargo.toml
+++ b/components/rust/examples/modules/example_lib/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-rt-rust = { path = "../../.." }
+rt-rust = { path = "../../../core" }

--- a/components/rust/examples/modules/example_lib/src/lib.rs
+++ b/components/rust/examples/modules/example_lib/src/lib.rs
@@ -11,7 +11,7 @@
 /* Bring rt-rust's println! macro into scope */ 
 use rt_rust::println;
 use core::ffi::{c_char, CStr};
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn rust_mylib_println(s: *const c_char) {
     if s.is_null() {
         println!("");
@@ -24,7 +24,7 @@ pub extern "C" fn rust_mylib_println(s: *const c_char) {
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn rust_mylib_add(a: usize, b: usize) -> usize {
     a + b
 }

--- a/components/rust/tools/build_component.py
+++ b/components/rust/tools/build_component.py
@@ -1,15 +1,124 @@
 import os
 import subprocess
+from SCons.Subst import quote_spaces
 
 
 # Configuration to feature mapping table for components
 # This table defines which RT-Thread configurations should enable which component features
 # All feature configurations are now defined in feature_config_component.py
-CONFIG_COMPONENT_FEATURE_MAP = {}
+CONFIG_COMPONENT_FEATURE_MAP = {
+}
 
 
 class ComponentBuildError(Exception):
     pass
+
+
+def load_toml_module():
+    try:
+        import toml
+        return toml
+    except ImportError as e:
+        raise ComponentBuildError("Missing toml module required to parse component Cargo.toml") from e
+
+
+def normalize_component_build_root(build_root, cwd):
+    """
+    Normalize the component build root directory.
+
+    Args:
+        build_root: Optional build root directory
+        cwd: Current working directory (component directory)
+
+    Returns:
+        str: Absolute build root path
+    """
+    if build_root is None:
+        if not cwd:
+            raise ComponentBuildError("Invalid build_root: cwd is required when build_root is None")
+        build_root = os.path.join(cwd, "build", "rust", "component")
+
+    try:
+        build_root = os.fspath(build_root)
+    except TypeError:
+        raise ComponentBuildError("Invalid build_root: expected a non-empty path")
+
+    if not isinstance(build_root, str) or not build_root:
+        raise ComponentBuildError("Invalid build_root: expected a non-empty path")
+
+    return os.path.abspath(build_root)
+
+
+def get_component_staticlib_artifact_name(rust_dir):
+    cargo_toml_path = os.path.join(rust_dir, "Cargo.toml")
+    lib_name = "em_component_registry"
+
+    try:
+        import toml
+        with open(cargo_toml_path, "r") as f:
+            cargo_data = toml.load(f)
+
+        package_name = cargo_data.get("package", {}).get("name")
+        lib_name = cargo_data.get("lib", {}).get("name") or package_name or lib_name
+    except Exception as e:
+        print(f"Warning: Failed to parse Rust component static library metadata from {cargo_toml_path}: {e}")
+
+    if not isinstance(lib_name, str) or not lib_name:
+        lib_name = "em_component_registry"
+
+    lib_name = lib_name.replace("-", "_")
+    return f"lib{lib_name}.a"
+
+
+def get_component_staticlib_link_name(rust_dir):
+    cargo_toml_path = os.path.join(rust_dir, "Cargo.toml")
+    lib_name = "em_component_registry"
+
+    try:
+        import toml
+        with open(cargo_toml_path, "r") as f:
+            cargo_data = toml.load(f)
+
+        package_name = cargo_data.get("package", {}).get("name")
+        lib_name = cargo_data.get("lib", {}).get("name") or package_name or lib_name
+    except Exception as e:
+        print(f"Warning: Failed to parse Rust component static library metadata from {cargo_toml_path}: {e}")
+
+    if not isinstance(lib_name, str) or not lib_name:
+        lib_name = "em_component_registry"
+
+    return lib_name.replace("-", "_")
+
+
+def get_staticlib_link_name_from_artifact(lib_path):
+    """
+    Derive the linker library name from the actual staticlib artifact file name.
+
+    Args:
+        lib_path: Path to the built staticlib artifact
+
+    Returns:
+        str: Link name (artifact name without the leading 'lib' and trailing
+             '.a'), or None if the artifact does not follow that convention.
+    """
+    artifact_name = os.path.basename(os.fspath(lib_path))
+    if artifact_name.startswith("lib") and artifact_name.endswith(".a"):
+        return artifact_name[3:-2]
+    return None
+
+
+def get_component_export_symbols(features):
+    enabled_features = set(features or [])
+    symbols = []
+    for config_info in CONFIG_COMPONENT_FEATURE_MAP.values():
+        if config_info['feature'] in enabled_features:
+            export_symbols = config_info.get('export_symbols', [])
+            if not export_symbols:
+                raise ComponentBuildError(
+                    f"No link anchor metadata registered for enabled component feature '{config_info['feature']}'"
+                )
+            symbols.extend(export_symbols)
+    return symbols
 
 
 def check_component_dependencies(component_dir, required_dependencies):
@@ -65,7 +174,7 @@ def collect_component_features(has_func, component_dir=None):
     # Iterate through all configured mappings
     for config_name, config_info in CONFIG_COMPONENT_FEATURE_MAP.items():
         # Check if this RT-Thread configuration is enabled
-        if has_func(config_name):
+        if has_func(config_name) or has_func('RT_RUST_BUILD_ALL_EXAMPLES'):
             feature_name = config_info['feature']
             required_deps = config_info.get('dependencies', [])
             
@@ -81,7 +190,27 @@ def collect_component_features(has_func, component_dir=None):
     
     return features
 
-def cargo_build_component_staticlib(rust_dir, target, features, debug, rustflags=None, build_root=None):
+
+def declared_component_features(component_dir):
+    cargo_toml_path = os.path.join(component_dir, 'Cargo.toml')
+    if not os.path.isfile(cargo_toml_path):
+        raise ComponentBuildError(f"Component Cargo.toml not found: {cargo_toml_path}")
+
+    toml = load_toml_module()
+    try:
+        with open(cargo_toml_path, 'r') as f:
+            cargo_data = toml.load(f)
+        return set(cargo_data.get('features', {}).keys())
+    except Exception as e:
+        raise ComponentBuildError(f"Failed to parse component features from {cargo_toml_path}: {e}") from e
+
+
+def filter_declared_component_features(component_dir, features):
+    declared_features = declared_component_features(component_dir)
+    return [feature for feature in features if feature in declared_features]
+
+
+def cargo_build_component_staticlib(rust_dir, target, features, debug, rustflags=None, build_root=None, cargo_extra_args=None):
     """
     Build a Rust component as a static library using Cargo.
     
@@ -91,15 +220,12 @@ def cargo_build_component_staticlib(rust_dir, target, features, debug, rustflags
         features: List of features to enable
         debug: Whether this is a debug build
         rustflags: Additional Rust compilation flags
-        build_root: Build root directory (if not provided, will raise error)
+        build_root: Build root directory
         
     Returns:
         str: Path to the built library file, or None if build failed
     """
-    if not build_root:
-        raise ComponentBuildError("build_root parameter is required")
-    
-    build_root = os.path.abspath(build_root)
+    build_root = normalize_component_build_root(build_root, None)
     os.makedirs(build_root, exist_ok=True)
 
     env = os.environ.copy()
@@ -116,15 +242,26 @@ def cargo_build_component_staticlib(rust_dir, target, features, debug, rustflags
     
     if not debug:
         cmd.insert(2, "--release")
+    if cargo_extra_args:
+        cmd[2:2] = cargo_extra_args
     
     if features:
         cmd += ["--no-default-features", "--features", ",".join(features)]
 
     print("Building example component log (cargo)…")
-    res = subprocess.run(cmd, cwd=rust_dir, env=env, capture_output=True, text=True)
+    try:
+        res = subprocess.run(cmd, cwd=rust_dir, env=env, capture_output=True, text=True)
+    except FileNotFoundError:
+        print("Error: cargo executable not found. Please install Rust/Cargo and ensure it is in PATH.")
+        return None
     
     if res.returncode != 0:
-        print("Warning: Example component build failed")
+        print(f"Warning: Example component build failed for {rust_dir}")
+        print(f"Target: {target}")
+        print(f"Command: {' '.join(cmd)}")
+        print(f"Return code: {res.returncode}")
+        if res.stdout:
+            print(res.stdout)
         if res.stderr:
             print(res.stderr)
         return None
@@ -132,12 +269,13 @@ def cargo_build_component_staticlib(rust_dir, target, features, debug, rustflags
     mode = "debug" if debug else "release"
     
     # Try target-specific path first, then fallback to direct path
-    lib_path = os.path.join(build_root, target, mode, "libem_component_registry.a")
-    if os.path.exists(lib_path):
+    artifact_name = get_component_staticlib_artifact_name(rust_dir)
+    lib_path = os.path.join(build_root, target, mode, artifact_name)
+    if os.path.isfile(lib_path) and os.path.getsize(lib_path) > 0:
         print("Example component log built successfully")
         return lib_path
     
-    print("Warning: Library not found at expected location")
+    print("Warning: Rust component static library artifact not found, is not a file, or is empty")
     print(f"Expected: {lib_path}")
     return None
 
@@ -157,26 +295,39 @@ def build_example_component(cwd, has_func, rtconfig, build_root=None):
     """
     LIBS = []
     LIBPATH = []
-    LINKFLAGS = ""
-    
+    LINKFLAGS = []
+
     # Import build support functions
     import sys
-    sys.path.append(os.path.join(cwd, '../rust/tools'))
+    tools_dir = os.path.abspath(os.path.join(cwd, '..', '..', 'tools'))
+    if tools_dir not in sys.path:
+        sys.path.append(tools_dir)
     from build_support import (
         detect_rust_target,
+        ensure_rust_target_installed,
+        collect_features,
         make_rustflags,
+        make_cargo_build_std_args,
     )
     
     target = detect_rust_target(has_func, rtconfig)
+    if not target:
+        raise ComponentBuildError(f'Could not detect Rust target for example component build in {cwd}')
     
     # Build mode and features
     debug = bool(has_func('RUST_DEBUG_BUILD'))
+    features = collect_features(has_func)
     
     # Build the component registry
     registry_dir = os.path.join(cwd, 'component_registry')
-    features = collect_component_features(has_func, registry_dir)
+    features += collect_component_features(has_func, registry_dir)
+    features = filter_declared_component_features(registry_dir, features)
     
     rustflags = make_rustflags(rtconfig, target)
+    cargo_extra_args = make_cargo_build_std_args(rtconfig, target)
+    build_root = normalize_component_build_root(build_root, cwd)
+    if not ensure_rust_target_installed(target):
+        raise ComponentBuildError(f"Rust target '{target}' is not installed; example component build failed")
     
     rust_lib = cargo_build_component_staticlib(
         rust_dir=registry_dir, 
@@ -184,17 +335,43 @@ def build_example_component(cwd, has_func, rtconfig, build_root=None):
         features=features, 
         debug=debug, 
         rustflags=rustflags,
-        build_root=build_root
+        build_root=build_root,
+        cargo_extra_args=cargo_extra_args
     )
     
     if rust_lib:
-        LIBS = ['em_component_registry']
-        LIBPATH = [os.path.dirname(rust_lib)]
-        # Add LINKFLAGS to ensure component is linked into final binary
-        LINKFLAGS += " -Wl,--whole-archive -lem_component_registry -Wl,--no-whole-archive"
-        LINKFLAGS += " -Wl,--allow-multiple-definition"
+        lib_dir = os.path.dirname(rust_lib)
+        # Derive the link name from the actual artifact so it always matches
+        # the file that was built. Only fall back to re-parsing Cargo.toml when
+        # the artifact name does not follow the lib<name>.a convention.
+        link_lib_name = get_staticlib_link_name_from_artifact(rust_lib)
+        if not link_lib_name:
+            link_lib_name = get_component_staticlib_link_name(registry_dir)
+        LIBS = [link_lib_name]
+        LIBPATH = [lib_dir]
+        platform = getattr(rtconfig, 'PLATFORM', None)
+        if platform == 'armclang':
+            if not (os.path.isfile(rust_lib) and os.path.getsize(rust_lib) > 0):
+                raise ComponentBuildError(
+                    f"ArmClang Rust component link requires a non-empty archive, but got: {rust_lib}"
+                )
+            anchors = get_component_export_symbols(features)
+            LINKFLAGS = [f"--undefined={symbol}" for symbol in anchors]
+            LINKFLAGS.append(quote_spaces(os.fspath(rust_lib)))
+            LINKFLAGS = " " + " ".join(LINKFLAGS)
+            LIBS = []
+            LIBPATH = []
+        else:
+            LINKFLAGS = [
+                quote_spaces(f"-L{os.fspath(lib_dir)}"),
+                "-Wl,--whole-archive",
+                f"-l{link_lib_name}",
+                "-Wl,--no-whole-archive",
+                "-Wl,--allow-multiple-definition",
+            ]
+            LINKFLAGS = " " + " ".join(LINKFLAGS)
         print('Example component registry library linked successfully')
     else:
-        print('Warning: Failed to build example component registry library')
+        raise ComponentBuildError(f"Failed to build example component registry library in {registry_dir} for target {target}")
     
     return LIBS, LIBPATH, LINKFLAGS

--- a/components/rust/tools/build_support.py
+++ b/components/rust/tools/build_support.py
@@ -48,10 +48,14 @@ def detect_rust_target(has, rtconfig):
         cflags = getattr(rtconfig, "CFLAGS", "")
         hard_float = "-mfloat-abi=hard" in cflags or has("ARCH_ARM_FPU") or has("ARCH_FPU_VFP")
 
+        if has("ARCH_ARM_CORTEX_M0") or has("ARCH_ARM_CORTEX_M0PLUS"):
+            return "thumbv6m-none-eabi"
         if has("ARCH_ARM_CORTEX_M3"):
             return "thumbv7m-none-eabi"
         if has("ARCH_ARM_CORTEX_M4") or has("ARCH_ARM_CORTEX_M7"):
             return "thumbv7em-none-eabihf" if hard_float else "thumbv7em-none-eabi"
+        if has("ARCH_ARM_CORTEX_M23"):
+            return "thumbv8m.base-none-eabi"
         if has("ARCH_ARM_CORTEX_M33"):
             # v8m.main
             return "thumbv8m.main-none-eabi"
@@ -93,8 +97,17 @@ def detect_rust_target(has, rtconfig):
             return "armv7a-none-eabi"
         if "riscv32" in arch_l:
             return "riscv32imac-unknown-none-elf"
-        if "riscv64" in arch_l or "risc-v" in arch_l:
-            # Many BSPs use "risc-v" token; assume 64-bit for virt64
+        if "riscv64" in arch_l:
+            return "riscv64imac-unknown-none-elf"
+        if "risc-v" in arch_l:
+            info = _parse_cflags(getattr(rtconfig, "CFLAGS", ""))
+            abi = info["mabi"] or ""
+            abi_has_fp = abi.endswith("f") or abi.endswith("d")
+            if info["rv_bits"] == 32:
+                return "riscv32imafc-unknown-none-elf" if abi_has_fp else "riscv32imac-unknown-none-elf"
+            if info["rv_bits"] == 64:
+                return "riscv64gc-unknown-none-elf" if abi_has_fp else "riscv64imac-unknown-none-elf"
+            # Many BSPs use "risc-v" token; assume 64-bit for virt64 when CFLAGS do not specify width
             return "riscv64imac-unknown-none-elf"
 
     # Parse CFLAGS for hints
@@ -106,42 +119,46 @@ def detect_rust_target(has, rtconfig):
             return "thumbv7em-none-eabihf"
         return "thumbv7em-none-eabi"
     if "-march=rv32" in cflags:
-        march_val = None
-        mabi_val = None
-        for flag in cflags.split():
-            if flag.startswith("-march="):
-                march_val = flag[len("-march="):]
-            elif flag.startswith("-mabi="):
-                mabi_val = flag[len("-mabi="):]
-        has_f_or_d = False
-        if march_val and any(x in march_val for x in ("f", "d")):
-            has_f_or_d = True
-        if mabi_val and any(x in mabi_val for x in ("f", "d")):
-            has_f_or_d = True
-        return "riscv32imafc-unknown-none-elf" if has_f_or_d else "riscv32imac-unknown-none-elf"
+        info = _parse_cflags(cflags)
+        abi = info["mabi"] or ""
+        abi_has_fp = abi.endswith("f") or abi.endswith("d")
+        return "riscv32imafc-unknown-none-elf" if abi_has_fp else "riscv32imac-unknown-none-elf"
     if "-march=rv64" in cflags:
-        march_val = None
-        mabi_val = None
-        for flag in cflags.split():
-            if flag.startswith("-march="):
-                march_val = flag[len("-march="):]
-            elif flag.startswith("-mabi="):
-                mabi_val = flag[len("-mabi="):]
-        has_f_or_d = False
-        if mabi_val and (("lp64d" in mabi_val) or ("lp64f" in mabi_val)):
-            has_f_or_d = True
-        if march_val and any(x in march_val for x in ("f", "d")):
-            has_f_or_d = True
-        if mabi_val and any(x in mabi_val for x in ("f", "d")):
-            has_f_or_d = True
-        if has_f_or_d:
+        info = _parse_cflags(cflags)
+        abi = info["mabi"] or ""
+        abi_has_fp = abi.endswith("f") or abi.endswith("d")
+        if abi_has_fp:
             return "riscv64gc-unknown-none-elf"
         return "riscv64imac-unknown-none-elf"
 
     return None
 
 
+def uses_short_wchar_abi(rtconfig, target: str):
+    if not isinstance(target, str) or not target:
+        return False
+    if not (target.startswith("thumb") or target.startswith("arm")):
+        return False
+
+    cflags = getattr(rtconfig, "CFLAGS", "")
+    return "-fshort-wchar" in cflags.split()
+
+
+def make_cargo_build_std_args(rtconfig, target: str):
+    if uses_short_wchar_abi(rtconfig, target):
+        return ["-Z", "build-std=core,alloc"]
+    return []
+
+
 def make_rustflags(rtconfig, target: str):
+    if not isinstance(target, str) or not target:
+        arch = getattr(rtconfig, "ARCH", None)
+        cflags = getattr(rtconfig, "CFLAGS", "")
+        raise ValueError(
+            "Unsupported Rust target: unable to detect a Rust target "
+            f"for ARCH={arch!r}, CFLAGS={cflags!r}"
+        )
+
     rustflags = [
         "-C", "opt-level=z",
         "-C", "panic=abort",
@@ -162,13 +179,76 @@ def make_rustflags(rtconfig, target: str):
     if "thumb" in target or "aarch64" in target:
         rustflags += ["-C", "link-arg=-nostartfiles"]
 
+    if uses_short_wchar_abi(rtconfig, target):
+        rustflags += ["-Zllvm_module_flag=wchar_size:u32:2:error"]
+
     return " ".join(rustflags)
 
 
 def collect_features(has):
+    cargo_toml_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "core", "Cargo.toml")
+    )
+    if not os.path.isfile(cargo_toml_path):
+        raise RuntimeError(f"Rust core Cargo.toml not found: {cargo_toml_path}")
+
+    try:
+        import toml
+    except ImportError as e:
+        raise RuntimeError("Missing toml module required to parse Rust core Cargo.toml") from e
+
+    try:
+        with open(cargo_toml_path, "r") as f:
+            cargo_data = toml.load(f)
+    except OSError as e:
+        raise RuntimeError(f"Failed to read Rust core Cargo.toml {cargo_toml_path}: {e}") from e
+    except Exception as e:
+        raise RuntimeError(f"Failed to parse Rust core Cargo.toml {cargo_toml_path}: {e}") from e
+
+    declared_features = cargo_data.get("features")
+    if not isinstance(declared_features, dict):
+        raise RuntimeError("Invalid Rust core Cargo.toml: [features] must be a table")
+
+    package = cargo_data.get("package")
+    metadata = package.get("metadata") if isinstance(package, dict) else None
+    rt_thread = metadata.get("rt-thread") if isinstance(metadata, dict) else None
+    feature_mappings = rt_thread.get("features") if isinstance(rt_thread, dict) else None
+    if not isinstance(feature_mappings, dict):
+        raise RuntimeError(
+            "Invalid Rust core feature metadata: package.metadata.rt-thread.features must be a table"
+        )
+
+    for feature in feature_mappings:
+        if feature not in declared_features:
+            raise RuntimeError(
+                f"Rust core feature metadata references undeclared Cargo feature: {feature}"
+            )
+
     feats = []
-    if has("RT_USING_SMP"):
-        feats.append("smp")
+    for feature in declared_features:
+        if feature == "default" or feature not in feature_mappings:
+            continue
+
+        mapping = feature_mappings[feature]
+        if not isinstance(mapping, dict):
+            raise RuntimeError(f"Invalid Rust core feature metadata for '{feature}': expected a table")
+        if set(mapping) != {"all"}:
+            raise RuntimeError(
+                f"Invalid Rust core feature metadata for '{feature}': only 'all' is supported"
+            )
+
+        symbols = mapping["all"]
+        if not isinstance(symbols, list):
+            raise RuntimeError(f"Invalid Rust core feature metadata for '{feature}': 'all' must be a list")
+        if not symbols:
+            raise RuntimeError(f"Invalid Rust core feature metadata for '{feature}': 'all' must not be empty")
+        if any(not isinstance(symbol, str) or not symbol for symbol in symbols):
+            raise RuntimeError(
+                f"Invalid Rust core feature metadata for '{feature}': 'all' must contain only non-empty strings"
+            )
+
+        if all(has(symbol) for symbol in symbols):
+            feats.append(feature)
     return feats
 
 
@@ -181,10 +261,60 @@ def verify_rust_toolchain():
         return False
 
 
+def parse_installed_rust_targets(output):
+    return {line.strip() for line in output.splitlines() if line.strip()}
+
+
+def get_staticlib_artifact_name(rust_dir):
+    cargo_toml_path = os.path.join(rust_dir, "Cargo.toml")
+    lib_name = "rt_rust"
+
+    try:
+        import toml
+        with open(cargo_toml_path, "r") as f:
+            cargo_data = toml.load(f)
+
+        package_name = cargo_data.get("package", {}).get("name")
+        lib_name = cargo_data.get("lib", {}).get("name") or package_name or lib_name
+    except Exception as e:
+        print(f"Warning: Failed to parse Rust static library metadata from {cargo_toml_path}: {e}")
+
+    if not isinstance(lib_name, str) or not lib_name:
+        lib_name = "rt_rust"
+
+    lib_name = lib_name.replace("-", "_")
+    return f"lib{lib_name}.a"
+
+
+def get_staticlib_link_name(rust_dir):
+    cargo_toml_path = os.path.join(rust_dir, "Cargo.toml")
+    lib_name = "rt_rust"
+
+    try:
+        import toml
+        with open(cargo_toml_path, "r") as f:
+            cargo_data = toml.load(f)
+
+        package_name = cargo_data.get("package", {}).get("name")
+        lib_name = cargo_data.get("lib", {}).get("name") or package_name or lib_name
+    except Exception as e:
+        print(f"Warning: Failed to parse Rust static library metadata from {cargo_toml_path}: {e}")
+
+    if not isinstance(lib_name, str) or not lib_name:
+        lib_name = "rt_rust"
+
+    return lib_name.replace("-", "_")
+
+
 def ensure_rust_target_installed(target: str):
+    if not isinstance(target, str) or not target:
+        print("Invalid Rust target: expected a non-empty string")
+        return False
+
     try:
         result = subprocess.run(["rustup", "target", "list", "--installed"], capture_output=True, text=True)
-        if result.returncode == 0 and target in result.stdout:
+        installed_targets = parse_installed_rust_targets(result.stdout)
+        if result.returncode == 0 and target in installed_targets:
             return True
         print(f"Rust target '{target}' is not installed.")
         print(f"Please install it with: rustup target add {target}")
@@ -193,8 +323,11 @@ def ensure_rust_target_installed(target: str):
     return False
 
 
-def cargo_build_staticlib(rust_dir: str, target: str, features, debug: bool, rustflags: str = None):
-    build_root = os.path.join((os.path.abspath(os.path.join(rust_dir, os.pardir, os.pardir))), "build", "rust")
+def cargo_build_staticlib(rust_dir: str, target: str, features, debug: bool, rustflags: str = None, build_root: str = None, cargo_extra_args=None):
+    if build_root is None:
+        build_root = os.path.join((os.path.abspath(os.path.join(rust_dir, os.pardir, os.pardir))), "build", "rust")
+    else:
+        build_root = os.path.abspath(os.fspath(build_root))
     target_dir = os.path.join(build_root, "target")
     os.makedirs(build_root, exist_ok=True)
 
@@ -207,11 +340,17 @@ def cargo_build_staticlib(rust_dir: str, target: str, features, debug: bool, rus
     cmd = ["cargo", "build", "--target", target, "--manifest-path", os.path.join(rust_dir, "Cargo.toml")]
     if not debug:
         cmd.insert(2, "--release")
+    if cargo_extra_args:
+        cmd[2:2] = cargo_extra_args
     if features:
         cmd += ["--no-default-features", "--features", ",".join(features)]
 
     print("Building Rust component (cargo)…")
-    res = subprocess.run(cmd, cwd=rust_dir, env=env, capture_output=True, text=True)
+    try:
+        res = subprocess.run(cmd, cwd=rust_dir, env=env, capture_output=True, text=True)
+    except FileNotFoundError:
+        print("Error: cargo executable not found. Please install Rust/Cargo and ensure it is in PATH.")
+        return None
     if res.returncode != 0:
         print("Warning: Rust build failed")
         if res.stderr:
@@ -219,11 +358,12 @@ def cargo_build_staticlib(rust_dir: str, target: str, features, debug: bool, rus
         return None
 
     mode = "debug" if debug else "release"
-    lib_path = os.path.join(target_dir, target, mode, "librt_rust.a")
-    if os.path.exists(lib_path):
+    artifact_name = get_staticlib_artifact_name(rust_dir)
+    lib_path = os.path.join(target_dir, target, mode, artifact_name)
+    if os.path.isfile(lib_path) and os.path.getsize(lib_path) > 0:
         print("Rust component built successfully")
         return lib_path
-    print("Warning: Library not found at expected location")
+    print(f"Warning: Rust static library artifact not found, is not a file, or is empty: {lib_path}")
     return None
 
 

--- a/components/rust/tools/build_usrapp.py
+++ b/components/rust/tools/build_usrapp.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
-import toml
 import shutil
+from SCons.Subst import quote_spaces
 
 
 # Configuration to feature mapping table
@@ -21,6 +21,35 @@ APP_CONFIG_MAP = {
     'thread': 'RT_RUST_EXAMPLE_THREAD'
 }
 
+APP_DEPENDENCY_MAP = {
+    'loadlib': ['RT_USING_MODULE'],
+}
+
+APP_EXPORT_SYMBOL_MAP = {
+    'fs':        ['__rust_file_demo_cmd_seg'],
+    'loadlib':   ['__rust_dl_demo_cmd_seg'],
+    'mutex':     ['__rust_mutex_demo_cmd_seg'],
+    'param':     ['__rust_param_demo_cmd_seg'],
+    'queue':     ['__rust_queue_demo_cmd_seg'],
+    'semaphore': ['__rust_sem_demo_cmd_seg'],
+    'thread':    ['__rust_thread_demo_cmd_seg'],
+}
+
+
+def app_dependencies_satisfied(app_name, has_func):
+    if app_name == 'fs':
+        if has_func('RT_USING_POSIX_FS'):
+            return True
+        if not has_func('RT_USING_DFS'):
+            return False
+        return has_func('DFS_USING_POSIX') or has_func('RT_USING_DFS_V2')
+
+    for dep in APP_DEPENDENCY_MAP.get(app_name, []):
+        if not has_func(dep):
+            return False
+
+    return True
+
 
 def should_build_app(app_dir, has_func):
     """
@@ -35,6 +64,12 @@ def should_build_app(app_dir, has_func):
     """
     # Get the application name from the directory
     app_name = os.path.basename(app_dir)
+
+    if not app_dependencies_satisfied(app_name, has_func):
+        return False
+
+    if has_func('RT_RUST_BUILD_ALL_EXAMPLES'):
+        return True
     
     # Check if there's a specific Kconfig option for this app
     if app_name in APP_CONFIG_MAP:
@@ -43,6 +78,16 @@ def should_build_app(app_dir, has_func):
     
     # If no specific config found, check if applications are enabled in general
     return has_func('RT_RUST_BUILD_APPLICATIONS')
+
+
+def get_app_export_symbols(app_dir):
+    app_name = os.path.basename(app_dir)
+    if app_name not in APP_EXPORT_SYMBOL_MAP:
+        raise UserAppBuildError(
+            f"No link anchor metadata registered for enabled user app '{app_name}'. "
+            f"Path: {app_dir}. Add its export anchor to APP_EXPORT_SYMBOL_MAP."
+        )
+    return list(APP_EXPORT_SYMBOL_MAP[app_name])
 
 
 def check_app_dependencies(app_dir, required_dependencies):
@@ -64,6 +109,7 @@ def check_app_dependencies(app_dir, required_dependencies):
         return False
     
     try:
+        toml = load_toml_module()
         with open(cargo_toml_path, 'r') as f:
             cargo_data = toml.load(f)
         
@@ -76,6 +122,25 @@ def check_app_dependencies(app_dir, required_dependencies):
         
         return True
         
+    except Exception as e:
+        print(f"Warning: Failed to parse {cargo_toml_path}: {e}")
+        return False
+
+
+def app_has_feature_dependency(app_dir, feature_name, dependency_name):
+    cargo_toml_path = os.path.join(app_dir, 'Cargo.toml')
+    if not os.path.exists(cargo_toml_path):
+        return False
+
+    try:
+        toml = load_toml_module()
+        with open(cargo_toml_path, 'r') as f:
+            cargo_data = toml.load(f)
+
+        features = cargo_data.get('features', {})
+        dependencies = cargo_data.get('dependencies', {})
+        return feature_name in features and dependency_name in dependencies
+
     except Exception as e:
         print(f"Warning: Failed to parse {cargo_toml_path}: {e}")
         return False
@@ -110,6 +175,10 @@ def collect_features(has_func, app_dir=None):
                 # If no app_dir provided, enable for all (backward compatibility)
                 features.append(feature_name)
                 print(f"Enabling feature '{feature_name}' for {config_name}")
+
+    if app_dir and os.path.basename(app_dir) == 'fs':
+        if app_has_feature_dependency(app_dir, 'enable-log', 'em_component_log') and 'enable-log' not in features:
+            features.append('enable-log')
     
     return features
 
@@ -120,6 +189,41 @@ def collect_features(has_func, app_dir=None):
 class UserAppBuildError(Exception):
     """User application build error exception"""
     pass
+
+
+def load_toml_module():
+    try:
+        import toml
+        return toml
+    except ImportError as e:
+        raise UserAppBuildError("Missing toml module required to parse Cargo.toml") from e
+
+
+def normalize_build_root(build_root, cwd):
+    """
+    Normalize the user application build root directory.
+
+    Args:
+        build_root: Optional build root directory
+        cwd: Current working directory (usrapp directory)
+
+    Returns:
+        str: Absolute build root path
+    """
+    if build_root is None:
+        if not cwd:
+            raise UserAppBuildError("Invalid build_root: cwd is required when build_root is None")
+        build_root = os.path.join(cwd, "build", "rust", "usrapp")
+
+    try:
+        build_root = os.fspath(build_root)
+    except TypeError:
+        raise UserAppBuildError("Invalid build_root: expected a non-empty path")
+
+    if not isinstance(build_root, str) or not build_root:
+        raise UserAppBuildError("Invalid build_root: expected a non-empty path")
+
+    return os.path.abspath(build_root)
 
 
 def parse_cargo_toml(cargo_toml_path):
@@ -133,6 +237,7 @@ def parse_cargo_toml(cargo_toml_path):
         tuple: (lib_name, is_staticlib)
     """
     try:
+        toml = load_toml_module()
         with open(cargo_toml_path, 'r') as f:
             cargo_data = toml.load(f)
         
@@ -166,15 +271,24 @@ def discover_user_apps(base_dir):
     user_apps = []
     
     for root, dirs, files in os.walk(base_dir):
+        dirs[:] = [d for d in dirs if d not in ("build", "target")]
         if 'Cargo.toml' in files:
-            if 'target' in root or 'build' in root:
-                continue
             user_apps.append(root)
     
     return user_apps
 
 
-def build_user_app(app_dir, target, debug, rustflags, build_root, features=None):
+def staticlib_candidates(lib_name):
+    normalized_name = lib_name.replace('-', '_')
+    candidates = [(f"lib{normalized_name}.a", normalized_name)]
+
+    if normalized_name != lib_name:
+        candidates.append((f"lib{lib_name}.a", lib_name))
+
+    return candidates
+
+
+def build_user_app(app_dir, target, debug, rustflags, build_root, features=None, cargo_extra_args=None):
     """
     Build a single user application
     
@@ -189,18 +303,29 @@ def build_user_app(app_dir, target, debug, rustflags, build_root, features=None)
     Returns:
         tuple: (success, lib_name, lib_path)
     """
+    build_root = normalize_build_root(build_root, None)
+
     try:
         cargo_toml_path = os.path.join(app_dir, 'Cargo.toml')
         lib_name, is_staticlib = parse_cargo_toml(cargo_toml_path)
         
         if not is_staticlib:
-            return False, None, None
+            raise UserAppBuildError(f"User app in {app_dir} is not configured as a staticlib")
         
         env = os.environ.copy()
-        env['RUSTFLAGS'] = rustflags
+        previous_rustflags = env.get('RUSTFLAGS', '').strip()
+        new_rustflags = rustflags.strip() if rustflags else ''
+        if previous_rustflags and new_rustflags:
+            env['RUSTFLAGS'] = f'{previous_rustflags} {new_rustflags}'
+        elif new_rustflags:
+            env['RUSTFLAGS'] = new_rustflags
+        elif previous_rustflags:
+            env['RUSTFLAGS'] = previous_rustflags
         env['CARGO_TARGET_DIR'] = build_root
         
         cmd = ['cargo', 'build', '--target', target]
+        if cargo_extra_args:
+            cmd[2:2] = cargo_extra_args
         if not debug:
             cmd.append('--release')
         
@@ -209,8 +334,12 @@ def build_user_app(app_dir, target, debug, rustflags, build_root, features=None)
             cmd.extend(['--features', ','.join(features)])
         
         print(f"Building example user app {lib_name} (cargo)…")
-        result = subprocess.run(cmd, cwd=app_dir, env=env, 
-                              capture_output=True, text=True)
+        try:
+            result = subprocess.run(cmd, cwd=app_dir, env=env,
+                                  capture_output=True, text=True)
+        except FileNotFoundError:
+            print("Error: cargo executable not found. Please install Rust/Cargo and ensure it is in PATH.")
+            raise UserAppBuildError(f"Cargo executable not found while building user app in {app_dir}")
         
         if result.returncode != 0:
             print(f"Failed to build user app in {app_dir}")
@@ -218,19 +347,20 @@ def build_user_app(app_dir, target, debug, rustflags, build_root, features=None)
             print(f"Return code: {result.returncode}")
             print(f"STDOUT: {result.stdout}")
             print(f"STDERR: {result.stderr}")
-            return False, None, None
+            raise UserAppBuildError(f"Failed to build user app in {app_dir}")
         
-        lib_file = find_library_file(build_root, target, lib_name, debug)
+        lib_file, link_lib_name = find_library_file(build_root, target, lib_name, debug)
         if lib_file:
             # Return the library name for linking
-            return True, lib_name, lib_file
+            return True, link_lib_name, lib_file
         else:
             print(f"Library file not found for lib {lib_name}")
-            return False, None, None
+            raise UserAppBuildError(f"Library file not found for user app {lib_name}")
             
+    except UserAppBuildError:
+        raise
     except Exception as e:
-        print(f"Exception occurred while building user app in {app_dir}: {e}")
-        return False, None, None
+        raise UserAppBuildError(f"Exception occurred while building user app in {app_dir}: {e}") from e
 
 
 def find_library_file(build_root, target, lib_name, debug):
@@ -244,15 +374,11 @@ def find_library_file(build_root, target, lib_name, debug):
         debug: Whether this is a debug build
         
     Returns:
-        str: Library file path, or None if not found
+        tuple: (library file path, link library name), or (None, None) if not found
     """
+    build_root = normalize_build_root(build_root, None)
     profile = "debug" if debug else "release"
-    
-    possible_names = [
-        f"lib{lib_name}.a",
-        f"lib{lib_name.replace('-', '_')}.a"
-    ]
-    
+
     search_paths = [
         os.path.join(build_root, target, profile),
         os.path.join(build_root, target, profile, "deps")
@@ -262,15 +388,17 @@ def find_library_file(build_root, target, lib_name, debug):
         if not os.path.exists(search_path):
             continue
                     
-        for name in possible_names:
+        for name, link_lib_name in staticlib_candidates(lib_name):
             lib_path = os.path.join(search_path, name)
             if os.path.exists(lib_path):
-                return lib_path
+                if os.path.isfile(lib_path) and os.path.getsize(lib_path) > 0:
+                    return lib_path, link_lib_name
+                print(f"Warning: Rust user app static library artifact not found, is not a file, or is empty: {lib_path}")
     
-    return None
+    return None, None
 
 
-def build_all_user_apps(base_dir, target, debug, rustflags, build_root, has_func):
+def build_all_user_apps(base_dir, target, debug, rustflags, build_root, has_func, require_export_symbols=False, cargo_extra_args=None):
     """
     Build all user applications
     
@@ -287,10 +415,12 @@ def build_all_user_apps(base_dir, target, debug, rustflags, build_root, has_func
     """
     LIBS = []
     LIBPATH = []
+    LIBFILES = []
+    UNDEFINED_SYMBOLS = []
     success_count = 0
+    total_count = 0
     
     user_apps = discover_user_apps(base_dir)
-    total_count = len(user_apps)
     
     for app_dir in user_apps:
         # Check if this application should be built based on Kconfig
@@ -298,24 +428,31 @@ def build_all_user_apps(base_dir, target, debug, rustflags, build_root, has_func
             app_name = os.path.basename(app_dir)
             print(f"Skipping {app_name} (disabled in Kconfig)")
             continue
+
+        total_count += 1
             
         # Collect features for this specific app
         features = collect_features(has_func, app_dir)
-        success, lib_name, lib_path = build_user_app(app_dir, target, debug, rustflags, build_root, features)
+        success, lib_name, lib_path = build_user_app(app_dir, target, debug, rustflags, build_root, features, cargo_extra_args)
         
         if success and lib_path:
             app_name = os.path.basename(app_dir)
             print(f"Example user app {app_name} built successfully")
             LIBS.append(lib_name)
+            LIBFILES.append(lib_path)
+            if require_export_symbols:
+                UNDEFINED_SYMBOLS.extend(get_app_export_symbols(app_dir))
             lib_dir = os.path.dirname(lib_path)
             if lib_dir not in LIBPATH:
                 LIBPATH.append(lib_dir)
             success_count += 1
+        else:
+            raise UserAppBuildError(f"Failed to build enabled user app: {app_dir}")
     
-    return LIBS, LIBPATH, success_count, total_count
+    return LIBS, LIBPATH, LIBFILES, UNDEFINED_SYMBOLS, success_count, total_count
 
 
-def generate_linkflags(LIBS, LIBPATH):
+def generate_linkflags(LIBS, LIBPATH, platform, LIBFILES=None, UNDEFINED_SYMBOLS=None):
     """
     Generate link flags
     
@@ -326,15 +463,39 @@ def generate_linkflags(LIBS, LIBPATH):
     Returns:
         str: Link flags string
     """
+    if platform == 'armclang':
+        if not LIBFILES:
+            raise UserAppBuildError(
+                "ArmClang Rust link requires built static library archives, but none were produced"
+            )
+        for lib in LIBFILES:
+            if not (os.path.isfile(lib) and os.path.getsize(lib) > 0):
+                raise UserAppBuildError(
+                    f"ArmClang Rust link requires a non-empty archive, but got: {lib}"
+                )
+        if not UNDEFINED_SYMBOLS:
+            raise UserAppBuildError(
+                "ArmClang Rust link requires at least one --undefined anchor symbol, but none were resolved"
+            )
+        linkflags = [f"--undefined={symbol}" for symbol in UNDEFINED_SYMBOLS]
+        linkflags.extend(quote_spaces(os.fspath(lib)) for lib in LIBFILES)
+        return " " + " ".join(linkflags)
+
     if not LIBS or not LIBPATH:
         return ""
-    
-    linkflags = f" -L{LIBPATH[0]} -Wl,--whole-archive"
+
+    linkflags = []
+    for path in LIBPATH:
+        linkflags.append(quote_spaces(f"-L{os.fspath(path)}"))
+    linkflags.append("-Wl,--whole-archive")
     for lib in LIBS:
-        linkflags += f" -l{lib}"
-    linkflags += " -Wl,--no-whole-archive -Wl,--allow-multiple-definition"
+        linkflags.append(f"-l{lib}")
+    linkflags.extend([
+        "-Wl,--no-whole-archive",
+        "-Wl,--allow-multiple-definition",
+    ])
     
-    return linkflags
+    return " " + " ".join(linkflags)
 
 
 def clean_user_apps_build(build_root):
@@ -368,25 +529,46 @@ def build_example_usrapp(cwd, has_func, rtconfig, build_root=None):
     try:
         # Import build support functions
         import sys
-        sys.path.append(os.path.join(cwd, '../rust/tools'))
+        tools_dir = os.path.abspath(os.path.join(cwd, '..', '..', 'tools'))
+        if tools_dir not in sys.path:
+            sys.path.append(tools_dir)
         import build_support as rust_build_support
-        
+
+        build_root = normalize_build_root(build_root, cwd)
+        enabled_apps = [
+            app_dir for app_dir in discover_user_apps(cwd)
+            if should_build_app(app_dir, has_func)
+        ]
+        if not enabled_apps:
+            print('No user applications enabled for Rust build')
+            return LIBS, LIBPATH, LINKFLAGS
+
         target = rust_build_support.detect_rust_target(has_func, rtconfig)
+        if not target:
+            raise UserAppBuildError('Could not detect Rust target for user application build')
         debug = bool(has_func('RUST_DEBUG_BUILD'))
         rustflags = rust_build_support.make_rustflags(rtconfig, target)
-        LIBS, LIBPATH, success_count, total_count = build_all_user_apps(
-            cwd, target, debug, rustflags, build_root, has_func
+        cargo_extra_args = rust_build_support.make_cargo_build_std_args(rtconfig, target)
+        if not rust_build_support.ensure_rust_target_installed(target):
+            raise UserAppBuildError('Rust target is not installed; user application build failed')
+
+        platform = getattr(rtconfig, 'PLATFORM', None)
+        LIBS, LIBPATH, LIBFILES, UNDEFINED_SYMBOLS, success_count, total_count = build_all_user_apps(
+            cwd, target, debug, rustflags, build_root, has_func, platform == 'armclang', cargo_extra_args
         )
         
-        if success_count == 0 and total_count > 0:
-            print(f'Warning: Failed to build all {total_count} user applications')
-        elif success_count > 0:
-            LINKFLAGS = generate_linkflags(LIBS, LIBPATH)
-            print(f'Example user apps linked successfully')
+        if success_count > 0:
+            LINKFLAGS = generate_linkflags(LIBS, LIBPATH, platform, LIBFILES, UNDEFINED_SYMBOLS)
+            if platform == 'armclang':
+                LIBS = []
+                LIBPATH = []
+            print('Example user apps linked successfully')
+        else:
+            print('No user applications enabled for Rust build')
             
-    except UserAppBuildError as e:
-        print(f'Error: {e}')
+    except UserAppBuildError:
+        raise
     except Exception as e:
-        print(f'Unexpected error during user apps build: {e}')
+        raise UserAppBuildError(f'Unexpected error during user apps build: {e}') from e
     
     return LIBS, LIBPATH, LINKFLAGS

--- a/components/rust/tools/feature_config_component.py
+++ b/components/rust/tools/feature_config_component.py
@@ -15,6 +15,7 @@ def setup_all_component_features():
         'RUST_LOG_COMPONENT': {
             'feature': 'enable-log',
             'dependencies': ['em_component_log'],
+            'export_symbols': ['__rust_component_registry_component_seg'],
             'description': 'Enable Rust logging component integration'
         },
     })

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -3,3 +3,4 @@ requests>=2.27.1
 tqdm>=4.67.1
 kconfiglib>=13.7.1
 PyYAML>=6.0
+toml>=0.10.2


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[
#### 为什么提交这份PR (why to submit this PR)
本 PR 修复 RT-Thread Rust 构建脚本中多处配置处理不一致的问题，主要涉及 Rust core、Rust application examples、Rust component examples、Rust module examples 的构建入口、Cargo 产物识别、Kconfig 选项门控、Cargo feature 传递、Rust target 推断、Cargo 失败诊断以及 SCons 链接参数生成。
原有实现中，部分 Rust 构建路径存在 Kconfig 配置、Cargo 实际产物和 SCons 链接设置不一致的问题。在特定配置组合下，可能导致 Rust 示例被错误跳过、使用错误的链接库名、向 Cargo 传入 manifest 未声明的 feature、在 Rust artifact 未生成时仍加入 SCons group，或者在缺少底层系统能力时仍构建相关 Rust example。这些问题会影响 Rust 构建系统在不同 BSP、不同 Rust target 和不同 example 配置组合下的稳定性、可诊断性和配置一致性。
本 PR 主要解决以下问题：
1. **Cargo 产物名与 SCons 链接库名可能不一致**
   原有部分构建脚本会根据固定名称推断 Rust staticlib 的链接名，而不是根据 Cargo 实际生成的 artifact 反推出 SCons `LIBS` 中应使用的库名。当 Cargo package name、lib name 或实际 artifact 名称和脚本假设不一致时，可能出现 Cargo 构建成功，但 SCons 链接阶段使用错误 `-lxxx` 的问题。
2. **Rust target 推断覆盖不足**
   原有 target 检测逻辑对部分 RISC-V fallback 和 Cortex-M 变体覆盖不足。例如 Cortex-M0、Cortex-M0+、Cortex-M23、Cortex-M85 等目标可能被推断为不合适的 Rust target，导致 Cargo target 与实际 MCU 架构不匹配。
3. **Rust core 构建开关与 SConscript 行为不完全一致**
   `RT_RUST_CORE` 是 Rust core library 的配置开关，但原有 `components/rust/core/SConscript` 对该开关的约束不完整。在 Rust core staticlib 未成功生成、Rust toolchain 不存在、Rust target 未安装或 target 检测失败时，仍可能把 `rust_cmd.c` 加入 SCons group，导致后续链接阶段进入无效链接路径或产生符号风险。
4. **Rust example 的 Kconfig 门控与实际构建入口不一致**
   部分 example 的 SConscript 或 build helper 没有严格遵守 Kconfig 语义。例如 module example 的子开关未被正确用于选择模块示例；component example 的总开关 `RT_RUST_BUILD_COMPONENTS` 曾被 `RUST_LOG_COMPONENT` 子开关错误门控；`RT_RUST_BUILD_ALL_EXAMPLES` 可能绕过部分 example 所需的底层依赖检查；`loadlib` example 依赖 `RT_USING_MODULE`，但原有 build-all 路径可能仍尝试构建；`fs` example 会引用 POSIX 文件 API，但原有逻辑未确认 DFS/POSIX 文件层是否可用。
5. **Cargo feature 传递不够精确**
   部分 Rust component/application 的 feature 传递逻辑不完整。例如 `RUST_LOG_COMPONENT` 对应的 `enable-log` feature 需要正确传递给 component registry；`fs` application 使用日志组件时需要补齐对应 feature；component 构建时不应把 manifest 未声明的 feature 传给 Cargo，否则 Cargo 会因为 unknown feature 失败。
6. **Cargo 失败诊断不够清晰**
   原有脚本在部分 Cargo 失败或 Cargo 不存在的场景下，错误输出不够完整，不利于用户定位 Rust toolchain、Rust target 或 Cargo manifest 问题。
综上，本 PR 主要修复 Rust 构建系统中的普通软件缺陷，使 Rust core、Rust application example、Rust component example 和 Rust module example 的构建行为更加符合 Kconfig 配置语义，并提高 Cargo 构建、artifact 查找和 SCons 链接过程的一致性与可诊断性。
#### 你的解决方案是什么 (what is your solution)
本 PR 对 Rust 构建脚本做了以下修复：
1. **根据 Cargo 实际产物反推链接库名**
   在 Rust core、component registry、user application 等构建路径中，根据实际生成的 staticlib artifact 反推链接库名，避免固定假设 `libxxx.a` 名称导致 SCons `LIBS` 与真实 Cargo 产物不一致。
2. **完善 Rust target 检测**
   改进 RISC-V fallback 逻辑，根据 `-march` / `-mabi` 等编译参数推断更合适的 Rust target。同时补充 Cortex-M 系列目标映射，包括：
   - Cortex-M0 / Cortex-M0+ -> `thumbv6m-none-eabi`
   - Cortex-M23 -> `thumbv8m.base-none-eabi`
   - Cortex-M85 -> `thumbv8m.main-none-eabi`
   这样可以避免部分 Cortex-M 目标被错误映射到不合适的 Rust target。
3. **修正 Rust core 构建门控**
   `components/rust/core/SConscript` 现在会正确遵守 `RT_RUST_CORE` 配置。当 Rust toolchain 不存在、target 检测失败、target 未安装或 Rust core staticlib 未成功生成时，不再把 `rust_cmd.c` 加入 SCons group，避免在 Rust core artifact 不存在时继续进入无效链接路径。
4. **修正 Rust module example 的构建选择**
   module example 的构建选择现在会遵守对应 Kconfig 子开关，例如 `RT_RUST_MODULE_SIMPLE_MODULE`。这样启用 Rust module example 总开关时，不会忽略具体 module example 的子配置。
5. **修正 Rust component example 的入口门控**
   `RT_RUST_BUILD_COMPONENTS` 是 component example 的总开关，`RUST_LOG_COMPONENT` 只是 log component 自动初始化相关子开关。修复后，`RT_RUST_BUILD_COMPONENTS=y` 时，即使 `RUST_LOG_COMPONENT=n`，component example 仍可正常进入构建流程；`RUST_LOG_COMPONENT` 只继续影响对应 Cargo feature，而不再错误地控制整个 component example 是否构建。
6. **修正 build-all 路径下的 example 依赖检查**
   对需要底层系统能力的 Rust application example 增加构建前依赖判断：
   - `loadlib` 依赖 `RT_USING_MODULE`。未启用 module 支持时，即使 `RT_RUST_BUILD_ALL_EXAMPLES=y`，也不会构建 `loadlib`。
   - `fs` 依赖 POSIX 文件 API。只有满足以下任一条件时才构建：
     - `RT_USING_POSIX_FS=y`
     - `RT_USING_DFS=y && DFS_USING_POSIX=y`
     - `RT_USING_DFS=y && RT_USING_DFS_V2=y`
   这样可以避免 Rust application staticlib 通过 `--whole-archive` 被强制链接后引用缺失的底层 C 符号。
7. **改进 Cargo feature 处理**
   本 PR 对 component/application 的 Cargo feature 处理进行了收敛和校验：
   - 为 component registry 补充 `RUST_LOG_COMPONENT -> enable-log` 的 feature 映射；
   - 对 component manifest 未声明的 feature 进行过滤，避免向 Cargo 传入 unknown feature；
   - 对 `fs` application 自动补齐日志相关 feature，保证其源码、Cargo manifest 和构建命令保持一致。
8. **修正 module example 的 `rt-rust` 依赖路径**
   修复 `components/rust/examples/modules/example_lib/Cargo.toml` 中 `rt-rust` 依赖路径，使其指向实际的 Rust core crate。
9. **改进 Cargo 失败输出**
   在 Cargo 执行失败或 Cargo 不存在时，输出更明确的错误信息和 Cargo stdout/stderr，方便用户定位 toolchain、target 或 manifest 问题。
整体上，本 PR 只修改 Rust 构建脚本、Rust example 构建入口和一个 Rust module example 的 Cargo 依赖路径，不修改 BSP、驱动、内核调度或运行时业务逻辑。
#### 请提供验证的bsp和config (provide the config and bsp)
- BSP:
本 PR 修改范围为 Rust 构建脚本和 Rust example 构建配置处理，不针对特定 BSP 修改运行时代码，因此没有限定单一验证 BSP。
本地验证主要覆盖以下 Rust 构建路径：
```text
components/rust/core/SConscript
components/rust/examples/application/SConscript
components/rust/examples/component/SConscript
components/rust/examples/modules/SConscript
components/rust/tools/build_support.py
components/rust/tools/build_component.py
components/rust/tools/build_usrapp.py
```
验证方式为本地构建脚本回归验证和静态编译检查，覆盖 Rust core、application example、component example、module example 的配置组合、Cargo 命令生成、artifact 查找、LIBS/LIBPATH/LINKFLAGS 生成和失败路径处理。
- .config:
本 PR 未要求固定某一个 BSP 的 `.config`。验证时覆盖了以下 Rust 相关配置组合：
```text
RT_USING_RUST=y
RT_RUST_CORE=y
RT_USING_RUST_EXAMPLES=y
RT_RUST_BUILD_APPLICATIONS=y
RT_RUST_BUILD_COMPONENTS=y
RT_RUST_BUILD_MODULES=y
RT_RUST_BUILD_ALL_EXAMPLES=y
RUST_LOG_COMPONENT=y / n
RT_RUST_MODULE_SIMPLE_MODULE=y / n
RT_USING_MODULE=y / n
RT_USING_DFS=y / n
DFS_USING_POSIX=y / n
RT_USING_DFS_V2=y / n
RT_USING_POSIX_FS=y / n
```
重点验证场景包括：
```text
1. RT_RUST_CORE=n 时，Rust core 不应进入构建。
2. Rust toolchain 缺失、target 缺失、Cargo 构建失败时，不应把 rust_cmd.c 加入无效链接路径。
3. RT_RUST_BUILD_COMPONENTS=y 且 RUST_LOG_COMPONENT=n 时，component example 仍应构建。
4. RUST_LOG_COMPONENT=y 时，component registry 应获得 enable-log feature。
5. component manifest 未声明 smp feature 时，不应向 Cargo 传入 smp feature。
6. RT_RUST_BUILD_ALL_EXAMPLES=y 但 RT_USING_MODULE=n 时，不应构建 loadlib example。
7. RT_RUST_BUILD_ALL_EXAMPLES=y 但 DFS/POSIX 文件 API 不可用时，不应构建 fs example。
8. DFS/POSIX 文件 API 可用时，fs example 应正常构建。
9. RT_RUST_MODULE_SIMPLE_MODULE=n 时，simple module example 不应被构建。
10. RISC-V 和 Cortex-M target 推断应匹配对应架构配置。
```
本地验证结果如下：
```text
Local Rust build-script regression checks:
Ran 101 tests
Result: OK
```
```text
Python syntax checks for Rust build helper scripts:
components\rust\tools\build_support.py
components\rust\tools\build_usrapp.py
components\rust\tools\build_component.py

Result: OK
```
说明：上述回归验证用于检查 Rust 构建脚本行为，包括 SConscript mock、fake Cargo 命令捕获、Cargo manifest 检查、link flag 生成检查和失败路径检查。PR 中未提交额外大型测试文件，避免引入与本次修复无关的测试体积。
- action:
GitHub Actions 已通过。当前 PR 检查结果为 103 successful checks，2 skipped checks，页面状态显示 All checks have passed。
]
### 当前拉取/合并请求的状态 Intent for your PR
必须选择一项 Choose one (Mandatory):
- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo
### 代码质量 Code Quality：
我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:
- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)