### PR TITLE
Fix CI changed file detection

### DIFF
--- a/tools/ci/ci_common.py
+++ b/tools/ci/ci_common.py
@@ -1,0 +1,187 @@
+#
+# Copyright (c) 2006-2025, RT-Thread Development Team
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Change Logs:
+# Date           Author       Notes
+# 2026-07-08     yan hu       add read-only changed-file helpers
+#
+
+"""Shared read-only helpers for the tools/ci scripts.
+
+Changed-file detection must never modify repository state (HEAD, index or
+working tree) or leave temporary files behind.
+"""
+
+import os
+import logging
+import subprocess
+from collections import namedtuple
+
+# Structured result of a git invocation; ``cmd`` keeps the exact argument list.
+GitResult = namedtuple("GitResult", ["returncode", "stdout", "stderr", "cmd"])
+
+DEFAULT_TARGET_REF = "origin/master"
+TARGET_REF_ENV_VAR = "RTT_CI_TARGET_REF"
+DEFAULT_DIFF_FILTER = "ACMR"
+
+
+def run_git(args, cwd=None):
+    """Run a git command (no shell) and return a GitResult.
+
+    A non-zero git exit code is reported via ``returncode``, not raised.
+    """
+    cmd = ["git"] + list(args)
+    try:
+        completed = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=cwd,
+        )
+    except OSError as e:
+        logging.error("failed to execute {}: {}".format(" ".join(cmd), e))
+        return GitResult(returncode=127, stdout="", stderr=str(e), cmd=cmd)
+
+    return GitResult(
+        returncode=completed.returncode,
+        stdout=completed.stdout or "",
+        stderr=completed.stderr or "",
+        cmd=cmd,
+    )
+
+
+def resolve_target_ref(default_ref=DEFAULT_TARGET_REF, env_var=TARGET_REF_ENV_VAR):
+    """Return the baseline ref to diff against.
+
+    Uses ``RTT_CI_TARGET_REF`` when set (for fork/CI setups), otherwise the
+    default. Read-only.
+    """
+    ref = os.environ.get(env_var)
+    if ref:
+        ref = ref.strip()
+        if ref:
+            return ref
+    return default_ref
+
+
+def normalize_changed_files(output):
+    """Split output into lines, drop empties and normalise separators to ``/``."""
+    files = []
+    for line in output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        files.append(line.replace("\\", "/"))
+    return files
+
+
+def get_merge_base(target_ref=DEFAULT_TARGET_REF, head_ref="HEAD", cwd=None):
+    """Return the merge base of the two refs, or ``None`` on failure. Read-only."""
+    result = run_git(["merge-base", target_ref, head_ref], cwd=cwd)
+    if result.returncode != 0:
+        logging.error(
+            "git merge-base {} {} failed: {}".format(
+                target_ref, head_ref, result.stderr.strip()
+            )
+        )
+        return None
+    base = result.stdout.strip()
+    if not base:
+        logging.error(
+            "git merge-base {} {} returned no commit".format(target_ref, head_ref)
+        )
+        return None
+    return base
+
+
+def get_changed_files_between(base_ref, head_ref="HEAD",
+                              diff_filter=DEFAULT_DIFF_FILTER, cwd=None):
+    """Files changed between two refs. ``None`` on failure, ``[]`` on empty diff."""
+    args = [
+        "diff",
+        "--name-only",
+        "--diff-filter={}".format(diff_filter),
+        "--no-renames",
+        "--full-index",
+        base_ref,
+        head_ref,
+    ]
+    result = run_git(args, cwd=cwd)
+    if result.returncode != 0:
+        logging.error(
+            "git diff {}..{} failed: {}".format(
+                base_ref, head_ref, result.stderr.strip()
+            )
+        )
+        return None
+    return normalize_changed_files(result.stdout)
+
+
+def get_changed_files(target_ref=DEFAULT_TARGET_REF, head_ref="HEAD",
+                      diff_filter=DEFAULT_DIFF_FILTER, cwd=None):
+    """Files changed on ``head_ref`` vs the merge base with ``target_ref``.
+
+    Read-only. ``None`` on git failure, ``[]`` on empty diff.
+    """
+    base = get_merge_base(target_ref, head_ref, cwd=cwd)
+    if base is None:
+        return None
+    return get_changed_files_between(base, head_ref, diff_filter=diff_filter, cwd=cwd)
+
+
+def maybe_fetch_remote(remote_name, remote_url=None, cwd=None):
+    """Ensure ``remote_name`` points at ``remote_url`` and fetch its refs.
+
+    Adds the remote when missing, or updates its URL when it already exists but
+    differs. Touches ``.git/config`` and ``FETCH_HEAD`` only, never HEAD, the
+    index or the working tree. Returns ``True`` on success, ``False`` on any
+    failure so callers stop instead of diffing against a stale baseline.
+    """
+    existing = run_git(["remote"], cwd=cwd)
+    if existing.returncode != 0:
+        logging.error("git remote failed: {}".format(existing.stderr.strip()))
+        return False
+
+    remotes = normalize_changed_files(existing.stdout)
+    if remote_name not in remotes:
+        if not remote_url:
+            logging.error(
+                "remote '{}' does not exist and no url was provided".format(remote_name)
+            )
+            return False
+        added = run_git(["remote", "add", remote_name, remote_url], cwd=cwd)
+        if added.returncode != 0:
+            logging.error(
+                "git remote add {} failed: {}".format(remote_name, added.stderr.strip())
+            )
+            return False
+    elif remote_url:
+        current = run_git(["remote", "get-url", remote_name], cwd=cwd)
+        if current.returncode != 0:
+            logging.error(
+                "git remote get-url {} failed: {}".format(
+                    remote_name, current.stderr.strip()
+                )
+            )
+            return False
+        if current.stdout.strip() != remote_url:
+            updated = run_git(["remote", "set-url", remote_name, remote_url], cwd=cwd)
+            if updated.returncode != 0:
+                logging.error(
+                    "git remote set-url {} failed: {}".format(
+                        remote_name, updated.stderr.strip()
+                    )
+                )
+                return False
+
+    fetched = run_git(["fetch", remote_name], cwd=cwd)
+    if fetched.returncode != 0:
+        logging.error(
+            "git fetch {} failed: {}".format(remote_name, fetched.stderr.strip())
+        )
+        return False
+
+    return True

--- a/tools/ci/compile_bsp_with_drivers.py
+++ b/tools/ci/compile_bsp_with_drivers.py
@@ -13,6 +13,8 @@ import logging
 import os
 import sys
 
+import ci_common
+
 CONFIG_BSP_USING_X = ["CONFIG_BSP_USING_UART", "CONFIG_BSP_USING_I2C", "CONFIG_BSP_USING_SPI", "CONFIG_BSP_USING_ADC", "CONFIG_BSP_USING_DAC"]
 
 def init_logger():
@@ -24,8 +26,13 @@ def init_logger():
                         )
 
 def diff():
-    result = subprocess.run(['git', 'diff', '--name-only', 'HEAD', 'origin/master', '--diff-filter=ACMR', '--no-renames', '--full-index'], stdout = subprocess.PIPE)
-    file_list = result.stdout.decode().strip().split('\n')
+    # Read-only diff against the configurable baseline. Returns None on git
+    # failure (so the caller can fail instead of trusting an unreliable empty
+    # result); an empty diff returns an empty set.
+    file_list = ci_common.get_changed_files(ci_common.resolve_target_ref())
+    if file_list is None:
+        logging.error("failed to determine changed files")
+        return None
     logging.info(file_list)
     bsp_paths = set()
     for file in file_list:
@@ -107,6 +114,9 @@ def recompile_bsp(dir):
 if __name__ == '__main__':
     init_logger()
     recompile_bsp_dirs = diff()
+    if recompile_bsp_dirs is None:
+        logging.error("failed to determine changed files, aborting")
+        sys.exit(1)
     failed = 0
     for dir in recompile_bsp_dirs:
         dot_config_path = dir + "/" + ".config"

--- a/tools/ci/file_check.py
+++ b/tools/ci/file_check.py
@@ -17,6 +17,8 @@ import chardet
 import logging
 import datetime
 
+import ci_common
+
 
 def init_logger():
     log_format = "[%(filename)s %(lineno)d %(levelname)s] %(message)s "
@@ -80,37 +82,28 @@ class CheckOut:
         return 1
 
     def get_new_file(self):
-        file_list = list()
-        try:
-            os.system('git remote add rtt_repo {}'.format(self.rtt_repo))
-            os.system('git fetch rtt_repo')
-            os.system('git merge rtt_repo/{}'.format(self.rtt_branch))
-            os.system('git reset rtt_repo/{} --soft'.format(self.rtt_branch))
-            os.system('git status > git.txt')
-        except Exception as e:
-            logging.error(e)
-            return None
-        try:
-            with open('git.txt', 'r') as f:
-                file_lines = f.readlines()
-        except Exception as e:
-            logging.error(e)
-            return None
-        file_path = ''
-        for line in file_lines:
-            if 'new file' in line:
-                file_path = line.split('new file:')[1].strip()
-                logging.info('new file -> {}'.format(file_path))
-            elif 'deleted' in line:
-                logging.info('deleted file -> {}'.format(line.split('deleted:')[1].strip()))
-            elif 'modified' in line:
-                file_path = line.split('modified:')[1].strip()
-                logging.info('modified file -> {}'.format(file_path))
-            else:
-                continue
+        # Read-only changed-file detection. When a repo/branch pair is given we
+        # fetch it into a dedicated remote (which only touches .git/config and
+        # FETCH_HEAD) and diff against it; otherwise we fall back to the
+        # configurable default baseline. HEAD, the index and the working tree
+        # are never modified and no temporary files are created.
+        if self.rtt_repo:
+            if not ci_common.maybe_fetch_remote("rtt_repo", self.rtt_repo):
+                logging.error("failed to fetch baseline repo, aborting file check")
+                return None
+            target_ref = "rtt_repo/{}".format(self.rtt_branch)
+        else:
+            target_ref = ci_common.resolve_target_ref()
 
-            result = self.__exclude_file(file_path)
-            if result != 0:
+        changed_files = ci_common.get_changed_files(target_ref)
+        if changed_files is None:
+            logging.error("failed to determine changed files")
+            return None
+
+        file_list = list()
+        for file_path in changed_files:
+            logging.info("changed file -> {}".format(file_path))
+            if self.__exclude_file(file_path) != 0:
                 file_list.append(file_path)
 
         return file_list

--- a/tools/ci/format_ignore.py
+++ b/tools/ci/format_ignore.py
@@ -11,7 +11,8 @@
 import yaml
 import logging
 import os
-import subprocess
+
+import ci_common
 
 def init_logger():
     log_format = "[%(filename)s %(lineno)d %(levelname)s] %(message)s "
@@ -72,13 +73,17 @@ class CheckOut:
         return 1
     
     def get_new_file(self):
-        result = subprocess.run(['git', 'diff', '--name-only', 'HEAD', 'origin/master', '--diff-filter=ACMR', '--no-renames', '--full-index'], stdout = subprocess.PIPE)
-        file_list = result.stdout.decode().strip().split('\n')
+        # Read-only diff against the configurable baseline (merge base of the
+        # target ref and HEAD). Returns None on git failure, [] on empty diff.
+        changed_files = ci_common.get_changed_files(ci_common.resolve_target_ref())
+        if changed_files is None:
+            logging.error("failed to determine changed files")
+            return None
+
         new_files = []
-        for line in file_list:
+        for line in changed_files:
             logging.info("modified file -> {}".format(line))
-            result = self.__exclude_file(line)
-            if result != 0:
+            if self.__exclude_file(line) != 0:
                 new_files.append(line)
-        
+
         return new_files


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[
#### 为什么提交这份PR (why to submit this PR)
本 PR 修复 `tools/ci` 中变更文件检测逻辑会修改 Git 工作区状态的问题。
当前 `tools/ci/file_check.py::CheckOut.get_new_file()` 原本通过以下流程获取变更文件：
* `git remote add rtt_repo ...`
* `git fetch rtt_repo`
* `git merge rtt_repo/<branch>`
* `git reset rtt_repo/<branch> --soft`
* `git status > git.txt`
该流程存在明显问题：CI 文件检查脚本本应只读地获取当前分支相对于目标分支的差异文件，但上述实现会改变当前仓库状态。通过临时 Git 仓库复现可以观察到：执行 `get_new_file()` 前，feature 分支 HEAD 位于新增文件提交上且 `git status --short` 为空；执行后，feature 分支 HEAD 被重置回基线提交，新增文件被重新置为 staged 状态，并且工作区留下 `git.txt` 临时文件。
这会导致 CI 后续步骤基于被修改过的 HEAD、index 或 working tree 继续运行，可能引起误检、漏检或污染后续检查环境。该问题属于 CI 辅助脚本的普通软件缺陷，不涉及功能新增，也不涉及安全漏洞。
此外，`tools/ci/format_ignore.py` 和 `tools/ci/compile_bsp_with_drivers.py` 原先直接使用 `git diff HEAD origin/master` 获取差异文件，存在以下问题：
* 基线分支硬编码为 `origin/master`，在 fork、不同 remote 名称或 CI 目标分支变化时不够可靠；
* 空 diff 可能被解析为 `['']`，导致后续出现空路径处理；
* Git 命令失败时缺少统一处理，容易继续使用不可靠输出。
因此，本 PR 将相关 CI 脚本的 changed-file detection 改为统一、只读、可配置且失败可感知的实现。
#### 你的解决方案是什么 (what is your solution)
本 PR 新增 `tools/ci/ci_common.py`，提供一组共享的只读 Git diff helper，并将相关 CI 脚本迁移到该公共实现。
主要修改如下：
1. 新增 `tools/ci/ci_common.py`
   新增公共 helper，用于统一处理 CI 脚本中的 Git 差异文件检测逻辑，包括：
   * `run_git()`：使用 `subprocess.run(["git", ...])` 执行 Git 命令，不使用 `shell=True`，不使用 `os.system`，并返回结构化结果；
   * `resolve_target_ref()`：支持通过 `RTT_CI_TARGET_REF` 指定目标基线分支，默认保持兼容 `origin/master`；
   * `get_merge_base()`：只读获取目标分支和当前 HEAD 的 merge-base；
   * `get_changed_files()`：使用 `git merge-base` + `git diff --name-only` 获取变更文件；
   * `get_changed_files_between()`：支持显式指定 base/head ref；
   * `normalize_changed_files()`：统一处理空 diff，过滤空行，并规范化路径分隔符；
   * `maybe_fetch_remote()`：用于兼容 `file_check.py` 原有传入 `rtt_repo` / `rtt_branch` 的调用方式；当 remote 不存在时添加 remote，当 remote 已存在但 URL 不一致时更新 URL，然后 fetch refs。该过程只会影响 `.git/config` 和 `FETCH_HEAD`，不会修改 HEAD、index 或 working tree。
2. 修改 `tools/ci/file_check.py`
   保留原有 `CheckOut` 类名和 `__init__(rtt_repo, rtt_branch)` 接口，避免破坏现有调用方式。
   修改 `get_new_file()` 的实现：
   * 删除原先会修改仓库状态的 `git merge`；
   * 删除原先会重置当前分支的 `git reset --soft`；
   * 删除 `git status > git.txt` 临时文件流程；
   * 改为 fetch 指定基线后，通过 merge-base + read-only diff 获取 changed files；
   * Git 命令失败时返回 `None`，避免继续使用不可靠结果；
   * 空 diff 返回 `[]`；
   * 保持原有 ignore 过滤逻辑。
3. 修改 `tools/ci/format_ignore.py`
   将原先硬编码的：
   ```text
   git diff --name-only HEAD origin/master
   ```
   替换为公共 helper：
   ```text
   ci_common.get_changed_files(ci_common.resolve_target_ref())
   ```
   这样可以：
   * 避免硬编码 `origin/master`；
   * 支持 `RTT_CI_TARGET_REF` 配置目标基线；
   * 空 diff 返回 `[]`；
   * Git 失败时返回 `None`，由调用方处理；
   * 保持原有 ignore 过滤逻辑。
4. 修改 `tools/ci/compile_bsp_with_drivers.py`
   将 `diff()` 中硬编码的 `git diff HEAD origin/master` 替换为公共 helper。
   同时调整失败处理逻辑：
   * 空 diff 返回空 `set()`，表示没有需要重新编译的 BSP；
   * Git diff / merge-base 失败时返回 `None`；
   * 主流程在 `diff()` 返回 `None` 时以错误退出，避免把 Git 失败误当作“没有 BSP 需要编译”。
整体修复后，CI changed-file detection 变为只读操作，不再修改 HEAD、index 或 working tree，也不会留下 `git.txt` 临时文件；同时多个 CI 脚本复用统一实现，避免不同脚本间的 diff 语义不一致。
#### 请提供验证的bsp和config (provide the config and bsp)
* BSP:
本 PR 为 `tools/ci` 辅助脚本修复，不涉及具体 BSP 源码、板级配置或硬件相关改动，因此无特定 BSP 要求。
验证类型为 CI helper 脚本级验证。
* .config:
本 PR 不修改任何 BSP 的 `.config`，也不要求开启或关闭额外配置项。
无 `.config` 变更。
* action:
本 PR 修改的是 CI helper 脚本逻辑，已完成本地脚本级验证。PR 创建后可由 GitHub Actions 自动触发进一步检查。
本地已完成以下验证：
1. Python 语法检查：
   ```powershell
   python -m py_compile tools\ci\ci_common.py tools\ci\file_check.py tools\ci\format_ignore.py tools\ci\compile_bsp_with_drivers.py tools\ci\cpp_check.py
   ```
   结果：通过，无语法错误。
2. Git diff whitespace 检查：
   ```powershell
   git diff --cached --check
   ```
   结果：通过，无 whitespace error。
3. 临时 Git 仓库复现验证：
   构造临时 base/work 仓库：
   * `base/master` 中包含基础提交；
   * `work/feature` 中新增并提交 `test.c`；
   * 调用 `file_check.py::CheckOut.get_new_file()` 获取 changed files。
   修复前行为：
   * `get_new_file()` 会将 feature 分支 HEAD 重置回 base/master；
   * 新增文件 `test.c` 变为 staged 状态；
   * 工作区留下 `git.txt` 临时文件。
   修复后行为：
   * `file_check.py::CheckOut.get_new_file()` 正确返回 `['test.c']`；
   * feature 分支 HEAD 保持不变；
   * `git status --short` 保持为空；
   * 不再生成 `git.txt`；
   * `format_ignore.py::CheckOut.get_new_file()` 同样能返回 changed file，并且不修改仓库状态；
   * `compile_bsp_with_drivers.py::diff()` 在空 diff 时返回空 `set()`；
   * `compile_bsp_with_drivers.py::diff()` 在 Git 失败时返回 `None`，不会再把失败误当作空变更成功处理。
4. 提交前检查：
   ```powershell
   git diff --cached --stat
   git diff --cached --numstat
   git status --short
   ```
   确认仅包含以下 4 个相关文件：

   * `tools/ci/ci_common.py`
   * `tools/ci/file_check.py`
   * `tools/ci/format_ignore.py`
   * `tools/ci/compile_bsp_with_drivers.py`
   未修改 Rust 相关代码，未修改 BSP，未修改无关组件，未提交临时复现仓库或构建产物。
   ]
### 当前拉取/合并请求的状态 Intent for your PR
必须选择一项 Choose one (Mandatory):
* [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
* [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo
### 代码质量 Code Quality：
我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:
* [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
* [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
* [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
* [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
* [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
* [x] 代码是高质量的 Code in this PR is of high quality
* [ ] 已经使用[[formatting](https://github.com/mysterywolf/formatting)](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [[RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
* [ ] 如果是新增bsp, 已经添加ci检查到[[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)