### PR TITLE
Fix env git clone handling

### DIFF
--- a/tools/env_utility.py
+++ b/tools/env_utility.py
@@ -17,6 +17,7 @@ import sys
 import shutil
 import hashlib
 import operator
+import subprocess
 
 
 def GetEnvPath():
@@ -102,6 +103,16 @@ def help_info():
     )
 
 
+def run_git_clone(url, dest):
+    '''Clone a git repo via an argv list (no shell), so paths that contain
+    spaces are not split. Returns True on success, False otherwise.'''
+    try:
+        return subprocess.run(['git', 'clone', url, dest], check=False).returncode == 0
+    except (OSError, ValueError):
+        # git not found / not on PATH, or invalid arguments
+        return False
+
+
 def touch_env(use_gitee=False):
     if sys.platform != 'win32':
         home_dir = os.environ['HOME']
@@ -133,98 +144,64 @@ def touch_env(use_gitee=False):
         kconfig.close()
 
     # git clone packages
-    if not os.path.exists(os.path.join(env_dir, 'packages', 'packages')):
-        try:
-            ret = os.system('git clone %s %s' % (pkg_url, os.path.join(env_dir, 'packages', 'packages')))
-            if ret != 0:
-                shutil.rmtree(os.path.join(env_dir, 'packages', 'packages'))
-                print(
-                    "********************************************************************************\n"
-                    "* Warnning:\n"
-                    "* Run command error for \"git clone https://github.com/RT-Thread/packages.git\".\n"
-                    "* This error may have been caused by not found a git tool or network error.\n"
-                    "* If the git tool is not installed, install the git tool first.\n"
-                    "* If the git utility is installed, check whether the git command is added to \n"
-                    "* the system PATH.\n"
-                    "* This error may cause the RT-Thread packages to not work properly.\n"
-                    "********************************************************************************\n"
-                )
-                help_info()
-            else:
-                kconfig = open(os.path.join(env_dir, 'packages', 'Kconfig'), 'w')
-                kconfig.write('source "$PKGS_DIR/packages/Kconfig"')
-                kconfig.close()
-        except:
+    packages_dir = os.path.join(env_dir, 'packages', 'packages')
+    if not os.path.exists(packages_dir):
+        if not run_git_clone(pkg_url, packages_dir):
+            shutil.rmtree(packages_dir, ignore_errors=True)
             print(
-                "**********************************************************************************\n"
+                "********************************************************************************\n"
                 "* Warnning:\n"
-                "* Run command error for \"git clone https://github.com/RT-Thread/packages.git\". \n"
-                "* This error may have been caused by not found a git tool or git tool not in \n"
-                "* the system PATH. \n"
-                "* This error may cause the RT-Thread packages to not work properly. \n"
-                "**********************************************************************************\n"
+                "* Run command error for \"git clone %s\".\n"
+                "* This error may have been caused by not found a git tool or network error.\n"
+                "* If the git tool is not installed, install the git tool first.\n"
+                "* If the git utility is installed, check whether the git command is added to \n"
+                "* the system PATH.\n"
+                "* This error may cause the RT-Thread packages to not work properly.\n"
+                "********************************************************************************\n" % pkg_url
             )
             help_info()
+            return False
+        kconfig = open(os.path.join(env_dir, 'packages', 'Kconfig'), 'w')
+        kconfig.write('source "$PKGS_DIR/packages/Kconfig"')
+        kconfig.close()
 
     # git clone env scripts
-    if not os.path.exists(os.path.join(env_dir, 'tools', 'scripts')):
-        try:
-            ret = os.system('git clone %s %s' % (env_url, os.path.join(env_dir, 'tools', 'scripts')))
-            if ret != 0:
-                shutil.rmtree(os.path.join(env_dir, 'tools', 'scripts'))
-                print(
-                    "********************************************************************************\n"
-                    "* Warnning:\n"
-                    "* Run command error for \"git clone https://github.com/RT-Thread/env.git\".\n"
-                    "* This error may have been caused by not found a git tool or network error.\n"
-                    "* If the git tool is not installed, install the git tool first.\n"
-                    "* If the git utility is installed, check whether the git command is added \n"
-                    "* to the system PATH.\n"
-                    "* This error may cause script tools to fail to work properly.\n"
-                    "********************************************************************************\n"
-                )
-                help_info()
-        except:
+    scripts_dir = os.path.join(env_dir, 'tools', 'scripts')
+    if not os.path.exists(scripts_dir):
+        if not run_git_clone(env_url, scripts_dir):
+            shutil.rmtree(scripts_dir, ignore_errors=True)
             print(
                 "********************************************************************************\n"
                 "* Warnning:\n"
-                "* Run command error for \"git clone https://github.com/RT-Thread/env.git\". \n"
-                "* This error may have been caused by not found a git tool or git tool not in \n"
-                "* the system PATH. \n"
-                "* This error may cause script tools to fail to work properly. \n"
-                "********************************************************************************\n"
+                "* Run command error for \"git clone %s\".\n"
+                "* This error may have been caused by not found a git tool or network error.\n"
+                "* If the git tool is not installed, install the git tool first.\n"
+                "* If the git utility is installed, check whether the git command is added \n"
+                "* to the system PATH.\n"
+                "* This error may cause script tools to fail to work properly.\n"
+                "********************************************************************************\n" % env_url
             )
             help_info()
+            return False
 
     # git clone sdk
-    if not os.path.exists(os.path.join(env_dir, 'packages', 'sdk')):
-        try:
-            ret = os.system('git clone %s %s' % (sdk_url, os.path.join(env_dir, 'packages', 'sdk')))
-            if ret != 0:
-                shutil.rmtree(os.path.join(env_dir, 'packages', 'sdk'))
-                print(
-                    "********************************************************************************\n"
-                    "* Warnning:\n"
-                    "* Run command error for \"git clone https://github.com/RT-Thread/sdk.git\".\n"
-                    "* This error may have been caused by not found a git tool or network error.\n"
-                    "* If the git tool is not installed, install the git tool first.\n"
-                    "* If the git utility is installed, check whether the git command is added \n"
-                    "* to the system PATH.\n"
-                    "* This error may cause the RT-Thread SDK to not work properly.\n"
-                    "********************************************************************************\n"
-                )
-                help_info()
-        except:
+    sdk_dir = os.path.join(env_dir, 'packages', 'sdk')
+    if not os.path.exists(sdk_dir):
+        if not run_git_clone(sdk_url, sdk_dir):
+            shutil.rmtree(sdk_dir, ignore_errors=True)
             print(
                 "********************************************************************************\n"
                 "* Warnning:\n"
-                "* Run command error for \"https://github.com/RT-Thread/sdk.git\".\n"
-                "* This error may have been caused by not found a git tool or git tool not in \n"
-                "* the system PATH. \n"
-                "* This error may cause the RT-Thread SDK to not work properly. \n"
-                "********************************************************************************\n"
+                "* Run command error for \"git clone %s\".\n"
+                "* This error may have been caused by not found a git tool or network error.\n"
+                "* If the git tool is not installed, install the git tool first.\n"
+                "* If the git utility is installed, check whether the git command is added \n"
+                "* to the system PATH.\n"
+                "* This error may cause the RT-Thread SDK to not work properly.\n"
+                "********************************************************************************\n" % sdk_url
             )
             help_info()
+            return False
 
     # try to create an empty .config file
     if not os.path.exists(os.path.join(env_dir, 'tools', '.config')):
@@ -232,7 +209,12 @@ def touch_env(use_gitee=False):
         kconfig.close()
 
     # copy env.sh or env.ps1, Kconfig
-    shutil.copy(os.path.join(env_dir, 'tools', 'scripts', 'Kconfig'), os.path.join(home_dir, '.env', 'tools'))
+    scripts_kconfig = os.path.join(env_dir, 'tools', 'scripts', 'Kconfig')
+    if not os.path.isfile(scripts_kconfig):
+        print("**ERROR**: env scripts are missing (%s not found), ENV was not "
+              "installed completely." % scripts_kconfig)
+        return False
+    shutil.copy(scripts_kconfig, os.path.join(home_dir, '.env', 'tools'))
     if sys.platform != 'win32':
         shutil.copy(os.path.join(env_dir, 'tools', 'scripts', 'env.sh'), os.path.join(home_dir, '.env', 'env.sh'))
     else:
@@ -247,6 +229,8 @@ def touch_env(use_gitee=False):
         #     for file in zip_file_obj.namelist():
         #         zip_file_obj.extract(file, zip_file_dir)
         #     zip_file_obj.close()
+
+    return True
 
 
 def is_pkg_special_config(config_str):
@@ -372,7 +356,9 @@ def kconfiglib_check_installed():
     if os.path.exists(pkg_dir):
         os.environ["PKGS_DIR"] = pkg_dir
     elif sys.platform != 'win32':
-        touch_env()
+        if not touch_env():
+            print("\033[1;31m**ERROR**: Failed to install RT-Thread ENV tools.\033[0m")
+            sys.exit(1)
         os.environ["PKGS_DIR"] = GetPkgPath()
     else:
         print("\033[1;33m**WARNING**: PKGS_DIR not found, please install ENV tools\033[0m")


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)
[
#### 为什么提交这份PR (why to submit this PR)
本 PR 修复 `tools/env_utility.py` 中 RT-Thread ENV 初始化时 `git clone` 处理不健壮的问题。
在 `scons menuconfig`、`scons guiconfig`、`scons defconfig` 等配置入口中，`building.py::PrepareBuilding()` 会调用 `tools/env_utility.py` 中的 `menuconfig()` / `guiconfig()` / `defconfig()`，这些函数会先执行 `kconfiglib_check_installed()`。当系统中尚未安装 RT-Thread ENV 工具、且 `PKGS_DIR` 不存在时，非 Windows 平台会进入 `touch_env()` 自动初始化 `.env` 目录和相关工具。
原实现中，`touch_env()` 使用类似下面的方式执行 `git clone`：
```python
os.system('git clone %s %s' % (url, path))
```
该实现存在两个问题：
1. 当目标路径包含空格时，`os.system()` 会通过 shell 执行命令，目标路径会被 shell 按空格拆分，导致 `git clone` 参数错误。例如用户目录或临时目录中包含空格时，目标路径可能被拆成多个参数，`git clone` 会报 `Too many arguments` 或 clone 到错误位置。
2. 当 `git clone` 因网络、缺少 git 工具、路径错误等原因失败后，原逻辑会继续执行后续初始化流程。此时如果 `.env/tools/scripts/Kconfig` 等文件不存在，后续 `shutil.copy()` 会抛出未解释的 `FileNotFoundError`，导致错误信息不清晰，并可能留下未完整初始化的 `.env` 目录结构。
该问题属于 ENV 初始化工具链的普通软件缺陷。ENV 初始化脚本应当能够正确处理包含空格的路径，并在 clone 失败时及时停止后续流程，而不是继续访问不存在的文件。
#### 你的解决方案是什么 (what is your solution)
本 PR 只修改 `tools/env_utility.py`，未修改 BSP、Kconfig、Rust、CI 或其它无关模块。
主要修改如下：
1. 新增 `run_git_clone(url, dest)` helper
   使用：
   ```python
   subprocess.run(['git', 'clone', url, dest], check=False)
   ```
   替代原先的 `os.system('git clone %s %s' % (...))`。
   这样 `git clone` 参数会以 argv list 形式传递，不再经过 shell 分词，因此目标路径中即使包含空格，也会作为完整路径传给 git。
2. 替换 `touch_env()` 中三处 clone 逻辑
   以下三类仓库 clone 均改为使用 `run_git_clone()`：
   * packages 仓库；
   * env scripts 仓库；
   * sdk 仓库。
   这样三处 clone 行为一致，均避免 shell 分词问题。
3. clone 失败时及时停止初始化流程
   当任意 clone 失败时：
   * 清理当前失败的目标目录；
   * 输出清晰错误提示；
   * 调用 `help_info()`；
   * `touch_env()` 返回 `False`；
   * 不再继续执行后续 `shutil.copy()`。
   需要说明的是，本 PR 没有尝试删除整个 `.env` 基础目录，以避免误删用户已有 ENV 内容；这里只清理当前失败的 clone 目标目录，并阻止后续流程继续执行。
4. 在复制 `scripts/Kconfig` 前增加存在性检查
   原逻辑直接执行：
   ```python
   shutil.copy(.../tools/scripts/Kconfig, ...)
   ```
   如果 env scripts clone 失败，则这里会抛出 `FileNotFoundError`。
   修改后会先检查 `scripts/Kconfig` 是否存在；如果不存在，则输出清晰错误并返回 `False`，不再抛出未解释的异常。
5. 调用方处理 `touch_env()` 失败结果
   `kconfiglib_check_installed()` 中调用 `touch_env()` 后，会检查返回值。若 ENV 初始化失败，则输出错误并 `sys.exit(1)`，避免继续执行 `menuconfig` / `guiconfig` / `defconfig` 后续逻辑。
本 PR 保持成功路径行为不变，仅修复路径含空格和 clone 失败场景下的错误处理。
#### 请提供验证的bsp和config (provide the config and bsp)
* BSP:
本 PR 修改的是 `tools/env_utility.py` 中的 ENV 初始化辅助逻辑，不涉及具体 BSP 源码、驱动或板级配置。
无特定 BSP 要求。
* .config:
本 PR 不修改任何 BSP 的 `.config`，也不要求开启或关闭额外配置项。
无 `.config` 变更。
* action:
本 PR 为工具脚本修复，已完成本地脚本级验证。PR 创建后可由 GitHub Actions 自动触发进一步检查。
本地验证如下：
1. Python 语法检查：
   ```powershell
   python -m py_compile tools\env_utility.py
   ```
   结果：通过，无语法错误。
2. Git diff whitespace 检查：
   ```powershell
   git diff --cached --check
   ```
   结果：通过，无 whitespace error。
3. 路径含空格场景验证：
   构造包含空格的目标路径，例如：
   ```text
   C:\Users\some user\...\packages
   ```
   修复前，`os.system('git clone %s %s')` 会通过 shell 执行命令，目标路径会被空格拆分，导致 `git clone` 参数错误。
   修复后，`subprocess.run(['git', 'clone', url, dest])` 接收到的 argv 中，目标路径作为单独完整参数传入，不会被空格拆分。
4. clone 失败场景验证：
   通过模拟 `git clone` 返回失败，验证 `touch_env()` 行为。
   修复前：
   * clone 失败后仍继续后续初始化；
   * 后续复制 `.env/tools/scripts/Kconfig` 时可能抛出 `FileNotFoundError`。
   修复后：
   * clone 失败后 `touch_env()` 返回 `False`；
   * 当前失败的 clone 目标目录会被清理；
   * 后续 `shutil.copy()` 不再执行；
   * `kconfiglib_check_installed()` 检测失败并退出；
   * 不再抛出未解释的 `FileNotFoundError`。
5. 缺失 `scripts/Kconfig` 场景验证：
   当 `.env/tools/scripts/Kconfig` 不存在时，修复后会输出清晰错误信息并返回 `False`，不会直接抛出 `FileNotFoundError`。
6. `mk_rtconfig()` 回归验证：
   使用临时 `.config` 验证以下内容：
   ```text
   CONFIG_FOO="a=b#c"
   ```
   生成的 `rtconfig.h` 中结果仍为：
   ```c
   #define FOO "a=b#c"
   ```
   说明本 PR 未修改 `.config -> rtconfig.h` 的解析逻辑，也未引入相关回归。
7. 提交前确认：
   ```powershell
   git diff --cached --stat
   git diff --cached --numstat
   git status --short
   ```
   确认本 PR 仅修改：
   ```text
   tools/env_utility.py
   ```
   未修改 BSP、Rust、CI、tools/targets 或其它无关文件。
   ]
### 当前拉取/合并请求的状态 Intent for your PR
必须选择一项 Choose one (Mandatory):
* [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
* [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo
### 代码质量 Code Quality：
我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:
* [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
* [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
* [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
* [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
* [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
* [x] 代码是高质量的 Code in this PR is of high quality
* [ ] 已经使用[[formatting](https://github.com/mysterywolf/formatting)](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [[RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
* [ ] 如果是新增bsp, 已经添加ci检查到[[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)