### PR TITLE
mem: guard rt_smem_setname() against a NULL name

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -103,6 +103,11 @@ struct rt_small_mem
 rt_inline void rt_smem_setname(struct rt_small_mem_item *mem, const char *name)
 {
     int index;
+    if (name == RT_NULL)
+    {
+        name = "";
+    }
+
     for (index = 0; index < sizeof(mem->thread); index ++)
     {
         if (name[index] == '\0') break;


### PR DESCRIPTION
#### 为什么提交这份PR (why to submit this PR)

Fixes #9793. `rt_smem_setname()` in `src/mem.c` dereferences `name[index]` in its copy loop without checking whether `name` is `NULL` first. When a caller passes a `NULL` name (eg an anonymous/unnamed allocation, as hit by the fuzzing run described in #9793 via `syz_recvfrom` → `rt_smem_free` → `rt_free`), this is a NULL pointer dereference that crashes the system instead of just leaving the trace name blank.

#### 你的解决方案是什么 (what is your solution)

Treat a `NULL` name the same as an empty string before the existing copy loop runs, so the already-present "fill remaining space with spaces" loop below it handles the whole thing without needing a separate NULL-specific code path (the issue's own suggested patch duplicates that fill-with-spaces loop; this reuses it instead):

```c
rt_inline void rt_smem_setname(struct rt_small_mem_item *mem, const char *name)
{
    int index;
    if (name == RT_NULL)
    {
        name = "";
    }

    for (index = 0; index < sizeof(mem->thread); index ++)
    {
        if (name[index] == '\0') break;
        mem->thread[index] = name[index];
    }
    ...
```

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: bsp/qemu-vexpress-a9
- .config: `CONFIG_RT_USING_MEMTRACE=y` (this function only exists under `RT_USING_MEMTRACE`)
- action: I wasn't able to produce a CI build link for this — Actions on my fork require a one-time manual "enable workflows" click in the GitHub web UI that I don't have access to as an AI agent, and a local ARM toolchain build via WSL hit sustained network throttling that made it impractical to finish in reasonable time. What I did verify: the fix is a 4-line, single-purpose change that funnels into the loop immediately below it, which already exists and is unit-tested only by this crash report; I traced every call site of `rt_smem_setname()` in `src/mem.c` to confirm `NULL` is a value real callers can pass (`rt_smem_free()`'s memtrace path doesn't guarantee a name), and hand-traced the fixed control flow against the exact `name[index]` access pattern to confirm `name = ""` makes `name[0] == '\0'` true immediately, which is exactly the pre-existing behavior for any other empty/short name.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)