### PR TITLE
lwp: copy timeout into kernel space in sys_select()

### DIFF
--- a/components/lwp/lwp_syscall.c
+++ b/components/lwp/lwp_syscall.c
@@ -970,6 +970,7 @@ sysret_t sys_select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptf
 #ifdef ARCH_MM_MMU
     int ret = -1;
     fd_set *kreadfds = RT_NULL, *kwritefds = RT_NULL, *kexceptfds = RT_NULL;
+    struct timeval ktimeout, *ptimeout = RT_NULL;
 
     if (readfds)
     {
@@ -1016,8 +1017,18 @@ sysret_t sys_select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptf
         }
         lwp_get_from_user(kexceptfds, exceptfds, sizeof *kexceptfds);
     }
+    if (timeout)
+    {
+        if (!lwp_user_accessable((void *)timeout, sizeof *timeout))
+        {
+            SET_ERRNO(EFAULT);
+            goto quit;
+        }
+        lwp_get_from_user(&ktimeout, timeout, sizeof ktimeout);
+        ptimeout = &ktimeout;
+    }
 
-    ret = select(nfds, kreadfds, kwritefds, kexceptfds, timeout);
+    ret = select(nfds, kreadfds, kwritefds, kexceptfds, ptimeout);
     if (kreadfds)
     {
         lwp_put_to_user(readfds, kreadfds, sizeof *kreadfds);


### PR DESCRIPTION
#### 为什么提交这份PR (why to submit this PR)

Fixes #10298. `sys_select()` in `components/lwp/lwp_syscall.c` passes the raw user-space `timeout` pointer straight through to `select()`, unlike `readfds`/`writefds`/`exceptfds`, which are all validated with `lwp_user_accessable()` and copied into kernel memory first. `select()` then dereferences `timeout->tv_sec`/`timeout->tv_usec` directly with no validation of its own. A user thread passing a `timeout` pointer to unmapped or otherwise invalid memory reaches that dereference straight from kernel context, as described in #10298.

#### 你的解决方案是什么 (what is your solution)

Validate and copy `timeout` into a kernel-local `struct timeval` the same way the three `fd_set` arguments already are, reusing the same `lwp_user_accessable()` + `goto quit` error path already in this function:

```c
struct timeval ktimeout, *ptimeout = RT_NULL;
...
if (timeout)
{
    if (!lwp_user_accessable((void *)timeout, sizeof *timeout))
    {
        SET_ERRNO(EFAULT);
        goto quit;
    }
    lwp_get_from_user(&ktimeout, timeout, sizeof ktimeout);
    ptimeout = &ktimeout;
}

ret = select(nfds, kreadfds, kwritefds, kexceptfds, ptimeout);
```

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: bsp/qemu-vexpress-a9
- .config: `CONFIG_ARCH_MM_MMU=y` (RT-Thread Smart / `ARCH_MM_MMU`, since `sys_select()`'s body is guarded by `#ifdef ARCH_MM_MMU`)
- action: I wasn't able to produce a CI build link — Actions on my fork need a one-time manual "enable workflows" click in the GitHub web UI that I don't have access to as an AI agent, and a local ARM toolchain build via WSL hit sustained network throttling that made it impractical to finish in reasonable time. What I did verify instead: this change is a direct structural copy of the exact validate-then-copy pattern already used three times in the same function for `readfds`/`writefds`/`exceptfds` (same `lwp_user_accessable()` call, same `goto quit` on failure, same `lwp_get_from_user()` copy), so it reuses an already-exercised code path rather than introducing a new one. I traced the `quit:` label and the rest of the function to confirm `ptimeout`/`ktimeout` are correctly scoped and that no other code path reads `timeout` directly after this change.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)