### PR TITLE
klibc: fix tiny vsnprintf long long formatting

### DIFF
--- a/src/klibc/rt_vsnprintf_tiny.c
+++ b/src/klibc/rt_vsnprintf_tiny.c
@@ -107,7 +107,15 @@ static char *print_number(char *buf,
                 num = (rt_uint16_t)-num;
             }
             break;
+#ifdef RT_KLIBC_USING_VSNPRINTF_LONGLONG
         case 'L':
+            if (num > (~0ULL >> 1))
+            {
+                sign = '-';
+                num = 0ULL - num;
+            }
+            break;
+#endif /* RT_KLIBC_USING_VSNPRINTF_LONGLONG */
         case 'l':
             if ((long)num < 0)
             {
@@ -552,7 +560,14 @@ int rt_vsnprintf(char *buf, size_t size, const char *fmt, va_list args)
 
         if (qualifier == 'L')
         {
-            num = va_arg(args, unsigned long long);
+            if (flags & SIGN)
+            {
+                num = (unsigned long long)va_arg(args, long long);
+            }
+            else
+            {
+                num = va_arg(args, unsigned long long);
+            }
         }
         else if (qualifier == 'l')
         {

--- a/src/klibc/utest/TC_rt_sprintf.c
+++ b/src/klibc/utest/TC_rt_sprintf.c
@@ -897,10 +897,12 @@ SPRINTF_TEST_CASE(integer_types)
     SPRINTF_CHECK("2147483647",              buffer, "%li", 2147483647L);
 #ifdef RT_KLIBC_USING_VSNPRINTF_LONGLONG
     SPRINTF_CHECK("30",                      buffer, "%lli", 30LL);
-#ifdef RT_KLIBC_USING_VSNPRINTF_STANDARD
     SPRINTF_CHECK("-9223372036854775807",    buffer, "%lli", -9223372036854775807LL);
     SPRINTF_CHECK("9223372036854775807",     buffer, "%lli", 9223372036854775807LL);
-#endif /* RT_KLIBC_USING_VSNPRINTF_STANDARD */
+    SPRINTF_CHECK("-2147483648",             buffer, "%lld", (long long)(rt_int64_t)-2147483648LL);
+    SPRINTF_CHECK("4294967295",              buffer, "%lld", (long long)(rt_int64_t)RT_UINT32_MAX);
+    SPRINTF_CHECK("-9223372036854775808",    buffer, "%lld", (long long)(-9223372036854775807LL - 1LL));
+    SPRINTF_CHECK("9223372036854775807",     buffer, "%lld", 9223372036854775807LL);
 #endif /* RT_KLIBC_USING_VSNPRINTF_LONGLONG */
     SPRINTF_CHECK("100000",                  buffer, "%lu", 100000L);
     SPRINTF_CHECK("4294967295",              buffer, "%lu", 0xFFFFFFFFL);


### PR DESCRIPTION
## 拉取/合并请求描述（PR description）

[
#### 为什么提交这份PR (why to submit this PR)

修复 issue #11596：tiny 版本 `rt_vsnprintf` 在格式化 `%lld/%lli` 时，把 `ll` qualifier 与 `l` qualifier 合并到 `long` 路径处理，导致 long long 数值被错误截断或符号判断错误，例如 `INT64_MAX` 输出为 `-1`。

#### 你的解决方案是什么 (what is your solution)

在 `rt_vsnprintf_tiny.c` 中将 `L`（内部用于表示 `ll`）和 `l` 的有符号处理拆开：`ll` 按 `long long` 取参并按 64 位符号范围处理，`l` 继续保持 `long` 路径。同步补充 `rt_sprintf` long long 边界值回归用例，覆盖 `INT32_MIN`、`UINT32_MAX`、`INT64_MIN`、`INT64_MAX`。

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: bsp/qemu-vexpress-a9

- .config: CONFIG_RT_KLIBC_USING_VSNPRINTF_LONGLONG=y，未启用 CONFIG_RT_KLIBC_USING_VSNPRINTF_STANDARD，使用 tiny 版本验证

- action: 本地环境缺少可用交叉编译工具链，未触发 action；已执行 `git diff --check`

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I have considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有冗余代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I have commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用formatting等源码格式化工具确保格式符合RT-Thread代码规范 This PR complies with RT-Thread code specification
- [ ] 如果是新增BSP，已经添加ci检查到 ALL_BSP_COMPILE.json
