### PR TITLE
[bsp][mcxn947] fix dead console RX on LPUART

### DIFF
--- a/bsp/nxp/mcx/mcxn/Libraries/drivers/drv_uart.c
+++ b/bsp/nxp/mcx/mcxn/Libraries/drivers/drv_uart.c
@@ -160,7 +160,18 @@ static rt_err_t mcx_configure(struct rt_serial_device *serial, struct serial_con
     config.enableTx     = true;
     config.enableRx     = true;
 
-    LPUART_Init(uart->uart_base, &config, CLOCK_GetFreq(uart->clock_src));
+    /* LPUART_Init resets the peripheral, wiping any RX interrupt enable set
+     * by a prior RT_DEVICE_CTRL_SET_INT (upstream fix, PR #11186). Preserve
+     * and restore it, or console RX goes permanently dead. */
+    {
+        rt_uint32_t irq_regval = LPUART_GetEnabledInterrupts(uart->uart_base);
+        LPUART_Init(uart->uart_base, &config, CLOCK_GetFreq(uart->clock_src));
+        if (irq_regval & kLPUART_RxDataRegFullInterruptEnable)
+        {
+            LPUART_EnableInterrupts(uart->uart_base, kLPUART_RxDataRegFullInterruptEnable);
+            EnableIRQ(uart->irqn);
+        }
+    }
 
     return RT_EOK;
 }
@@ -247,6 +258,12 @@ static void uart_isr(struct rt_serial_device *serial)
 
     /* UART in mode Receiver -------------------------------------------------*/
     rt_hw_serial_isr(serial, RT_SERIAL_EVENT_RX_IND);
+
+    /* Clear error flags: an uncleared overrun (OR) inhibits all further
+     * reception on LPUART, permanently wedging RX. */
+    LPUART_ClearStatusFlags(uart->uart_base,
+                            kLPUART_RxOverrunFlag | kLPUART_FramingErrorFlag |
+                            kLPUART_NoiseErrorFlag | kLPUART_ParityErrorFlag);
 
     /* leave interrupt */
     rt_interrupt_leave();

--- a/bsp/nxp/mcx/mcxn/frdm-mcxn947/board/SConscript
+++ b/bsp/nxp/mcx/mcxn/frdm-mcxn947/board/SConscript
@@ -24,7 +24,7 @@ if GetDepend(['PKG_USING_CJSON']) and GetDepend(['PKG_USING_WEBCLIENT']):
 
 
 CPPPATH = [cwd, cwd + '/MCUX_Config/board']
-CPPDEFINES = ['DEBUG', 'CPU_MCXN947VDF_cm33_core0']
+CPPDEFINES = ['DEBUG', 'CPU_MCXN947VDF_cm33_core0', 'LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER=1']
 
 group = DefineGroup('Drivers', src, depend = [''], CPPPATH = CPPPATH, CPPDEFINES=CPPDEFINES)
 

--- a/bsp/nxp/mcx/mcxn/frdm-mcxn947/board/board.c
+++ b/bsp/nxp/mcx/mcxn/frdm-mcxn947/board/board.c
@@ -18,6 +18,7 @@
 #include "drv_uart.h"
 #include "fsl_port.h"
 #include "fsl_cache_lpcac.h"
+#include "fsl_lpflexcomm.h"
 
 /**
  * This is the timer interrupt service routine.
@@ -34,6 +35,47 @@ void SysTick_Handler(void)
     rt_interrupt_leave();
 }
 
+/* One-time LP_FLEXCOMM function selection (upstream PR #11186). With
+ * LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER=1 the fsl drivers no longer re-run
+ * LP_FLEXCOMM_Init on every configure (which reset the peripheral and
+ * killed console RX), so the mode must be selected once here. */
+static void rt_hw_flexcomm_mode_init(void)
+{
+    /* One entry per FLEXCOMM instance, covering every peripheral the
+     * drv_uart/drv_i2c/drv_spi drivers can enable on it. Instances that
+     * support several functions are mutually exclusive per Kconfig,
+     * except FC2 whose LPI2CAndLPUART mode serves both users at once
+     * (this board routes FC2 I2C on P0/P1 and UART on P2/P3). */
+#ifdef BSP_USING_I2C0
+    LP_FLEXCOMM_Init(0, LP_FLEXCOMM_PERIPH_LPI2C);
+#endif
+#if defined(BSP_USING_SPI1)
+    LP_FLEXCOMM_Init(1, LP_FLEXCOMM_PERIPH_LPSPI);
+#elif defined(BSP_USING_I2C1)
+    LP_FLEXCOMM_Init(1, LP_FLEXCOMM_PERIPH_LPI2C);
+#endif
+#if defined(BSP_USING_UART2) || defined(BSP_USING_I2C2)
+    LP_FLEXCOMM_Init(2, LP_FLEXCOMM_PERIPH_LPI2CAndLPUART);
+#endif
+#ifdef BSP_USING_SPI3
+    LP_FLEXCOMM_Init(3, LP_FLEXCOMM_PERIPH_LPSPI);
+#endif
+#ifdef BSP_USING_UART4
+    LP_FLEXCOMM_Init(4, LP_FLEXCOMM_PERIPH_LPUART);
+#endif
+#ifdef BSP_USING_UART5
+    LP_FLEXCOMM_Init(5, LP_FLEXCOMM_PERIPH_LPUART);
+#endif
+#if defined(BSP_USING_UART6)
+    LP_FLEXCOMM_Init(6, LP_FLEXCOMM_PERIPH_LPUART);
+#elif defined(BSP_USING_SPI6)
+    LP_FLEXCOMM_Init(6, LP_FLEXCOMM_PERIPH_LPSPI);
+#endif
+#ifdef BSP_USING_SPI7
+    LP_FLEXCOMM_Init(7, LP_FLEXCOMM_PERIPH_LPSPI);
+#endif
+}
+
 /**
  * This function will initial board.
  */
@@ -41,6 +83,7 @@ void rt_hw_board_init()
 {
     /* Hardware Initialization */
     BOARD_InitBootPins();
+    rt_hw_flexcomm_mode_init();
     L1CACHE_EnableCodeCache();
 
     CLOCK_EnableClock(kCLOCK_Freqme);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

On current master the `frdm-mcxn947` BSP console **cannot receive any input**: the board boots to `msh >` but never reacts to a keystroke, and the boot banner is intermittently corrupted. This regressed the BSP into an unusable state for interactive use since #11186 (which fixed exactly this) was reverted by #11191.

Root cause, confirmed on hardware with GDB against stock master:

- `LPUART_Init()` re-runs `LP_FLEXCOMM_Init()` on **every** serial configure, which resets the FlexComm block. The reset wipes `CTRL.RIE` that `RT_DEVICE_CTRL_SET_INT` had armed when the console/finsh device was opened, so the RX interrupt is never active (NVIC pending never fires; a hardware breakpoint on `uart_isr` is never hit). Mid-stream re-initialisation is also what garbles the boot output.
- Additionally, `uart_isr()` never clears LPUART error flags. On LPUART an uncleared overrun (`STAT.OR`) **inhibits all further reception**, so even a transient overrun permanently wedges RX.

#### 你的解决方案是什么 (what is your solution)

Three coordinated changes (one commit):

1. `bsp/nxp/mcx/mcxn/frdm-mcxn947/board/SConscript`: define `LPFLEXCOMM_INIT_NOT_USED_IN_DRIVER=1` so the fsl drivers stop re-initialising the FlexComm on every configure.
2. `bsp/nxp/mcx/mcxn/frdm-mcxn947/board/board.c`: select each FlexComm function **once** in `rt_hw_flexcomm_mode_init()`, called from `rt_hw_board_init()` (required consequence of 1).
3. `bsp/nxp/mcx/mcxn/Libraries/drivers/drv_uart.c`: preserve/restore the RX-interrupt enable across `LPUART_Init()` (re-introduces the `drv_uart.c` fix from #11186), and clear `OR/FE/NF/PF` status flags in `uart_isr()` so an overrun can no longer lock up reception.

Compared with #11186 alone, this PR pairs the interrupt restore with the one-time FlexComm mode selection, which removes the underlying repeated-reset behaviour instead of only compensating for it. Happy to adjust if the maintainers know the concrete regression that motivated the revert in #11191 — we could not find a stated technical reason, and we are available for follow-up testing on real hardware.

Verified on a physical FRDM-MCXN947 (MCU-Link CMSIS-DAP, `/dev/ttyACM0` @ 115200, ARM GCC 13.2.1, scons):

- before: banner corrupted, `msh` never echoes a byte; GDB shows RX IRQ never armed and `uart_isr` breakpoint never hit;
- after: clean boot banner, fully interactive `msh` (`version`, `ps`, `list device` all clean), no corruption.

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: bsp/nxp/mcx/mcxn/frdm-mcxn947

- .config: default BSP configuration (`BSP_USING_UART4` console on LP_FLEXCOMM4 / MCU-Link VCOM); no config changes are required to reproduce or verify.

- action: https://github.com/ajsb85/rt-thread/actions (fork `manual_dist.yml` run for `nxp/mcx/mcxn/frdm-mcxn947` will be linked in a comment as soon as fork Actions finish; the branch builds clean locally with scons + ARM GCC 13.2.1)

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
