### PR TITLE
MCX/A366 CANFD BSP driver support

### DIFF
--- a/bsp/nxp/mcx/mcxa/Libraries/drivers/drv_can.c
+++ b/bsp/nxp/mcx/mcxa/Libraries/drivers/drv_can.c
@@ -17,10 +17,10 @@
 #include "fsl_clock.h"
 #include "fsl_flexcan.h"
 
-#define TX_MB_IDX       (0)
-#define RX_MB_IDX       (1)
-#define RX_MB_COUNT     (1)
-#define CAN_TX_WAIT_MS   (2000U)
+#define TX_MB_IDX      (0)
+#define RX_MB_IDX      (1)
+#define RX_MB_COUNT    (1)
+#define CAN_TX_WAIT_MS (2000U)
 
 enum
 {
@@ -34,20 +34,20 @@ enum
 
 struct imxrt_can
 {
-    char                    *name;
-    CAN_Type                *base;
-    IRQn_Type               irqn;
-    uint32_t                instance;
-    clock_div_name_t        clock_div_name;
-    clock_attach_id_t       clock_attach_id;
-    flexcan_handle_t        handle;
-    struct rt_can_device    can_dev;
-    flexcan_frame_t         frame[RX_MB_COUNT];
+    char *name;
+    CAN_Type *base;
+    IRQn_Type irqn;
+    uint32_t instance;
+    clock_div_name_t clock_div_name;
+    clock_attach_id_t clock_attach_id;
+    flexcan_handle_t handle;
+    struct rt_can_device can_dev;
+    flexcan_frame_t frame[RX_MB_COUNT];
 #ifdef RT_CAN_USING_CANFD
-    flexcan_fd_frame_t      framefd[RX_MB_COUNT];
-    rt_bool_t               fd_enabled;
+    flexcan_fd_frame_t framefd[RX_MB_COUNT];
+    rt_bool_t fd_enabled;
 #endif
-    rt_uint32_t             filter_mask;
+    rt_uint32_t filter_mask;
 };
 
 static void _can_dump_err(struct imxrt_can *can, const char *stage)
@@ -129,18 +129,72 @@ static rt_uint8_t _can_dlc2len(rt_uint8_t dlc)
 
 static rt_uint8_t _can_len2dlc(rt_uint8_t len)
 {
-    static const rt_uint8_t table[] =
-    {
-        0, 1, 2, 3, 4, 5, 6, 7, 8,
-        9, 9, 9, 9,
-        10, 10, 10, 10,
-        11, 11, 11, 11,
-        12, 12, 12, 12,
-        13, 13, 13, 13, 13, 13, 13, 13,
-        14, 14, 14, 14, 14, 14, 14, 14,
-        14, 14, 14, 14, 14, 14, 14, 14,
-        15, 15, 15, 15, 15, 15, 15, 15,
-        15, 15, 15, 15, 15, 15, 15, 15,
+    static const rt_uint8_t table[] = {
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        9,
+        9,
+        9,
+        10,
+        10,
+        10,
+        10,
+        11,
+        11,
+        11,
+        11,
+        12,
+        12,
+        12,
+        12,
+        13,
+        13,
+        13,
+        13,
+        13,
+        13,
+        13,
+        13,
+        14,
+        14,
+        14,
+        14,
+        14,
+        14,
+        14,
+        14,
+        14,
+        14,
+        14,
+        14,
+        14,
+        14,
+        14,
+        14,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
     };
 
     if (len <= 64)
@@ -202,8 +256,7 @@ static void _can_parse_classic_frame(struct rt_can_msg *msg, const flexcan_frame
     msg->data[7] = frame->dataByte7;
 }
 
-struct imxrt_can flexcans[] =
-{
+struct imxrt_can flexcans[] = {
 #ifdef BSP_USING_CAN0
     {
         .name = "can0",
@@ -381,9 +434,9 @@ static void _can_start_rx(struct imxrt_can *can)
 static void _can_enable_controller_irq(struct imxrt_can *can)
 {
     FLEXCAN_EnableInterrupts(can->base, (uint32_t)kFLEXCAN_BusOffInterruptEnable |
-                                         (uint32_t)kFLEXCAN_ErrorInterruptEnable |
-                                         (uint32_t)kFLEXCAN_RxWarningInterruptEnable |
-                                         (uint32_t)kFLEXCAN_TxWarningInterruptEnable);
+                                            (uint32_t)kFLEXCAN_ErrorInterruptEnable |
+                                            (uint32_t)kFLEXCAN_RxWarningInterruptEnable |
+                                            (uint32_t)kFLEXCAN_TxWarningInterruptEnable);
     EnableIRQ(can->irqn);
 }
 
@@ -480,7 +533,7 @@ static rt_err_t _can_config(struct rt_can_device *can_dev, struct can_configure 
 #ifdef RT_CAN_USING_CANFD
         || (cfg->enable_canfd == 0)
 #endif
-       )
+    )
     {
         config.enableTransceiverDelayMeasure = false;
     }
@@ -496,12 +549,10 @@ static rt_err_t _can_config(struct rt_can_device *can_dev, struct can_configure 
 
     if (can->fd_enabled)
     {
-        bool brs_enable = _can_is_loopback(cfg) ? false :
-                          (cfg->baud_rate_fd > cfg->baud_rate);
+        bool brs_enable = _can_is_loopback(cfg) ? false : (cfg->baud_rate_fd > cfg->baud_rate);
         bool timing_ok;
 
-        config.bitRateFD = _can_is_loopback(cfg) ? config.baudRate :
-                           (cfg->baud_rate_fd ? cfg->baud_rate_fd : 2000000U);
+        config.bitRateFD = _can_is_loopback(cfg) ? config.baudRate : (cfg->baud_rate_fd ? cfg->baud_rate_fd : 2000000U);
 
         timing_ok = FLEXCAN_FDCalculateImprovedTimingValues(can->base, config.baudRate,
                                                             config.bitRateFD, clk_freq, &timing_config);
@@ -986,12 +1037,11 @@ static rt_ssize_t _can_sendmsg_nonblocking(struct rt_can_device *can_dev, const 
     return (ret == kStatus_Success) ? RT_EOK : -RT_ERROR;
 }
 
-static struct rt_can_ops imxrt_can_ops =
-{
-    .configure    = _can_config,
-    .control      = _can_control,
-    .sendmsg      = _can_sendmsg,
-    .recvmsg      = _can_recvmsg,
+static struct rt_can_ops imxrt_can_ops = {
+    .configure = _can_config,
+    .control = _can_control,
+    .sendmsg = _can_sendmsg,
+    .recvmsg = _can_recvmsg,
     .sendmsg_nonblocking = _can_sendmsg_nonblocking
 };
 

--- a/bsp/nxp/mcx/mcxa/Libraries/drivers/drv_can.c
+++ b/bsp/nxp/mcx/mcxa/Libraries/drivers/drv_can.c
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2025-12-23     CYFS         the first version.
+ * 2026-07-05     WANGYU       add CAN-FD and loopback support.
  */
 
 #include <rtdevice.h>
@@ -13,12 +14,13 @@
 #ifdef RT_USING_CAN
 
 #include "fsl_common.h"
+#include "fsl_clock.h"
 #include "fsl_flexcan.h"
 
-#define TX_MB_IDX       (6)
+#define TX_MB_IDX       (0)
+#define RX_MB_IDX       (1)
 #define RX_MB_COUNT     (1)
-static flexcan_frame_t frame[RX_MB_COUNT];    /* one frame buffer per RX MB */
-static rt_uint32_t filter_mask = 0;
+#define CAN_TX_WAIT_MS   (2000U)
 
 enum
 {
@@ -40,7 +42,165 @@ struct imxrt_can
     clock_attach_id_t       clock_attach_id;
     flexcan_handle_t        handle;
     struct rt_can_device    can_dev;
+    flexcan_frame_t         frame[RX_MB_COUNT];
+#ifdef RT_CAN_USING_CANFD
+    flexcan_fd_frame_t      framefd[RX_MB_COUNT];
+    rt_bool_t               fd_enabled;
+#endif
+    rt_uint32_t             filter_mask;
 };
+
+static void _can_dump_err(struct imxrt_can *can, const char *stage)
+{
+    uint32_t esr1 = can->base->ESR1;
+    uint32_t fltconf = (esr1 & CAN_ESR1_FLTCONF_MASK) >> CAN_ESR1_FLTCONF_SHIFT;
+    const char *flt = "active";
+
+    if (fltconf == 1U)
+    {
+        flt = "passive";
+    }
+    else if (fltconf >= 2U)
+    {
+        flt = "busoff";
+    }
+
+    rt_kprintf("%s: %s, MCR=0x%08x ESR1=0x%08x IFLAG1=0x%08x flt=%s",
+               can->name, stage, can->base->MCR, esr1, can->base->IFLAG1, flt);
+    if (0U != (esr1 & CAN_ESR1_ACKERR_MASK))
+    {
+        rt_kprintf(" ACKERR");
+    }
+    if (0U != (esr1 & CAN_ESR1_BIT1ERR_MASK))
+    {
+        rt_kprintf(" BIT1ERR");
+    }
+    if (0U != (esr1 & CAN_ESR1_BIT0ERR_MASK))
+    {
+        rt_kprintf(" BIT0ERR");
+    }
+    rt_kprintf("\n");
+}
+
+static void _can_recover_bus(struct imxrt_can *can)
+{
+    CAN_Type *base = can->base;
+    uint32_t fltconf = (base->ESR1 & CAN_ESR1_FLTCONF_MASK) >> CAN_ESR1_FLTCONF_SHIFT;
+
+    if (fltconf < 2U)
+    {
+        return;
+    }
+
+    (void)FLEXCAN_EnterFreezeMode(base);
+    base->MCR &= ~CAN_MCR_HALT_MASK;
+    (void)FLEXCAN_ExitFreezeMode(base);
+    FLEXCAN_ClearStatusFlags(base, (uint32_t)kFLEXCAN_BusOffIntFlag);
+}
+
+static void _can_setup_loopback_mb(struct imxrt_can *can)
+{
+    flexcan_rx_mb_config_t mb_config;
+
+    mb_config.format = kFLEXCAN_FrameFormatStandard;
+    mb_config.type = kFLEXCAN_FrameTypeData;
+    mb_config.id = FLEXCAN_ID_STD(0);
+
+    FLEXCAN_SetRxMbGlobalMask(can->base, 0U);
+    FLEXCAN_SetRxIndividualMask(can->base, RX_MB_IDX, 0U);
+
+#ifdef RT_CAN_USING_CANFD
+    if (can->fd_enabled)
+    {
+        FLEXCAN_SetFDRxMbConfig(can->base, RX_MB_IDX, &mb_config, true);
+    }
+    else
+#endif
+    {
+        FLEXCAN_SetRxMbConfig(can->base, RX_MB_IDX, &mb_config, true);
+    }
+}
+
+#ifdef RT_CAN_USING_CANFD
+static rt_uint8_t _can_dlc2len(rt_uint8_t dlc)
+{
+    return (rt_uint8_t)DLC_LENGTH_DECODE(dlc);
+}
+
+static rt_uint8_t _can_len2dlc(rt_uint8_t len)
+{
+    static const rt_uint8_t table[] =
+    {
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+        9, 9, 9, 9,
+        10, 10, 10, 10,
+        11, 11, 11, 11,
+        12, 12, 12, 12,
+        13, 13, 13, 13, 13, 13, 13, 13,
+        14, 14, 14, 14, 14, 14, 14, 14,
+        14, 14, 14, 14, 14, 14, 14, 14,
+        15, 15, 15, 15, 15, 15, 15, 15,
+        15, 15, 15, 15, 15, 15, 15, 15,
+    };
+
+    if (len <= 64)
+    {
+        return table[len];
+    }
+
+    return 15;
+}
+#endif
+
+static void _can_fill_classic_frame(flexcan_frame_t *frame, const struct rt_can_msg *msg)
+{
+    if (RT_CAN_STDID == msg->ide)
+    {
+        frame->id = FLEXCAN_ID_STD(msg->id);
+        frame->format = kFLEXCAN_FrameFormatStandard;
+    }
+    else
+    {
+        frame->id = FLEXCAN_ID_EXT(msg->id);
+        frame->format = kFLEXCAN_FrameFormatExtend;
+    }
+
+    frame->type = (RT_CAN_DTR == msg->rtr) ? kFLEXCAN_FrameTypeData : kFLEXCAN_FrameTypeRemote;
+    frame->length = msg->len;
+    frame->dataByte0 = msg->data[0];
+    frame->dataByte1 = msg->data[1];
+    frame->dataByte2 = msg->data[2];
+    frame->dataByte3 = msg->data[3];
+    frame->dataByte4 = msg->data[4];
+    frame->dataByte5 = msg->data[5];
+    frame->dataByte6 = msg->data[6];
+    frame->dataByte7 = msg->data[7];
+}
+
+static void _can_parse_classic_frame(struct rt_can_msg *msg, const flexcan_frame_t *frame)
+{
+    if (frame->format == kFLEXCAN_FrameFormatStandard)
+    {
+        msg->ide = RT_CAN_STDID;
+        msg->id = frame->id >> CAN_ID_STD_SHIFT;
+    }
+    else
+    {
+        msg->ide = RT_CAN_EXTID;
+        msg->id = frame->id >> CAN_ID_EXT_SHIFT;
+    }
+
+    msg->rtr = (frame->type == kFLEXCAN_FrameTypeData) ? RT_CAN_DTR : RT_CAN_RTR;
+    msg->len = frame->length;
+    msg->data[0] = frame->dataByte0;
+    msg->data[1] = frame->dataByte1;
+    msg->data[2] = frame->dataByte2;
+    msg->data[3] = frame->dataByte3;
+    msg->data[4] = frame->dataByte4;
+    msg->data[5] = frame->dataByte5;
+    msg->data[6] = frame->dataByte6;
+    msg->data[7] = frame->dataByte7;
+}
 
 struct imxrt_can flexcans[] =
 {
@@ -66,91 +226,322 @@ struct imxrt_can flexcans[] =
 #endif
 };
 
+static rt_bool_t _can_is_loopback(const struct can_configure *cfg)
+{
+    return (cfg->mode == RT_CAN_MODE_LOOPBACK) ||
+           (cfg->mode == RT_CAN_MODE_LOOPBACKANLISTEN);
+}
+
+static void _can_abort_rx(struct imxrt_can *can)
+{
+#ifdef RT_CAN_USING_CANFD
+    if (can->fd_enabled)
+    {
+        FLEXCAN_TransferFDAbortReceive(can->base, &can->handle, RX_MB_IDX);
+    }
+    else
+#endif
+    {
+        FLEXCAN_TransferAbortReceive(can->base, &can->handle, RX_MB_IDX);
+    }
+}
+
+static void _can_enable_periph_clock(struct imxrt_can *can)
+{
+    clock_ip_name_t can_clocks[] = FLEXCAN_CLOCKS;
+
+    CLOCK_EnableClock(can_clocks[can->instance]);
+    CLOCK_SetClockDiv(can->clock_div_name, 2u);
+    CLOCK_AttachClk(can->clock_attach_id);
+}
+
+static void _can_safe_deinit(struct imxrt_can *can)
+{
+    CAN_Type *base = can->base;
+
+    _can_enable_periph_clock(can);
+
+    /* FLEXCAN_Reset() inside FLEXCAN_Deinit() requires MDIS cleared. */
+    if (0U != (base->MCR & CAN_MCR_MDIS_MASK))
+    {
+        (void)FLEXCAN_Enable(base, true);
+    }
+
+    FLEXCAN_Deinit(base);
+}
+
+static status_t _can_wait_mb_tx_done(struct imxrt_can *can, uint8_t mb_idx)
+{
+    CAN_Type *base = can->base;
+    rt_tick_t start = rt_tick_get();
+    rt_tick_t timeout = rt_tick_from_millisecond(CAN_TX_WAIT_MS);
+
+    while (0U == FLEXCAN_GetMbStatusFlags(base, (uint64_t)1U << mb_idx))
+    {
+        if ((rt_tick_get() - start) >= timeout)
+        {
+            _can_dump_err(can, "tx timeout");
+            return kStatus_Timeout;
+        }
+        rt_thread_mdelay(1);
+    }
+
+    FLEXCAN_ClearMbStatusFlags(base, (uint64_t)1U << mb_idx);
+    return kStatus_Success;
+}
+
+static status_t _can_wait_mb_rx_done(CAN_Type *base, uint8_t mb_idx)
+{
+    rt_tick_t start = rt_tick_get();
+    rt_tick_t timeout = rt_tick_from_millisecond(CAN_TX_WAIT_MS);
+
+    while (0U == FLEXCAN_GetMbStatusFlags(base, (uint64_t)1U << mb_idx))
+    {
+        if ((rt_tick_get() - start) >= timeout)
+        {
+            return kStatus_Timeout;
+        }
+        rt_thread_mdelay(1);
+    }
+
+    FLEXCAN_ClearMbStatusFlags(base, (uint64_t)1U << mb_idx);
+    return kStatus_Success;
+}
+
+static void _can_loopback_post_rx(struct imxrt_can *can)
+{
+    rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_RX_IND | RX_MB_IDX << 8);
+}
+
+static void _can_setup_mode(flexcan_config_t *config, const struct can_configure *cfg)
+{
+    switch (cfg->mode)
+    {
+    case RT_CAN_MODE_NORMAL:
+        break;
+    case RT_CAN_MODE_LISTEN:
+        config->enableListenOnlyMode = true;
+        break;
+    case RT_CAN_MODE_LOOPBACK:
+        config->enableLoopBack = true;
+        config->disableSelfReception = false;
+        config->enableIndividMask = false;
+        break;
+    case RT_CAN_MODE_LOOPBACKANLISTEN:
+        config->enableLoopBack = true;
+        config->enableListenOnlyMode = true;
+        config->disableSelfReception = false;
+        config->enableIndividMask = false;
+        break;
+    default:
+        break;
+    }
+}
+
+static void _can_start_rx(struct imxrt_can *can)
+{
+    flexcan_rx_mb_config_t mbConfig;
+    flexcan_mb_transfer_t rxXfer;
+    rt_uint8_t i, mailbox;
+
+    mbConfig.format = kFLEXCAN_FrameFormatStandard;
+    mbConfig.type = kFLEXCAN_FrameTypeData;
+    mbConfig.id = FLEXCAN_ID_STD(0);
+
+    FLEXCAN_SetRxMbGlobalMask(can->base, 0U);
+
+    for (i = 0; i < RX_MB_COUNT; i++)
+    {
+        mailbox = RX_MB_IDX + i;
+        FLEXCAN_SetRxIndividualMask(can->base, mailbox, 0U);
+
+#ifdef RT_CAN_USING_CANFD
+        if (can->fd_enabled)
+        {
+            FLEXCAN_SetFDRxMbConfig(can->base, mailbox, &mbConfig, true);
+            rxXfer.framefd = &can->framefd[i];
+            rxXfer.frame = RT_NULL;
+            rxXfer.mbIdx = mailbox;
+            FLEXCAN_TransferFDReceiveNonBlocking(can->base, &can->handle, &rxXfer);
+        }
+        else
+#endif
+        {
+            FLEXCAN_SetRxMbConfig(can->base, mailbox, &mbConfig, true);
+            rxXfer.frame = &can->frame[i];
+#ifdef RT_CAN_USING_CANFD
+            rxXfer.framefd = RT_NULL;
+#endif
+            rxXfer.mbIdx = mailbox;
+            FLEXCAN_TransferReceiveNonBlocking(can->base, &can->handle, &rxXfer);
+        }
+    }
+}
+
+static void _can_enable_controller_irq(struct imxrt_can *can)
+{
+    FLEXCAN_EnableInterrupts(can->base, (uint32_t)kFLEXCAN_BusOffInterruptEnable |
+                                         (uint32_t)kFLEXCAN_ErrorInterruptEnable |
+                                         (uint32_t)kFLEXCAN_RxWarningInterruptEnable |
+                                         (uint32_t)kFLEXCAN_TxWarningInterruptEnable);
+    EnableIRQ(can->irqn);
+}
+
+#ifdef BSP_USING_CAN0
+void CAN0_IRQHandler(void)
+{
+    rt_interrupt_enter();
+    FLEXCAN_TransferHandleIRQ(CAN0, &flexcans[CAN0_INDEX].handle);
+    rt_interrupt_leave();
+}
+#endif
+
+#ifdef BSP_USING_CAN1
+void CAN1_IRQHandler(void)
+{
+    rt_interrupt_enter();
+    FLEXCAN_TransferHandleIRQ(CAN1, &flexcans[CAN1_INDEX].handle);
+    rt_interrupt_leave();
+}
+#endif
+
 static void flexcan_callback(CAN_Type *base, flexcan_handle_t *handle, status_t status, uint64_t result, void *userData)
 {
     struct imxrt_can *can;
     flexcan_mb_transfer_t rxXfer;
+    rt_uint8_t mb_idx;
 
     can = (struct imxrt_can *)userData;
 
     switch (status)
     {
-        case kStatus_FLEXCAN_RxIdle:
-            rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_RX_IND | result << 8);
-            rxXfer.frame = &frame[result - 1];
-            rxXfer.mbIdx = result;
-            FLEXCAN_TransferReceiveNonBlocking(can->base, &can->handle, &rxXfer);
-            break;
+    case kStatus_FLEXCAN_RxIdle:
+        mb_idx = (rt_uint8_t)result;
+        rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_RX_IND | mb_idx << 8);
 
-        case kStatus_FLEXCAN_TxIdle:
-            rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_TX_DONE | result << 8);
-            break;
-        default:
-            break;
+#ifdef RT_CAN_USING_CANFD
+        if (can->fd_enabled)
+        {
+            rxXfer.framefd = &can->framefd[mb_idx - RX_MB_IDX];
+            rxXfer.frame = RT_NULL;
+            rxXfer.mbIdx = mb_idx;
+            FLEXCAN_TransferFDReceiveNonBlocking(can->base, &can->handle, &rxXfer);
+        }
+        else
+#endif
+        {
+            rxXfer.frame = &can->frame[mb_idx - RX_MB_IDX];
+#ifdef RT_CAN_USING_CANFD
+            rxXfer.framefd = RT_NULL;
+#endif
+            rxXfer.mbIdx = mb_idx;
+            FLEXCAN_TransferReceiveNonBlocking(can->base, &can->handle, &rxXfer);
+        }
+        break;
+
+    case kStatus_FLEXCAN_TxIdle:
+        rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_TX_DONE | result << 8);
+        break;
+    default:
+        break;
     }
 }
 
 static rt_err_t _can_config(struct rt_can_device *can_dev, struct can_configure *cfg)
 {
-    struct imxrt_can *can =  (struct imxrt_can *)can_dev->parent.user_data;
+    struct imxrt_can *can = (struct imxrt_can *)can_dev->parent.user_data;
     flexcan_config_t config;
-    rt_uint32_t res = RT_EOK;
-    flexcan_rx_mb_config_t mbConfig;
-    flexcan_mb_transfer_t rxXfer;
-    rt_uint8_t i, mailbox;
+    flexcan_timing_config_t timing_config;
+    rt_uint32_t clk_freq;
+    rt_err_t res = RT_EOK;
+
+    can_dev->config = *cfg;
+    _can_enable_periph_clock(can);
+    clk_freq = CLOCK_GetFlexcanClkFreq(can->instance);
+    if (clk_freq == 0U)
+    {
+        rt_kprintf("%s: flexcan clock is 0\n", can->name);
+        return -RT_ERROR;
+    }
+
+    rt_kprintf("%s: flexcan clk=%u Hz, baud=%u\n", can->name, clk_freq, cfg->baud_rate);
+
+    _can_safe_deinit(can);
 
     FLEXCAN_GetDefaultConfig(&config);
     config.baudRate = cfg->baud_rate;
-    config.enableIndividMask = true;    /* one filter per MB */
-    config.disableSelfReception = true;
+    config.maxMbNum = 8;
+    config.enableIndividMask = false;
+    config.enableSupervisorMode = false;
+    config.disableSelfReception = !_can_is_loopback(cfg);
+    _can_setup_mode(&config, cfg);
 
-    switch (cfg->mode)
+    if (_can_is_loopback(cfg)
+#ifdef RT_CAN_USING_CANFD
+        || (cfg->enable_canfd == 0)
+#endif
+       )
     {
-    case RT_CAN_MODE_NORMAL:
-        /* default mode */
-        break;
-    case RT_CAN_MODE_LISTEN:
-        break;
-    case RT_CAN_MODE_LOOPBACK:
-        config.enableLoopBack = true;
-        break;
-    case RT_CAN_MODE_LOOPBACKANLISTEN:
-        break;
-    }
-
-    flexcan_timing_config_t timing_config;
-    rt_memset(&timing_config, 0, sizeof(flexcan_timing_config_t));
-
-    if(FLEXCAN_CalculateImprovedTimingValues(can->base, config.baudRate, CLOCK_GetFlexcanClkFreq(can->instance), &timing_config))
-    {
-        /* Update the improved timing configuration*/
-        rt_memcpy(&(config.timingConfig), &timing_config, sizeof(flexcan_timing_config_t));
+        config.enableTransceiverDelayMeasure = false;
     }
     else
     {
-        //rt_kprintf("No found Improved Timing Configuration. Just used default configuration\n");
+        config.enableTransceiverDelayMeasure = true;
     }
 
-    FLEXCAN_Init(can->base, &config, CLOCK_GetFlexcanClkFreq(can->instance));
-    FLEXCAN_TransferCreateHandle(can->base, &can->handle, flexcan_callback, can);
+    rt_memset(&timing_config, 0, sizeof(flexcan_timing_config_t));
 
-    /* init RX_MB_COUNT RX MB to default status */
-    mbConfig.format = kFLEXCAN_FrameFormatStandard;  /* standard ID */
-    mbConfig.type = kFLEXCAN_FrameTypeData;          /* data frame */
-    mbConfig.id = FLEXCAN_ID_STD(0);                 /* default ID is 0 */
-    for (i = 0; i < RX_MB_COUNT; i++)
+#ifdef RT_CAN_USING_CANFD
+    can->fd_enabled = (cfg->enable_canfd != 0) ? RT_TRUE : RT_FALSE;
+
+    if (can->fd_enabled)
     {
-        /* the used MB index from 1 to RX_MB_COUNT */
-        mailbox = i + 1;
+        bool brs_enable = _can_is_loopback(cfg) ? false :
+                          (cfg->baud_rate_fd > cfg->baud_rate);
+        bool timing_ok;
 
-        /* all ID bit in the filter is "don't care" */
-        FLEXCAN_SetRxIndividualMask(can->base, mailbox, FLEXCAN_RX_MB_STD_MASK(0, 0, 0));
-        FLEXCAN_SetRxMbConfig(can->base, mailbox, &mbConfig, true);
-        /* one frame buffer per MB */
-        rxXfer.frame = &frame[i];
-        rxXfer.mbIdx = mailbox;
-        FLEXCAN_TransferReceiveNonBlocking(can->base, &can->handle, &rxXfer);
+        config.bitRateFD = _can_is_loopback(cfg) ? config.baudRate :
+                           (cfg->baud_rate_fd ? cfg->baud_rate_fd : 2000000U);
+
+        timing_ok = FLEXCAN_FDCalculateImprovedTimingValues(can->base, config.baudRate,
+                                                            config.bitRateFD, clk_freq, &timing_config);
+        if (timing_ok)
+        {
+            rt_memcpy(&(config.timingConfig), &timing_config, sizeof(flexcan_timing_config_t));
+        }
+
+        FLEXCAN_FDInit(can->base, &config, clk_freq, kFLEXCAN_16BperMB, brs_enable);
+        if (!timing_ok)
+        {
+            if (FLEXCAN_SetFDBitRate(can->base, clk_freq, config.baudRate, config.bitRateFD) != kStatus_Success)
+            {
+                rt_kprintf("%s: CAN FD timing setup failed, clk=%u\n", can->name, clk_freq);
+                return -RT_ERROR;
+            }
+        }
     }
+    else
+#endif
+    {
+        if (FLEXCAN_CalculateImprovedTimingValues(can->base, config.baudRate, clk_freq, &timing_config))
+        {
+            rt_memcpy(&(config.timingConfig), &timing_config, sizeof(flexcan_timing_config_t));
+        }
+
+        FLEXCAN_Init(can->base, &config, clk_freq);
+    }
+
+    can->filter_mask = 0;
+    FLEXCAN_TransferCreateHandle(can->base, &can->handle, flexcan_callback, can);
+    if (_can_is_loopback(cfg))
+    {
+        _can_setup_loopback_mb(can);
+    }
+    else
+    {
+        _can_start_rx(can);
+    }
+    _can_enable_controller_irq(can);
 
     return res;
 }
@@ -159,9 +550,9 @@ static rt_err_t _can_control(struct rt_can_device *can_dev, int cmd, void *arg)
 {
     struct imxrt_can *can;
     rt_uint32_t argval, mask;
-    rt_uint32_t res = RT_EOK;
+    rt_err_t res = RT_EOK;
     flexcan_rx_mb_config_t mbConfig;
-    struct rt_can_filter_config  *cfg;
+    struct rt_can_filter_config *cfg;
     struct rt_can_filter_item *item;
     rt_uint8_t i, count, index;
 
@@ -173,24 +564,18 @@ static rt_err_t _can_control(struct rt_can_device *can_dev, int cmd, void *arg)
     switch (cmd)
     {
     case RT_DEVICE_CTRL_SET_INT:
-        argval = (rt_uint32_t) arg;
-        if (argval == RT_DEVICE_FLAG_INT_RX)
+        argval = (rt_uint32_t)arg;
+        if (argval == RT_DEVICE_FLAG_INT_RX || argval == RT_DEVICE_FLAG_INT_TX ||
+            argval == RT_DEVICE_CAN_INT_ERR)
         {
-            mask = kFLEXCAN_RxWarningInterruptEnable;
+            _can_enable_controller_irq(can);
         }
-        else if (argval == RT_DEVICE_FLAG_INT_TX)
+        else
         {
-            mask = kFLEXCAN_TxWarningInterruptEnable;
+            res = -RT_ERROR;
         }
-        else if (argval == RT_DEVICE_CAN_INT_ERR)
-        {
-            mask = kFLEXCAN_ErrorInterruptEnable;
-        }
-        FLEXCAN_EnableInterrupts(can->base, mask);
-        EnableIRQ(can->irqn);
         break;
     case RT_DEVICE_CTRL_CLR_INT:
-        /* each CAN device have one IRQ number. */
         DisableIRQ(can->irqn);
         break;
     case RT_CAN_CMD_SET_FILTER:
@@ -198,18 +583,26 @@ static rt_err_t _can_control(struct rt_can_device *can_dev, int cmd, void *arg)
         item = cfg->items;
         count = cfg->count;
 
-        if (filter_mask == 0xffffffff)
+        if (can->filter_mask == 0xffffffff)
         {
             rt_kprintf("%s filter is full!\n", can->name);
             res = -RT_ERROR;
             break;
         }
-        else if (filter_mask == 0)
+        else if (can->filter_mask == 0)
         {
-            /* deinit all init RX MB */
             for (i = 0; i < RX_MB_COUNT; i++)
             {
-                FLEXCAN_SetRxMbConfig(can->base, i + 1, RT_NULL, false);
+#ifdef RT_CAN_USING_CANFD
+                if (can->fd_enabled)
+                {
+                    FLEXCAN_SetFDRxMbConfig(can->base, i + 1, RT_NULL, false);
+                }
+                else
+#endif
+                {
+                    FLEXCAN_SetRxMbConfig(can->base, i + 1, RT_NULL, false);
+                }
             }
         }
 
@@ -228,81 +621,98 @@ static rt_err_t _can_control(struct rt_can_device *can_dev, int cmd, void *arg)
                 mask = FLEXCAN_RX_MB_STD_MASK(item->mask, 0, 0);
             }
 
-            if (item->rtr)
-            {
-                mbConfig.type = kFLEXCAN_FrameTypeRemote;
-            }
-            else
-            {
-                mbConfig.type = kFLEXCAN_FrameTypeData;
-            }
+            mbConfig.type = item->rtr ? kFLEXCAN_FrameTypeRemote : kFLEXCAN_FrameTypeData;
 
-            /* user does not specify hdr index,set hdr_bank from RX MB 1 */
             if (item->hdr_bank == -1)
             {
-
                 for (i = 0; i < 32; i++)
                 {
-                    if (!(filter_mask & (1 << i)))
+                    if (!(can->filter_mask & (1 << i)))
                     {
                         index = i;
                         break;
                     }
                 }
             }
-            else    /* use user specified hdr_bank */
+            else
             {
-                if (filter_mask & (1 << item->hdr_bank))
+                if (can->filter_mask & (1 << item->hdr_bank))
                 {
                     res = -RT_ERROR;
                     rt_kprintf("%s hdr%d filter already set!\n", can->name, item->hdr_bank);
                     break;
                 }
-                else
-                {
-                    index = item->hdr_bank;
-                }
+                index = item->hdr_bank;
             }
 
-            /* RX MB index from 1 to 32,hdr index 0~31 map RX MB index 1~32. */
             FLEXCAN_SetRxIndividualMask(can->base, index + 1, mask);
-            FLEXCAN_SetRxMbConfig(can->base, index + 1, &mbConfig, true);
-            filter_mask |= 1 << index;
+#ifdef RT_CAN_USING_CANFD
+            if (can->fd_enabled)
+            {
+                FLEXCAN_SetFDRxMbConfig(can->base, index + 1, &mbConfig, true);
+            }
+            else
+#endif
+            {
+                FLEXCAN_SetRxMbConfig(can->base, index + 1, &mbConfig, true);
+            }
+            can->filter_mask |= 1 << index;
 
             item++;
             count--;
         }
-
         break;
 
     case RT_CAN_CMD_SET_BAUD:
+        argval = (rt_uint32_t)arg;
+        if (argval != 0)
         {
-            struct can_configure *cfg = (struct can_configure *)arg;
-            if (cfg != RT_NULL)
-            {
-                can->can_dev.config = *cfg;
-                _can_config(can_dev, cfg);
-                res = RT_EOK;
-            }
-            else
-            {
-                res = -RT_ERROR;
-            }
+            can->can_dev.config.baud_rate = argval;
+            res = _can_config(can_dev, &can->can_dev.config);
+        }
+        else
+        {
+            res = -RT_ERROR;
+        }
+        break;
+    case RT_CAN_CMD_SET_MODE:
+        argval = (rt_uint32_t)arg;
+        if (argval > RT_CAN_MODE_LOOPBACKANLISTEN)
+        {
+            res = -RT_ERROR;
             break;
         }
-    case RT_CAN_CMD_SET_MODE:
-        res = -RT_ERROR;
+        can->can_dev.config.mode = argval;
+        res = _can_config(can_dev, &can->can_dev.config);
         break;
-
+#ifdef RT_CAN_USING_CANFD
+    case RT_CAN_CMD_SET_CANFD:
+        argval = (rt_uint32_t)arg;
+        can->can_dev.config.enable_canfd = argval ? 1 : 0;
+        res = _can_config(can_dev, &can->can_dev.config);
+        break;
+    case RT_CAN_CMD_SET_BAUD_FD:
+        argval = (rt_uint32_t)arg;
+        if (argval != 0)
+        {
+            can->can_dev.config.baud_rate_fd = argval;
+            res = _can_config(can_dev, &can->can_dev.config);
+        }
+        else
+        {
+            res = -RT_ERROR;
+        }
+        break;
+#endif
     case RT_CAN_CMD_SET_PRIV:
         res = -RT_ERROR;
         break;
     case RT_CAN_CMD_GET_STATUS:
-        FLEXCAN_GetBusErrCount(can->base, (rt_uint8_t *)(&can->can_dev.status.snderrcnt), (rt_uint8_t *)(&can->can_dev.status.rcverrcnt));
+        FLEXCAN_GetBusErrCount(can->base, (rt_uint8_t *)(&can->can_dev.status.snderrcnt),
+                               (rt_uint8_t *)(&can->can_dev.status.rcverrcnt));
         rt_memcpy(arg, &can->can_dev.status, sizeof(can->can_dev.status));
         break;
     case RT_CAN_CMD_START:
-        /* already started in can_cfg */
         break;
     default:
         res = -RT_ERROR;
@@ -312,70 +722,167 @@ static rt_err_t _can_control(struct rt_can_device *can_dev, int cmd, void *arg)
     return res;
 }
 
+#ifdef RT_CAN_USING_CANFD
+static void _can_fill_fd_frame(flexcan_fd_frame_t *frame, const struct rt_can_msg *msg)
+{
+    rt_uint8_t dlc;
+    rt_uint8_t data_len;
+
+    rt_memset(frame, 0, sizeof(*frame));
+
+    if (RT_CAN_STDID == msg->ide)
+    {
+        frame->id = FLEXCAN_ID_STD(msg->id);
+        frame->format = kFLEXCAN_FrameFormatStandard;
+    }
+    else
+    {
+        frame->id = FLEXCAN_ID_EXT(msg->id);
+        frame->format = kFLEXCAN_FrameFormatExtend;
+    }
+
+    frame->type = (RT_CAN_DTR == msg->rtr) ? kFLEXCAN_FrameTypeData : kFLEXCAN_FrameTypeRemote;
+    frame->edl = 1;
+    frame->brs = msg->brs ? 1 : 0;
+
+    dlc = (msg->len <= 15) ? msg->len : _can_len2dlc((rt_uint8_t)msg->len);
+    frame->length = dlc;
+    data_len = _can_dlc2len(dlc);
+    rt_memcpy(frame->dataWord, msg->data, data_len);
+}
+
+static void _can_parse_fd_frame(struct rt_can_msg *msg, const flexcan_fd_frame_t *frame)
+{
+    rt_uint8_t data_len;
+
+    if (frame->format == kFLEXCAN_FrameFormatStandard)
+    {
+        msg->ide = RT_CAN_STDID;
+        msg->id = frame->id >> CAN_ID_STD_SHIFT;
+    }
+    else
+    {
+        msg->ide = RT_CAN_EXTID;
+        msg->id = frame->id >> CAN_ID_EXT_SHIFT;
+    }
+
+    msg->rtr = (frame->type == kFLEXCAN_FrameTypeData) ? RT_CAN_DTR : RT_CAN_RTR;
+    msg->fd_frame = frame->edl ? 1 : 0;
+    msg->brs = frame->brs ? 1 : 0;
+    msg->len = frame->length;
+    data_len = _can_dlc2len(frame->length);
+    rt_memcpy(msg->data, frame->dataWord, data_len);
+}
+#endif
+
 static rt_ssize_t _can_sendmsg(struct rt_can_device *can_dev, const void *buf, rt_uint32_t boxno)
 {
     struct imxrt_can *can;
     struct rt_can_msg *msg;
-    status_t ret;
-    flexcan_frame_t frame;
-    flexcan_mb_transfer_t txXfer;
+    status_t ret = kStatus_Fail;
+    rt_uint8_t hw_mb = TX_MB_IDX;
 
     RT_ASSERT(can_dev != RT_NULL);
     RT_ASSERT(buf != RT_NULL);
 
     can = (struct imxrt_can *)can_dev->parent.user_data;
-    msg = (struct rt_can_msg *) buf;
+    msg = (struct rt_can_msg *)buf;
+    RT_UNUSED(boxno);
 
-    RT_ASSERT(can != RT_NULL);
-    RT_ASSERT(msg != RT_NULL);
-
-    FLEXCAN_SetTxMbConfig(can->base, boxno, true);
-
-    if (RT_CAN_STDID == msg->ide)
+    if (!_can_is_loopback(&can_dev->config))
     {
-        frame.id = FLEXCAN_ID_STD(msg->id);
-        frame.format = kFLEXCAN_FrameFormatStandard;
-    }
-    else if (RT_CAN_EXTID == msg->ide)
-    {
-        frame.id = FLEXCAN_ID_EXT(msg->id);
-        frame.format = kFLEXCAN_FrameFormatExtend;
+        _can_recover_bus(can);
     }
 
-    if (RT_CAN_DTR == msg->rtr)
+    if (!_can_is_loopback(&can_dev->config))
     {
-        frame.type = kFLEXCAN_FrameTypeData;
+        _can_abort_rx(can);
     }
-    else if (RT_CAN_RTR == msg->rtr)
+    else
     {
-        frame.type = kFLEXCAN_FrameTypeRemote;
+        _can_setup_loopback_mb(can);
     }
 
-    frame.length = msg->len;
-    frame.dataByte0 = msg->data[0];
-    frame.dataByte1 = msg->data[1];
-    frame.dataByte2 = msg->data[2];
-    frame.dataByte3 = msg->data[3];
-    frame.dataByte4 = msg->data[4];
-    frame.dataByte5 = msg->data[5];
-    frame.dataByte6 = msg->data[6];
-    frame.dataByte7 = msg->data[7];
-
-    txXfer.mbIdx = boxno;
-    txXfer.frame = &frame;
-    ret = FLEXCAN_TransferSendBlocking(can->base, boxno, txXfer.frame);
-    switch (ret)
+#ifdef RT_CAN_USING_CANFD
+    if (can->fd_enabled && msg->fd_frame)
     {
-    case kStatus_Success:
-        ret = RT_EOK;
+        flexcan_fd_frame_t tx_frame;
+
+        FLEXCAN_ClearMbStatusFlags(can->base, ((uint64_t)1U << hw_mb) | ((uint64_t)1U << RX_MB_IDX));
+        FLEXCAN_SetFDTxMbConfig(can->base, hw_mb, true);
+        _can_fill_fd_frame(&tx_frame, msg);
+
+        if (FLEXCAN_WriteFDTxMb(can->base, hw_mb, &tx_frame) != kStatus_Success)
+        {
+            ret = kStatus_Fail;
+        }
+        else
+        {
+            ret = _can_wait_mb_tx_done(can, hw_mb);
+        }
+
+        if (ret == kStatus_Success && _can_is_loopback(&can_dev->config))
+        {
+            ret = _can_wait_mb_rx_done(can->base, RX_MB_IDX);
+            if (ret == kStatus_Success)
+            {
+                ret = FLEXCAN_ReadFDRxMb(can->base, RX_MB_IDX, &can->framefd[0]);
+                if (ret == kStatus_Success)
+                {
+                    _can_loopback_post_rx(can);
+                }
+            }
+        }
+    }
+    else
+#endif
+    {
+        flexcan_frame_t tx_frame;
+
+        FLEXCAN_ClearMbStatusFlags(can->base, ((uint64_t)1U << hw_mb) | ((uint64_t)1U << RX_MB_IDX));
+        FLEXCAN_SetTxMbConfig(can->base, hw_mb, true);
+        _can_fill_classic_frame(&tx_frame, msg);
+
+        if (FLEXCAN_WriteTxMb(can->base, hw_mb, &tx_frame) != kStatus_Success)
+        {
+            ret = kStatus_Fail;
+        }
+        else
+        {
+            ret = _can_wait_mb_tx_done(can, hw_mb);
+        }
+
+        if (ret == kStatus_Success && _can_is_loopback(&can_dev->config))
+        {
+            ret = _can_wait_mb_rx_done(can->base, RX_MB_IDX);
+            if (ret == kStatus_Success)
+            {
+                ret = FLEXCAN_ReadRxMb(can->base, RX_MB_IDX, &can->frame[0]);
+                if (ret == kStatus_Success)
+                {
+                    _can_loopback_post_rx(can);
+                }
+            }
+        }
+    }
+
+    if (ret == kStatus_Success)
+    {
+        if (!_can_is_loopback(&can_dev->config))
+        {
+            _can_start_rx(can);
+        }
+
         rt_hw_can_isr(&can->can_dev, RT_CAN_EVENT_TX_DONE | boxno << 8);
-        break;
-    case kStatus_Fail:
-        ret = -RT_ERROR;
-        break;
+        return RT_EOK;
     }
 
-    return (rt_ssize_t)ret;
+    if (ret == kStatus_Timeout)
+    {
+        _can_dump_err(can, "tx fail");
+    }
+
+    return -RT_ERROR;
 }
 
 static rt_ssize_t _can_recvmsg(struct rt_can_device *can_dev, void *buf, rt_uint32_t boxno)
@@ -387,40 +894,27 @@ static rt_ssize_t _can_recvmsg(struct rt_can_device *can_dev, void *buf, rt_uint
     RT_ASSERT(can_dev != RT_NULL);
 
     can = (struct imxrt_can *)can_dev->parent.user_data;
-    pmsg = (struct rt_can_msg *) buf;
-    RT_ASSERT(can != RT_NULL);
+    pmsg = (struct rt_can_msg *)buf;
+    index = (boxno >= RX_MB_IDX) ? (boxno - RX_MB_IDX) : 0;
 
-    index = boxno - 1;
-
-    if (frame[index].format == kFLEXCAN_FrameFormatStandard)
+#ifdef RT_CAN_USING_CANFD
+    if (can->fd_enabled && can->framefd[index].edl)
     {
-        pmsg->ide = RT_CAN_STDID;
-        pmsg->id = frame[index].id >> CAN_ID_STD_SHIFT;
+        _can_parse_fd_frame(pmsg, &can->framefd[index]);
+    }
+    else if (can->fd_enabled)
+    {
+        _can_parse_classic_frame(pmsg, (const flexcan_frame_t *)&can->framefd[index]);
+        pmsg->fd_frame = 0;
+        pmsg->brs = 0;
     }
     else
+#endif
     {
-        pmsg->ide = RT_CAN_EXTID;
-        pmsg->id = frame[index].id >> CAN_ID_EXT_SHIFT;
+        _can_parse_classic_frame(pmsg, &can->frame[index]);
     }
 
-    if (frame[index].type == kFLEXCAN_FrameTypeData)
-    {
-        pmsg->rtr = RT_CAN_DTR;
-    }
-    else if (frame[index].type == kFLEXCAN_FrameTypeRemote)
-    {
-        pmsg->rtr = RT_CAN_RTR;
-    }
-    pmsg->hdr_index = index;      /* one hdr filter per MB */
-    pmsg->len = frame[index].length;
-    pmsg->data[0] = frame[index].dataByte0;
-    pmsg->data[1] = frame[index].dataByte1;
-    pmsg->data[2] = frame[index].dataByte2;
-    pmsg->data[3] = frame[index].dataByte3;
-    pmsg->data[4] = frame[index].dataByte4;
-    pmsg->data[5] = frame[index].dataByte5;
-    pmsg->data[6] = frame[index].dataByte6;
-    pmsg->data[7] = frame[index].dataByte7;
+    pmsg->hdr_index = index;
 
     return 0;
 }
@@ -442,23 +936,18 @@ static uint8_t FLEXCAN_GetFirstValidMb(CAN_Type *base)
     return firstValidMbNum;
 }
 
-rt_ssize_t _can_sendmsg_nonblocking(struct rt_can_device *can_dev, const void *buf)
+static rt_ssize_t _can_sendmsg_nonblocking(struct rt_can_device *can_dev, const void *buf)
 {
     struct imxrt_can *can;
     struct rt_can_msg *msg;
     status_t ret;
-    flexcan_frame_t frame;
-    flexcan_mb_transfer_t txXfer;
     rt_uint32_t boxno;
+
     RT_ASSERT(can_dev != RT_NULL);
     RT_ASSERT(buf != RT_NULL);
 
     can = (struct imxrt_can *)can_dev->parent.user_data;
-    msg = (struct rt_can_msg *) buf;
-
-    RT_ASSERT(can != RT_NULL);
-    RT_ASSERT(msg != RT_NULL);
-
+    msg = (struct rt_can_msg *)buf;
     boxno = FLEXCAN_GetFirstValidMb(can->base);
 
     if (boxno == 0xFF)
@@ -466,50 +955,35 @@ rt_ssize_t _can_sendmsg_nonblocking(struct rt_can_device *can_dev, const void *b
         return -RT_EBUSY;
     }
 
-    if (RT_CAN_STDID == msg->ide)
+#ifdef RT_CAN_USING_CANFD
+    if (can->fd_enabled && msg->fd_frame)
     {
-        frame.id = FLEXCAN_ID_STD(msg->id);
-        frame.format = kFLEXCAN_FrameFormatStandard;
+        flexcan_mb_transfer_t txXfer;
+        flexcan_fd_frame_t tx_frame;
+
+        FLEXCAN_SetFDTxMbConfig(can->base, boxno, true);
+        _can_fill_fd_frame(&tx_frame, msg);
+        txXfer.mbIdx = boxno;
+        txXfer.framefd = &tx_frame;
+        txXfer.frame = RT_NULL;
+        ret = FLEXCAN_TransferFDSendNonBlocking(can->base, &can->handle, &txXfer);
     }
-    else if (RT_CAN_EXTID == msg->ide)
+    else
+#endif
     {
-        frame.id = FLEXCAN_ID_EXT(msg->id);
-        frame.format = kFLEXCAN_FrameFormatExtend;
+        flexcan_mb_transfer_t txXfer;
+        flexcan_frame_t tx_frame;
+
+        _can_fill_classic_frame(&tx_frame, msg);
+        txXfer.mbIdx = boxno;
+        txXfer.frame = &tx_frame;
+#ifdef RT_CAN_USING_CANFD
+        txXfer.framefd = RT_NULL;
+#endif
+        ret = FLEXCAN_TransferSendNonBlocking(can->base, &can->handle, &txXfer);
     }
 
-    if (RT_CAN_DTR == msg->rtr)
-    {
-        frame.type = kFLEXCAN_FrameTypeData;
-    }
-    else if (RT_CAN_RTR == msg->rtr)
-    {
-        frame.type = kFLEXCAN_FrameTypeRemote;
-    }
-
-    frame.length = msg->len;
-    frame.dataByte0 = msg->data[0];
-    frame.dataByte1 = msg->data[1];
-    frame.dataByte2 = msg->data[2];
-    frame.dataByte3 = msg->data[3];
-    frame.dataByte4 = msg->data[4];
-    frame.dataByte5 = msg->data[5];
-    frame.dataByte6 = msg->data[6];
-    frame.dataByte7 = msg->data[7];
-
-    txXfer.mbIdx = boxno;
-    txXfer.frame = &frame;
-    ret = FLEXCAN_TransferSendNonBlocking(can->base, &can->handle, &txXfer);
-    switch (ret)
-    {
-    case kStatus_Success:
-        ret = RT_EOK;
-        break;
-    case kStatus_Fail:
-        ret = -RT_ERROR;
-        break;
-    }
-
-    return (rt_ssize_t)ret;
+    return (ret == kStatus_Success) ? RT_EOK : -RT_ERROR;
 }
 
 static struct rt_can_ops imxrt_can_ops =
@@ -532,14 +1006,18 @@ int rt_hw_can_init(void)
     config.sndboxnumber = 1;
     config.msgboxsz = RX_MB_COUNT;
 #ifdef RT_CAN_USING_HDR
-    config.maxhdr = RX_MB_COUNT;          /* filter count,one filter per MB */
+    config.maxhdr = RX_MB_COUNT;
+#endif
+#ifdef RT_CAN_USING_CANFD
+    config.enable_canfd = 1;
+    config.baud_rate_fd = 2000000;
 #endif
 
     for (i = 0; i < sizeof(flexcans) / sizeof(flexcans[0]); i++)
     {
         flexcans[i].can_dev.config = config;
-        CLOCK_SetClockDiv(flexcans[i].clock_div_name, 1u);
-        CLOCK_AttachClk(flexcans[i].clock_attach_id);
+        flexcans[i].filter_mask = 0;
+        _can_enable_periph_clock(&flexcans[i]);
 
         ret = rt_hw_can_register(&flexcans[i].can_dev, flexcans[i].name, &imxrt_can_ops, &flexcans[i]);
     }
@@ -548,4 +1026,4 @@ int rt_hw_can_init(void)
 }
 INIT_BOARD_EXPORT(rt_hw_can_init);
 
-#endif /*RT_USING_CAN */
+#endif /* RT_USING_CAN */

--- a/bsp/nxp/mcx/mcxa/frdm-mcxa366/.ci/attachconfig/ci.attachconfig.yml
+++ b/bsp/nxp/mcx/mcxa/frdm-mcxa366/.ci/attachconfig/ci.attachconfig.yml
@@ -31,6 +31,19 @@ Peripheral.arduino:
     kconfig:
       - CONFIG_BSP_USING_ARDUINO=y
 
+Peripheral.canfd:
+    kconfig:
+      - CONFIG_BSP_USING_CAN=y
+      - CONFIG_BSP_USING_CAN0=y
+      - CONFIG_BSP_USING_CAN1=y
+      - CONFIG_RT_USING_CAN=y
+      - CONFIG_RT_CAN_USING_HDR=y
+      - CONFIG_RT_CAN_USING_CANFD=y
+      - CONFIG_RT_CANMSG_BOX_SZ=16
+      - CONFIG_RT_CANSND_BOX_NUM=1
+      - CONFIG_RT_CANSND_MSG_TIMEOUT=100
+      - CONFIG_RT_CAN_NB_TX_FIFO_SIZE=1024
+
 # ------ utest CI ------
 utest.pin:
     <<: *scons

--- a/bsp/nxp/mcx/mcxa/frdm-mcxa366/board/MCUX_Config/board/pin_mux.c
+++ b/bsp/nxp/mcx/mcxa/frdm-mcxa366/board/MCUX_Config/board/pin_mux.c
@@ -435,4 +435,38 @@ void BOARD_InitPins(void)
                                                      .lockRegister = kPORT_UnlockRegister};
     /* PORT1_2 (pin 137) is configured as CAN0_TXD */
     PORT_SetPinConfig(PORT1, 2U, &port1_2_pin137_config);
+
+#ifdef BSP_USING_CAN1
+    const port_pin_config_t port1_12_pin5_config = {/* Internal pull-up/down resistor is disabled */
+                                                    .pullSelect = kPORT_PullDisable,
+                                                    .pullValueSelect = kPORT_LowPullResistor,
+                                                    .slewRate = kPORT_FastSlewRate,
+                                                    .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                    .openDrainEnable = kPORT_OpenDrainDisable,
+                                                    .driveStrength = kPORT_LowDriveStrength,
+                                                    .driveStrength1 = kPORT_NormalDriveStrength,
+                                                    /* Pin is configured as CAN1_RXD */
+                                                    .mux = kPORT_MuxAlt11,
+                                                    .inputBuffer = kPORT_InputBufferEnable,
+                                                    .invertInput = kPORT_InputNormal,
+                                                    .lockRegister = kPORT_UnlockRegister};
+    /* PORT1_12 (pin 5) is configured as CAN1_RXD */
+    PORT_SetPinConfig(PORT1, 12U, &port1_12_pin5_config);
+
+    const port_pin_config_t port1_17_pin10_config = {/* Internal pull-up/down resistor is disabled */
+                                                     .pullSelect = kPORT_PullDisable,
+                                                     .pullValueSelect = kPORT_LowPullResistor,
+                                                     .slewRate = kPORT_FastSlewRate,
+                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                     .openDrainEnable = kPORT_OpenDrainDisable,
+                                                     .driveStrength = kPORT_LowDriveStrength,
+                                                     .driveStrength1 = kPORT_NormalDriveStrength,
+                                                     /* Pin is configured as CAN1_TXD */
+                                                     .mux = kPORT_MuxAlt11,
+                                                     .inputBuffer = kPORT_InputBufferEnable,
+                                                     .invertInput = kPORT_InputNormal,
+                                                     .lockRegister = kPORT_UnlockRegister};
+    /* PORT1_17 (pin 10) is configured as CAN1_TXD */
+    PORT_SetPinConfig(PORT1, 17U, &port1_17_pin10_config);
+#endif /* BSP_USING_CAN1 */
 }

--- a/bsp/nxp/mcx/mcxa/frdm-mcxa366/board/MCUX_Config/board/pin_mux.c
+++ b/bsp/nxp/mcx/mcxa/frdm-mcxa366/board/MCUX_Config/board/pin_mux.c
@@ -25,7 +25,8 @@ void BOARD_InitBootPins(void)
 
 static void release_reset_array(const reset_ip_name_t *resets, uint32_t count)
 {
-    for (uint32_t i = 0; i < count; i++) {
+    for (uint32_t i = 0; i < count; i++)
+    {
         RESET_ReleasePeripheralReset(resets[i]);
     }
 }
@@ -36,7 +37,8 @@ void BOARD_InitPins(void)
     static const clock_ip_name_t gpio_clocks[] = GPIO_CLOCKS;
 
     // Enable clocks
-    for (uint32_t i = 0; i < ARRAY_SIZE(port_clocks); i++) {
+    for (uint32_t i = 0; i < ARRAY_SIZE(port_clocks); i++)
+    {
         CLOCK_EnableClock(port_clocks[i]);
         CLOCK_EnableClock(gpio_clocks[i]);
     }
@@ -60,400 +62,399 @@ void BOARD_InitPins(void)
     release_reset_array(can_resets, ARRAY_SIZE(can_resets));
 
     const port_pin_config_t port2_2_pin35_config = {/* Internal pull-up resistor is enabled */
-                                                    .pullSelect = kPORT_PullUp,
+                                                     .pullSelect = kPORT_PullUp,
                                                     /* Low internal pull resistor value is selected. */
-                                                    .pullValueSelect = kPORT_LowPullResistor,
+                                                     .pullValueSelect = kPORT_LowPullResistor,
                                                     /* Fast slew rate is configured */
-                                                    .slewRate = kPORT_FastSlewRate,
+                                                     .slewRate = kPORT_FastSlewRate,
                                                     /* Passive input filter is disabled */
-                                                    .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                     /* Open drain output is disabled */
-                                                    .openDrainEnable = kPORT_OpenDrainDisable,
+                                                     .openDrainEnable = kPORT_OpenDrainDisable,
                                                     /* Low drive strength is configured */
-                                                    .driveStrength = kPORT_LowDriveStrength,
+                                                     .driveStrength = kPORT_LowDriveStrength,
                                                     /* Normal drive strength is configured */
-                                                    .driveStrength1 = kPORT_NormalDriveStrength,
+                                                     .driveStrength1 = kPORT_NormalDriveStrength,
                                                     /* Pin is configured as LPUART2_TXD */
-                                                    .mux = kPORT_MuxAlt3,
+                                                     .mux = kPORT_MuxAlt3,
                                                     /* Digital input enabled */
-                                                    .inputBuffer = kPORT_InputBufferEnable,
+                                                     .inputBuffer = kPORT_InputBufferEnable,
                                                     /* Digital input is not inverted */
-                                                    .invertInput = kPORT_InputNormal,
+                                                     .invertInput = kPORT_InputNormal,
                                                     /* Pin Control Register fields [15:0] are not locked */
-                                                    .lockRegister = kPORT_UnlockRegister};
+                                                     .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT2_2 (pin 35) is configured as LPUART2_TXD */
     PORT_SetPinConfig(PORT2, 2U, &port2_2_pin35_config);
 
     const port_pin_config_t port2_3_pin36_config = {/* Internal pull-up resistor is enabled */
-                                                    .pullSelect = kPORT_PullUp,
+                                                     .pullSelect = kPORT_PullUp,
                                                     /* Low internal pull resistor value is selected. */
-                                                    .pullValueSelect = kPORT_LowPullResistor,
+                                                     .pullValueSelect = kPORT_LowPullResistor,
                                                     /* Fast slew rate is configured */
-                                                    .slewRate = kPORT_FastSlewRate,
+                                                     .slewRate = kPORT_FastSlewRate,
                                                     /* Passive input filter is disabled */
-                                                    .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                     /* Open drain output is disabled */
-                                                    .openDrainEnable = kPORT_OpenDrainDisable,
+                                                     .openDrainEnable = kPORT_OpenDrainDisable,
                                                     /* Low drive strength is configured */
-                                                    .driveStrength = kPORT_LowDriveStrength,
+                                                     .driveStrength = kPORT_LowDriveStrength,
                                                     /* Normal drive strength is configured */
-                                                    .driveStrength1 = kPORT_NormalDriveStrength,
+                                                     .driveStrength1 = kPORT_NormalDriveStrength,
                                                     /* Pin is configured as LPUART2_RXD */
-                                                    .mux = kPORT_MuxAlt3,
+                                                     .mux = kPORT_MuxAlt3,
                                                     /* Digital input enabled */
-                                                    .inputBuffer = kPORT_InputBufferEnable,
+                                                     .inputBuffer = kPORT_InputBufferEnable,
                                                     /* Digital input is not inverted */
-                                                    .invertInput = kPORT_InputNormal,
+                                                     .invertInput = kPORT_InputNormal,
                                                     /* Pin Control Register fields [15:0] are not locked */
-                                                    .lockRegister = kPORT_UnlockRegister};
+                                                     .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT2_3 (pin 36) is configured as LPUART2_RXD */
     PORT_SetPinConfig(PORT2, 3U, &port2_3_pin36_config);
 
 
     const port_pin_config_t LED_RED = {/* Internal pull-up/down resistor is disabled */
-                                       .pullSelect = kPORT_PullDisable,
+                                        .pullSelect = kPORT_PullDisable,
                                        /* Low internal pull resistor value is selected. */
-                                       .pullValueSelect = kPORT_LowPullResistor,
+                                        .pullValueSelect = kPORT_LowPullResistor,
                                        /* Fast slew rate is configured */
-                                       .slewRate = kPORT_FastSlewRate,
+                                        .slewRate = kPORT_FastSlewRate,
                                        /* Passive input filter is disabled */
-                                       .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                        .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                        /* Open drain output is disabled */
-                                       .openDrainEnable = kPORT_OpenDrainDisable,
+                                        .openDrainEnable = kPORT_OpenDrainDisable,
                                        /* Low drive strength is configured */
-                                       .driveStrength = kPORT_LowDriveStrength,
+                                        .driveStrength = kPORT_LowDriveStrength,
                                        /* Normal drive strength is configured */
-                                       .driveStrength1 = kPORT_NormalDriveStrength,
+                                        .driveStrength1 = kPORT_NormalDriveStrength,
                                        /* Pin is configured as P3_18 */
-                                       .mux = kPORT_MuxAlt0,
+                                        .mux = kPORT_MuxAlt0,
                                        /* Digital input enabled */
-                                       .inputBuffer = kPORT_InputBufferEnable,
+                                        .inputBuffer = kPORT_InputBufferEnable,
                                        /* Digital input is not inverted */
-                                       .invertInput = kPORT_InputNormal,
+                                        .invertInput = kPORT_InputNormal,
                                        /* Pin Control Register fields [15:0] are not locked */
-                                       .lockRegister = kPORT_UnlockRegister};
+                                        .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT3_18 (pin 86) is configured as P3_18 */
     PORT_SetPinConfig(BOARD_INITLEDSPINS_LED_RED_PORT, BOARD_INITLEDSPINS_LED_RED_PIN, &LED_RED);
 
     const port_pin_config_t LED_GREEN = {/* Internal pull-up/down resistor is disabled */
-                                         .pullSelect = kPORT_PullDisable,
+                                          .pullSelect = kPORT_PullDisable,
                                          /* Low internal pull resistor value is selected. */
-                                         .pullValueSelect = kPORT_LowPullResistor,
+                                          .pullValueSelect = kPORT_LowPullResistor,
                                          /* Fast slew rate is configured */
-                                         .slewRate = kPORT_FastSlewRate,
+                                          .slewRate = kPORT_FastSlewRate,
                                          /* Passive input filter is disabled */
-                                         .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                          .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                          /* Open drain output is disabled */
-                                         .openDrainEnable = kPORT_OpenDrainDisable,
+                                          .openDrainEnable = kPORT_OpenDrainDisable,
                                          /* Low drive strength is configured */
-                                         .driveStrength = kPORT_LowDriveStrength,
+                                          .driveStrength = kPORT_LowDriveStrength,
                                          /* Normal drive strength is configured */
-                                         .driveStrength1 = kPORT_NormalDriveStrength,
+                                          .driveStrength1 = kPORT_NormalDriveStrength,
                                          /* Pin is configured as P3_19 */
-                                         .mux = kPORT_MuxAlt0,
+                                          .mux = kPORT_MuxAlt0,
                                          /* Digital input enabled */
-                                         .inputBuffer = kPORT_InputBufferEnable,
+                                          .inputBuffer = kPORT_InputBufferEnable,
                                          /* Digital input is not inverted */
-                                         .invertInput = kPORT_InputNormal,
+                                          .invertInput = kPORT_InputNormal,
                                          /* Pin Control Register fields [15:0] are not locked */
-                                         .lockRegister = kPORT_UnlockRegister};
+                                          .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT3_19 (pin 85) is configured as P3_19 */
     PORT_SetPinConfig(BOARD_INITLEDSPINS_LED_GREEN_PORT, BOARD_INITLEDSPINS_LED_GREEN_PIN, &LED_GREEN);
 
     const port_pin_config_t LED_BLUE = {/* Internal pull-up/down resistor is disabled */
-                                        .pullSelect = kPORT_PullDisable,
+                                         .pullSelect = kPORT_PullDisable,
                                         /* Low internal pull resistor value is selected. */
-                                        .pullValueSelect = kPORT_LowPullResistor,
+                                         .pullValueSelect = kPORT_LowPullResistor,
                                         /* Fast slew rate is configured */
-                                        .slewRate = kPORT_FastSlewRate,
+                                         .slewRate = kPORT_FastSlewRate,
                                         /* Passive input filter is disabled */
-                                        .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                         .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                         /* Open drain output is disabled */
-                                        .openDrainEnable = kPORT_OpenDrainDisable,
+                                         .openDrainEnable = kPORT_OpenDrainDisable,
                                         /* Low drive strength is configured */
-                                        .driveStrength = kPORT_LowDriveStrength,
+                                         .driveStrength = kPORT_LowDriveStrength,
                                         /* Normal drive strength is configured */
-                                        .driveStrength1 = kPORT_NormalDriveStrength,
+                                         .driveStrength1 = kPORT_NormalDriveStrength,
                                         /* Pin is configured as P3_21 */
-                                        .mux = kPORT_MuxAlt0,
+                                         .mux = kPORT_MuxAlt0,
                                         /* Digital input enabled */
-                                        .inputBuffer = kPORT_InputBufferEnable,
+                                         .inputBuffer = kPORT_InputBufferEnable,
                                         /* Digital input is not inverted */
-                                        .invertInput = kPORT_InputNormal,
+                                         .invertInput = kPORT_InputNormal,
                                         /* Pin Control Register fields [15:0] are not locked */
-                                        .lockRegister = kPORT_UnlockRegister};
+                                         .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT3_21 (pin 82) is configured as P3_21 */
     PORT_SetPinConfig(BOARD_INITLEDSPINS_LED_BLUE_PORT, BOARD_INITLEDSPINS_LED_BLUE_PIN, &LED_BLUE);
 
 
     const port_pin_config_t port1_8_pin1_config = {/* Internal pull-up/down resistor is disabled */
-                                                   .pullSelect = kPORT_PullDisable,
+                                                    .pullSelect = kPORT_PullDisable,
                                                    /* Low internal pull resistor value is selected. */
-                                                   .pullValueSelect = kPORT_LowPullResistor,
+                                                    .pullValueSelect = kPORT_LowPullResistor,
                                                    /* Fast slew rate is configured */
-                                                   .slewRate = kPORT_FastSlewRate,
+                                                    .slewRate = kPORT_FastSlewRate,
                                                    /* Passive input filter is disabled */
-                                                   .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                    .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                    /* Open drain output is disabled */
-                                                   .openDrainEnable = kPORT_OpenDrainDisable,
+                                                    .openDrainEnable = kPORT_OpenDrainDisable,
                                                    /* Low drive strength is configured */
-                                                   .driveStrength = kPORT_LowDriveStrength,
+                                                    .driveStrength = kPORT_LowDriveStrength,
                                                    /* Normal drive strength is configured */
-                                                   .driveStrength1 = kPORT_NormalDriveStrength,
+                                                    .driveStrength1 = kPORT_NormalDriveStrength,
                                                    /* Pin is configured as LPI2C2_SDA */
-                                                   .mux = kPORT_MuxAlt3,
+                                                    .mux = kPORT_MuxAlt3,
                                                    /* Digital input enabled */
-                                                   .inputBuffer = kPORT_InputBufferEnable,
+                                                    .inputBuffer = kPORT_InputBufferEnable,
                                                    /* Digital input is not inverted */
-                                                   .invertInput = kPORT_InputNormal,
+                                                    .invertInput = kPORT_InputNormal,
                                                    /* Pin Control Register fields [15:0] are not locked */
-                                                   .lockRegister = kPORT_UnlockRegister};
+                                                    .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT1_8 (pin 1) is configured as LPI2C2_SDA */
     PORT_SetPinConfig(PORT1, 8U, &port1_8_pin1_config);
 
     const port_pin_config_t port1_9_pin2_config = {/* Internal pull-up/down resistor is disabled */
-                                                   .pullSelect = kPORT_PullDisable,
+                                                    .pullSelect = kPORT_PullDisable,
                                                    /* Low internal pull resistor value is selected. */
-                                                   .pullValueSelect = kPORT_LowPullResistor,
+                                                    .pullValueSelect = kPORT_LowPullResistor,
                                                    /* Fast slew rate is configured */
-                                                   .slewRate = kPORT_FastSlewRate,
+                                                    .slewRate = kPORT_FastSlewRate,
                                                    /* Passive input filter is disabled */
-                                                   .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                    .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                    /* Open drain output is disabled */
-                                                   .openDrainEnable = kPORT_OpenDrainDisable,
+                                                    .openDrainEnable = kPORT_OpenDrainDisable,
                                                    /* Low drive strength is configured */
-                                                   .driveStrength = kPORT_LowDriveStrength,
+                                                    .driveStrength = kPORT_LowDriveStrength,
                                                    /* Normal drive strength is configured */
-                                                   .driveStrength1 = kPORT_NormalDriveStrength,
+                                                    .driveStrength1 = kPORT_NormalDriveStrength,
                                                    /* Pin is configured as LPI2C2_SCL */
-                                                   .mux = kPORT_MuxAlt3,
+                                                    .mux = kPORT_MuxAlt3,
                                                    /* Digital input enabled */
-                                                   .inputBuffer = kPORT_InputBufferEnable,
+                                                    .inputBuffer = kPORT_InputBufferEnable,
                                                    /* Digital input is not inverted */
-                                                   .invertInput = kPORT_InputNormal,
+                                                    .invertInput = kPORT_InputNormal,
                                                    /* Pin Control Register fields [15:0] are not locked */
-                                                   .lockRegister = kPORT_UnlockRegister};
+                                                    .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT1_9 (pin 2) is configured as LPI2C2_SCL */
     PORT_SetPinConfig(PORT1, 9U, &port1_9_pin2_config);
 
     const port_pin_config_t port3_27_pin74_config = {/* Internal pull-up/down resistor is disabled */
-                                                     .pullSelect = kPORT_PullDisable,
+                                                      .pullSelect = kPORT_PullDisable,
                                                      /* Low internal pull resistor value is selected. */
-                                                     .pullValueSelect = kPORT_LowPullResistor,
+                                                      .pullValueSelect = kPORT_LowPullResistor,
                                                      /* Fast slew rate is configured */
-                                                     .slewRate = kPORT_FastSlewRate,
+                                                      .slewRate = kPORT_FastSlewRate,
                                                      /* Passive input filter is disabled */
-                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                      .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                      /* Open drain output is disabled */
-                                                     .openDrainEnable = kPORT_OpenDrainDisable,
+                                                      .openDrainEnable = kPORT_OpenDrainDisable,
                                                      /* Low drive strength is configured */
-                                                     .driveStrength = kPORT_LowDriveStrength,
+                                                      .driveStrength = kPORT_LowDriveStrength,
                                                      /* Normal drive strength is configured */
-                                                     .driveStrength1 = kPORT_NormalDriveStrength,
+                                                      .driveStrength1 = kPORT_NormalDriveStrength,
                                                      /* Pin is configured as LPI2C3_SCL */
-                                                     .mux = kPORT_MuxAlt2,
+                                                      .mux = kPORT_MuxAlt2,
                                                      /* Digital input enabled */
-                                                     .inputBuffer = kPORT_InputBufferEnable,
+                                                      .inputBuffer = kPORT_InputBufferEnable,
                                                      /* Digital input is not inverted */
-                                                     .invertInput = kPORT_InputNormal,
+                                                      .invertInput = kPORT_InputNormal,
                                                      /* Pin Control Register fields [15:0] are not locked */
-                                                     .lockRegister = kPORT_UnlockRegister};
+                                                      .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT3_27 (pin 74) is configured as LPI2C3_SCL */
     PORT_SetPinConfig(PORT3, 27U, &port3_27_pin74_config);
 
     const port_pin_config_t port3_28_pin73_config = {/* Internal pull-up/down resistor is disabled */
-                                                     .pullSelect = kPORT_PullDisable,
+                                                      .pullSelect = kPORT_PullDisable,
                                                      /* Low internal pull resistor value is selected. */
-                                                     .pullValueSelect = kPORT_LowPullResistor,
+                                                      .pullValueSelect = kPORT_LowPullResistor,
                                                      /* Fast slew rate is configured */
-                                                     .slewRate = kPORT_FastSlewRate,
+                                                      .slewRate = kPORT_FastSlewRate,
                                                      /* Passive input filter is disabled */
-                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                      .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                      /* Open drain output is disabled */
-                                                     .openDrainEnable = kPORT_OpenDrainDisable,
+                                                      .openDrainEnable = kPORT_OpenDrainDisable,
                                                      /* Low drive strength is configured */
-                                                     .driveStrength = kPORT_LowDriveStrength,
+                                                      .driveStrength = kPORT_LowDriveStrength,
                                                      /* Normal drive strength is configured */
-                                                     .driveStrength1 = kPORT_NormalDriveStrength,
+                                                      .driveStrength1 = kPORT_NormalDriveStrength,
                                                      /* Pin is configured as LPI2C3_SDA */
-                                                     .mux = kPORT_MuxAlt2,
+                                                      .mux = kPORT_MuxAlt2,
                                                      /* Digital input enabled */
-                                                     .inputBuffer = kPORT_InputBufferEnable,
+                                                      .inputBuffer = kPORT_InputBufferEnable,
                                                      /* Digital input is not inverted */
-                                                     .invertInput = kPORT_InputNormal,
+                                                      .invertInput = kPORT_InputNormal,
                                                      /* Pin Control Register fields [15:0] are not locked */
-                                                     .lockRegister = kPORT_UnlockRegister};
+                                                      .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT3_28 (pin 73) is configured as LPI2C3_SDA */
     PORT_SetPinConfig(PORT3, 28U, &port3_28_pin73_config);
 
     const port_pin_config_t port3_10_pin96_config = {/* Internal pull-up/down resistor is disabled */
-                                                     .pullSelect = kPORT_PullDisable,
+                                                      .pullSelect = kPORT_PullDisable,
                                                      /* Low internal pull resistor value is selected. */
-                                                     .pullValueSelect = kPORT_LowPullResistor,
+                                                      .pullValueSelect = kPORT_LowPullResistor,
                                                      /* Fast slew rate is configured */
-                                                     .slewRate = kPORT_FastSlewRate,
+                                                      .slewRate = kPORT_FastSlewRate,
                                                      /* Passive input filter is disabled */
-                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                      .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                      /* Open drain output is disabled */
-                                                     .openDrainEnable = kPORT_OpenDrainDisable,
+                                                      .openDrainEnable = kPORT_OpenDrainDisable,
                                                      /* Low drive strength is configured */
-                                                     .driveStrength = kPORT_LowDriveStrength,
+                                                      .driveStrength = kPORT_LowDriveStrength,
                                                      /* Normal drive strength is configured */
-                                                     .driveStrength1 = kPORT_NormalDriveStrength,
+                                                      .driveStrength1 = kPORT_NormalDriveStrength,
                                                      /* Pin is configured as LPSPI1_SCK */
-                                                     .mux = kPORT_MuxAlt2,
+                                                      .mux = kPORT_MuxAlt2,
                                                      /* Digital input enabled */
-                                                     .inputBuffer = kPORT_InputBufferEnable,
+                                                      .inputBuffer = kPORT_InputBufferEnable,
                                                      /* Digital input is not inverted */
-                                                     .invertInput = kPORT_InputNormal,
+                                                      .invertInput = kPORT_InputNormal,
                                                      /* Pin Control Register fields [15:0] are not locked */
-                                                     .lockRegister = kPORT_UnlockRegister};
+                                                      .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT3_10 (pin 96) is configured as LPSPI1_SCK */
     PORT_SetPinConfig(PORT3, 10U, &port3_10_pin96_config);
 
     const port_pin_config_t port3_11_pin95_config = {/* Internal pull-up/down resistor is disabled */
-                                                     .pullSelect = kPORT_PullDisable,
+                                                      .pullSelect = kPORT_PullDisable,
                                                      /* Low internal pull resistor value is selected. */
-                                                     .pullValueSelect = kPORT_LowPullResistor,
+                                                      .pullValueSelect = kPORT_LowPullResistor,
                                                      /* Fast slew rate is configured */
-                                                     .slewRate = kPORT_FastSlewRate,
+                                                      .slewRate = kPORT_FastSlewRate,
                                                      /* Passive input filter is disabled */
-                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                      .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                      /* Open drain output is disabled */
-                                                     .openDrainEnable = kPORT_OpenDrainDisable,
+                                                      .openDrainEnable = kPORT_OpenDrainDisable,
                                                      /* Low drive strength is configured */
-                                                     .driveStrength = kPORT_LowDriveStrength,
+                                                      .driveStrength = kPORT_LowDriveStrength,
                                                      /* Normal drive strength is configured */
-                                                     .driveStrength1 = kPORT_NormalDriveStrength,
+                                                      .driveStrength1 = kPORT_NormalDriveStrength,
                                                      /* Pin is configured as LPSPI1_PCS0 */
-                                                     .mux = kPORT_MuxAlt2,
+                                                      .mux = kPORT_MuxAlt2,
                                                      /* Digital input enabled */
-                                                     .inputBuffer = kPORT_InputBufferEnable,
+                                                      .inputBuffer = kPORT_InputBufferEnable,
                                                      /* Digital input is not inverted */
-                                                     .invertInput = kPORT_InputNormal,
+                                                      .invertInput = kPORT_InputNormal,
                                                      /* Pin Control Register fields [15:0] are not locked */
-                                                     .lockRegister = kPORT_UnlockRegister};
+                                                      .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT3_11 (pin 95) is configured as LPSPI1_PCS0 */
     PORT_SetPinConfig(PORT3, 11U, &port3_11_pin95_config);
 
     const port_pin_config_t port3_8_pin98_config = {/* Internal pull-up/down resistor is disabled */
-                                                    .pullSelect = kPORT_PullDisable,
+                                                     .pullSelect = kPORT_PullDisable,
                                                     /* Low internal pull resistor value is selected. */
-                                                    .pullValueSelect = kPORT_LowPullResistor,
+                                                     .pullValueSelect = kPORT_LowPullResistor,
                                                     /* Fast slew rate is configured */
-                                                    .slewRate = kPORT_FastSlewRate,
+                                                     .slewRate = kPORT_FastSlewRate,
                                                     /* Passive input filter is disabled */
-                                                    .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                     /* Open drain output is disabled */
-                                                    .openDrainEnable = kPORT_OpenDrainDisable,
+                                                     .openDrainEnable = kPORT_OpenDrainDisable,
                                                     /* Low drive strength is configured */
-                                                    .driveStrength = kPORT_LowDriveStrength,
+                                                     .driveStrength = kPORT_LowDriveStrength,
                                                     /* Normal drive strength is configured */
-                                                    .driveStrength1 = kPORT_NormalDriveStrength,
+                                                     .driveStrength1 = kPORT_NormalDriveStrength,
                                                     /* Pin is configured as LPSPI1_SDO */
-                                                    .mux = kPORT_MuxAlt2,
+                                                     .mux = kPORT_MuxAlt2,
                                                     /* Digital input enabled */
-                                                    .inputBuffer = kPORT_InputBufferEnable,
+                                                     .inputBuffer = kPORT_InputBufferEnable,
                                                     /* Digital input is not inverted */
-                                                    .invertInput = kPORT_InputNormal,
+                                                     .invertInput = kPORT_InputNormal,
                                                     /* Pin Control Register fields [15:0] are not locked */
-                                                    .lockRegister = kPORT_UnlockRegister};
+                                                     .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT3_8 (pin 98) is configured as LPSPI1_SDO */
     PORT_SetPinConfig(PORT3, 8U, &port3_8_pin98_config);
 
     const port_pin_config_t port3_9_pin97_config = {/* Internal pull-up/down resistor is disabled */
-                                                    .pullSelect = kPORT_PullDisable,
+                                                     .pullSelect = kPORT_PullDisable,
                                                     /* Low internal pull resistor value is selected. */
-                                                    .pullValueSelect = kPORT_LowPullResistor,
+                                                     .pullValueSelect = kPORT_LowPullResistor,
                                                     /* Fast slew rate is configured */
-                                                    .slewRate = kPORT_FastSlewRate,
+                                                     .slewRate = kPORT_FastSlewRate,
                                                     /* Passive input filter is disabled */
-                                                    .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                     /* Open drain output is disabled */
-                                                    .openDrainEnable = kPORT_OpenDrainDisable,
+                                                     .openDrainEnable = kPORT_OpenDrainDisable,
                                                     /* Low drive strength is configured */
-                                                    .driveStrength = kPORT_LowDriveStrength,
+                                                     .driveStrength = kPORT_LowDriveStrength,
                                                     /* Normal drive strength is configured */
-                                                    .driveStrength1 = kPORT_NormalDriveStrength,
+                                                     .driveStrength1 = kPORT_NormalDriveStrength,
                                                     /* Pin is configured as LPSPI1_SDI */
-                                                    .mux = kPORT_MuxAlt2,
+                                                     .mux = kPORT_MuxAlt2,
                                                     /* Digital input enabled */
-                                                    .inputBuffer = kPORT_InputBufferEnable,
+                                                     .inputBuffer = kPORT_InputBufferEnable,
                                                     /* Digital input is not inverted */
-                                                    .invertInput = kPORT_InputNormal,
+                                                     .invertInput = kPORT_InputNormal,
                                                     /* Pin Control Register fields [15:0] are not locked */
-                                                    .lockRegister = kPORT_UnlockRegister};
+                                                     .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT3_9 (pin 97) is configured as LPSPI1_SDI */
     PORT_SetPinConfig(PORT3, 9U, &port3_9_pin97_config);
 
     const port_pin_config_t port1_11_pin4_config = {/* Internal pull-up/down resistor is disabled */
-                                                    .pullSelect = kPORT_PullDisable,
+                                                     .pullSelect = kPORT_PullDisable,
                                                     /* Low internal pull resistor value is selected. */
-                                                    .pullValueSelect = kPORT_LowPullResistor,
+                                                     .pullValueSelect = kPORT_LowPullResistor,
                                                     /* Fast slew rate is configured */
-                                                    .slewRate = kPORT_FastSlewRate,
+                                                     .slewRate = kPORT_FastSlewRate,
                                                     /* Passive input filter is disabled */
-                                                    .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                     /* Open drain output is disabled */
-                                                    .openDrainEnable = kPORT_OpenDrainDisable,
+                                                     .openDrainEnable = kPORT_OpenDrainDisable,
                                                     /* Low drive strength is configured */
-                                                    .driveStrength = kPORT_LowDriveStrength,
+                                                     .driveStrength = kPORT_LowDriveStrength,
                                                     /* Normal drive strength is configured */
-                                                    .driveStrength1 = kPORT_NormalDriveStrength,
+                                                     .driveStrength1 = kPORT_NormalDriveStrength,
                                                     /* Pin is configured as CAN0_RXD */
-                                                    .mux = kPORT_MuxAlt11,
+                                                     .mux = kPORT_MuxAlt11,
                                                     /* Digital input enabled */
-                                                    .inputBuffer = kPORT_InputBufferEnable,
+                                                     .inputBuffer = kPORT_InputBufferEnable,
                                                     /* Digital input is not inverted */
-                                                    .invertInput = kPORT_InputNormal,
+                                                     .invertInput = kPORT_InputNormal,
                                                     /* Pin Control Register fields [15:0] are not locked */
-                                                    .lockRegister = kPORT_UnlockRegister};
+                                                     .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT1_11 (pin 4) is configured as CAN0_RXD */
     PORT_SetPinConfig(PORT1, 11U, &port1_11_pin4_config);
 
     const port_pin_config_t port1_2_pin137_config = {/* Internal pull-up/down resistor is disabled */
-                                                     .pullSelect = kPORT_PullDisable,
+                                                      .pullSelect = kPORT_PullDisable,
                                                      /* Low internal pull resistor value is selected. */
-                                                     .pullValueSelect = kPORT_LowPullResistor,
+                                                      .pullValueSelect = kPORT_LowPullResistor,
                                                      /* Fast slew rate is configured */
-                                                     .slewRate = kPORT_FastSlewRate,
+                                                      .slewRate = kPORT_FastSlewRate,
                                                      /* Passive input filter is disabled */
-                                                     .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                      .passiveFilterEnable = kPORT_PassiveFilterDisable,
                                                      /* Open drain output is disabled */
-                                                     .openDrainEnable = kPORT_OpenDrainDisable,
+                                                      .openDrainEnable = kPORT_OpenDrainDisable,
                                                      /* Low drive strength is configured */
-                                                     .driveStrength = kPORT_LowDriveStrength,
+                                                      .driveStrength = kPORT_LowDriveStrength,
                                                      /* Normal drive strength is configured */
-                                                     .driveStrength1 = kPORT_NormalDriveStrength,
+                                                      .driveStrength1 = kPORT_NormalDriveStrength,
                                                      /* Pin is configured as CAN0_TXD */
-                                                     .mux = kPORT_MuxAlt11,
+                                                      .mux = kPORT_MuxAlt11,
                                                      /* Digital input enabled */
-                                                     .inputBuffer = kPORT_InputBufferEnable,
+                                                      .inputBuffer = kPORT_InputBufferEnable,
                                                      /* Digital input is not inverted */
-                                                     .invertInput = kPORT_InputNormal,
+                                                      .invertInput = kPORT_InputNormal,
                                                      /* Pin Control Register fields [15:0] are not locked */
-                                                     .lockRegister = kPORT_UnlockRegister};
+                                                      .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT1_2 (pin 137) is configured as CAN0_TXD */
     PORT_SetPinConfig(PORT1, 2U, &port1_2_pin137_config);
 
 #ifdef BSP_USING_CAN1
     const port_pin_config_t port1_12_pin5_config = {/* Internal pull-up/down resistor is disabled */
-                                                    .pullSelect = kPORT_PullDisable,
-                                                    .pullValueSelect = kPORT_LowPullResistor,
-                                                    .slewRate = kPORT_FastSlewRate,
-                                                    .passiveFilterEnable = kPORT_PassiveFilterDisable,
-                                                    .openDrainEnable = kPORT_OpenDrainDisable,
-                                                    .driveStrength = kPORT_LowDriveStrength,
-                                                    .driveStrength1 = kPORT_NormalDriveStrength,
-                                                    /* Pin is configured as CAN1_RXD */
-                                                    .mux = kPORT_MuxAlt11,
-                                                    .inputBuffer = kPORT_InputBufferEnable,
-                                                    .invertInput = kPORT_InputNormal,
-                                                    .lockRegister = kPORT_UnlockRegister};
-    /* PORT1_12 (pin 5) is configured as CAN1_RXD */
-    PORT_SetPinConfig(PORT1, 12U, &port1_12_pin5_config);
-
-    const port_pin_config_t port1_17_pin10_config = {/* Internal pull-up/down resistor is disabled */
                                                      .pullSelect = kPORT_PullDisable,
                                                      .pullValueSelect = kPORT_LowPullResistor,
                                                      .slewRate = kPORT_FastSlewRate,
@@ -461,11 +462,29 @@ void BOARD_InitPins(void)
                                                      .openDrainEnable = kPORT_OpenDrainDisable,
                                                      .driveStrength = kPORT_LowDriveStrength,
                                                      .driveStrength1 = kPORT_NormalDriveStrength,
-                                                     /* Pin is configured as CAN1_TXD */
+                                                    /* Pin is configured as CAN1_RXD */
                                                      .mux = kPORT_MuxAlt11,
                                                      .inputBuffer = kPORT_InputBufferEnable,
                                                      .invertInput = kPORT_InputNormal,
-                                                     .lockRegister = kPORT_UnlockRegister};
+                                                     .lockRegister = kPORT_UnlockRegister
+    };
+    /* PORT1_12 (pin 5) is configured as CAN1_RXD */
+    PORT_SetPinConfig(PORT1, 12U, &port1_12_pin5_config);
+
+    const port_pin_config_t port1_17_pin10_config = {/* Internal pull-up/down resistor is disabled */
+                                                      .pullSelect = kPORT_PullDisable,
+                                                      .pullValueSelect = kPORT_LowPullResistor,
+                                                      .slewRate = kPORT_FastSlewRate,
+                                                      .passiveFilterEnable = kPORT_PassiveFilterDisable,
+                                                      .openDrainEnable = kPORT_OpenDrainDisable,
+                                                      .driveStrength = kPORT_LowDriveStrength,
+                                                      .driveStrength1 = kPORT_NormalDriveStrength,
+                                                     /* Pin is configured as CAN1_TXD */
+                                                      .mux = kPORT_MuxAlt11,
+                                                      .inputBuffer = kPORT_InputBufferEnable,
+                                                      .invertInput = kPORT_InputNormal,
+                                                      .lockRegister = kPORT_UnlockRegister
+    };
     /* PORT1_17 (pin 10) is configured as CAN1_TXD */
     PORT_SetPinConfig(PORT1, 17U, &port1_17_pin10_config);
 #endif /* BSP_USING_CAN1 */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

FRDM-MCXA366（MCXA366）板载 FlexCAN0/1 与 TJA1057 收发器，但当前 MCXA BSP 的 CAN 驱动仅覆盖经典 CAN 基础能力，存在以下缺口：

1. **不支持 CAN-FD**：无法使用 `RT_CAN_USING_CANFD`、FD 帧收发及 Loopback 验证。
2. **双路 CAN 不可用**：`drv_can.c` 缺少 CAN1 完整初始化、错误恢复与 Normal 模式收发逻辑；`pin_mux.c` 未配置 CAN1 引脚（P1_17 TX / P1_12 RX），`can1` 无法在硬件上工作。
3. **外总线可靠性不足**：Normal 模式下 TX 易因无 ACK 长时间阻塞；缺少 busoff 恢复、ESR1 诊断及 TX 后重启 RX，双节点互测不稳定。
4. **Keil 链接配置不足**：`MCXA366_flash.scf` 默认堆仅 1KB，双路 CAN 开启 `RT_CAN_USING_HDR` 时 `rt_can_open()` 易因堆不足触发断言；GCC 侧 `rtconfig.py` 已为 32KB，Keil 需对齐。

本 PR 补齐 MCXA 共用 CAN 驱动与 FRDM-MCXA366 板级支持，使社区用户可在该板上进行 CAN-FD 片内回环及 CAN0↔CAN1 外总线互测。

#### 你的解决方案是什么 (what is your solution)

##### 1. 驱动层（`bsp/nxp/mcx/mcxa/Libraries/drivers/drv_can.c`）

- 增加 **CAN-FD** 支持：`FLEXCAN_FDInit`、FD 帧编解码、Loopback / Normal / Listen 模式。
- 支持 **CAN0 + CAN1** 双控制器注册与独立 IRQ 处理。
- Normal 模式改进：
  - TX 前 `_can_recover_bus()`，TX 后 `_can_start_rx()` 保证双向通信；
  - `enableIndividMask = false` + 全局 RX 掩码 0，接受标准帧；
  - TX 2s 超时 + `_can_dump_err()` 输出 ESR1/ACKERR，避免无应答时死等。
- Loopback 模式：关闭 Individual Mask，配置全局滤波，支持 8/16 字节 FD 回环自测。
- 显式使能 FlexCAN 时钟门控，修复 `MDIS` 断言问题。

##### 2. 板级引脚（`frdm-mcxa366/board/MCUX_Config/board/pin_mux.c`）

在 `#ifdef BSP_USING_CAN1` 下增加 CAN1 引脚复用，与 NXP SDK `BOARD_InitCANPins` 一致：

| 信号 | 引脚 |
|------|------|
| CAN1_TXD | PORT1_17 |
| CAN1_RXD | PORT1_12 |

##### 3. Keil 链接脚本（`board/linker_scripts/MCXA366_flash.scf`）

将默认堆由 `0x0400`（1KB）调整为 `0x8000`（32KB），与 GCC `rtconfig.py` 中 `__heap_size__=0x8000` 一致，满足双路 CAN 设备打开时的动态内存需求。

##### 4. 使用方式（需在 menuconfig 中启用）

```text
RT_USING_CAN
RT_CAN_USING_CANFD
RT_CAN_USING_HDR
BSP_USING_CAN
BSP_USING_CAN0
BSP_USING_CAN1
```

修改 `.config` 后执行：

```bash
scons --pyconfig-silent
```

##### 5. 建议验证步骤

| 步骤 | 命令 | 条件 |
|------|------|------|
| 片内回环 | `canfd_loopback_test` | 无需外接线 |
| 双路诊断 | `canfd_dual_diag` | 确认 can0/can1 注册 |
| 双路互测 | `canfd_dual_test` | JP7 短接；J16↔J17 短接 CAN_H/CAN_L/GND |


#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: bsp/nxp/mcx/mcxa/frdm-mcxa366

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

```
CONFIG_RT_USING_CAN=y
CONFIG_RT_CAN_USING_HDR=y
CONFIG_RT_CAN_USING_CANFD=y
CONFIG_RT_CANMSG_BOX_SZ=16
CONFIG_RT_CANSND_BOX_NUM=1
CONFIG_RT_CANSND_MSG_TIMEOUT=100
CONFIG_RT_CAN_NB_TX_FIFO_SIZE=1024
# CONFIG_RT_CAN_MALLOC_NB_TX_BUFFER is not set

CONFIG_BSP_USING_CAN=y
CONFIG_BSP_USING_CAN0=y
CONFIG_BSP_USING_CAN1=y
```
<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action: https://github.com/yuplus/rt-thread/actions/runs/29143467316

##### 验证截图

**CAN0与CAN1直接短接**
|CAN0|CAN1|
|-|-|
|PIN-1|PIN-1|
|PIN-2|PIN-2|
|PIN-4|PIN-4|

PIN-3是电源，不用接。

<img width="1919" height="1080" alt="1c3f9c2aa1dec8ada07e6430d75c3e4c" src="https://github.com/user-attachments/assets/843d2c1f-fbe9-48cd-8897-185c50ea4d48" />


**FDCAN0 环回测试**
<img width="734" height="254" alt="image" src="https://github.com/user-attachments/assets/c7cc3bda-4602-4e8b-bb02-eb1ef04a9a04" />


**经典CAN 8字节通信**
<img width="1116" height="830" alt="image" src="https://github.com/user-attachments/assets/75623b8c-db29-45fa-9379-3f52007e988e" />

**FDCAN0 <---> FDCAN1**
<img width="983" height="520" alt="image" src="https://github.com/user-attachments/assets/a5426bbe-45c6-4061-b419-96413e1d81cd" />

<img width="950" height="585" alt="image" src="https://github.com/user-attachments/assets/03b5efa7-c87c-40e0-b430-382d4941114e" />


]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
