### PR TITLE
[fix][dfs_elm] 修复关闭目录和释放vnode时的资源泄露

### DIFF
--- a/components/dfs/dfs_v1/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/dfs_v1/filesystems/elmfat/dfs_elm.c
@@ -478,6 +478,7 @@ int dfs_elm_close(struct dfs_file *file)
         dir = (DIR *)(file->data);
         RT_ASSERT(dir != RT_NULL);
 
+        f_closedir(dir);
         /* release memory */
         rt_free(dir);
     }

--- a/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
@@ -1015,14 +1015,6 @@ static struct dfs_vnode *dfs_elm_create_vnode(struct dfs_dentry *dentry, int typ
 
 static int dfs_elm_free_vnode(struct dfs_vnode *vnode)
 {
-    /* free_vnode is the backstop destruction point: called from
-       dfs_vnode_unref when ref_count drops to 0, and from dfs_vnode_destroy on
-       a create/lookup failure (ref_count == 1). Normally dfs_elm_close has
-       already released the resource and set data = NULL, so this is a no-op.
-       It only tears down the resource when close bailed out early due to
-       ref_count > 1 (a transient lookup had raised it), which is exactly the
-       leak this guards against. data != NULL means the resource is still
-       live and the lock is still initialized, so both are released here. */
     if (vnode && vnode->ref_count <= 1 && vnode->data != RT_NULL)
     {
         if (vnode->type == FT_DIRECTORY)

--- a/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
@@ -522,6 +522,7 @@ int dfs_elm_close(struct dfs_file *file)
         dir = (DIR *)(file->vnode->data);
         RT_ASSERT(dir != RT_NULL);
 
+        f_closedir(dir);
         /* release memory */
         rt_free(dir);
     }
@@ -1014,10 +1015,27 @@ static struct dfs_vnode *dfs_elm_create_vnode(struct dfs_dentry *dentry, int typ
 
 static int dfs_elm_free_vnode(struct dfs_vnode *vnode)
 {
-    /* nothing to be freed */
-    if (vnode && vnode->ref_count <= 1)
+    /* free_vnode is the backstop destruction point: called from
+       dfs_vnode_unref when ref_count drops to 0, and from dfs_vnode_destroy on
+       a create/lookup failure (ref_count == 1). Normally dfs_elm_close has
+       already released the resource and set data = NULL, so this is a no-op.
+       It only tears down the resource when close bailed out early due to
+       ref_count > 1 (a transient lookup had raised it), which is exactly the
+       leak this guards against. data != NULL means the resource is still
+       live and the lock is still initialized, so both are released here. */
+    if (vnode && vnode->ref_count <= 1 && vnode->data != RT_NULL)
     {
-        vnode->data = NULL;
+        if (vnode->type == FT_DIRECTORY)
+        {
+            f_closedir((DIR *)vnode->data);
+        }
+        else if (vnode->type == FT_REGULAR)
+        {
+            f_close((FIL *)vnode->data);
+        }
+        rt_free(vnode->data);
+        vnode->data = RT_NULL;
+        rt_mutex_detach(&vnode->lock);
     }
 
     return 0;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
关闭目录和释放vnode时存在资源泄露

#### 你的解决方案是什么 (what is your solution)
补充关闭目录和释放vnode时的资源释放


#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:

- .config:

- action:

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
