### PR TITLE
[fix][dfs] 增加文件系统操作的类型检查，防止类型不匹配导致数据结构不一致引发的异常

### DIFF
--- a/components/dfs/dfs_v1/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/dfs_v1/filesystems/elmfat/dfs_elm.c
@@ -584,6 +584,11 @@ int dfs_elm_flush(struct dfs_file *file)
     FIL *fd;
     FRESULT result;
 
+    if (file->vnode->type == FT_DIRECTORY)
+    {
+        return -EISDIR;
+    }
+
     fd = (FIL *)(file->data);
     RT_ASSERT(fd != RT_NULL);
 

--- a/components/dfs/dfs_v1/src/dfs_posix.c
+++ b/components/dfs/dfs_v1/src/dfs_posix.c
@@ -460,6 +460,11 @@ int fsync(int fildes)
     }
 
     ret = dfs_file_flush(d);
+    if (ret < 0)
+    {
+        rt_set_errno(ret);
+        return -1;
+    }
 
     return ret;
 }

--- a/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
@@ -619,6 +619,11 @@ int dfs_elm_flush(struct dfs_file *file)
     FIL *fd;
     FRESULT result;
 
+    if (file->vnode->type == FT_DIRECTORY)
+    {
+        return -EISDIR;
+    }
+
     fd = (FIL *)(file->vnode->data);
     RT_ASSERT(fd != RT_NULL);
 

--- a/components/dfs/dfs_v2/src/dfs_file.c
+++ b/components/dfs/dfs_v2/src/dfs_file.c
@@ -2202,6 +2202,7 @@ int dfs_file_rename(const char *old_file, const char *new_file)
  * @return int Operation result:
  *         - 0 on success
  *         -EBADF if invalid file descriptor
+ *         -EISDIR if the file is a directory (directories cannot be truncated)
  *         -ENOSYS if truncate operation not supported
  *         -EINVAL if invalid parameters or not mounted
  *
@@ -2214,6 +2215,11 @@ int dfs_file_ftruncate(struct dfs_file *file, off_t length)
 
     if (file)
     {
+        if (file->vnode->type == FT_DIRECTORY)
+        {
+            return -EISDIR;
+        }
+
         if (file->fops->truncate)
         {
             if (dfs_is_mounted(file->vnode->mnt) == 0)

--- a/components/dfs/dfs_v2/src/dfs_posix.c
+++ b/components/dfs/dfs_v2/src/dfs_posix.c
@@ -605,6 +605,11 @@ int fsync(int fildes)
     }
 
     ret = dfs_file_fsync(file);
+    if (ret < 0)
+    {
+        rt_set_errno(ret);
+        return -1;
+    }
 
     return ret;
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
部分文件系统操作不支持全部类型，传入不匹配的类型导致强转为不一致的数据结构，继而引发后续操作的异常

#### 你的解决方案是什么 (what is your solution)
在这类文件系统操作的入口处新增类型检查，避免后续异常


#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:

- .config:

- action:

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
