### PR TITLE
[documentation][finsh] Clarify variable export support

### DIFF
--- a/documentation/6.components/finsh/finsh.md
+++ b/documentation/6.components/finsh/finsh.md
@@ -29,11 +29,11 @@ FinSH supports auto-completion, and viewing history commands, etc. These functio
 | Backspace key | Delete character                                             |
 | ←→ key  | Move the cursor left or right |
 
-FinSH supports two input modes, the traditional command line mode and the C language interpreter mode.
+FinSH uses the traditional command line mode, also known as MSH (module shell).
 
-## Traditional Command Line Mode
+## MSH Command-Line Mode
 
-This mode is also known as msh(module shell). In msh mode, FinSH is implemented in the same way as the traditional shell (dos/bash). For example, you can switch directories to the root directory with the `cd /` command.
+In MSH mode, FinSH works like a traditional shell such as DOS or Bash. For example, you can switch to the root directory with the `cd /` command.
 
 MSH can parse commands into parameters and parameters separated by spaces. Its command execution format is as follows:
 
@@ -43,17 +43,9 @@ command [arg1] [arg2] [...]
 
 The command can be either a built-in command in RT-Thread or an executable file.
 
-## C Language Interpreter Mode
-
-This mode is also known as C-Style mode. In C language interpreter mode, FinSH can solve and parse most C language expressions, and use functions like C to access functions and global variables in the system. In addition, it can create variables through the command line. In this mode, the command entered must be similar to the function call in C language, that is, you must carry the `()` symbol. For example, to output all current threads and their status in the system, type `list_thread()` in FinSH to print out the required information. The output of the FinSH command is the return value of this function. For some functions that do not have a return value (void return value), this printout has no meaning.
-
-Initially FinSH only supported C-Style mode. Later, with the development of RT-Thread, C-Style mode is not convenient when running scripts or programs, and it is more convenient to use traditional shell method. In addition, in C-Style mode, FinSH takes up a lot of volume. For these reasons, the msh mode has been added to RT-Thread. The msh mode is small and easy to use. It is recommended that you use the msh mode.
-
-If both modes are enabled in the RT-Thread, they can be dynamically switched. Enter the `exit` in msh mode and press `Enter` to switch to C-Style mode. Enter `msh()` in C-Style mode and press `Enter` to enter msh mode. The commands of the two modes are not common, and the msh command cannot be used in C-Style mode, and vice versa.
-
 # FinSH Built-in Commands
 
-Some FinSH commands are built in by default in RT-Thread. You can print all commands supported by the current system by entering help in FinSH and pressing Enter or directly pressing Tab. The built-in commands in C-Style and msh mode are basically the same, so msh is taken as an example here.
+Some FinSH commands are built in by default in RT-Thread. You can print all commands supported by the current system by entering help in FinSH and pressing Enter or directly pressing Tab.
 
 In msh mode, you can list all currently supported commands by pressing the Tab key. The number of default commands is not fixed, and the various components of RT-Thread will output some commands to FinSH. For example, when the DFS component is opened, commands such as `ls`, `cp`, and `cd` are added to FinSH for developers to debug.
 
@@ -323,63 +315,55 @@ static void atcmd(int argc, char**argv)
 MSH_CMD_EXPORT(atcmd, atcmd sample: atcmd <server|client>);
 ```
 
-## Custom C-Style Commands and Variables
+## Access Variables from an MSH Command
 
-Export custom commands to C-Style mode can use the following interface：
+The C-Style interpreter and `FINSH_VAR_EXPORT` were removed from RT-Thread. There is no direct replacement for exporting a variable to the shell. To inspect or change a variable at runtime, expose a small MSH command that reads or updates it.
 
-```
-FINSH_FUNCTION_EXPORT(name, desc);
-```
-
-|**Parameter**| **Description**                   |
-|----------|----------------|
-| name     | The command to export             |
-| desc     | Description of the export command |
-
-The following example defines a `hello` function and exports it as a command in C-Style mode：
+The following example exports a `dummy` command. Run `dummy` to read the value or `dummy <value>` to change it:
 
 ```c
-void hello(void)
+#include <stdlib.h>
+#include <rtthread.h>
+#include <finsh.h>
+
+static int dummy = 0;
+
+static void dummy_cmd(int argc, char **argv)
 {
-    rt_kprintf("hello RT-Thread!\n");
+    if (argc == 1)
+    {
+        rt_kprintf("dummy = %d\n", dummy);
+        return;
+    }
+
+    if (argc == 2)
+    {
+        dummy = atoi(argv[1]);
+        rt_kprintf("dummy = %d\n", dummy);
+        return;
+    }
+
+    rt_kprintf("Usage: dummy [value]\n");
 }
 
-FINSH_FUNCTION_EXPORT(hello , say hello to RT-Thread);
+MSH_CMD_EXPORT_ALIAS(dummy_cmd, dummy, show or set the dummy value);
 ```
 
-In a similar way, you can also export a variable that can be accessed through the following interface：
+## Custom MSH Command Name
+
+Use `MSH_CMD_EXPORT_ALIAS` to expose a function under a different command name:
 
 ```
-FINSH_VAR_EXPORT(name, type, desc);
-```
-
-| Parameter | **Description**                      |
-|----------|----------------|
-| name     | The variable to be exported          |
-| type     | Type of variable                     |
-| desc     | Description of the exported variable |
-
-The following example defines a `dummy` variable and exports it to a variable command in C-Style mode.：
-
-```c
-static int dummy = 0;
-FINSH_VAR_EXPORT(dummy, finsh_type_int, dummy variable for finsh)
-```
-## Custom Command Rename
-
-The function name length of FinSH is limited. It is controlled by the macro definition `FINSH_NAME_MAX` in `finsh.h`. The default is 16 bytes, which means that the FinSH command will not exceed 16 bytes in length. There is a potential problem here: when a function name is longer than FINSH_NAME_MAX, after using FINSH_FUNCTION_EXPORT to export the function to the command table, the full function name is seen in the FinSH symbol table, but a full node execution will result in a *null node* error. This is because although the full function name is displayed, in fact FinSH saves the first 16 bytes as a command. Too many inputs will result in the command not being found correctly. In this case, you can use `FINSH_FUNCTION_EXPORT_ALIAS` to re-export the command name.
-
-```
-FINSH_FUNCTION_EXPORT_ALIAS(name, alias, desc);
+MSH_CMD_EXPORT_ALIAS(name, alias, desc);
 ```
 
 | Parameter | Description                                        |
 |----------|-------------------------|
-| name     | The command to export                              |
-| alias    | The name that is displayed when exporting to FinSH |
-| desc     | Description of the export command |
+| name     | The function to export                              |
+| alias    | The command name displayed in MSH                   |
+| desc     | Description of the exported command                 |
 
-The command can be exported to msh mode by adding `__cmd_` to the renamed command name. Otherwise, the command will be exported to C-Style mode. The following example defines a `hello` function and renames it to `ho` and exports it to a command in C-Style mode.
+The following example exports the `hello` function under the command name `ho`:
 
 ```c
 void hello(void)
@@ -387,22 +371,23 @@ void hello(void)
     rt_kprintf("hello RT-Thread!\n");
 }
 
-FINSH_FUNCTION_EXPORT_ALIAS(hello , ho, say hello to RT-Thread);
+MSH_CMD_EXPORT_ALIAS(hello, ho, say hello to RT-Thread);
 ```
+
 # FinSH Function Configuration
 
 The FinSH function can be cropped, and the macro configuration options are defined in the rtconfig.h file. The specific configuration items are shown in the following table.
 
 | **Macro Definition**              | **Value Type** | Description                                                | Default |
 |-----------------------------------|----------------|------------------------------------------------------------|---------|
-| `#define RT_USING_FINSH`          | None           | Enable FinSH                                               | on      |
+| `#define RT_USING_MSH`            | None           | Enable the MSH command shell                               | on      |
+| `#define RT_USING_FINSH`          | None           | Enable FinSH support (selected by `RT_USING_MSH`)           | on      |
 | `#define FINSH_THREAD_NAME`       | String         | FinSH thread name                                          | "tshell"|
 | `#define FINSH_USING_HISTORY`     | None           | Turn on historical traceback                               | on      |
 | `#define FINSH_HISTORY_LINES`     | Integer type   | Number of historical command lines that can be traced back | 5       |
 | `#define FINSH_USING_SYMTAB`      | None           | Symbol table can be used in FinSH                          | on      |
 | `#define FINSH_USING_DESCRIPTION` | None           | Add a description to each FinSH symbol                     | on      |
-| `#define FINSH_USING_MSH`         | None           | Enable msh mode                                            | on      |
-| `#define FINSH_USING_MSH_ONLY`    | None           | Use only msh mode                                          | on      |
+| `#define FINSH_USING_MSH`         | None           | Enable the MSH implementation (selected by `RT_USING_MSH`)  | on      |
 | `#define FINSH_ARG_MAX`           | Integer type   | Maximum number of input parameters                         | 10      |
 | `#define FINSH_USING_AUTH`        | None           | Enable permission verification                             | off     |
 | `#define FINSH_DEFAULT_PASSWORD`  | String         | Authority verification password                            | off     |
@@ -410,8 +395,12 @@ The FinSH function can be cropped, and the macro configuration options are defin
 The reference configuration example in rtconfig.h is as follows, and can be configured according to actual functional requirements.
 
 ```c
-/* Open FinSH */
+/* Enable the MSH command shell */
+#define RT_USING_MSH
+
+/* Symbols selected by RT_USING_MSH */
 #define RT_USING_FINSH
+#define FINSH_USING_MSH
 
 /* Define the thread name as tshell */
 #define FINSH_THREAD_NAME "tshell"
@@ -433,10 +422,6 @@ The reference configuration example in rtconfig.h is as follows, and can be conf
 /* Define the command character length to 80 bytes */
 #define FINSH_CMD_SIZE 80
 
-/* Open msh function */
-#define FINSH_USING_MSH
-/* Use msh function by default */
-#define FINSH_USING_MSH_DEFAULT
 /* The maximum number of input parameters is 10 */
 #define FINSH_ARG_MAX 10
 ```


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

The FinSH documentation still described the C-Style interpreter and `FINSH_VAR_EXPORT`, although both were removed in 2021. This leaves users without an accurate answer for inspecting or changing a variable from current RT-Thread releases.

Closes #7519.

#### 你的解决方案是什么 (what is your solution)

- Describe MSH as the supported FinSH command mode.
- Replace the removed direct-variable export example with an `MSH_CMD_EXPORT_ALIAS` getter/setter command.
- Update the command-alias and configuration examples to match the current FinSH headers and Kconfig symbols.

The change is limited to `documentation/6.components/finsh/finsh.md`.

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP: N/A (documentation-only change; no BSP behavior is modified)

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config: N/A (no configuration changes)

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action: N/A (documentation-only); validated with `git diff --check`, balanced Markdown code fences, and direct comparison against `components/finsh/finsh.h` and `components/finsh/Kconfig`

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
