### PR TITLE
[mutex] 跨线程 rt_thread_delete  被删线程持有的mutex也一并释放

### DIFF
--- a/src/ipc.c
+++ b/src/ipc.c
@@ -1613,13 +1613,30 @@ rt_err_t rt_mutex_release(rt_mutex_t mutex)
 
     RT_OBJECT_HOOK_CALL(rt_object_put_hook, (&(mutex->parent.parent)));
 
-    /* mutex only can be released by owner */
+    /*
+     * Mutex can only be released by its owner.
+     * Exception: if the owner thread is already closed, allow other threads
+     * to release so the orphaned mutex can be cleaned up (e.g. cross-thread
+     * rt_thread_delete path in _thread_detach_from_mutex).
+     */
     if (thread != mutex->owner)
     {
-        thread->error = -RT_ERROR;
-        rt_spin_unlock(&(mutex->spinlock));
+        rt_bool_t owner_closed = RT_FALSE;
 
-        return -RT_ERROR;
+        if (mutex->owner != RT_NULL)
+        {
+            rt_sched_lock(&slvl);
+            owner_closed =
+                (rt_sched_thread_get_stat(mutex->owner) == RT_THREAD_CLOSE);
+            rt_sched_unlock(slvl);
+        }
+
+        if (!owner_closed)
+        {
+            thread->error = -RT_ERROR;
+            rt_spin_unlock(&(mutex->spinlock));
+            return -RT_ERROR;
+        }
     }
 
     /* decrease hold */
@@ -1627,13 +1644,16 @@ rt_err_t rt_mutex_release(rt_mutex_t mutex)
     /* if no hold */
     if (mutex->hold == 0)
     {
+        /* always restore priority of the owner, not the caller */
+        struct rt_thread *owner = mutex->owner;
+
         rt_sched_lock(&slvl);
 
         /* remove mutex from thread's taken list */
         rt_list_remove(&mutex->taken_list);
 
         /* whether change the thread priority */
-        need_schedule = _check_and_update_prio(thread, mutex);
+        need_schedule = _check_and_update_prio(owner, mutex);
 
         /* wakeup suspended thread */
         if (!rt_list_isempty(&mutex->parent.suspend_thread))

--- a/src/utest/mutex_tc.c
+++ b/src/utest/mutex_tc.c
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2021-09.01     luckyzjq     the first version
  * 2023-09-15     xqyjlj       change stack size in cpu64
+ * 2026-07-15     meng-plus    add cross-thread delete owner regression (#11619)
  */
 
 /**
@@ -22,6 +23,7 @@
  * - Priority inheritance when high-priority threads are blocked by lower-priority holders
  * - Behavior differences between static and dynamic mutexes
  * - Mutex release error handling, invalid release, and cleanup
+ * - Cross-thread delete of a mutex owner must release the lock and wake waiters
  * Verification Metrics:
  * - Correct return codes for all mutex operations (RT_EOK, timeouts, error states)
  * - Proper priority inheritance and restoration during contention
@@ -790,6 +792,118 @@ static void test_recurse_lock(void)
     uassert_true(result == RT_EOK);
 }
 
+#ifdef RT_USING_HEAP
+/*
+ * Issue #11619: deleting a thread that still holds a mutex must not leave an
+ * orphan lock; waiters blocked on that mutex must be woken and acquire ownership.
+ */
+static volatile int _holder_ready;
+static volatile int _waiter_got;
+
+static void orphan_mutex_holder_entry(void *param)
+{
+    rt_mutex_t mutex = (rt_mutex_t)param;
+
+    if (rt_mutex_take(mutex, RT_WAITING_FOREVER) != RT_EOK)
+    {
+        uassert_true(RT_FALSE);
+        return;
+    }
+
+    _holder_ready = 1;
+
+    /* Hold forever until deleted by another thread */
+    while (1)
+    {
+        rt_thread_mdelay(1000);
+    }
+}
+
+static void orphan_mutex_waiter_entry(void *param)
+{
+    rt_err_t result;
+    rt_mutex_t mutex = (rt_mutex_t)param;
+
+    result = rt_mutex_take(mutex, RT_WAITING_FOREVER);
+    uassert_true(result == RT_EOK);
+
+    result = rt_mutex_release(mutex);
+    uassert_true(result == RT_EOK);
+
+    /* Signal after release so the main thread can take without racing */
+    _waiter_got = 1;
+}
+
+static void test_cross_thread_delete_mutex_owner(void)
+{
+    rt_err_t result;
+    rt_thread_t holder;
+    rt_thread_t waiter;
+    int timeout;
+
+    _holder_ready = 0;
+    _waiter_got = 0;
+
+    result = rt_mutex_init(&static_mutex, "orphan_mtx", RT_IPC_FLAG_PRIO);
+    uassert_true(result == RT_EOK);
+
+    /* Lower priority holder takes the mutex and keeps it */
+    holder = rt_thread_create("mtx_hold",
+                              orphan_mutex_holder_entry,
+                              &static_mutex,
+                              THREAD_STACKSIZE,
+                              12,
+                              10);
+    uassert_true(holder != RT_NULL);
+    rt_thread_startup(holder);
+
+    timeout = 100;
+    while ((_holder_ready == 0) && (timeout-- > 0))
+    {
+        rt_thread_mdelay(10);
+    }
+    uassert_true(_holder_ready == 1);
+
+    /* Higher priority waiter blocks on the held mutex */
+    waiter = rt_thread_create("mtx_wait",
+                              orphan_mutex_waiter_entry,
+                              &static_mutex,
+                              THREAD_STACKSIZE,
+                              10,
+                              10);
+    uassert_true(waiter != RT_NULL);
+    rt_thread_startup(waiter);
+
+    /* Ensure waiter is pending before cross-thread delete */
+    rt_thread_mdelay(50);
+    uassert_true(_waiter_got == 0);
+
+    result = rt_thread_delete(holder);
+    uassert_true(result == RT_EOK);
+
+    timeout = 100;
+    while ((_waiter_got == 0) && (timeout-- > 0))
+    {
+        rt_thread_mdelay(10);
+    }
+    uassert_true(_waiter_got == 1);
+
+    /* After waiter releases, mutex must be acquirable again */
+    result = rt_mutex_take(&static_mutex, rt_tick_from_millisecond(500));
+    uassert_true(result == RT_EOK);
+    uassert_true(rt_mutex_get_hold(&static_mutex) == 1);
+
+    result = rt_mutex_release(&static_mutex);
+    uassert_true(result == RT_EOK);
+
+    result = rt_mutex_detach(&static_mutex);
+    uassert_true(result == RT_EOK);
+
+    /* Let waiter thread exit cleanly */
+    rt_thread_mdelay(50);
+}
+#endif /* RT_USING_HEAP */
+
 static rt_err_t utest_tc_init(void)
 {
 #ifdef RT_USING_HEAP
@@ -821,6 +935,7 @@ static void testcase(void)
     UTEST_UNIT_RUN(test_dynamic_mutex_release);
     UTEST_UNIT_RUN(test_dynamic_mutex_trytake);
     UTEST_UNIT_RUN(test_dynamic_pri_reverse);
+    UTEST_UNIT_RUN(test_cross_thread_delete_mutex_owner);
 #endif
     UTEST_UNIT_RUN(test_recurse_lock);
 }


### PR DESCRIPTION
Clarified mutex release conditions and added exception handling for closed owner threads.

## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
https://github.com/RT-Thread/rt-thread/issues/11619

#### 你的解决方案是什么 (what is your solution)

结合_thread_detach 清理流程可以看到先执行的    error = rt_thread_close(thread); 将 线程标记为RT_THREAD_CLOSE状态
再进入_thread_detach_from_mutex 清理所有mutex, 同时看到  `   mutex->hold = 1;` 可知此处意图也是释放mutex
```c
        /* recursively take */
        mutex->hold = 1;
        rt_mutex_release(mutex);
```
但是rt_mutex_release 处只进行了所有者的判定，未覆盖更多场景，如线程被外部杀死，线程锁死无法恢复等情况，
因此在释放处保留所有着判定外，额外增加 线程关闭也允许释放，以满足上述需求

对比工单11619 可看到解决效果
<img width="1878" height="1162" alt="PixPin_2026-07-15_11-12-45" src="https://github.com/user-attachments/assets/32eb4a59-c5aa-4232-a89e-127a9434ce55" />

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
