### PR TITLE
[fix][tmpfs]修正 getdents 中文件类型错误的判断变量

### DIFF
--- a/components/dfs/dfs_v1/filesystems/tmpfs/dfs_tmpfs.c
+++ b/components/dfs/dfs_v1/filesystems/tmpfs/dfs_tmpfs.c
@@ -607,11 +607,11 @@ int dfs_tmpfs_getdents(struct dfs_file *file,
         if (index >= (rt_size_t)file->pos)
         {
             d = dirp + count;
-            if (d_file->type == TMPFS_TYPE_FILE)
+            if (n_file->type == TMPFS_TYPE_FILE)
             {
                 d->d_type = DT_REG;
             }
-            if (d_file->type == TMPFS_TYPE_DIR)
+            if (n_file->type == TMPFS_TYPE_DIR)
             {
                 d->d_type = DT_DIR;
             }

--- a/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
+++ b/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
@@ -525,11 +525,11 @@ static int dfs_tmpfs_getdents(struct dfs_file *file,
         if (index >= (rt_size_t)file->fpos)
         {
             d = dirp + count;
-            if (d_file->type == TMPFS_TYPE_FILE)
+            if (n_file->type == TMPFS_TYPE_FILE)
             {
                 d->d_type = DT_REG;
             }
-            if (d_file->type == TMPFS_TYPE_DIR)
+            if (n_file->type == TMPFS_TYPE_DIR)
             {
                 d->d_type = DT_DIR;
             }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
getdents 遍历 d_file(父目录)的子节点 n_file,填 d->d_name 用的是 n_file->name(正确),但判断类型用的却是 d_file->type(父目录类型),而不是 n_file->type(当前条目类型)。

由于 d_file 是被 opendir 的目录,其 type 恒为 TMPFS_TYPE_DIR,导致所有目录条目都被标记为 DT_DIR,即使子项是普通文件也报为目录。

#### 你的解决方案是什么 (what is your solution)
类型判断改用 n_file->type。


#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:

- .config:

- action:

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
