### PR TITLE
[fix][dfs] 修复ramfs与tmpfs对文件名超长的处理逻辑

### DIFF
--- a/components/dfs/dfs_v2/filesystems/ramfs/dfs_ramfs.c
+++ b/components/dfs/dfs_v2/filesystems/ramfs/dfs_ramfs.c
@@ -434,6 +434,7 @@ int dfs_ramfs_rename(struct dfs_filesystem *fs,
     struct ramfs_dirent *dirent;
     struct dfs_ramfs *ramfs;
     rt_size_t size;
+    int ret;
 
     ramfs = (struct dfs_ramfs *)fs->data;
     RT_ASSERT(ramfs != NULL);

--- a/components/dfs/dfs_v2/filesystems/ramfs/dfs_ramfs.c
+++ b/components/dfs/dfs_v2/filesystems/ramfs/dfs_ramfs.c
@@ -59,6 +59,51 @@ int dfs_ramfs_ioctl(struct dfs_file *file, int cmd, void *args)
     return -EIO;
 }
 
+static int _ramfs_set_name(char *name, rt_size_t name_size, const char *path)
+{
+    const char *name_ptr = path;
+    const char *name_scan;
+    rt_size_t name_len;
+
+    if (path == RT_NULL)
+    {
+        return -EINVAL;
+    }
+
+    /* strip leading '/' */
+    while (*name_ptr == '/' && *name_ptr)
+    {
+        name_ptr++;
+    }
+
+    if (*name_ptr == '\0')
+    {
+        return -ENOENT;
+    }
+
+    /* reject multi-level paths (ramfs is flat) */
+    name_scan = name_ptr;
+    while (*name_scan)
+    {
+        if (*name_scan == '/')
+        {
+            return -EINVAL;
+        }
+        name_scan++;
+    }
+
+    name_len = rt_strlen(name_ptr);
+    if (name_len >= name_size)
+    {
+        return -ENAMETOOLONG;
+    }
+
+    rt_memcpy(name, name_ptr, name_len);
+    name[name_len] = '\0';
+
+    return RT_EOK;
+}
+
 struct ramfs_dirent *dfs_ramfs_lookup(struct dfs_ramfs *ramfs,
                                       const char       *path,
                                       rt_size_t        *size)
@@ -232,7 +277,7 @@ int dfs_ramfs_open(struct dfs_file *file)
         {
             if (file->flags & O_CREAT || file->flags & O_WRONLY)
             {
-                char *name_ptr;
+                int ret;
 
                 /* create a file entry */
                 dirent = (struct ramfs_dirent *)
@@ -243,13 +288,12 @@ int dfs_ramfs_open(struct dfs_file *file)
                     return -ENOMEM;
                 }
 
-                /* remove '/' separator */
-                name_ptr = file->vnode->path;
-                while (*name_ptr == '/' && *name_ptr)
+                ret = _ramfs_set_name(dirent->name, sizeof(dirent->name), file->vnode->path);
+                if (ret != RT_EOK)
                 {
-                    name_ptr++;
+                    rt_memheap_free(dirent);
+                    return ret;
                 }
-                strncpy(dirent->name, name_ptr, RAMFS_NAME_MAX);
 
                 rt_list_init(&(dirent->list));
                 dirent->data = NULL;
@@ -402,7 +446,11 @@ int dfs_ramfs_rename(struct dfs_filesystem *fs,
     if (dirent == NULL)
         return -ENOENT;
 
-    strncpy(dirent->name, newpath, RAMFS_NAME_MAX);
+    ret = _ramfs_set_name(dirent->name, sizeof(dirent->name), newpath);
+    if (ret != RT_EOK)
+    {
+        return ret;
+    }
 
     return RT_EOK;
 }
@@ -471,7 +519,7 @@ struct dfs_ramfs *dfs_ramfs_create(rt_uint8_t *pool, rt_size_t size)
     rt_memset(&(ramfs->root), 0x00, sizeof(ramfs->root));
     rt_list_init(&(ramfs->root.list));
     ramfs->root.size = 0;
-    strcpy(ramfs->root.name, ".");
+    rt_strcpy(ramfs->root.name, ".");
     ramfs->root.fs = ramfs;
 
     return ramfs;

--- a/components/dfs/dfs_v2/filesystems/ramfs/dfs_ramfs.c
+++ b/components/dfs/dfs_v2/filesystems/ramfs/dfs_ramfs.c
@@ -59,6 +59,51 @@ int dfs_ramfs_ioctl(struct dfs_file *file, int cmd, void *args)
     return -EIO;
 }
 
+static int _ramfs_set_name(char *name, rt_size_t name_size, const char *path)
+{
+    const char *name_ptr = path;
+    const char *name_scan;
+    rt_size_t name_len;
+
+    if (path == RT_NULL)
+    {
+        return -EINVAL;
+    }
+
+    /* strip leading '/' */
+    while (*name_ptr == '/' && *name_ptr)
+    {
+        name_ptr++;
+    }
+
+    if (*name_ptr == '\0')
+    {
+        return -ENOENT;
+    }
+
+    /* reject multi-level paths (ramfs is flat) */
+    name_scan = name_ptr;
+    while (*name_scan)
+    {
+        if (*name_scan == '/')
+        {
+            return -EINVAL;
+        }
+        name_scan++;
+    }
+
+    name_len = rt_strlen(name_ptr);
+    if (name_len >= name_size)
+    {
+        return -ENAMETOOLONG;
+    }
+
+    rt_memcpy(name, name_ptr, name_len);
+    name[name_len] = '\0';
+
+    return RT_EOK;
+}
+
 struct ramfs_dirent *dfs_ramfs_lookup(struct dfs_ramfs *ramfs,
                                       const char       *path,
                                       rt_size_t        *size)
@@ -232,7 +277,7 @@ int dfs_ramfs_open(struct dfs_file *file)
         {
             if (file->flags & O_CREAT || file->flags & O_WRONLY)
             {
-                char *name_ptr;
+                int ret;
 
                 /* create a file entry */
                 dirent = (struct ramfs_dirent *)
@@ -243,13 +288,12 @@ int dfs_ramfs_open(struct dfs_file *file)
                     return -ENOMEM;
                 }
 
-                /* remove '/' separator */
-                name_ptr = file->vnode->path;
-                while (*name_ptr == '/' && *name_ptr)
+                ret = _ramfs_set_name(dirent->name, sizeof(dirent->name), file->vnode->path);
+                if (ret != RT_EOK)
                 {
-                    name_ptr++;
+                    rt_memheap_free(dirent);
+                    return ret;
                 }
-                strncpy(dirent->name, name_ptr, RAMFS_NAME_MAX);
 
                 rt_list_init(&(dirent->list));
                 dirent->data = NULL;
@@ -390,6 +434,7 @@ int dfs_ramfs_rename(struct dfs_filesystem *fs,
     struct ramfs_dirent *dirent;
     struct dfs_ramfs *ramfs;
     rt_size_t size;
+    int ret;
 
     ramfs = (struct dfs_ramfs *)fs->data;
     RT_ASSERT(ramfs != NULL);
@@ -402,7 +447,11 @@ int dfs_ramfs_rename(struct dfs_filesystem *fs,
     if (dirent == NULL)
         return -ENOENT;
 
-    strncpy(dirent->name, newpath, RAMFS_NAME_MAX);
+    ret = _ramfs_set_name(dirent->name, sizeof(dirent->name), newpath);
+    if (ret != RT_EOK)
+    {
+        return ret;
+    }
 
     return RT_EOK;
 }
@@ -471,7 +520,7 @@ struct dfs_ramfs *dfs_ramfs_create(rt_uint8_t *pool, rt_size_t size)
     rt_memset(&(ramfs->root), 0x00, sizeof(ramfs->root));
     rt_list_init(&(ramfs->root.list));
     ramfs->root.size = 0;
-    strcpy(ramfs->root.name, ".");
+    rt_strcpy(ramfs->root.name, ".");
     ramfs->root.fs = ramfs;
 
     return ramfs;

--- a/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
+++ b/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
@@ -726,6 +726,7 @@ static struct dfs_vnode *dfs_tmpfs_create_vnode(struct dfs_dentry *dentry, int t
         if (_path_separate(dentry->pathname, parent_path, DFS_PATH_MAX,
                            file_name, sizeof(file_name)) != RT_EOK)
         {
+            rt_set_errno(-ENAMETOOLONG);
             rt_free(parent_path);
             dfs_vnode_destroy(vnode);
             return NULL;

--- a/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
+++ b/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
@@ -43,13 +43,16 @@ static struct dfs_aspace_ops dfs_tmp_aspace_ops =
 };
 #endif
 
-static int _path_separate(const char *path, char *parent_path, char *file_name)
+static int _path_separate(const char *path, char *parent_path, rt_size_t parent_size,
+                          char *file_name, rt_size_t file_size)
 {
     const char *path_p, *path_q;
+    rt_size_t parent_len, file_len;
 
     RT_ASSERT(path[0] == '/');
 
     file_name[0] = '\0';
+    parent_path[0] = '\0';
     path_p = path_q = &path[1];
 __next_dir:
     while (*path_q != '/' && *path_q != '\0')
@@ -66,10 +69,18 @@ __next_dir:
         }
         else /* Last level dir */
         {
-            rt_memcpy(parent_path, path, path_p - path - 1);
-            parent_path[path_p - path - 1] = '\0';
-            rt_memcpy(file_name, path_p, path_q - path_p);
-            file_name[path_q - path_p] = '\0';
+            parent_len = path_p - path - 1;
+            file_len = path_q - path_p;
+
+            if ((parent_len + 1 > parent_size) || (file_len + 1 > file_size))
+            {
+                return -ENAMETOOLONG;
+            }
+
+            rt_memcpy(parent_path, path, parent_len);
+            parent_path[parent_len] = '\0';
+            rt_memcpy(file_name, path_p, file_len);
+            file_name[file_len] = '\0';
         }
     }
     if (parent_path[0] == 0)
@@ -83,17 +94,31 @@ __next_dir:
     return 0;
 }
 
-static int _get_subdir(const char *path, char *name)
+static int _get_subdir(const char *path, char *name, rt_size_t name_size)
 {
     const char *subpath = path;
+    rt_size_t len = 0;
+
+    if (name_size == 0)
+    {
+        return -EINVAL;
+    }
+
     while (*subpath == '/' && *subpath)
         subpath ++;
     while (*subpath != '/' && *subpath)
     {
+        if (len + 1 >= name_size)
+        {
+            name[0] = '\0';
+            return -ENAMETOOLONG;
+        }
         *name = *subpath;
         name ++;
         subpath ++;
+        len ++;
     }
+    *name = '\0';
     return 0;
 }
 
@@ -256,7 +281,10 @@ find_subpath:
         subpath ++; /* skip '/' */
 
     memset(subdir_name, 0, TMPFS_NAME_MAX);
-    _get_subdir(curpath, subdir_name);
+    if (_get_subdir(curpath, subdir_name, sizeof(subdir_name)) != 0)
+    {
+        return RT_NULL;
+    }
 
     rt_spin_lock(&superblock->lock);
 
@@ -612,7 +640,12 @@ static int dfs_tmpfs_rename(struct dfs_dentry *old_dentry, struct dfs_dentry *ne
     }
 
     /* find parent file */
-    _path_separate(new_dentry->pathname, parent_path, file_name);
+    if (_path_separate(new_dentry->pathname, parent_path, DFS_PATH_MAX,
+                       file_name, sizeof(file_name)) != RT_EOK)
+    {
+        rt_free(parent_path);
+        return -ENAMETOOLONG;
+    }
     if (file_name[0] == '\0') /* it's root dir */
     {
         rt_free(parent_path);
@@ -626,7 +659,8 @@ static int dfs_tmpfs_rename(struct dfs_dentry *old_dentry, struct dfs_dentry *ne
     dfs_vfs_remove_node(&d_file->node);
     rt_spin_unlock(&superblock->lock);
 
-    strncpy(d_file->name, file_name, TMPFS_NAME_MAX);
+    rt_strncpy(d_file->name, file_name, TMPFS_NAME_MAX);
+    d_file->name[TMPFS_NAME_MAX - 1] = '\0';
 
     rt_spin_lock(&superblock->lock);
     dfs_vfs_append_node(&p_file->node, &d_file->node);
@@ -707,7 +741,13 @@ static struct dfs_vnode *dfs_tmpfs_create_vnode(struct dfs_dentry *dentry, int t
     if (vnode)
     {
         /* find parent file */
-        _path_separate(dentry->pathname, parent_path, file_name);
+        if (_path_separate(dentry->pathname, parent_path, DFS_PATH_MAX,
+                           file_name, sizeof(file_name)) != RT_EOK)
+        {
+            rt_free(parent_path);
+            dfs_vnode_destroy(vnode);
+            return NULL;
+        }
         if (file_name[0] == '\0') /* it's root dir */
         {
             rt_free(parent_path);
@@ -735,7 +775,8 @@ static struct dfs_vnode *dfs_tmpfs_create_vnode(struct dfs_dentry *dentry, int t
 
         superblock->df_size += sizeof(struct tmpfs_file);
 
-        strncpy(d_file->name, file_name, TMPFS_NAME_MAX);
+        rt_strncpy(d_file->name, file_name, TMPFS_NAME_MAX);
+        d_file->name[TMPFS_NAME_MAX - 1] = '\0';
 
         dfs_vfs_init_node(&d_file->node);
         d_file->data = NULL;

--- a/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
+++ b/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
@@ -43,13 +43,16 @@ static struct dfs_aspace_ops dfs_tmp_aspace_ops =
 };
 #endif
 
-static int _path_separate(const char *path, char *parent_path, char *file_name)
+static int _path_separate(const char *path, char *parent_path, rt_size_t parent_size,
+                          char *file_name, rt_size_t file_size)
 {
     const char *path_p, *path_q;
+    rt_size_t parent_len, file_len;
 
     RT_ASSERT(path[0] == '/');
 
     file_name[0] = '\0';
+    parent_path[0] = '\0';
     path_p = path_q = &path[1];
 __next_dir:
     while (*path_q != '/' && *path_q != '\0')
@@ -66,10 +69,18 @@ __next_dir:
         }
         else /* Last level dir */
         {
-            rt_memcpy(parent_path, path, path_p - path - 1);
-            parent_path[path_p - path - 1] = '\0';
-            rt_memcpy(file_name, path_p, path_q - path_p);
-            file_name[path_q - path_p] = '\0';
+            parent_len = path_p - path - 1;
+            file_len = path_q - path_p;
+
+            if ((parent_len + 1 > parent_size) || (file_len + 1 > file_size))
+            {
+                return -ENAMETOOLONG;
+            }
+
+            rt_memcpy(parent_path, path, parent_len);
+            parent_path[parent_len] = '\0';
+            rt_memcpy(file_name, path_p, file_len);
+            file_name[file_len] = '\0';
         }
     }
     if (parent_path[0] == 0)
@@ -612,7 +623,12 @@ static int dfs_tmpfs_rename(struct dfs_dentry *old_dentry, struct dfs_dentry *ne
     }
 
     /* find parent file */
-    _path_separate(new_dentry->pathname, parent_path, file_name);
+    if (_path_separate(new_dentry->pathname, parent_path, DFS_PATH_MAX,
+                       file_name, sizeof(file_name)) != RT_EOK)
+    {
+        rt_free(parent_path);
+        return -ENAMETOOLONG;
+    }
     if (file_name[0] == '\0') /* it's root dir */
     {
         rt_free(parent_path);
@@ -626,7 +642,7 @@ static int dfs_tmpfs_rename(struct dfs_dentry *old_dentry, struct dfs_dentry *ne
     dfs_vfs_remove_node(&d_file->node);
     rt_spin_unlock(&superblock->lock);
 
-    strncpy(d_file->name, file_name, TMPFS_NAME_MAX);
+    rt_strncpy(d_file->name, file_name, TMPFS_NAME_MAX);
 
     rt_spin_lock(&superblock->lock);
     dfs_vfs_append_node(&p_file->node, &d_file->node);
@@ -707,7 +723,13 @@ static struct dfs_vnode *dfs_tmpfs_create_vnode(struct dfs_dentry *dentry, int t
     if (vnode)
     {
         /* find parent file */
-        _path_separate(dentry->pathname, parent_path, file_name);
+        if (_path_separate(dentry->pathname, parent_path, DFS_PATH_MAX,
+                           file_name, sizeof(file_name)) != RT_EOK)
+        {
+            rt_free(parent_path);
+            dfs_vnode_destroy(vnode);
+            return NULL;
+        }
         if (file_name[0] == '\0') /* it's root dir */
         {
             rt_free(parent_path);
@@ -735,7 +757,7 @@ static struct dfs_vnode *dfs_tmpfs_create_vnode(struct dfs_dentry *dentry, int t
 
         superblock->df_size += sizeof(struct tmpfs_file);
 
-        strncpy(d_file->name, file_name, TMPFS_NAME_MAX);
+        rt_strncpy(d_file->name, file_name, TMPFS_NAME_MAX);
 
         dfs_vfs_init_node(&d_file->node);
         d_file->data = NULL;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
tmpfs对超长文件名无保护，会导致溢出，且被截断
ramfs对超长文件名有保护，但会被截断

#### 你的解决方案是什么 (what is your solution)
参考V1版本的实现，修复V2版本ramfs与tmpfs对文件名超长的处理逻辑


#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:

- .config:

- action:

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
