### PR TITLE
bsp: raspberry-pico: fix SDK sub-build invocation

### DIFF
--- a/bsp/raspberry-pico/RP2040/SConstruct
+++ b/bsp/raspberry-pico/RP2040/SConstruct
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 import rtconfig
 
@@ -32,11 +33,17 @@ objs = PrepareBuilding(env, RTT_ROOT)
 ocwd = os.getcwd()
 os.chdir(find_package_path(os.getcwd(), 'raspberrypi-pico-sdk-latest'))
 print("Enter " + os.getcwd())
+package_env = os.environ.copy()
+package_env['RTT_EXEC_PATH'] = rtconfig.EXEC_PATH
+package_command = [sys.executable, '-m', 'SCons']
 if GetOption('clean'):
-    os.system("scons -c")
-else:
-    os.system("scons")
-os.chdir(ocwd)
+    package_command.append('-c')
+try:
+    package_result = subprocess.call(package_command, env=package_env)
+finally:
+    os.chdir(ocwd)
+if package_result:
+    Exit(package_result)
 
 objs.extend(SConscript(os.path.join(os.getcwd(), 'board', 'ports', 'SConscript')))
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

RP2040 BSP 通过 `os.system("scons")` 启动 Raspberry Pi Pico SDK 子构建，但没有传递 BSP 已配置的 GNU Arm 工具链路径，也没有检查子构建的返回值。

在 Windows 下，SDK 子构建无法找到 `arm-none-eabi-gcc` 或因其他原因失败后，外层构建仍会继续，最终表现为 `pico/version.h` 缺失等次生错误，掩盖真正的失败原因。

相关 SDK 跨平台修复：<https://github.com/RT-Thread-packages/raspberrypi-pico-sdk/pull/13>

#### 你的解决方案是什么 (what is your solution)

- 使用当前 Python 解释器通过 `python -m SCons` 启动 SDK 子构建，避免依赖平台相关的 SCons 启动脚本。
- 将 `rtconfig.EXEC_PATH` 通过 `RTT_EXEC_PATH` 传递给子构建，使其复用 BSP 工具链配置。
- 传播清理选项并检查子构建返回值；子构建失败时立即终止外层构建。
- 使用 `try/finally` 确保构建目录始终恢复。

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: `bsp/raspberry-pico/RP2040`
- .config: 无需修改，使用 BSP 现有配置
- action: 暂无；已在本地 RT-Thread Env/Windows 和 WSL2 Ubuntu 环境验证

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json) 详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
