### PR TITLE
[clang-format] Improve declaration alignment and spacing

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,7 +10,7 @@ AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
 AlignConsecutiveAssignments:
-  Enabled: false
+  Enabled: true
   AcrossEmptyLines: false
   AcrossComments: false
   AlignCompound: true
@@ -22,10 +22,12 @@ AlignConsecutiveBitFields:
   AlignCompound: true
   PadOperators: true
 AlignConsecutiveDeclarations:
-  Enabled: false
+  Enabled: true
   AcrossEmptyLines: false
   AcrossComments: false
   AlignCompound: false
+  AlignFunctionDeclarations: false
+  AlignFunctionPointers: true
   PadOperators: false
 AlignConsecutiveMacros:
   Enabled: true
@@ -152,7 +154,7 @@ LambdaBodyIndentation: Signature
 LineEnding: DeriveLF
 MacroBlockBegin: ""
 MacroBlockEnd: ""
-MaxEmptyLinesToKeep: 2
+MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

当前 `.clang-format` 未启用连续赋值和连续声明对齐，函数形参中的普通指针、函数指针及标量参数无法形成统一的变量名列。同时，配置最多保留两个连续空行，与 RT-Thread 编码规范中避免连续使用两个以上空行的要求不完全一致。

#### 你的解决方案是什么 (what is your solution)

启用连续赋值和连续声明对齐，并让函数指针参与声明对齐；普通函数声明不参与该对齐，避免扩大格式化范围。将最多保留的连续空行从两个调整为一个。

格式化修改效果说明：

1. `AlignConsecutiveAssignments.Enabled: false` -> `AlignConsecutiveAssignments.Enabled: true`

格式化前：

```c
thread->entry = entry;
thread->parameter = parameter;
```

格式化后：

```c
thread->entry     = entry;
thread->parameter = parameter;
```

2. `AlignConsecutiveDeclarations.Enabled: false` -> `AlignConsecutiveDeclarations.Enabled: true`

同时增加：

```yaml
AlignFunctionDeclarations: false
AlignFunctionPointers: true
```

格式化前：

```c
static rt_err_t _thread_init(struct rt_thread *thread,
                             const char *name,
                             void (*entry)(void *parameter),
                             void *parameter,
                             void *stack_start,
                             rt_uint32_t stack_size,
                             rt_uint8_t priority,
                             rt_uint32_t tick)
```

格式化后：

```c
static rt_err_t _thread_init(struct rt_thread *thread,
                             const char       *name,
                             void              (*entry)(void *parameter),
                             void             *parameter,
                             void             *stack_start,
                             rt_uint32_t       stack_size,
                             rt_uint8_t        priority,
                             rt_uint32_t       tick)
```

3. `MaxEmptyLinesToKeep: 2` -> `MaxEmptyLinesToKeep: 1`

格式化前（两个连续空行）：

```c
int first = 1;


int second = 2;
```

格式化后（一个空行）：

```c
int first = 1;

int second = 2;
```

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: N/A（本次仅修改格式化配置，不涉及 BSP 运行时功能）

- .config: N/A

- action: 本地使用 clang-format 22.1.5 验证配置解析，并验证上述三组格式化示例。

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck)
