### PR TITLE
[drivers][dac] Fix wrong rt_dac_write arguments in doxygen example

### DIFF
--- a/components/drivers/include/drivers/dac.h
+++ b/components/drivers/include/drivers/dac.h
@@ -43,7 +43,7 @@
  *     ret = rt_dac_enable(dac_dev, DAC_DEV_CHANNEL);
  *
  *     value = atoi(argv[1]);
- *     rt_dac_write(dac_dev, DAC_DEV_NAME, DAC_DEV_CHANNEL, value);
+ *     rt_dac_write(dac_dev, DAC_DEV_CHANNEL, value);
  *     rt_kprintf("the value is :%d \n", value);
  *
  *     vol = value * REFER_VOLTAGE / CONVERT_BITS;


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

The doxygen example in `dac.h` calls `rt_dac_write` with four arguments and passes `DAC_DEV_NAME` as the second parameter. The public API only accepts three parameters `(dev, channel, value)`, so the example does not compile and misleads users (same class of error as discussed in #6568).

#### 你的解决方案是什么 (what is your solution)

Update the example to:

`c
rt_dac_write(dac_dev, DAC_DEV_CHANNEL, value);
`

Change is limited to the doxygen Example block in `components/drivers/include/drivers/dac.h`.

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: N/A (documentation / doxygen example only)
- Validation: compared example against `rt_dac_write` prototype and the MSH helper in `components/drivers/misc/dac.c`

### 当前拉取/合并请求的状态 Intent for your PR

- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确 Style guide is adhered to
- [x] 没有垃圾代码 All redundant code is removed
- [x] 所有变更均有原因及合理的 All modifications are justified
- [x] 代码是高质量的 Code in this PR is of high quality