### PR TITLE
[drivers][adc] Fix misleading doxygen for rt_adc_voltage

### DIFF
--- a/components/drivers/include/drivers/adc.h
+++ b/components/drivers/include/drivers/adc.h
@@ -135,10 +135,10 @@ rt_err_t rt_adc_enable(rt_adc_device_t dev, rt_int8_t channel);
 rt_err_t rt_adc_disable(rt_adc_device_t dev, rt_int8_t channel);
 
 /**
- * @brief get the adc resolution
+ * @brief get the converted voltage value from an ADC channel
  * @param dev adc device
  * @param channel adc channel
- * @return rt_int16_t adc resolution
+ * @return rt_int16_t voltage value (implementation-defined unit, typically mV)
  * @ingroup group_drivers_adc
  */
 rt_int16_t rt_adc_voltage(rt_adc_device_t dev, rt_int8_t channel);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

`rt_adc_voltage()` is documented as \"get the adc resolution\" and its `@return` says \"adc resolution\". That description belongs to resolution APIs, not voltage conversion, and confuses readers of the driver API docs (#9424 related doxygen quality).

#### 你的解决方案是什么 (what is your solution)

Correct the `@brief` / `@return` text for `rt_adc_voltage` so it describes returning a converted voltage value.

Change is limited to doxygen comments in `components/drivers/include/drivers/adc.h`.

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: N/A (doxygen comment only)
- Validation: checked function name and nearby ADC APIs in the same header

### 当前拉取/合并请求的状态 Intent for your PR

- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确 Style guide is adhered to
- [x] 没有垃圾代码 All redundant code is removed
- [x] 所有变更均有原因及合理的 All modifications are justified
- [x] 代码是高质量的 Code in this PR is of high quality