### PR TITLE
ipc: fix recursive data queue locking on SMP

### DIFF
--- a/components/drivers/ipc/dataqueue.c
+++ b/components/drivers/ipc/dataqueue.c
@@ -22,6 +22,20 @@ struct rt_data_item
     rt_size_t data_size;
 };
 
+static rt_uint16_t _data_queue_len_nolock(struct rt_data_queue *queue)
+{
+    if (queue->is_empty)
+    {
+        return 0;
+    }
+    if (queue->put_index > queue->get_index)
+    {
+        return queue->put_index - queue->get_index;
+    }
+
+    return queue->size + queue->put_index - queue->get_index;
+}
+
 /**
  * @brief    This function will initialize the data queue. Calling this function will
  *           initialize the data queue control block and set the notification callback function.
@@ -283,7 +297,7 @@ rt_err_t rt_data_queue_pop(struct rt_data_queue *queue,
         queue->is_empty = 1;
     }
 
-    if (rt_data_queue_len(queue) <= queue->lwm)
+    if (_data_queue_len_nolock(queue) <= queue->lwm)
     {
         /* there is at least one thread in suspended list */
         if (rt_susp_list_dequeue(&queue->suspended_push_list,
@@ -432,30 +446,15 @@ RTM_EXPORT(rt_data_queue_deinit);
 rt_uint16_t rt_data_queue_len(struct rt_data_queue *queue)
 {
     rt_base_t level;
-    rt_int16_t len;
+    rt_uint16_t len;
 
     RT_ASSERT(queue != RT_NULL);
     RT_ASSERT(queue->magic == DATAQUEUE_MAGIC);
 
-    if (queue->is_empty)
-    {
-        return 0;
-    }
-
     level = rt_spin_lock_irqsave(&(queue->spinlock));
-
-    if (queue->put_index > queue->get_index)
-    {
-        len = queue->put_index - queue->get_index;
-    }
-    else
-    {
-        len = queue->size + queue->put_index - queue->get_index;
-    }
-
+    len = _data_queue_len_nolock(queue);
     rt_spin_unlock_irqrestore(&(queue->spinlock), level);
 
     return len;
 }
 RTM_EXPORT(rt_data_queue_len);
-


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
rt_data_queue_pop() holds the data queue spinlock while updating the ring state, then calls rt_data_queue_len(). The length function tries to acquire the same non-recursive spinlock again, causing an SMP deadlock when a pop leaves the queue non-empty.

Add a private _data_queue_len_nolock() helper for callers which already hold the queue lock. Keep the public rt_data_queue_len() protected by one spinlock acquisition.

This does not change the public API, ABI, queue state transitions, low-water mark wakeups, or event callback behavior.

Tested on a four-core Spacemit K1 with cyclic HDMI playback and by building the SMP QEMU Virt64 RISC-V BSP with generic audio, Intel HDA and VirtIO Sound.

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
