### PR TITLE
[dm][nvme] replace the CPU physical address to DMA address

### DIFF
--- a/components/drivers/nvme/nvme.c
+++ b/components/drivers/nvme/nvme.c
@@ -100,6 +100,11 @@ rt_inline rt_le16_t nvme_next_cmdid(struct rt_nvme_controller *nvme)
     return rt_cpu_to_le16((rt_uint16_t)rt_atomic_add(&nvme->cmdid, 1));
 }
 
+rt_inline rt_ubase_t nvme_queue_dma_flags(void)
+{
+    return RT_DMA_F_NOCACHE | RT_DMA_F_LINEAR;
+}
+
 static rt_err_t nvme_submit_cmd(struct rt_nvme_queue *queue,
         struct rt_nvme_command *cmd)
 {
@@ -397,7 +402,8 @@ static rt_ssize_t nvme_blk_rw(struct rt_nvme_device *ndev, rt_off_t slba,
                     prp_list_size = pages * (prps_per_page - 1) + 1;
                 }
                 prp_list_ptr = prp_list;
-                prp_list_dma = (rt_uint64_t)rt_kmem_v2p(prp_list_ptr);
+                rt_dma_sync_out_data(nvme->dev, prp_list_ptr, prp_list_size,
+                        (rt_ubase_t *)&prp_list_dma, nvme_queue_dma_flags());
 
                 prp2_addr = prp_list_dma;
 
@@ -452,7 +458,7 @@ static rt_ssize_t nvme_blk_read(struct rt_blk_disk *disk, rt_off_t sector,
     rt_uint32_t page_bits;
     rt_size_t buffer_size;
     rt_ubase_t buffer_dma;
-    void *temp_buffer = RT_NULL;
+    void *temp_buffer = RT_NULL, *dma_ptr = buffer;
     struct rt_nvme_device *ndev = rt_disk_to_nvme_device(disk);
     struct rt_nvme_controller *nvme = ndev->ctrl;
 
@@ -472,8 +478,10 @@ static rt_ssize_t nvme_blk_read(struct rt_blk_disk *disk, rt_off_t sector,
             return -RT_ENOMEM;
         }
 
-        buffer_dma = (rt_ubase_t)rt_kmem_v2p(temp_buffer);
+        dma_ptr = temp_buffer;
     }
+
+    rt_dma_sync_out_data(nvme->dev, dma_ptr, buffer_size, &buffer_dma, nvme_queue_dma_flags());
 
     res = nvme_blk_rw(ndev, sector, buffer_dma, sector_count, RT_NVME_CMD_READ);
 
@@ -515,6 +523,7 @@ static rt_ssize_t nvme_blk_write(struct rt_blk_disk *disk, rt_off_t sector,
     rt_size_t buffer_size;
     rt_ubase_t buffer_dma;
     void *temp_buffer = RT_NULL;
+    const void *dma_ptr = buffer;
     struct rt_nvme_device *ndev = rt_disk_to_nvme_device(disk);
     struct rt_nvme_controller *nvme = ndev->ctrl;
 
@@ -534,13 +543,12 @@ static rt_ssize_t nvme_blk_write(struct rt_blk_disk *disk, rt_off_t sector,
             return -RT_ENOMEM;
         }
 
-        buffer_dma = (rt_ubase_t)rt_kmem_v2p(temp_buffer);
-
         rt_memcpy(temp_buffer, buffer, buffer_size);
-        buffer = temp_buffer;
+        dma_ptr = temp_buffer;
     }
 
-    rt_hw_cpu_dcache_ops(RT_HW_CACHE_FLUSH, (void *)buffer, buffer_size);
+    rt_hw_cpu_dcache_ops(RT_HW_CACHE_FLUSH, (void *)dma_ptr, buffer_size);
+    rt_dma_sync_out_data(nvme->dev, (void *)dma_ptr, buffer_size, &buffer_dma, nvme_queue_dma_flags());
 
     res = nvme_blk_rw(ndev, sector, buffer_dma, sector_count, RT_NVME_CMD_WRITE);
 
@@ -694,10 +702,14 @@ static rt_err_t nvme_identify(struct rt_nvme_controller *nvme,
         rt_uint32_t nsid, rt_uint32_t cns, void *data)
 {
     rt_err_t err;
-    rt_uint32_t page_size = nvme->page_size;
-    rt_ubase_t data_phy = (rt_ubase_t)rt_kmem_v2p(data);
-    int offset = data_phy & (page_size - 1);
+    rt_ssize_t offset;
+    rt_ubase_t data_phy = 0;
+    rt_size_t page_size = nvme->page_size;
     struct rt_nvme_command cmd;
+
+    rt_dma_sync_out_data(nvme->dev, data, sizeof(struct rt_nvme_id_ctrl),
+            &data_phy, nvme_queue_dma_flags());
+    offset = data_phy & (page_size - 1);
 
     rt_memset(&cmd, 0, sizeof(cmd));
     cmd.identify.opcode = RT_NVME_ADMIN_OPCODE_IDENTIFY;
@@ -710,8 +722,9 @@ static rt_err_t nvme_identify(struct rt_nvme_controller *nvme,
     }
     else
     {
-        data_phy += (page_size - offset);
-        cmd.identify.prp2 = rt_cpu_to_le64(data_phy);
+        rt_ubase_t data_phy2 = data_phy + (page_size - offset);
+
+        cmd.identify.prp2 = rt_cpu_to_le64(data_phy2);
     }
     cmd.identify.cns = rt_cpu_to_le32(cns);
 
@@ -781,11 +794,6 @@ static rt_err_t nvme_detach_queue(struct rt_nvme_queue *queue,
     cmd.delete_queue.qid = rt_cpu_to_le16(queue->qid);
 
     return nvme_submit_cmd(&nvme->admin_queue, &cmd);
-}
-
-rt_inline rt_ubase_t nvme_queue_dma_flags(void)
-{
-    return RT_DMA_F_NOCACHE | RT_DMA_F_LINEAR;
 }
 
 static void nvme_free_queue(struct rt_nvme_queue *queue)
@@ -863,7 +871,7 @@ static struct rt_nvme_queue *nvme_alloc_queue(struct rt_nvme_controller *nvme,
 
     if (nvme->ops->setup_queue)
     {
-        if (!(err = nvme->ops->setup_queue(queue)))
+        if ((err = nvme->ops->setup_queue(queue)))
         {
             LOG_E("Setup[%s] queue error = %s", nvme->ops->name, rt_strerror(err));
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
Replace the CPU physical address to DMA address, the PCI DMA address maybe not equ to CPU physical address

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
