### PR TITLE
fix: bsp/stm32: drv_qspi: zero-initialize qspi_device struct

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_qspi.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_qspi.c
@@ -314,6 +314,8 @@ rt_err_t rt_hw_qspi_device_attach(const char *bus_name, const char *device_name,
         goto __exit;
     }
 
+    rt_memset(qspi_device, 0, sizeof(struct rt_qspi_device));
+
     /* Safe type conversion to resolve interface contract mismatch.
      * Caller ensures the function pointer is compatible via adapter pattern.
      */


### PR DESCRIPTION
rt_hw_qspi_device_attach() allocates qspi_device via rt_malloc() but does not zero it, leaving uninitialized fields with random values. This can cause undefined behavior when fields like enter_qspi_mode are checked before being explicitly set.

Fix: Add rt_memset() right after allocation and error check.