### PR TITLE
feat: bsp/stm32: drv_usart: add DMA TX done callback

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart.c
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart.c
@@ -1175,7 +1175,16 @@ static void _dma_tx_complete(struct rt_serial_device *serial)
     if (trans_total_index == 0)
     {
         rt_hw_serial_isr(serial, RT_SERIAL_EVENT_TX_DMADONE);
+        if (uart->dma_tx_done_callback)
+            uart->dma_tx_done_callback(serial);
     }
+}
+
+void stm32_uart_set_tx_done_callback(struct rt_serial_device *serial,
+                                      void (*callback)(struct rt_serial_device *))
+{
+    struct stm32_uart *uart = rt_container_of(serial, struct stm32_uart, serial);
+    uart->dma_tx_done_callback = callback;
 }
 
 /**

--- a/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart.h
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/drv_usart.h
@@ -68,6 +68,10 @@ struct stm32_uart
 #endif
     rt_uint16_t uart_dma_flag;
     struct rt_serial_device serial;
+    void (*dma_tx_done_callback)(struct rt_serial_device *serial);
 };
+
+void stm32_uart_set_tx_done_callback(struct rt_serial_device *serial,
+                                      void (*callback)(struct rt_serial_device *));
 
 #endif  /* __DRV_USART_H__ */


### PR DESCRIPTION
Add stm32_uart_set_tx_done_callback() to allow applications to register a callback invoked when DMA TX completes. Required for USB-UART bridge scenarios where the application needs to know exactly when the DMA transfer finishes before starting the next one.

- drv_usart.h: add dma_tx_done_callback pointer to struct stm32_uart
- drv_usart.h: declare stm32_uart_set_tx_done_callback()
- drv_usart.c: call callback in _dma_tx_complete() on TX_DMADONE
- drv_usart.c: implement stm32_uart_set_tx_done_callback()