### PR TITLE
fix: serial: add D-Cache invalidate in DMA RX path

### DIFF
--- a/components/drivers/serial/dev_serial.c
+++ b/components/drivers/serial/dev_serial.c
@@ -563,11 +563,20 @@ rt_inline int _serial_dma_rx(struct rt_serial_device *serial, rt_uint8_t *data, 
             recv_len = fifo_recved_len;
 
         if (rx_fifo->get_index + recv_len < serial->config.bufsz)
+        {
+            rt_hw_cpu_dcache_ops(RT_HW_CACHE_INVALIDATE,
+                                 rx_fifo->buffer + rx_fifo->get_index, recv_len);
             rt_memcpy(data, rx_fifo->buffer + rx_fifo->get_index, recv_len);
+        }
         else
         {
+            rt_hw_cpu_dcache_ops(RT_HW_CACHE_INVALIDATE,
+                                 rx_fifo->buffer + rx_fifo->get_index,
+                                 serial->config.bufsz - rx_fifo->get_index);
             rt_memcpy(data, rx_fifo->buffer + rx_fifo->get_index,
                     serial->config.bufsz - rx_fifo->get_index);
+            rt_hw_cpu_dcache_ops(RT_HW_CACHE_INVALIDATE, rx_fifo->buffer,
+                                 recv_len + rx_fifo->get_index - serial->config.bufsz);
             rt_memcpy(data + serial->config.bufsz - rx_fifo->get_index, rx_fifo->buffer,
                     recv_len + rx_fifo->get_index - serial->config.bufsz);
         }


### PR DESCRIPTION
On Cortex-M7 with D-Cache enabled, DMA writes to the RX ring buffer bypass the cache. When the CPU reads the buffer via rt_memcpy(), it may get stale cached data instead of the actual DMA-written content.

Add rt_hw_cpu_dcache_ops(RT_HW_CACHE_INVALIDATE) before each rt_memcpy() in _serial_dma_rx() to ensure cache coherence.