### PR TITLE
fix: cherryusb: daplink: fix 4-byte alignment and build conflict on STM32H7

### DIFF
--- a/bsp/stm32/libraries/HAL_Drivers/drivers/SConscript
+++ b/bsp/stm32/libraries/HAL_Drivers/drivers/SConscript
@@ -123,7 +123,7 @@ if GetDepend(['BSP_USING_SDIO']):
     else:
         src += ['drv_sdio.c']
 
-if GetDepend(['BSP_USING_USBD']):
+if GetDepend(['BSP_USING_USBD']) and not GetDepend(['RT_CHERRYUSB_DEVICE']):
     src += ['drv_usbd.c']
 
 if GetDepend(['BSP_USING_PULSE_ENCODER']):

--- a/components/drivers/usb/cherryusb/platform/daplink/dap_main.c
+++ b/components/drivers/usb/cherryusb/platform/daplink/dap_main.c
@@ -342,6 +342,7 @@ volatile uint8_t config_uart_transfer = 0;
 USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t uartrx_ringbuffer[CONFIG_UARTRX_RINGBUF_SIZE];
 USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t usbrx_ringbuffer[CONFIG_USBRX_RINGBUF_SIZE];
 USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t usb_tmpbuffer[DAP_PACKET_SIZE];
+USB_NOCACHE_RAM_SECTION USB_MEM_ALIGNX uint8_t usb_intmpbuffer[DAP_PACKET_SIZE];
 
 static volatile uint8_t usbrx_idle_flag = 0;
 static volatile uint8_t usbtx_idle_flag = 0;
@@ -447,7 +448,13 @@ void usbd_cdc_acm_bulk_in(uint8_t busid, uint8_t ep, uint32_t nbytes)
     } else {
         if (chry_ringbuffer_get_used(&g_uartrx)) {
             buffer = chry_ringbuffer_linear_read_setup(&g_uartrx, &size);
-            usbd_ep_start_write(0, CDC_IN_EP, buffer, size);
+            if ((uint32_t)buffer & 0x3) {
+                if (size > DAP_PACKET_SIZE) size = DAP_PACKET_SIZE;
+                memcpy(usb_intmpbuffer, buffer, size);
+                usbd_ep_start_write(0, CDC_IN_EP, usb_intmpbuffer, size);
+            } else {
+                usbd_ep_start_write(0, CDC_IN_EP, buffer, size);
+            }
         } else {
             usbtx_idle_flag = 1;
         }
@@ -669,7 +676,14 @@ void chry_dap_usb2uart_handle(void)
             usbtx_idle_flag = 0;
             /* start first transfer */
             buffer = chry_ringbuffer_linear_read_setup(&g_uartrx, &size);
-            usbd_ep_start_write(0, CDC_IN_EP, buffer, size);
+            /* DWC2 requires 4-byte-aligned data; bounce if needed */
+            if ((uint32_t)buffer & 0x3) {
+                if (size > DAP_PACKET_SIZE) size = DAP_PACKET_SIZE;
+                memcpy(usb_intmpbuffer, buffer, size);
+                usbd_ep_start_write(0, CDC_IN_EP, usb_intmpbuffer, size);
+            } else {
+                usbd_ep_start_write(0, CDC_IN_EP, buffer, size);
+            }
         }
     }
 


### PR DESCRIPTION
STM32H7 DWC2 USB driver asserts that all endpoint data buffers are 4-byte aligned. When the ringbuffer read offset drifts due to non-aligned UART writes, usbd_ep_start_write() receives a misaligned pointer and triggers the assertion.

## Changes

- Add USB_MEM_ALIGNX aligned bounce buffer (usb_intmpbuffer)
- Check 4-byte alignment at both CDC IN send sites (usbd_cdc_acm_bulk_in and chry_dap_usb2uart_handle). Misaligned pointers go through the bounce buffer; aligned pointers keep the zero-copy path.
- SConscript: exclude drv_usbd.c when CherryUSB device is enabled, preventing duplicate symbol errors from the legacy USB device driver.