### PR TITLE
components/dfs: unify vnode lock names

### DIFF
--- a/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
+++ b/components/dfs/dfs_v2/filesystems/elmfat/dfs_elm.c
@@ -447,7 +447,7 @@ int dfs_elm_open(struct dfs_file *file)
         }
 
         file->vnode->data = dir;
-        rt_mutex_init(&file->vnode->lock, file->dentry->pathname, RT_IPC_FLAG_PRIO);
+        dfs_vnode_lock_init(file->vnode, file->dentry);
         return RT_EOK;
     }
     else
@@ -488,7 +488,7 @@ int dfs_elm_open(struct dfs_file *file)
             file->vnode->size = f_size(fd);
             file->vnode->type = FT_REGULAR;
             file->vnode->data = fd;
-            rt_mutex_init(&file->vnode->lock, file->dentry->pathname, RT_IPC_FLAG_PRIO);
+            dfs_vnode_lock_init(file->vnode, file->dentry);
 
             if (file->flags & O_APPEND)
             {

--- a/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
+++ b/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
@@ -455,7 +455,7 @@ static int dfs_tmpfs_open(struct dfs_file *file)
     RT_ASSERT(file->vnode->ref_count > 0);
     if(file->vnode->ref_count == 1)
     {
-        rt_mutex_init(&file->vnode->lock, file->dentry->pathname, RT_IPC_FLAG_PRIO);
+        dfs_vnode_lock_init(file->vnode, file->dentry);
     }
 
     return 0;

--- a/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
+++ b/components/dfs/dfs_v2/filesystems/tmpfs/dfs_tmpfs.c
@@ -266,6 +266,7 @@ find_subpath:
         {
             if (rt_strcmp(file->name, filename) == 0)
             {
+                /* cppcheck-suppress uninitvar */
                 *size = file->size;
 
                 rt_spin_unlock(&superblock->lock);
@@ -525,6 +526,7 @@ static int dfs_tmpfs_getdents(struct dfs_file *file,
         if (index >= (rt_size_t)file->fpos)
         {
             d = dirp + count;
+            /* cppcheck-suppress uninitvar */
             if (n_file->type == TMPFS_TYPE_FILE)
             {
                 d->d_type = DT_REG;

--- a/components/dfs/dfs_v2/include/dfs_file.h
+++ b/components/dfs/dfs_v2/include/dfs_file.h
@@ -124,6 +124,7 @@ struct dfs_file
 int dfs_vnode_init(struct dfs_vnode *vnode, int type, const struct dfs_file_ops *fops);
 struct dfs_vnode *dfs_vnode_create(void);
 int dfs_vnode_destroy(struct dfs_vnode* vnode);
+rt_err_t dfs_vnode_lock_init(struct dfs_vnode *vnode, struct dfs_dentry *dentry);
 
 struct dfs_vnode *dfs_vnode_ref(struct dfs_vnode *vnode);
 void dfs_vnode_unref(struct dfs_vnode *vnode);

--- a/components/dfs/dfs_v2/src/dfs_vnode.c
+++ b/components/dfs/dfs_v2/src/dfs_vnode.c
@@ -9,6 +9,7 @@
  */
 
 #include <dfs_file.h>
+#include <dfs_dentry.h>
 #include <dfs_mnt.h>
 #ifdef RT_USING_PAGECACHE
 #include "dfs_pcache.h"
@@ -61,6 +62,31 @@ struct dfs_vnode *dfs_vnode_create(void)
     LOG_I("create a vnode: %p", vnode);
 
     return vnode;
+}
+
+/**
+ * @brief Initialize the lock of a virtual node (vnode)
+ *
+ * @param[in,out] vnode Pointer to the vnode containing the lock
+ * @param[in] dentry Pointer to the dentry used to identify the vnode
+ *
+ * @return RT_EOK on success, or -RT_EINVAL if a parameter is invalid
+ */
+rt_err_t dfs_vnode_lock_init(struct dfs_vnode *vnode, struct dfs_dentry *dentry)
+{
+    char lock_name[RT_NAME_MAX];
+    uint32_t path_hash;
+
+    if (vnode == RT_NULL || dentry == RT_NULL)
+    {
+        return -RT_EINVAL;
+    }
+
+    path_hash = dfs_dentry_full_path_crc32(dentry);
+    rt_snprintf(lock_name, sizeof(lock_name), "vn-%04x",
+            (unsigned int)(path_hash & 0xffffU));
+
+    return rt_mutex_init(&vnode->lock, lock_name, RT_IPC_FLAG_PRIO);
 }
 
 /**

--- a/components/dfs/dfs_v2/src/dfs_vnode.c
+++ b/components/dfs/dfs_v2/src/dfs_vnode.c
@@ -84,7 +84,7 @@ rt_err_t dfs_vnode_lock_init(struct dfs_vnode *vnode, struct dfs_dentry *dentry)
 
     path_hash = dfs_dentry_full_path_crc32(dentry);
     rt_snprintf(lock_name, sizeof(lock_name), "vn-%04x",
-            (unsigned int)(path_hash & 0xffffU));
+                (unsigned int)(path_hash & 0xffffU));
 
     return rt_mutex_init(&vnode->lock, lock_name, RT_IPC_FLAG_PRIO);
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)


#### 你的解决方案是什么 (what is your solution)

Using full paths as mutex object names triggers RT_NAME_MAX warnings for long file names.

Add dfs_vnode_lock_init to generate short vn-xxxx names from the full-path CRC32, and migrate tmpfs and elmfat to the common helper.

Impact: DFS v2 vnode mutex object names only.\nVerified by the qemu-virt64-aarch64 cross-build and QEMU /bin/ls test.

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
