### PR TITLE
[libcpu][aarch64] fix boot failure when dropping from EL2 in entry_point.S

### DIFF
--- a/libcpu/aarch64/cortex-a/entry_point.S
+++ b/libcpu/aarch64/cortex-a/entry_point.S
@@ -89,8 +89,6 @@ _start:
  *   x3 = 0 (reserved for future use)
  */
 
-    /* Ensure CPU drops to EL1 before touching _el1 registers */
-    bl      init_cpu_el
     mov     dtb_paddr, x0
     mov     boot_arg0, x1
     mov     boot_arg1, x2
@@ -98,6 +96,10 @@ _start:
 
     /* Save cpu stack */
     get_phy stack_top, .boot_cpu_stack_top
+
+    /* Drop to EL1 and clean up hypervisor state */
+    bl      init_cpu_el
+    
     /* Save cpu id temp */
     msr     tpidr_el1, xzr
 

--- a/libcpu/aarch64/cortex-a/entry_point.S
+++ b/libcpu/aarch64/cortex-a/entry_point.S
@@ -88,6 +88,9 @@ _start:
  *   x2 = 0 (reserved for future use)
  *   x3 = 0 (reserved for future use)
  */
+
+    /* Ensure CPU drops to EL1 before touching _el1 registers */
+    bl      init_cpu_el
     mov     dtb_paddr, x0
     mov     boot_arg0, x1
     mov     boot_arg1, x2
@@ -96,13 +99,8 @@ _start:
     /* Save cpu stack */
     get_phy stack_top, .boot_cpu_stack_top
     /* Save cpu id temp */
-#ifdef ARCH_USING_HW_THREAD_SELF
-    msr     tpidrro_el0, xzr
-    /* Save thread self */
-#endif /* ARCH_USING_HW_THREAD_SELF */
     msr     tpidr_el1, xzr
 
-    bl      init_cpu_el
     bl      init_kernel_bss
     bl      init_cpu_stack_early
 
@@ -113,15 +111,15 @@ _start:
 #endif
 
     /* Now we are in the end of boot cpu process */
-    ldr     x19, =rtthread_startup
+    ldr     x8, =rtthread_startup
     b       init_mmu_early
     /* never come back */
 
 kernel_start:
     /* jump to the PE's system entry */
     mov     x29, xzr
-    mov     x30, x19
-    br      x19
+    mov     x30, x8
+    br      x8
 
 cpu_idle:
     wfe
@@ -154,10 +152,11 @@ _secondary_cpu_entry:
 
     /* Get cpu id success */
     sub     x0, x2, #1
-#endif /* RT_USING_OFW */
-    /* Save cpu id global */
+    msr     tpidr_el1, x0           /* Save cpu id global */
+#else
     bl      rt_hw_cpu_id_set
-    bl      rt_hw_cpu_id
+    mrs     x0, tpidr_el1
+#endif /* RT_USING_OFW */
 
     /* Set current cpu's stack top */
     sub     x0, x0, #1
@@ -169,7 +168,7 @@ _secondary_cpu_entry:
     bl      init_cpu_stack_early
 
     /* secondary cpu start to startup */
-    ldr     x19, =rt_hw_secondary_cpu_bsp_start
+    ldr     x8, =rt_hw_secondary_cpu_bsp_start
     b       enable_mmu_early
 #endif /* RT_USING_SMP */
 
@@ -180,9 +179,9 @@ init_cpu_el:
 
     /* running at EL3? */
     cmp     x0, #3
-    bne     .init_cpu_hyp_test
+    bne     .init_cpu_hyp
 
-    /* should never be executed, just for completeness. (EL3) */
+    /* Drop from EL3 to EL2 */
     mov     x1, #(1 << 0)           /* EL0 and EL1 are in Non-Secure state */
     orr     x1, x1, #(1 << 4)       /* RES1 */
     orr     x1, x1, #(1 << 5)       /* RES1 */
@@ -200,12 +199,24 @@ init_cpu_el:
     msr     elr_el3, x1
     eret
 
-.init_cpu_hyp_test:
+.init_cpu_hyp:
+    /* Re-evaluate CurrentEL in case we dropped from EL3 */
+    mrs     x0, CurrentEL
+    lsr     x0, x0, #2
+    and     x0, x0, #3
+
     /* running at EL2? */
     cmp     x0, #2                  /* EL2 = 0b10  */
     bne     .init_cpu_sys
 
-.init_cpu_hyp:
+    /* Disable EL2 MMU and Caches */
+    mrs     x0, sctlr_el2
+    bic     x0, x0, #(1 << 0)       /* Clear M bit: disable EL2 MMU */
+    bic     x0, x0, #(1 << 2)       /* Clear C bit: disable D-Cache */
+    bic     x0, x0, #(1 << 12)      /* Clear I bit: disable I-Cache */
+    msr     sctlr_el2, x0
+    isb
+
     /* Enable CNTP for EL1 */
     mrs     x0, cnthctl_el2         /* Counter-timer Hypervisor Control register */
     orr     x0, x0, #(1 << 0)       /* Don't traps NS EL0/1 accesses to the physical counter */
@@ -213,10 +224,23 @@ init_cpu_el:
     msr     cnthctl_el2, x0
     msr     cntvoff_el2, xzr
 
-    mov     x0, #(1 << 31)          /* Enable AArch64 in EL1 */
+    /* Configure HCR_EL2: Enable AArch64 for EL1, disable Stage-2 MMU and traps */
+    mov     x0, #(1 << 31)          /* Bit 31: Enable AArch64 in EL1 */
     orr     x0, x0, #(1 << 1)       /* SWIO hardwired */
     msr     hcr_el2, x0
+    isb
 
+    /* Do not trap FP/SIMD instructions to EL2 */
+    msr     cptr_el2, xzr
+
+    /* Invalidate stale EL2 and Stage-2 TLBs left by bootloader */
+    tlbi    alle2is
+    tlbi    vmalle1is
+    ic      iallu
+    dsb     sy
+    isb
+
+    /* Configure target exception level (EL1h) */
     mov     x0, #5                  /* Next level is 0b0101->EL1h */
     orr     x0, x0, #(1 << 6)       /* Mask FIQ */
     orr     x0, x0, #(1 << 7)       /* Mask IRQ */
@@ -233,10 +257,6 @@ init_cpu_el:
     bic     x0, x0, #(3 << 3)       /* Disable SP Alignment check */
     bic     x0, x0, #(1 << 1)       /* Disable Alignment check */
     msr     sctlr_el1, x0
-
-    mrs     x0, cntkctl_el1
-    orr     x0, x0, #(1 << 1)      /* Set EL0VCTEN, enabling the EL0 Virtual Count Timer */
-    msr     cntkctl_el1, x0
 
     /* Avoid trap from SIMD or float point instruction */
     mov     x0, #0x00300000         /* Don't trap any SIMD/FP instructions in both EL0 and EL1 */
@@ -323,10 +343,6 @@ enable_mmu_early:
     isb
 
     ic      ialluis     /* Invalidate all instruction caches in Inner Shareable domain to Point of Unification */
-    dsb     ish
-    isb
-
-    tlbi    vmalle1     /* Invalidate all stage 1 translations used at EL1 with the current VMID */
     dsb     ish
     isb
 

--- a/libcpu/aarch64/cortex-a/entry_point.S
+++ b/libcpu/aarch64/cortex-a/entry_point.S
@@ -348,6 +348,10 @@ enable_mmu_early:
     dsb     ish
     isb
 
+    tlbi    vmalle1     /* Invalidate all stage 1 translations used at EL1 with the current VMID */
+    dsb     ish
+    isb
+
     ret
 
 /*


### PR DESCRIPTION

## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

Fix AArch64 cold boot failure (`HPFAR_EL2` Stage-2 fault / panic) when booted directly from U-Boot in EL2 mode.

#### 你的解决方案是什么 (what is your solution)

1. **Reordered startup sequence**: Executed `init_cpu_el` before accessing any `_el1` system registers (e.g. `tpidr_el1`) in `_start`.
2. **Fixed `CurrentEL` logic**: Re-evaluated `CurrentEL` after dropping from EL3 to EL2 in `.init_cpu_hyp`.
3. **Cleaned up EL2 hardware context**:
   - Disabled EL2 MMU and Caches (`sctlr_el2`).
   - Cleared FP/SIMD traps (`cptr_el2`).
   - Invalidated stale EL2/Stage-2 TLBs (`tlbi alle2is`, `tlbi vmalle1is`) to resolve hardware fault traps.

#### 如何测试 / How to test?

   - **Hardware Platform**: AArch64 board (Cortex-A CPU)
   - **Bootloader**: U-Boot (running in EL2 mode, without prior ATF cleanup)
   - **Test Result**: Cold boot successfully enters the `msh` prompt every time without hanging or throwing `HPFAR_EL2` exceptions.

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
