### PR TITLE
wlan: fix silent failure of wifi cmd when device mode not bound

### DIFF
--- a/components/drivers/wlan/dev_wlan_cmd.c
+++ b/components/drivers/wlan/dev_wlan_cmd.c
@@ -103,9 +103,9 @@ static int wifi_check_sta_mode(void)
 #else
         LOG_E("sta mode not set, bind it in code: rt_wlan_set_mode(RT_WLAN_DEVICE_STA_NAME, RT_WLAN_STATION)!");
 #endif
-        return -1;
+        return -RT_ERROR;
     }
-    return 0;
+    return RT_EOK;
 }
 
 static int wifi_check_ap_mode(void)
@@ -117,9 +117,9 @@ static int wifi_check_ap_mode(void)
 #else
         LOG_E("ap mode not set, bind it in code: rt_wlan_set_mode(RT_WLAN_DEVICE_AP_NAME, RT_WLAN_AP)!");
 #endif
-        return -1;
+        return -RT_ERROR;
     }
-    return 0;
+    return RT_EOK;
 }
 
 static int wifi_help(int argc, char *argv[])
@@ -478,7 +478,7 @@ static int wifi_scan(int argc, char *argv[])
         info = &filter;
     }
 
-    if (wifi_check_sta_mode() != 0)
+    if (wifi_check_sta_mode() != RT_EOK)
     {
         return 0;
     }
@@ -519,7 +519,7 @@ static int wifi_join(int argc, char *argv[])
     struct rt_wlan_cfg_info cfg_info;
 
     rt_memset(&cfg_info, 0, sizeof(cfg_info));
-    if (wifi_check_sta_mode() != 0)
+    if (wifi_check_sta_mode() != RT_EOK)
     {
         return 0;
     }
@@ -580,7 +580,7 @@ static int wifi_ap(int argc, char *argv[])
         return -1;
     }
 
-    if (wifi_check_ap_mode() != 0)
+    if (wifi_check_ap_mode() != RT_EOK)
     {
         return 0;
     }
@@ -601,7 +601,7 @@ static int wifi_list_sta(int argc, char *argv[])
     {
         return -1;
     }
-    if (wifi_check_ap_mode() != 0)
+    if (wifi_check_ap_mode() != RT_EOK)
     {
         return 0;
     }
@@ -631,7 +631,7 @@ static int wifi_disconnect(int argc, char *argv[])
         return -1;
     }
 
-    if (wifi_check_sta_mode() != 0)
+    if (wifi_check_sta_mode() != RT_EOK)
     {
         return 0;
     }

--- a/components/drivers/wlan/dev_wlan_cmd.c
+++ b/components/drivers/wlan/dev_wlan_cmd.c
@@ -145,7 +145,9 @@ static int wifi_status(int argc, char *argv[])
     struct rt_wlan_info info;
 
     if (argc > 2)
+    {
         return -1;
+    }
 
     if (rt_wlan_is_connected() == 1)
     {
@@ -234,7 +236,9 @@ static rt_err_t wifi_scan_result_cache(struct rt_wlan_info *info)
     rt_base_t level;
 
     if ((info == RT_NULL) || (info->ssid.len == 0))
+    {
         return -RT_EINVAL;
+    }
 
     LOG_D("ssid:%s len:%d mac:%02x:%02x:%02x:%02x:%02x:%02x", info->ssid.val, info->ssid.len,
           info->bssid[0], info->bssid[1], info->bssid[2], info->bssid[3], info->bssid[4], info->bssid[5]);
@@ -308,10 +312,14 @@ static rt_err_t wifi_scan_result_cache(struct rt_wlan_info *info)
 
     /* Insert the end */
     if (insert == -1)
+    {
         insert = scan_result.num;
+    }
 
     if (scan_result.num >= RT_WLAN_SCAN_CACHE_NUM)
+    {
         return RT_EOK;
+    }
 
     /* malloc memory */
     ptable = rt_malloc(sizeof(struct rt_wlan_info) * (scan_result.num + 1));
@@ -459,7 +467,9 @@ static int wifi_scan(int argc, char *argv[])
     int i = 0;
 
     if (argc > 3)
+    {
         return -1;
+    }
 
     if (argc == 3)
     {
@@ -469,7 +479,9 @@ static int wifi_scan(int argc, char *argv[])
     }
 
     if (wifi_check_sta_mode() != 0)
+    {
         return 0;
+    }
 
     ret = rt_wlan_register_event_handler(RT_WLAN_EVT_SCAN_REPORT, user_ap_info_callback, &i);
     if (ret != RT_EOK)
@@ -508,7 +520,9 @@ static int wifi_join(int argc, char *argv[])
 
     rt_memset(&cfg_info, 0, sizeof(cfg_info));
     if (wifi_check_sta_mode() != 0)
+    {
         return 0;
+    }
     if (argc == 2)
     {
 #ifdef RT_WLAN_CFG_ENABLE
@@ -517,7 +531,9 @@ static int wifi_join(int argc, char *argv[])
         {
             ssid = (char *)(&cfg_info.info.ssid.val[0]);
             if (cfg_info.key.len)
+            {
                 key = (char *)(&cfg_info.key.val[0]);
+            }
         }
         else
 #endif
@@ -565,7 +581,9 @@ static int wifi_ap(int argc, char *argv[])
     }
 
     if (wifi_check_ap_mode() != 0)
+    {
         return 0;
+    }
     err = rt_wlan_start_ap(ssid, key);
     if (err != RT_EOK)
     {
@@ -580,9 +598,13 @@ static int wifi_list_sta(int argc, char *argv[])
     int num, i;
 
     if (argc > 2)
+    {
         return -1;
+    }
     if (wifi_check_ap_mode() != 0)
+    {
         return 0;
+    }
     num = rt_wlan_ap_get_sta_num();
     sta_info = rt_malloc(sizeof(struct rt_wlan_info) * num);
     if (sta_info == RT_NULL)
@@ -610,7 +632,9 @@ static int wifi_disconnect(int argc, char *argv[])
     }
 
     if (wifi_check_sta_mode() != 0)
+    {
         return 0;
+    }
 
     rt_wlan_disconnect();
     return 0;
@@ -752,7 +776,9 @@ static int wifi_debug_set_mode(int argc, char *argv[])
     rt_wlan_mode_t mode;
 
     if (argc != 3)
+    {
         return -1;
+    }
 
     if (rt_strcmp("sta", argv[1]) == 0)
     {
@@ -767,7 +793,9 @@ static int wifi_debug_set_mode(int argc, char *argv[])
         mode = RT_WLAN_NONE;
     }
     else
+    {
         return -1;
+    }
 
     rt_wlan_set_mode(argv[2], mode);
     return 0;
@@ -794,9 +822,13 @@ static int wifi_debug_set_autoconnect(int argc, char *argv[])
     if (argc == 2)
     {
         if (rt_strcmp(argv[1], "enable") == 0)
+        {
             rt_wlan_config_autoreconnect(RT_TRUE);
+        }
         else if (rt_strcmp(argv[1], "disable") == 0)
+        {
             rt_wlan_config_autoreconnect(RT_FALSE);
+        }
     }
     else
     {

--- a/components/drivers/wlan/dev_wlan_cmd.c
+++ b/components/drivers/wlan/dev_wlan_cmd.c
@@ -480,7 +480,7 @@ static int wifi_scan(int argc, char *argv[])
 
     if (wifi_check_sta_mode() != RT_EOK)
     {
-        return 0;
+        return -RT_ERROR;
     }
 
     ret = rt_wlan_register_event_handler(RT_WLAN_EVT_SCAN_REPORT, user_ap_info_callback, &i);
@@ -521,7 +521,7 @@ static int wifi_join(int argc, char *argv[])
     rt_memset(&cfg_info, 0, sizeof(cfg_info));
     if (wifi_check_sta_mode() != RT_EOK)
     {
-        return 0;
+        return -RT_ERROR;
     }
     if (argc == 2)
     {
@@ -582,7 +582,7 @@ static int wifi_ap(int argc, char *argv[])
 
     if (wifi_check_ap_mode() != RT_EOK)
     {
-        return 0;
+        return -RT_ERROR;
     }
     err = rt_wlan_start_ap(ssid, key);
     if (err != RT_EOK)
@@ -603,7 +603,7 @@ static int wifi_list_sta(int argc, char *argv[])
     }
     if (wifi_check_ap_mode() != RT_EOK)
     {
-        return 0;
+        return -RT_ERROR;
     }
     num = rt_wlan_ap_get_sta_num();
     sta_info = rt_malloc(sizeof(struct rt_wlan_info) * num);
@@ -633,7 +633,7 @@ static int wifi_disconnect(int argc, char *argv[])
 
     if (wifi_check_sta_mode() != RT_EOK)
     {
-        return 0;
+        return -RT_ERROR;
     }
 
     rt_wlan_disconnect();

--- a/components/drivers/wlan/dev_wlan_cmd.c
+++ b/components/drivers/wlan/dev_wlan_cmd.c
@@ -487,7 +487,7 @@ static int wifi_scan(int argc, char *argv[])
     if (ret != RT_EOK)
     {
         LOG_E("Scan register user callback error:%d!\n", ret);
-        return 0;
+        return -RT_ERROR;
     }
 
     if (info)
@@ -509,7 +509,7 @@ static int wifi_scan(int argc, char *argv[])
     {
         scan_filter = RT_NULL;
     }
-    return 0;
+    return ret;
 }
 
 static int wifi_join(int argc, char *argv[])
@@ -588,6 +588,7 @@ static int wifi_ap(int argc, char *argv[])
     if (err != RT_EOK)
     {
         LOG_E("start ap failed:%d!", err);
+        return -RT_ERROR;
     }
     return 0;
 }
@@ -653,6 +654,7 @@ static int wifi_ap_stop(int argc, char *argv[])
     if (err != RT_EOK)
     {
         LOG_E("ap stop failed:%d!", err);
+        return -RT_ERROR;
     }
     return 0;
 }

--- a/components/drivers/wlan/dev_wlan_cmd.c
+++ b/components/drivers/wlan/dev_wlan_cmd.c
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2018-08-13     tyx          the first version
  * 2024-03-24     Evlers       fixed a duplicate issue with the wifi scan command
+ * 2026-08-11     Kai          fixed silent failure of wifi cmd when wlan device mode is not bound
  */
 
 #include <rtthread.h>
@@ -87,6 +88,39 @@ static const struct wifi_cmd_des debug_tab[] = {
     { "auto", wifi_debug_set_autoconnect },
 };
 #endif
+
+/* Check that the STA/AP device is bound to its mode before issuing
+ * commands that would otherwise fail silently at the mgnt layer.
+ * The mode can only be bound from the shell when RT_WLAN_CMD_DEBUG
+ * is enabled ('wifi -d mode ...'); otherwise tell the user to bind
+ * it in code via rt_wlan_set_mode(). */
+static int wifi_check_sta_mode(void)
+{
+    if (rt_wlan_get_mode(RT_WLAN_DEVICE_STA_NAME) != RT_WLAN_STATION)
+    {
+#ifdef RT_WLAN_CMD_DEBUG
+        LOG_E("sta mode not set, run 'wifi -d mode sta wlan0' first!");
+#else
+        LOG_E("sta mode not set, bind it in code: rt_wlan_set_mode(RT_WLAN_DEVICE_STA_NAME, RT_WLAN_STATION)!");
+#endif
+        return -1;
+    }
+    return 0;
+}
+
+static int wifi_check_ap_mode(void)
+{
+    if (rt_wlan_get_mode(RT_WLAN_DEVICE_AP_NAME) != RT_WLAN_AP)
+    {
+#ifdef RT_WLAN_CMD_DEBUG
+        LOG_E("ap mode not set, run 'wifi -d mode ap wlan1' first!");
+#else
+        LOG_E("ap mode not set, bind it in code: rt_wlan_set_mode(RT_WLAN_DEVICE_AP_NAME, RT_WLAN_AP)!");
+#endif
+        return -1;
+    }
+    return 0;
+}
 
 static int wifi_help(int argc, char *argv[])
 {
@@ -434,6 +468,9 @@ static int wifi_scan(int argc, char *argv[])
         info = &filter;
     }
 
+    if (wifi_check_sta_mode() != 0)
+        return 0;
+
     ret = rt_wlan_register_event_handler(RT_WLAN_EVT_SCAN_REPORT, user_ap_info_callback, &i);
     if (ret != RT_EOK)
     {
@@ -470,6 +507,8 @@ static int wifi_join(int argc, char *argv[])
     struct rt_wlan_cfg_info cfg_info;
 
     rt_memset(&cfg_info, 0, sizeof(cfg_info));
+    if (wifi_check_sta_mode() != 0)
+        return 0;
     if (argc == 2)
     {
 #ifdef RT_WLAN_CFG_ENABLE
@@ -509,6 +548,7 @@ static int wifi_ap(int argc, char *argv[])
 {
     const char *ssid = RT_NULL;
     const char *key = RT_NULL;
+    rt_err_t err;
 
     if (argc == 3)
     {
@@ -524,7 +564,13 @@ static int wifi_ap(int argc, char *argv[])
         return -1;
     }
 
-    rt_wlan_start_ap(ssid, key);
+    if (wifi_check_ap_mode() != 0)
+        return 0;
+    err = rt_wlan_start_ap(ssid, key);
+    if (err != RT_EOK)
+    {
+        LOG_E("start ap failed:%d!", err);
+    }
     return 0;
 }
 
@@ -535,6 +581,8 @@ static int wifi_list_sta(int argc, char *argv[])
 
     if (argc > 2)
         return -1;
+    if (wifi_check_ap_mode() != 0)
+        return 0;
     num = rt_wlan_ap_get_sta_num();
     sta_info = rt_malloc(sizeof(struct rt_wlan_info) * num);
     if (sta_info == RT_NULL)
@@ -561,18 +609,27 @@ static int wifi_disconnect(int argc, char *argv[])
         return -1;
     }
 
+    if (wifi_check_sta_mode() != 0)
+        return 0;
+
     rt_wlan_disconnect();
     return 0;
 }
 
 static int wifi_ap_stop(int argc, char *argv[])
 {
+    rt_err_t err;
+
     if (argc != 2)
     {
         return -1;
     }
 
-    rt_wlan_ap_stop();
+    err = rt_wlan_ap_stop();
+    if (err != RT_EOK)
+    {
+        LOG_E("ap stop failed:%d!", err);
+    }
     return 0;
 }
 


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

不启用ap时候用wifi ap开ap，不报错直接失败，让人摸不着头脑

#### 你的解决方案是什么 (what is your solution)

检查一下，然后提供log提示

#### 请提供验证的bsp和config (provide the config and bsp) 

自己的板子，hpm+esp hosted

- BSP:

- .config:

- action:

]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
