### PR TITLE
[lwip-dhcpd] Fix pbuf leak for oversized requests

### DIFF
--- a/components/net/lwip-dhcpd/dhcp_server_raw.c
+++ b/components/net/lwip-dhcpd/dhcp_server_raw.c
@@ -338,6 +338,7 @@ dhcp_server_recv(void *arg, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t
     if (q->tot_len < p->tot_len)
     {
         LWIP_DEBUGF(DHCP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_WARNING, ("pbuf_alloc dhcp_msg too small %d:%d\n", q->tot_len, p->tot_len));
+        pbuf_free(q);
         pbuf_free(p);
         return;
     }


### PR DESCRIPTION
## Description

Fix the pbuf leak in the lwIP DHCP raw server when an incoming request is larger than the allocated response buffer.

## Root cause

`dhcp_server_recv()` allocates `q` and returns early when `q->tot_len < p->tot_len`. That error path freed the received request pbuf `p`, but did not free the newly allocated pbuf `q`.

## Changes

- Free `q` before returning from the oversized-request error path.
- Keep the existing cleanup of `p` unchanged.

## Impact

Prevents a pbuf leak for oversized DHCP requests. Normal request handling is unchanged.

## Validation

- `git diff --check`
- Reviewed all early returns after `q` allocation to confirm both pbufs are released on this path.

Fixes #11590
