### PR TITLE
[dfs] Fix path buffer leaks in utimensat

### DIFF
--- a/components/dfs/dfs_v2/src/dfs_posix.c
+++ b/components/dfs/dfs_v2/src/dfs_posix.c
@@ -157,9 +157,10 @@ int utimensat(int __fd, const char *__path, const struct timespec __times[2], in
     struct stat buffer;
     struct dfs_file *d;
     char *fullpath;
+    char *allocated_path = RT_NULL;
     struct dfs_attr attr;
     time_t current_time;
-    char *link_fn = (char *)rt_malloc(DFS_PATH_MAX);
+    char *link_fn = RT_NULL;
     int err;
 
     if (__path == NULL)
@@ -188,12 +189,13 @@ int utimensat(int __fd, const char *__path, const struct timespec __times[2], in
                 return -EBADF;
             }
 
-            fullpath = dfs_dentry_full_path(d->dentry);
-            if (!fullpath)
+            allocated_path = dfs_dentry_full_path(d->dentry);
+            if (!allocated_path)
             {
                 rt_set_errno(-ENOMEM);
                 return -1;
             }
+            fullpath = allocated_path;
         }
     }
 
@@ -230,30 +232,35 @@ int utimensat(int __fd, const char *__path, const struct timespec __times[2], in
     {
         if (S_ISLNK(buffer.st_mode) && (__flags != AT_SYMLINK_NOFOLLOW))
         {
-            if (link_fn)
+            link_fn = (char *)rt_malloc(DFS_PATH_MAX);
+            if (!link_fn)
             {
-                err = dfs_file_readlink(fullpath, link_fn, DFS_PATH_MAX);
-                if (err < 0)
-                {
-                    rt_free(link_fn);
-                    return -ENOENT;
-                }
-                else
-                {
-                    fullpath = link_fn;
-                    if (dfs_file_stat(fullpath, &buffer) != 0)
-                    {
-                        rt_free(link_fn);
-                        return -ENOENT;
-                    }
-                }
+                rt_set_errno(-ENOMEM);
+                ret = -1;
+                goto exit;
             }
 
+            err = dfs_file_readlink(fullpath, link_fn, DFS_PATH_MAX);
+            if (err < 0)
+            {
+                ret = -ENOENT;
+                goto exit;
+            }
+
+            fullpath = link_fn;
+            if (dfs_file_stat(fullpath, &buffer) != 0)
+            {
+                ret = -ENOENT;
+                goto exit;
+            }
         }
     }
     attr.st_mode = buffer.st_mode;
     ret = dfs_file_setattr(fullpath, &attr);
+
+exit:
     rt_free(link_fn);
+    rt_free(allocated_path);
 
     return ret;
 }


### PR DESCRIPTION
## Description

Fix path buffer leaks in the DFS v2 `utimensat()` implementation.

## Root cause

`link_fn` was allocated before validating the path and before several early returns, so those error paths leaked the buffer. In addition, the path returned by `dfs_dentry_full_path()` for a relative path was not retained separately and was never released; it could also be overwritten while resolving a symbolic link.

## Changes

- Allocate the symbolic-link buffer only when a link must be followed.
- Keep ownership of the dynamically generated relative path in a separate pointer.
- Route post-allocation error paths through common cleanup.
- Return an allocation error when the symbolic-link buffer cannot be allocated.

## Impact

Prevents heap growth from failed or repeated `utimensat()` calls while preserving the existing path and timestamp handling behavior.

## Validation

- `git diff --check`
- Built `bsp/qemu-vexpress-a9` successfully with `scons -j4`; this configuration compiles DFS v2 and the modified `dfs_posix.c`.

Fixes #11605
