### PR TITLE
[kernel/memheap] fix: stop invalid frees from corrupting heap

### DIFF
--- a/src/memheap.c
+++ b/src/memheap.c
@@ -619,6 +619,7 @@ void rt_memheap_free(void *ptr)
         RT_ASSERT(header_ptr->magic == (RT_MEMHEAP_MAGIC | RT_MEMHEAP_USED));
         /* check whether this block of memory has been over-written. */
         RT_ASSERT((header_ptr->next->magic & RT_MEMHEAP_MASK) == RT_MEMHEAP_MAGIC);
+        return;
     }
 
     /* get pool ptr */


### PR DESCRIPTION
RT_ASSERT() does not stop execution when RT_DEBUGING_ASSERT is disabled. Return after the existing block validation so a sequential duplicate free cannot update heap accounting or the free list in release builds.

Before fix:
  memheap double-free used: before=64 alloc=224 free=64 after=4294959232

Validation:
scons -C bsp/qemu-vexpress-a9 -j$(nproc)

## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

`rt_memheap_free()` 在释放内存块前会检查 block magic 和 USED 状态。

当 `RT_DEBUGING_ASSERT` 开启时，非法 free 或重复 free 会触发 `RT_ASSERT()`。但是当 `RT_DEBUGING_ASSERT` 关闭时，`RT_ASSERT()` 不会阻止后续代码继续执行，因此一个已经释放的 block 再次进入 `rt_memheap_free()` 后，仍会继续修改 `available_size` 和 free list，导致 memheap 元数据损坏。

实际复现中，连续释放同一个 memheap block 两次后，修复前 heap used 统计出现异常：
memheap double-free used: before=64 alloc=224 free=64 after=4294959232

#### 你的解决方案是什么 (what is your solution)
在现有 block validation 失败路径中的两个 `RT_ASSERT()` 后增加 `return`。
这样：
* Debug 构建仍然保留现有的 assertion 诊断行为；
* Release 构建在 validation 失败后直接返回，不再继续修改 heap accounting 和 free list；
* 不影响合法的 `rt_memheap_free()` 正常释放路径。

修改仅增加一行控制流保护：

```c
RT_ASSERT(header_ptr->magic == (RT_MEMHEAP_MAGIC | RT_MEMHEAP_USED));
RT_ASSERT((header_ptr->next->magic & RT_MEMHEAP_MASK) == RT_MEMHEAP_MAGIC);
return;
```

#### 请提供验证的bsp和config (provide the config and bsp)
* BSP:
bsp/qemu-vexpress-a9

* .config:
用于复现 Release 构建下的问题：
# CONFIG_RT_DEBUGING_ASSERT is not set

并完成 BSP 编译验证：
scons -C bsp/qemu-vexpress-a9 -j$(nproc)

* action:
待 push 分支并触发 GitHub Action 后补充链接


<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
