### PR TITLE
[bsp][nuvoton] Clamp CAN receive DLC

### DIFF
--- a/bsp/nuvoton/libraries/m2354/rtt_port/drv_can.c
+++ b/bsp/nuvoton/libraries/m2354/rtt_port/drv_can.c
@@ -515,6 +515,10 @@ static int nu_can_recvmsg(struct rt_can_device *can, void *buf, rt_uint32_t boxn
     pmsg->rtr = (tMsg.FrameType == CAN_DATA_FRAME) ? RT_CAN_DTR : RT_CAN_RTR;
     pmsg->id  = tMsg.Id;
     pmsg->len = tMsg.DLC ;
+    if (pmsg->len > sizeof(tMsg.Data))
+    {
+        pmsg->len = sizeof(tMsg.Data);
+    }
 
     if (pmsg->data && pmsg->len)
         rt_memcpy(pmsg->data, &tMsg.Data[0], pmsg->len);

--- a/bsp/nuvoton/libraries/m480/rtt_port/drv_can.c
+++ b/bsp/nuvoton/libraries/m480/rtt_port/drv_can.c
@@ -566,6 +566,10 @@ static int nu_can_recvmsg(struct rt_can_device *can, void *buf, rt_uint32_t boxn
     pmsg->rtr = (tMsg.FrameType == CAN_DATA_FRAME) ? RT_CAN_DTR : RT_CAN_RTR;
     pmsg->id  = tMsg.Id;
     pmsg->len = tMsg.DLC ;
+    if (pmsg->len > sizeof(tMsg.Data))
+    {
+        pmsg->len = sizeof(tMsg.Data);
+    }
 
     if (pmsg->data && pmsg->len)
         rt_memcpy(pmsg->data, &tMsg.Data[0], pmsg->len);

--- a/bsp/nuvoton/libraries/n9h30/rtt_port/drv_can.c
+++ b/bsp/nuvoton/libraries/n9h30/rtt_port/drv_can.c
@@ -515,6 +515,10 @@ static int nu_can_recvmsg(struct rt_can_device *can, void *buf, rt_uint32_t boxn
     pmsg->rtr = (tMsg.FrameType == CAN_DATA_FRAME) ? RT_CAN_DTR : RT_CAN_RTR;
     pmsg->id  = tMsg.Id;
     pmsg->len = tMsg.DLC ;
+    if (pmsg->len > sizeof(tMsg.Data))
+    {
+        pmsg->len = sizeof(tMsg.Data);
+    }
 
     if (pmsg->data && pmsg->len)
         rt_memcpy(pmsg->data, &tMsg.Data[0], pmsg->len);

--- a/bsp/nuvoton/libraries/nuc980/rtt_port/drv_can.c
+++ b/bsp/nuvoton/libraries/nuc980/rtt_port/drv_can.c
@@ -539,6 +539,10 @@ static int nu_can_recvmsg(struct rt_can_device *can, void *buf, rt_uint32_t boxn
     pmsg->rtr = (tMsg.FrameType == CAN_DATA_FRAME) ? RT_CAN_DTR : RT_CAN_RTR;
     pmsg->id  = tMsg.Id;
     pmsg->len = tMsg.DLC ;
+    if (pmsg->len > sizeof(tMsg.Data))
+    {
+        pmsg->len = sizeof(tMsg.Data);
+    }
 
     if (pmsg->data && pmsg->len)
         rt_memcpy(pmsg->data, &tMsg.Data[0], pmsg->len);


### PR DESCRIPTION
## Description / 描述

The nuvoton classic CAN drivers clamp the received DLC value from the hardware register in `nu_can_recvmsg()`, preventing out-of-bounds read/write on the fixed-size `Data[8]` buffer when the hardware reports an abnormal DLC (9~15).

nuvoton 经典 CAN 驱动在 `nu_can_recvmsg()` 中对来自硬件寄存器的接收 DLC 值做 clamp，防止当硬件报告异常 DLC（9~15）时对固定大小 `Data[8]` 缓冲区越界读写。

## Why / 为什么需要

`pmsg->len = tMsg.DLC` 直接使用硬件寄存器值，随后 `rt_memcpy(pmsg->data, &tMsg.Data[0], pmsg->len)` 以该值作为拷贝长度。经典 CAN 的 `tMsg.Data` 和 `pmsg->data` 都是 8 字节，若 DLC > 8 会导致越界读（`tMsg.Data`）和越界写（`pmsg->data`）。发送侧 `nu_can_sendmsg` 已用 `IS_CAN_DLC(len) <= 8U` 校验，接收侧却缺失，不对称。

## How / 修改了哪些文件

- `bsp/nuvoton/libraries/m2354/rtt_port/drv_can.c`: clamp DLC to `sizeof(tMsg.Data)`
- `bsp/nuvoton/libraries/m480/rtt_port/drv_can.c`: clamp DLC to `sizeof(tMsg.Data)`
- `bsp/nuvoton/libraries/n9h30/rtt_port/drv_can.c`: clamp DLC to `sizeof(tMsg.Data)`
- `bsp/nuvoton/libraries/nuc980/rtt_port/drv_can.c`: clamp DLC to `sizeof(tMsg.Data)`

This fix mirrors the previously merged `[bsp][loongson] Clamp CAN receive DLC` change.