### PR TITLE
[drivers][virtio] Fix RX buffer leak on pbuf allocation failure

### DIFF
--- a/components/drivers/virtio/virtio-net.c
+++ b/components/drivers/virtio/virtio-net.c
@@ -124,6 +124,19 @@ static struct pbuf *virtio_net_rx(rt_device_t dev)
 
         if (!p)
         {
+            level = rt_spin_lock_irqsave(&vnet->rx_lock);
+
+            if (!rt_virtqueue_poll(vq, packet - vnet->rx_packet))
+            {
+                rt_list_remove(&vq->user_list);
+            }
+
+            rt_virtqueue_add_inbuf(vq, packet, sizeof(*packet));
+
+            rt_virtqueue_kick(vq);
+
+            rt_spin_unlock_irqrestore(&vnet->rx_lock, level);
+
             return RT_NULL;
         }
 


### PR DESCRIPTION
## Description / 描述

Fix a receive buffer leak in `virtio_net_rx()`: when `pbuf_alloc()` fails, the buffer already read from the virtqueue used ring is not returned to the available ring, permanently losing that RX slot.

修复 `virtio_net_rx()` 中的接收缓冲泄漏：当 `pbuf_alloc()` 失败时，已从 virtqueue used ring 读出的 buffer 未归还到 available ring，导致该接收槽位永久丢失。

## Why / 为什么需要

In `virtio_net_rx()`, after `rt_virtqueue_read_buf()` consumes a buffer (`vq->num_free++` but the buffer is not yet re-queued), the code unlocks and calls `pbuf_alloc()`. On failure the original code simply `return RT_NULL` without calling `rt_virtqueue_add_inbuf()` to return the buffer. Repeated OOM eventually exhausts the RX queue.

The success path re-acquires the lock and returns the buffer via `rt_virtqueue_add_inbuf() + rt_virtqueue_kick()`; the failure path was missing this symmetric cleanup.

在 `virtio_net_rx()` 中，`rt_virtqueue_read_buf()` 消费 buffer 后（`vq->num_free++` 但 buffer 尚未重新入队），代码解锁并调用 `pbuf_alloc()`。失败时原代码直接 `return RT_NULL`，未调用 `rt_virtqueue_add_inbuf()` 归还 buffer。反复 OOM 会逐步耗尽接收队列。成功路径会重新加锁并通过 `rt_virtqueue_add_inbuf() + rt_virtqueue_kick()` 归还 buffer，失败路径缺失了这个对称清理。

## How / 修改了哪些文件

- `components/drivers/virtio/virtio-net.c`: in the `pbuf_alloc()` failure branch, re-acquire `rx_lock`, mirror the success path's `rt_virtqueue_poll` / `rt_list_remove` / `rt_virtqueue_add_inbuf` / `rt_virtqueue_kick` sequence before returning `RT_NULL`.