### PR TITLE
[bsp/qemu-vexpress-a9] support function names in backtraces

### DIFF
--- a/bsp/qemu-vexpress-a9/SConstruct
+++ b/bsp/qemu-vexpress-a9/SConstruct
@@ -2,6 +2,16 @@ import os
 import sys
 import rtconfig
 
+TRACE_CONFIG = ''
+try:
+    with open('rtconfig.h') as f:
+        for line in f:
+            if line.strip() == '#define RT_BACKTRACE_FUNCTION_NAME':
+                TRACE_CONFIG = '-mpoke-function-name'
+                break
+except OSError:
+    pass
+
 if os.getenv('RTT_ROOT'):
     RTT_ROOT = os.getenv('RTT_ROOT')
 else:
@@ -20,6 +30,11 @@ env = Environment(tools = ['mingw'],
     AR   = rtconfig.AR, ARFLAGS = '-rc',
     LINK = rtconfig.LINK, LINKFLAGS = rtconfig.LFLAGS)
 env.PrependENVPath('PATH', rtconfig.EXEC_PATH)
+
+if TRACE_CONFIG:
+    env.AppendUnique(CCFLAGS=[TRACE_CONFIG])
+    env['ASPPCOM'] += ' ' + TRACE_CONFIG
+
 env['ASCOM'] = env['ASPPCOM']
 
 Export('RTT_ROOT')


### PR DESCRIPTION
Pass -mpoke-function-name to the compiler and assembler when RT_BACKTRACE_FUNCTION_NAME is enabled for the Cortex-A9 QEMU BSP. Keep the BSP configuration opt-in so users can enable symbolized backtraces through menuconfig without changing the default build.

Validation:
- scons --pyconfig-silent
- scons -C bsp/qemu-vexpress-a9 -j2
- QEMU function-name backtrace verified with RT_BACKTRACE_FUNCTION_NAME enabled in a local configuration.

#### 为什么提交这份PR (why to submit this PR)
qemu-vexpress-a9 BSP 默认没有开启函数名符号支持，导致启用 `RT_BACKTRACE_FUNCTION_NAME` 后 backtrace 仍然只能打印地址，无法直接显示函数名，调试体验较差。

#### 你的解决方案是什么 (what is your solution)
在 `bsp/qemu-vexpress-a9/SConstruct` 中检测 `rtconfig.h` 是否定义了 `RT_BACKTRACE_FUNCTION_NAME`，若已启用则向编译器和汇编器追加 `-mpoke-function-name` 选项。该选项由 GCC ARM 提供，会把函数名嵌入 text 段，使 Cortex-A 的 backtrace 能直接输出函数名。此配置保持 opt-in，不影响默认构建。

#### 请提供验证的bsp和config (provide the config and bsp)
- BSP: bsp/qemu-vexpress-a9
- .config: CONFIG_RT_BACKTRACE_FUNCTION_NAME=y
- action: （请在这里填上你自己仓库触发的 GitHub Actions 编译成功链接，例如 https://github.com/你的用户名/rt-thread/actions/runs/xxxxxx）

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
