### PR TITLE
[kernel/mutex] fix: reject deleted mutex waiters

### DIFF
--- a/include/rtthread.h
+++ b/include/rtthread.h
@@ -466,6 +466,10 @@ rt_mutex_t rt_mutex_create(const char *name, rt_uint8_t flag);
 rt_err_t rt_mutex_delete(rt_mutex_t mutex);
 #endif /* RT_USING_HEAP */
 void rt_mutex_drop_thread(rt_mutex_t mutex, rt_thread_t thread);
+#if defined(__RT_KERNEL_SOURCE__) || defined(__RT_IPC_SOURCE__)
+void rt_mutex_drop_thread_locked(rt_mutex_t mutex, rt_thread_t thread);
+rt_bool_t rt_mutex_timeout_waiter(rt_thread_t thread);
+#endif /* defined(__RT_KERNEL_SOURCE__) || defined(__RT_IPC_SOURCE__) */
 rt_uint8_t rt_mutex_setprioceiling(rt_mutex_t mutex, rt_uint8_t priority);
 rt_uint8_t rt_mutex_getprioceiling(rt_mutex_t mutex);
 

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -888,6 +888,16 @@ rt_inline void _thread_update_priority(struct rt_thread *thread, rt_uint8_t prio
             rt_uint8_t mutex_priority = 0xff;
             struct rt_mutex* pending_mutex = (struct rt_mutex *)pending_obj;
 
+            /*
+             * A mutex owned by this thread is an in-flight handoff token,
+             * not a mutex wait dependency.
+             */
+            if (pending_mutex->owner == thread)
+            {
+                ret = -RT_ERROR;
+                break;
+            }
+
             /* re-insert thread to suspended thread list to resort priority list */
             rt_list_remove(&RT_THREAD_LIST_NODE(thread));
 
@@ -922,6 +932,96 @@ rt_inline void _thread_update_priority(struct rt_thread *thread, rt_uint8_t prio
     }
 }
 
+/*
+ * Detach a mutex waiter from the mutex object.
+ *
+ * The scheduler lock must be held. This only unlinks the waiter from the
+ * mutex wait list and clears its pending_object; the priority inheritance
+ * updates are done by the callers, so a batch of waiters costs a single
+ * recompute instead of one per waiter.
+ *
+ * Return the detached mutex, or RT_NULL when the thread is not pending on
+ * a mutex waiter.
+ */
+static rt_mutex_t _mutex_detach_waiter_locked(rt_thread_t thread,
+                                              rt_bool_t remove_from_list)
+{
+    rt_mutex_t mutex;
+
+    RT_SCHED_DEBUG_IS_LOCKED;
+
+    if ((thread->pending_object == RT_NULL) ||
+        (rt_object_get_type(thread->pending_object) != RT_Object_Class_Mutex))
+    {
+        return RT_NULL;
+    }
+
+    mutex = (rt_mutex_t)thread->pending_object;
+
+    /*
+     * A mutex owned by this thread is an in-flight handoff token, not a
+     * waiter. Keep the token until the mutex take path consumes it.
+     */
+    if (mutex->owner == thread)
+    {
+        return RT_NULL;
+    }
+
+    if (remove_from_list)
+    {
+        rt_list_remove(&RT_THREAD_LIST_NODE(thread));
+        /*
+         * Self-link the node: the timeout callback of an already expired
+         * timer still removes the waiter from its suspend list when it
+         * finally runs, and rt_list_remove() on a self-linked node is a
+         * safe no-op.
+         */
+        rt_list_init(&RT_THREAD_LIST_NODE(thread));
+    }
+
+    thread->pending_object = RT_NULL;
+
+    return mutex;
+}
+
+/*
+ * Timeout path of a mutex waiter. The mutex keeps living, so the mutex
+ * priority and the owner PI priority must be settled here, before the
+ * waiter leaves the wait list.
+ */
+rt_bool_t rt_mutex_timeout_waiter(rt_thread_t thread)
+{
+    rt_mutex_t mutex;
+    rt_uint8_t priority;
+    rt_bool_t need_update = RT_FALSE;
+
+    mutex = _mutex_detach_waiter_locked(thread, RT_TRUE);
+    if (mutex == RT_NULL)
+    {
+        return RT_FALSE;
+    }
+
+    if (mutex->owner &&
+        (rt_sched_thread_get_curr_prio(mutex->owner) ==
+         rt_sched_thread_get_curr_prio(thread)))
+    {
+        need_update = RT_TRUE;
+    }
+
+    _mutex_update_priority(mutex);
+
+    if (need_update && mutex->owner)
+    {
+        priority = _thread_get_mutex_priority(mutex->owner);
+        if (priority != rt_sched_thread_get_curr_prio(mutex->owner))
+        {
+            _thread_update_priority(mutex->owner, priority, RT_UNINTERRUPTIBLE);
+        }
+    }
+
+    return RT_TRUE;
+}
+
 static rt_bool_t _check_and_update_prio(rt_thread_t thread, rt_mutex_t mutex)
 {
     RT_SCHED_DEBUG_IS_LOCKED;
@@ -951,18 +1051,77 @@ static void _mutex_before_delete_detach(rt_mutex_t mutex)
     rt_bool_t need_schedule = RT_FALSE;
 
     rt_spin_lock(&(mutex->spinlock));
-    /* wakeup all suspended threads */
-    rt_susp_list_resume_all(&(mutex->parent.suspend_thread), RT_ERROR);
+
+    /*
+     * Wake waiters and clear their mutex references under one scheduler lock.
+     * If timeout owns a waiter's timer, only clean the mutex state here; the
+     * timeout callback still owns making the thread ready.
+     *
+     * The waiters are only detached here (no PI recompute); the owner
+     * priority is settled once after the whole batch.
+     */
+    for (;;)
+    {
+        rt_thread_t thread;
+        rt_mutex_t detached;
+
+        rt_sched_lock(&slvl);
+        if (rt_list_isempty(&mutex->parent.suspend_thread))
+        {
+            rt_sched_unlock(slvl);
+            break;
+        }
+
+        thread = RT_THREAD_LIST_NODE_ENTRY(mutex->parent.suspend_thread.next);
+        if (rt_sched_thread_ready(thread) == RT_EOK)
+        {
+            detached = _mutex_detach_waiter_locked(thread, RT_FALSE);
+            RT_ASSERT(detached != RT_NULL);
+            thread->error = RT_ERROR;
+            rt_sched_unlock(slvl);
+        }
+        else
+        {
+            detached = _mutex_detach_waiter_locked(thread, RT_TRUE);
+            RT_ASSERT(detached != RT_NULL);
+            rt_sched_unlock(slvl);
+        }
+    }
 
     rt_sched_lock(&slvl);
 
     /* remove mutex from thread's taken list */
     rt_list_remove(&mutex->taken_list);
 
-    /* whether change the thread priority */
     if (mutex->owner)
     {
-        need_schedule = _check_and_update_prio(mutex->owner, mutex);
+        /*
+         * The wait list is empty and the mutex no longer contributes to
+         * the owner's inherited priority, so recompute the owner PI once
+         * for the whole batch of waiters.
+         */
+        rt_uint8_t priority = _thread_get_mutex_priority(mutex->owner);
+        rt_uint8_t current_priority =
+            rt_sched_thread_get_curr_prio(mutex->owner);
+
+        mutex->priority = 0xff;
+
+        if (priority != current_priority)
+        {
+            _thread_update_priority(mutex->owner, priority, RT_UNINTERRUPTIBLE);
+            need_schedule = RT_TRUE;
+        }
+
+        /*
+         * A handed-off owner keeps pending_object as an in-flight token until
+         * _rt_mutex_take() finishes. Clear it before the mutex can be freed.
+         */
+        if (mutex->owner->pending_object == &mutex->parent.parent)
+        {
+            mutex->owner->pending_object = RT_NULL;
+            mutex->owner->error = RT_ERROR;
+        }
+
     }
 
     if (need_schedule)
@@ -1072,6 +1231,53 @@ RTM_EXPORT(rt_mutex_detach);
 
 /* drop a thread from the suspend list of mutex */
 
+static void _mutex_drop_thread_locked(rt_mutex_t mutex, rt_thread_t thread)
+{
+    rt_uint8_t priority;
+    rt_bool_t need_update = RT_FALSE;
+
+    RT_SCHED_DEBUG_IS_LOCKED;
+
+    RT_ASSERT(mutex != RT_NULL);
+    RT_ASSERT(thread != RT_NULL);
+    RT_ASSERT(thread->pending_object == &mutex->parent.parent);
+
+    /* detach from suspended list */
+    rt_list_remove(&RT_THREAD_LIST_NODE(thread));
+    thread->pending_object = RT_NULL;
+
+    /*
+     * After the waiter is detached, the mutex owner may already have
+     * released the mutex. In that case its priority is already restored.
+     */
+    if (mutex->owner && rt_sched_thread_get_curr_prio(mutex->owner) ==
+                            rt_sched_thread_get_curr_prio(thread))
+    {
+        need_update = RT_TRUE;
+    }
+
+    /* update the priority of mutex */
+    _mutex_update_priority(mutex);
+
+    /* try to change the priority of mutex owner thread */
+    if (need_update && mutex->owner)
+    {
+        priority = _thread_get_mutex_priority(mutex->owner);
+        if (priority != rt_sched_thread_get_curr_prio(mutex->owner))
+        {
+            _thread_update_priority(mutex->owner, priority, RT_UNINTERRUPTIBLE);
+        }
+    }
+}
+
+/*
+ * Drop a mutex waiter while the scheduler lock is already held.
+ */
+void rt_mutex_drop_thread_locked(rt_mutex_t mutex, rt_thread_t thread)
+{
+    _mutex_drop_thread_locked(mutex, thread);
+}
+
 /**
  * @brief drop a thread from the suspend list of mutex
  *
@@ -1080,8 +1286,6 @@ RTM_EXPORT(rt_mutex_detach);
  */
 void rt_mutex_drop_thread(rt_mutex_t mutex, rt_thread_t thread)
 {
-    rt_uint8_t priority;
-    rt_bool_t need_update = RT_FALSE;
     rt_sched_lock_level_t slvl;
 
     /* parameter check */
@@ -1091,52 +1295,9 @@ void rt_mutex_drop_thread(rt_mutex_t mutex, rt_thread_t thread)
 
     rt_spin_lock(&(mutex->spinlock));
 
-    RT_ASSERT(thread->pending_object == &mutex->parent.parent);
-
     rt_sched_lock(&slvl);
 
-    /* detach from suspended list */
-    rt_list_remove(&RT_THREAD_LIST_NODE(thread));
-
-    /**
-     * Should change the priority of mutex owner thread
-     * Note: After current thread is detached from mutex pending list, there is
-     *       a chance that the mutex owner has been released the mutex. Which
-     *       means mutex->owner can be NULL at this point. If that happened,
-     *       it had already reset its priority. So it's okay to skip
-     */
-    if (mutex->owner && rt_sched_thread_get_curr_prio(mutex->owner) ==
-                            rt_sched_thread_get_curr_prio(thread))
-    {
-        need_update = RT_TRUE;
-    }
-
-    /* update the priority of mutex */
-    if (!rt_list_isempty(&mutex->parent.suspend_thread))
-    {
-        /* more thread suspended in the list */
-        struct rt_thread *th;
-
-        th = RT_THREAD_LIST_NODE_ENTRY(mutex->parent.suspend_thread.next);
-        /* update the priority of mutex */
-        mutex->priority = rt_sched_thread_get_curr_prio(th);
-    }
-    else
-    {
-        /* set mutex priority to maximal priority */
-        mutex->priority = 0xff;
-    }
-
-    /* try to change the priority of mutex owner thread */
-    if (need_update)
-    {
-        /* get the maximal priority of mutex in thread */
-        priority = _thread_get_mutex_priority(mutex->owner);
-        if (priority != rt_sched_thread_get_curr_prio(mutex->owner))
-        {
-            _thread_update_priority(mutex->owner, priority, RT_UNINTERRUPTIBLE);
-        }
-    }
+    _mutex_drop_thread_locked(mutex, thread);
 
     rt_sched_unlock(slvl);
     rt_spin_unlock(&(mutex->spinlock));
@@ -1452,80 +1613,99 @@ static rt_err_t _rt_mutex_take(rt_mutex_t mutex, rt_int32_t timeout, int suspend
                 /* do schedule */
                 rt_schedule();
 
-                rt_spin_lock(&(mutex->spinlock));
-
-                if (mutex->owner == thread)
                 {
-                    /**
-                     * get mutex successfully
-                     * Note: assert to avoid an unexpected resume
-                     */
-                    RT_ASSERT(thread->error == RT_EOK);
-                }
-                else
-                {
-                    /* the mutex has not been taken and thread has detach from the pending list. */
-
+                    rt_sched_lock_level_t slvl;
+                    rt_mutex_t pending_mutex = RT_NULL;
                     rt_bool_t need_update = RT_FALSE;
-                    RT_ASSERT(mutex->owner != thread);
+                    rt_err_t wake_error = RT_EOK;
 
-                    /* get value first before calling to other APIs */
-                    ret = thread->error;
-
-                    /* unexpected resume */
-                    if (ret == RT_EOK)
-                    {
-                        ret = -RT_EINTR;
-                    }
-
+                    /*
+                     * Serialize token consumption with mutex deletion. The
+                     * mutex pointer is only dereferenced after the token
+                     * proves that deletion has not won the wakeup race.
+                     */
                     rt_sched_lock(&slvl);
 
-                    /**
-                     * Should change the priority of mutex owner thread
-                     * Note: After current thread is detached from mutex pending list, there is
-                     *       a chance that the mutex owner has been released the mutex. Which
-                     *       means mutex->owner can be NULL at this point. If that happened,
-                     *       it had already reset its priority. So it's okay to skip
-                     */
-                    if (mutex->owner && rt_sched_thread_get_curr_prio(mutex->owner) == rt_sched_thread_get_curr_prio(thread))
-                        need_update = RT_TRUE;
-
-                    /* update the priority of mutex */
-                    if (!rt_list_isempty(&mutex->parent.suspend_thread))
+                    if ((thread->pending_object == RT_NULL) &&
+                        ((thread->error == RT_ERROR) ||
+                         (thread->error == -RT_ETIMEOUT)))
                     {
-                        /* more thread suspended in the list */
-                        struct rt_thread *th;
-
-                        th = RT_THREAD_LIST_NODE_ENTRY(mutex->parent.suspend_thread.next);
-                        /* update the priority of mutex */
-                        mutex->priority = rt_sched_thread_get_curr_prio(th);
-                    }
-                    else
-                    {
-                        /* set mutex priority to maximal priority */
-                        mutex->priority = 0xff;
+                        wake_error = thread->error == RT_ERROR ?
+                                     -RT_ERROR : thread->error;
+                        rt_sched_unlock(slvl);
+                        return wake_error;
                     }
 
-                    /* try to change the priority of mutex owner thread */
-                    if (need_update)
+                    if (thread->pending_object == (rt_object_t)mutex)
                     {
-                        /* get the maximal priority of mutex in thread */
-                        priority = _thread_get_mutex_priority(mutex->owner);
-                        if (priority != rt_sched_thread_get_curr_prio(mutex->owner))
+                        pending_mutex = mutex;
+
+                        if (pending_mutex->owner == thread)
                         {
-                            _thread_update_priority(mutex->owner, priority, RT_UNINTERRUPTIBLE);
+                            /*
+                             * The release handoff completed. Keep the object
+                             * alive while invoking the take hook. Object
+                             * hooks must not block or access the scheduler.
+                             */
+                            thread->error = RT_EOK;
+                            thread->pending_object = RT_NULL;
+                            RT_OBJECT_HOOK_CALL(
+                                rt_object_take_hook,
+                                (&(pending_mutex->parent.parent)));
+                            rt_sched_unlock(slvl);
+                            return RT_EOK;
                         }
+
+                        /*
+                         * The thread was resumed without receiving the
+                         * mutex. It is already out of the suspend list.
+                         */
+                        if (pending_mutex->owner &&
+                            (rt_sched_thread_get_curr_prio(pending_mutex->owner) ==
+                             rt_sched_thread_get_curr_prio(thread)))
+                        {
+                            need_update = RT_TRUE;
+                        }
+
+                        _mutex_detach_waiter_locked(thread, RT_FALSE);
+                        _mutex_update_priority(pending_mutex);
+
+                        if (need_update && pending_mutex->owner)
+                        {
+                            rt_uint8_t priority;
+
+                            priority = _thread_get_mutex_priority(
+                                pending_mutex->owner);
+                            if (priority != rt_sched_thread_get_curr_prio(
+                                    pending_mutex->owner))
+                            {
+                                _thread_update_priority(
+                                    pending_mutex->owner,
+                                    priority,
+                                    RT_UNINTERRUPTIBLE);
+                            }
+                        }
+
+                        wake_error = thread->error;
+                        if (wake_error == RT_EOK)
+                        {
+                            wake_error = -RT_EINTR;
+                        }
+                        rt_sched_unlock(slvl);
+                        return wake_error > 0 ? -wake_error : wake_error;
                     }
 
+                    /*
+                     * A missing token means that another wakeup path already
+                     * completed the mutex cleanup. Do not dereference mutex.
+                     */
+                    wake_error = thread->error;
+                    if (wake_error == RT_EOK)
+                    {
+                        wake_error = -RT_EINTR;
+                    }
                     rt_sched_unlock(slvl);
-
-                    rt_spin_unlock(&(mutex->spinlock));
-
-                    /* clear pending object before exit */
-                    thread->pending_object = RT_NULL;
-
-                    /* fix thread error number to negative value and return */
-                    return ret > 0 ? -ret : ret;
+                    return wake_error > 0 ? -wake_error : wake_error;
                 }
             }
         }
@@ -1657,32 +1837,27 @@ rt_err_t rt_mutex_release(rt_mutex_t mutex)
         /* whether change the thread priority */
         need_schedule = _check_and_update_prio(owner, mutex);
 
-        /* wakeup suspended thread */
-        if (!rt_list_isempty(&mutex->parent.suspend_thread))
+        /* wakeup the first waiter that still owns its timer */
+        for (;;)
         {
             struct rt_thread *next_thread;
-            do
+            rt_mutex_t detached;
+
+            if (rt_list_isempty(&mutex->parent.suspend_thread))
             {
-                /* get the first suspended thread */
-                next_thread = RT_THREAD_LIST_NODE_ENTRY(mutex->parent.suspend_thread.next);
+                /* no waiting thread is woke up, clear owner */
+                mutex->owner = RT_NULL;
+                mutex->priority = 0xff;
+                rt_sched_unlock(slvl);
+                break;
+            }
 
-                RT_ASSERT(rt_sched_thread_is_suspended(next_thread));
+            /* get the first suspended thread */
+            next_thread = RT_THREAD_LIST_NODE_ENTRY(mutex->parent.suspend_thread.next);
+            RT_ASSERT(rt_sched_thread_is_suspended(next_thread));
 
-                /* remove the thread from the suspended list of mutex */
-                rt_list_remove(&RT_THREAD_LIST_NODE(next_thread));
-
-                /* resume thread to ready queue */
-                if (rt_sched_thread_ready(next_thread) != RT_EOK)
-                {
-                    /**
-                     * a timeout timer had triggered while we try. So we skip
-                     * this thread and try again.
-                     */
-                    next_thread = RT_NULL;
-                }
-            } while (!next_thread && !rt_list_isempty(&mutex->parent.suspend_thread));
-
-            if (next_thread)
+            /* resume thread to ready queue */
+            if (rt_sched_thread_ready(next_thread) == RT_EOK)
             {
                 LOG_D("mutex_release: resume thread: %s",
                     next_thread->parent.name);
@@ -1691,9 +1866,6 @@ rt_err_t rt_mutex_release(rt_mutex_t mutex)
                 mutex->owner = next_thread;
                 mutex->hold  = 1;
                 rt_list_insert_after(&next_thread->taken_object_list, &mutex->taken_list);
-
-                /* cleanup pending object */
-                next_thread->pending_object = RT_NULL;
 
                 /* update mutex priority */
                 if (!rt_list_isempty(&(mutex->parent.suspend_thread)))
@@ -1709,23 +1881,19 @@ rt_err_t rt_mutex_release(rt_mutex_t mutex)
                 }
 
                 need_schedule = RT_TRUE;
-            }
-            else
-            {
-                /* no waiting thread is woke up, clear owner */
-                mutex->owner = RT_NULL;
-                mutex->priority = 0xff;
+                rt_sched_unlock(slvl);
+                break;
             }
 
-            rt_sched_unlock(slvl);
-        }
-        else
-        {
-            rt_sched_unlock(slvl);
-
-            /* clear owner */
-            mutex->owner    = RT_NULL;
-            mutex->priority = 0xff;
+            /**
+             * A timeout callback owns this waiter. Detach it from the
+             * mutex state only (no PI recompute, the old owner PI was
+             * already restored above) and leave READY/error ownership to
+             * the callback, then retry the list head while the mutex
+             * remains locked.
+             */
+            detached = _mutex_detach_waiter_locked(next_thread, RT_TRUE);
+            RT_ASSERT(detached != RT_NULL);
         }
     }
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -82,19 +82,37 @@ static void _thread_detach_from_mutex(rt_thread_t thread)
     rt_list_t *node;
     rt_list_t *tmp_list;
     struct rt_mutex *mutex;
+    rt_sched_lock_level_t slvl;
     rt_base_t level;
 
     level = rt_spin_lock_irqsave(&thread->spinlock);
 
-    /* check if thread is waiting on a mutex */
+    rt_sched_lock(&slvl);
+
+    /*
+     * Validate the pending object while the scheduler lock protects mutex
+     * deletion and handoff token consumption.
+     */
     if ((thread->pending_object) &&
         (rt_object_get_type(thread->pending_object) == RT_Object_Class_Mutex))
     {
-        /* remove it from its waiting list */
-        struct rt_mutex *mutex = (struct rt_mutex*)thread->pending_object;
-        rt_mutex_drop_thread(mutex, thread);
-        thread->pending_object = RT_NULL;
+        /*
+         * A handed-off owner keeps pending_object until _rt_mutex_take()
+         * completes. Do not treat that token as a suspended waiter.
+         */
+        mutex = (struct rt_mutex *)thread->pending_object;
+        if (mutex->owner == thread)
+        {
+            thread->pending_object = RT_NULL;
+        }
+        else
+        {
+            /* Remove a thread that is still waiting on the mutex. */
+            rt_mutex_drop_thread_locked(mutex, thread);
+        }
     }
+
+    rt_sched_unlock(slvl);
 
     /* free taken mutex after detaching from waiting, so we don't lost mutex just got */
     rt_list_for_each_safe(node, tmp_list, &(thread->taken_object_list))
@@ -147,6 +165,7 @@ static void _thread_timeout(void *parameter)
 {
     struct rt_thread *thread;
     rt_sched_lock_level_t slvl;
+    rt_bool_t mutex_timeout = RT_FALSE;
 
     thread = (struct rt_thread *)parameter;
 
@@ -168,8 +187,16 @@ static void _thread_timeout(void *parameter)
     /* set error number */
     thread->error = -RT_ETIMEOUT;
 
-    /* remove from suspend list */
-    rt_list_remove(&RT_THREAD_LIST_NODE(thread));
+    /* Mutex timeout also removes the waiter from the mutex wait list. */
+#ifdef RT_USING_MUTEX
+    mutex_timeout = rt_mutex_timeout_waiter(thread);
+#endif /* RT_USING_MUTEX */
+
+    if (!mutex_timeout)
+    {
+        /* remove from suspend list */
+        rt_list_remove(&RT_THREAD_LIST_NODE(thread));
+    }
     /* insert to schedule ready list */
     rt_sched_insert_thread(thread);
     /* do schedule and release the scheduler lock */

--- a/src/utest/mutex_tc.c
+++ b/src/utest/mutex_tc.c
@@ -44,6 +44,7 @@
 #define __RT_IPC_SOURCE__
 
 #include <rtthread.h>
+#include <rtsched.h>
 #include <stdlib.h>
 #include "utest.h"
 
@@ -904,10 +905,737 @@ static void test_cross_thread_delete_mutex_owner(void)
 }
 #endif /* RT_USING_HEAP */
 
+#ifdef RT_USING_HEAP
+static struct rt_semaphore mutex_delete_ready;
+static struct rt_semaphore mutex_delete_done;
+static struct rt_semaphore mutex_delete_restart;
+static struct rt_semaphore mutex_delete_restart_done;
+static rt_mutex_t mutex_delete_dynamic;
+static void *mutex_delete_replacement_memory;
+static struct rt_mutex mutex_delete_static;
+static volatile rt_err_t mutex_delete_wait_result;
+static volatile rt_bool_t mutex_handoff_delete_detach_mode;
+static volatile rt_err_t mutex_delete_next_wait_result;
+static volatile rt_err_t mutex_delete_restart_result;
+static rt_thread_t mutex_delete_waiter;
+static rt_int32_t mutex_delete_wait_timeout;
+static rt_bool_t mutex_delete_semaphores_initialized;
+#ifdef RT_USING_SMP
+static int mutex_delete_bind_cpu;
+#endif /* RT_USING_SMP */
+
+static void mutex_delete_bind_waiter(rt_thread_t thread)
+{
+#ifdef RT_USING_SMP
+    /* Use the hardware CPU ID to avoid the debug SMP binding assertion. */
+    uassert_int_equal(rt_thread_control(thread,
+                                        RT_THREAD_CTRL_BIND_CPU,
+                                        (void *)(rt_ubase_t)mutex_delete_bind_cpu),
+                      RT_EOK);
+#else
+    RT_UNUSED(thread);
+#endif /* RT_USING_SMP */
+}
+
+static void mutex_delete_bind_test_thread(void)
+{
+#ifdef RT_USING_SMP
+    /* Keep the test and regression threads on one CPU for deterministic timing. */
+    mutex_delete_bind_cpu = rt_hw_cpu_id();
+    mutex_delete_bind_waiter(rt_thread_self());
+#endif /* RT_USING_SMP */
+}
+
+static void mutex_delete_unbind_test_thread(void)
+{
+#ifdef RT_USING_SMP
+    /* Restore the default CPU affinity of the UTest thread after the case. */
+    uassert_int_equal(rt_thread_control(rt_thread_self(),
+                                        RT_THREAD_CTRL_BIND_CPU,
+                                        (void *)(rt_ubase_t)RT_CPUS_NR),
+                      RT_EOK);
+#endif /* RT_USING_SMP */
+}
+
+/* Record the result returned by a waiter after its mutex is deleted. */
+static void mutex_delete_waiter_entry(void *parameter)
+{
+    rt_sem_release(&mutex_delete_ready);
+    mutex_delete_wait_result =
+        rt_mutex_take((rt_mutex_t)parameter, mutex_delete_wait_timeout);
+    rt_sem_release(&mutex_delete_done);
+}
+
+#ifdef RT_USING_SIGNALS
+static volatile rt_err_t mutex_handoff_signal_result;
+
+static void mutex_handoff_signal_handler(int signo)
+{
+    RT_UNUSED(signo);
+    mutex_handoff_signal_result = rt_sem_take(&mutex_delete_restart, 1);
+}
+
+static void mutex_handoff_signal_waiter_entry(void *parameter)
+{
+    rt_mutex_t mutex = (rt_mutex_t)parameter;
+
+    rt_signal_install(SIGUSR1, mutex_handoff_signal_handler);
+    rt_signal_unmask(SIGUSR1);
+    rt_sem_release(&mutex_delete_ready);
+
+    mutex_delete_wait_result = rt_mutex_take(mutex, RT_WAITING_FOREVER);
+    if (mutex_delete_wait_result == RT_EOK)
+    {
+        rt_mutex_release(mutex);
+    }
+    rt_sem_release(&mutex_delete_done);
+}
+#endif /* RT_USING_SIGNALS */
+
+/* Delete/detach a handed-off mutex before its new owner gets the CPU. */
+static void mutex_handoff_delete_controller_entry(void *parameter)
+{
+    rt_mutex_t mutex = (rt_mutex_t)parameter;
+
+    if (mutex_handoff_delete_detach_mode)
+    {
+        rt_mutex_detach(mutex);
+        rt_memset(mutex, 0xA5, sizeof(struct rt_mutex));
+    }
+    else
+    {
+        rt_mutex_delete(mutex);
+
+        /* Fill the released object address to make reuse observable. */
+        mutex_delete_replacement_memory = rt_malloc(sizeof(struct rt_mutex));
+        if (mutex_delete_replacement_memory != RT_NULL)
+        {
+            rt_memset(mutex_delete_replacement_memory,
+                      0xA5,
+                      sizeof(struct rt_mutex));
+        }
+    }
+
+    /* The handed-off owner is still READY and has not touched the mutex. */
+    rt_sem_release(&mutex_delete_ready);
+}
+
+static void mutex_delete_next_waiter_entry(void *parameter)
+{
+    rt_mutex_t mutex = (rt_mutex_t)parameter;
+
+    rt_sem_release(&mutex_delete_ready);
+    mutex_delete_next_wait_result =
+        rt_mutex_take(mutex, mutex_delete_wait_timeout);
+    if (mutex_delete_next_wait_result == RT_EOK)
+    {
+        mutex_delete_next_wait_result = rt_mutex_release(mutex);
+    }
+    rt_sem_release(&mutex_delete_done);
+}
+
+/* Restart a timeout after release has observed timer ownership. */
+static void mutex_delete_restart_timeout_entry(void *parameter)
+{
+    rt_thread_t thread = (rt_thread_t)parameter;
+    rt_tick_t timeout = 1;
+
+    rt_sem_take(&mutex_delete_restart, RT_WAITING_FOREVER);
+    mutex_delete_restart_result =
+        rt_timer_control(&thread->thread_timer,
+                         RT_TIMER_CTRL_SET_TIME,
+                         &timeout);
+    if (mutex_delete_restart_result == RT_EOK)
+    {
+        mutex_delete_restart_result = rt_timer_start(&thread->thread_timer);
+    }
+    rt_sem_release(&mutex_delete_restart_done);
+}
+
+/* Wait until the mutex waiter enters the suspend list. */
+static void mutex_delete_wait_until_suspended(rt_thread_t thread)
+{
+    rt_sched_lock_level_t slvl;
+
+    for (;;)
+    {
+        rt_sched_lock(&slvl);
+        if ((RT_SCHED_CTX(thread).stat & RT_THREAD_SUSPEND_MASK) ==
+            RT_THREAD_SUSPEND_MASK)
+        {
+            rt_sched_unlock(slvl);
+            break;
+        }
+        rt_sched_unlock(slvl);
+        rt_thread_delay(1);
+    }
+}
+
+/* Wait until timeout cleanup is complete while keeping the waiter READY. */
+static rt_bool_t mutex_delete_wait_until_timeout(rt_thread_t thread)
+{
+    rt_tick_t start;
+    rt_tick_t timeout = rt_tick_from_millisecond(1000);
+
+    start = rt_tick_get();
+    for (;;)
+    {
+        rt_sched_lock_level_t slvl;
+        rt_bool_t ready;
+        rt_bool_t cleaned;
+
+        rt_sched_lock(&slvl);
+        ready = ((RT_SCHED_CTX(thread).stat & RT_THREAD_STAT_MASK) ==
+                 RT_THREAD_READY);
+        cleaned = ((thread->pending_object == RT_NULL) &&
+                   (thread->error == -RT_ETIMEOUT));
+        rt_sched_unlock(slvl);
+
+        if (ready && cleaned)
+        {
+            return RT_TRUE;
+        }
+
+        if ((rt_tick_get() - start) >= timeout)
+        {
+            return RT_FALSE;
+        }
+
+        /* The controller has higher priority than the waiter. */
+        rt_thread_yield();
+    }
+}
+
+/* Verify that deleted mutex waiters do not access stale objects. */
+static void test_mutex_delete_waiter(void)
+{
+    rt_mutex_t deleted_mutex;
+
+    mutex_delete_bind_test_thread();
+    mutex_delete_wait_timeout = RT_WAITING_FOREVER;
+    mutex_delete_dynamic = rt_mutex_create("delmtx", RT_IPC_FLAG_PRIO);
+    uassert_true(mutex_delete_dynamic != RT_NULL);
+    uassert_int_equal(rt_mutex_take(mutex_delete_dynamic,
+                                    RT_WAITING_FOREVER),
+                      RT_EOK);
+
+    mutex_delete_wait_result = -RT_ERROR;
+
+    mutex_delete_waiter = rt_thread_create("mtxwait",
+                                           mutex_delete_waiter_entry,
+                                           mutex_delete_dynamic,
+                                           UTEST_THR_STACK_SIZE,
+                                           UTEST_THR_PRIORITY + 1,
+                                           10);
+    uassert_true(mutex_delete_waiter != RT_NULL);
+    mutex_delete_bind_waiter(mutex_delete_waiter);
+    uassert_int_equal(rt_thread_startup(mutex_delete_waiter), RT_EOK);
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_ready,
+                                  RT_WAITING_FOREVER),
+                      RT_EOK);
+    mutex_delete_wait_until_suspended(mutex_delete_waiter);
+
+    deleted_mutex = mutex_delete_dynamic;
+    uassert_int_equal(rt_mutex_delete(mutex_delete_dynamic), RT_EOK);
+    mutex_delete_dynamic = RT_NULL;
+
+    mutex_delete_replacement_memory =
+        rt_malloc(sizeof(struct rt_mutex));
+    uassert_true(mutex_delete_replacement_memory != RT_NULL);
+    if (mutex_delete_replacement_memory == (void *)deleted_mutex)
+    {
+        rt_memset(mutex_delete_replacement_memory,
+                  0xA5,
+                  sizeof(struct rt_mutex));
+    }
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_done,
+                                  rt_tick_from_millisecond(1000)),
+                      RT_EOK);
+    uassert_int_equal(mutex_delete_wait_result, -RT_ERROR);
+    rt_free(mutex_delete_replacement_memory);
+    mutex_delete_replacement_memory = RT_NULL;
+
+    uassert_int_equal(rt_mutex_init(&mutex_delete_static,
+                                    "detmtx",
+                                    RT_IPC_FLAG_PRIO),
+                      RT_EOK);
+    uassert_int_equal(rt_mutex_take(&mutex_delete_static,
+                                    RT_WAITING_FOREVER),
+                      RT_EOK);
+
+    mutex_delete_waiter = rt_thread_create("mtxwait2",
+                                           mutex_delete_waiter_entry,
+                                           &mutex_delete_static,
+                                           UTEST_THR_STACK_SIZE,
+                                           UTEST_THR_PRIORITY + 1,
+                                           10);
+    uassert_true(mutex_delete_waiter != RT_NULL);
+    mutex_delete_bind_waiter(mutex_delete_waiter);
+    uassert_int_equal(rt_thread_startup(mutex_delete_waiter), RT_EOK);
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_ready,
+                                  RT_WAITING_FOREVER),
+                      RT_EOK);
+    mutex_delete_wait_until_suspended(mutex_delete_waiter);
+
+    uassert_int_equal(rt_mutex_detach(&mutex_delete_static), RT_EOK);
+    rt_memset(&mutex_delete_static, 0xA5, sizeof(mutex_delete_static));
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_done,
+                                  rt_tick_from_millisecond(1000)),
+                      RT_EOK);
+    uassert_int_equal(mutex_delete_wait_result, -RT_ERROR);
+    mutex_delete_unbind_test_thread();
+}
+
+/* Verify a timed out waiter does not access a detached mutex. */
+static void test_mutex_timeout_delete_waiter(void)
+{
+    rt_sched_lock_level_t slvl;
+    rt_thread_t waiter;
+    rt_thread_t restart_thread;
+    rt_bool_t suspended;
+    rt_err_t stop_result;
+
+    mutex_delete_bind_test_thread();
+    mutex_delete_wait_timeout = rt_tick_from_millisecond(1000);
+    mutex_delete_restart_result = -RT_ERROR;
+    uassert_int_equal(rt_mutex_init(&mutex_delete_static,
+                                    "timemtx",
+                                    RT_IPC_FLAG_PRIO),
+                      RT_EOK);
+    uassert_int_equal(rt_mutex_take(&mutex_delete_static,
+                                    RT_WAITING_FOREVER),
+                      RT_EOK);
+
+    mutex_delete_waiter = rt_thread_create("mtxwait3",
+                                           mutex_delete_waiter_entry,
+                                           &mutex_delete_static,
+                                           UTEST_THR_STACK_SIZE,
+                                           UTEST_THR_PRIORITY + 1,
+                                           10);
+    uassert_true(mutex_delete_waiter != RT_NULL);
+    waiter = mutex_delete_waiter;
+    mutex_delete_bind_waiter(waiter);
+    uassert_int_equal(rt_thread_startup(waiter), RT_EOK);
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_ready,
+                                  RT_WAITING_FOREVER),
+                      RT_EOK);
+    mutex_delete_wait_until_suspended(waiter);
+
+    /* Stop the timer without clearing the scheduler timer ownership flag. */
+    rt_sched_lock(&slvl);
+    suspended = rt_sched_thread_is_suspended(waiter);
+    stop_result = rt_timer_stop(&waiter->thread_timer);
+    rt_sched_unlock(slvl);
+    uassert_true(suspended);
+    uassert_int_equal(stop_result, RT_EOK);
+
+    restart_thread = rt_thread_create("mtxrst2",
+                                      mutex_delete_restart_timeout_entry,
+                                      waiter,
+                                      UTEST_THR_STACK_SIZE,
+                                      UTEST_THR_PRIORITY + 3,
+                                      10);
+    uassert_true(restart_thread != RT_NULL);
+    mutex_delete_bind_waiter(restart_thread);
+    uassert_int_equal(rt_thread_startup(restart_thread), RT_EOK);
+    uassert_int_equal(rt_sem_release(&mutex_delete_restart), RT_EOK);
+
+    /* Delete owns bookkeeping; the timeout callback still owns wakeup. */
+    uassert_int_equal(rt_mutex_detach(&mutex_delete_static), RT_EOK);
+    rt_sched_lock(&slvl);
+    suspended = rt_sched_thread_is_suspended(waiter);
+    rt_sched_unlock(slvl);
+    uassert_true(suspended);
+    uassert_true(waiter->pending_object == RT_NULL);
+
+    /* Make a stale mutex dereference fail deterministically. */
+    rt_memset(&mutex_delete_static, 0xA5, sizeof(mutex_delete_static));
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_restart_done,
+                                  rt_tick_from_millisecond(1000)),
+                      RT_EOK);
+    uassert_int_equal(mutex_delete_restart_result, RT_EOK);
+    uassert_int_equal(rt_sem_take(&mutex_delete_done,
+                                  rt_tick_from_millisecond(1000)),
+                      RT_EOK);
+    uassert_int_equal(mutex_delete_wait_result, -RT_ETIMEOUT);
+    mutex_delete_wait_timeout = RT_WAITING_FOREVER;
+    mutex_delete_unbind_test_thread();
+}
+
+/* Verify a completed timeout cannot leave a stale mutex reference in READY. */
+static void test_mutex_timeout_ready_delete_waiter(void)
+{
+    rt_sched_lock_level_t slvl;
+    rt_thread_t waiter;
+    rt_bool_t ready;
+    rt_bool_t cleaned;
+
+    mutex_delete_bind_test_thread();
+    mutex_delete_wait_timeout = rt_tick_from_millisecond(20);
+    mutex_delete_wait_result = -RT_ERROR;
+    uassert_int_equal(rt_mutex_init(&mutex_delete_static,
+                                    "rdymtx",
+                                    RT_IPC_FLAG_PRIO),
+                      RT_EOK);
+    uassert_int_equal(rt_mutex_take(&mutex_delete_static,
+                                    RT_WAITING_FOREVER),
+                      RT_EOK);
+
+    waiter = rt_thread_create("mtxwait4",
+                              mutex_delete_waiter_entry,
+                              &mutex_delete_static,
+                              UTEST_THR_STACK_SIZE,
+                              UTEST_THR_PRIORITY + 1,
+                              10);
+    uassert_true(waiter != RT_NULL);
+    mutex_delete_bind_waiter(waiter);
+    uassert_int_equal(rt_thread_startup(waiter), RT_EOK);
+    uassert_int_equal(rt_sem_take(&mutex_delete_ready,
+                                  RT_WAITING_FOREVER),
+                      RT_EOK);
+    mutex_delete_wait_until_suspended(waiter);
+
+    /* The high-priority controller keeps the timed-out waiter from running. */
+    uassert_true(mutex_delete_wait_until_timeout(waiter));
+    rt_sched_lock(&slvl);
+    ready = ((RT_SCHED_CTX(waiter).stat & RT_THREAD_STAT_MASK) ==
+             RT_THREAD_READY);
+    cleaned = ((waiter->pending_object == RT_NULL) &&
+               (waiter->error == -RT_ETIMEOUT));
+    rt_sched_unlock(slvl);
+    uassert_true(ready);
+    uassert_true(cleaned);
+
+    uassert_int_equal(rt_mutex_detach(&mutex_delete_static), RT_EOK);
+    rt_memset(&mutex_delete_static, 0xA5, sizeof(mutex_delete_static));
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_done,
+                                  rt_tick_from_millisecond(1000)),
+                      RT_EOK);
+    uassert_int_equal(mutex_delete_wait_result, -RT_ETIMEOUT);
+    mutex_delete_wait_timeout = RT_WAITING_FOREVER;
+    mutex_delete_unbind_test_thread();
+}
+
+/* Verify a timed out head waiter does not starve later mutex waiters. */
+static void test_mutex_release_timeout_waiter(void)
+{
+    rt_sched_lock_level_t slvl;
+    rt_thread_t timeout_waiter;
+    rt_thread_t next_waiter;
+    rt_thread_t restart_thread;
+    rt_bool_t suspended;
+    rt_err_t stop_result;
+
+    mutex_delete_bind_test_thread();
+    mutex_delete_wait_timeout = rt_tick_from_millisecond(1000);
+    mutex_delete_wait_result = -RT_ERROR;
+    mutex_delete_next_wait_result = -RT_ERROR;
+    mutex_delete_restart_result = -RT_ERROR;
+
+    uassert_int_equal(rt_mutex_init(&mutex_delete_static,
+                                    "relmtx",
+                                    RT_IPC_FLAG_PRIO),
+                      RT_EOK);
+    uassert_int_equal(rt_mutex_take(&mutex_delete_static,
+                                    RT_WAITING_FOREVER),
+                      RT_EOK);
+
+    timeout_waiter = rt_thread_create("mtxwait5",
+                                      mutex_delete_waiter_entry,
+                                      &mutex_delete_static,
+                                      UTEST_THR_STACK_SIZE,
+                                      UTEST_THR_PRIORITY + 1,
+                                      10);
+    uassert_true(timeout_waiter != RT_NULL);
+    mutex_delete_bind_waiter(timeout_waiter);
+    uassert_int_equal(rt_thread_startup(timeout_waiter), RT_EOK);
+    uassert_int_equal(rt_sem_take(&mutex_delete_ready,
+                                  RT_WAITING_FOREVER),
+                      RT_EOK);
+    mutex_delete_wait_until_suspended(timeout_waiter);
+
+    next_waiter = rt_thread_create("mtxwait6",
+                                   mutex_delete_next_waiter_entry,
+                                   &mutex_delete_static,
+                                   UTEST_THR_STACK_SIZE,
+                                   UTEST_THR_PRIORITY + 2,
+                                   10);
+    uassert_true(next_waiter != RT_NULL);
+    mutex_delete_bind_waiter(next_waiter);
+    uassert_int_equal(rt_thread_startup(next_waiter), RT_EOK);
+    uassert_int_equal(rt_sem_take(&mutex_delete_ready,
+                                  RT_WAITING_FOREVER),
+                      RT_EOK);
+    mutex_delete_wait_until_suspended(next_waiter);
+
+    /* Stop the timer without clearing the scheduler timer ownership flag. */
+    rt_sched_lock(&slvl);
+    suspended = rt_sched_thread_is_suspended(timeout_waiter);
+    stop_result = rt_timer_stop(&timeout_waiter->thread_timer);
+    rt_sched_unlock(slvl);
+    uassert_true(suspended);
+    uassert_int_equal(stop_result, RT_EOK);
+
+    restart_thread = rt_thread_create("mtxrst",
+                                      mutex_delete_restart_timeout_entry,
+                                      timeout_waiter,
+                                      UTEST_THR_STACK_SIZE,
+                                      UTEST_THR_PRIORITY + 3,
+                                      10);
+    uassert_true(restart_thread != RT_NULL);
+    mutex_delete_bind_waiter(restart_thread);
+    uassert_int_equal(rt_thread_startup(restart_thread), RT_EOK);
+    uassert_int_equal(rt_sem_release(&mutex_delete_restart), RT_EOK);
+
+    uassert_int_equal(rt_mutex_release(&mutex_delete_static), RT_EOK);
+    uassert_int_equal(rt_sem_take(&mutex_delete_restart_done,
+                                  rt_tick_from_millisecond(1000)),
+                      RT_EOK);
+    uassert_int_equal(mutex_delete_restart_result, RT_EOK);
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_done,
+                                  rt_tick_from_millisecond(1000)),
+                      RT_EOK);
+    uassert_int_equal(rt_sem_take(&mutex_delete_done,
+                                  rt_tick_from_millisecond(1000)),
+                      RT_EOK);
+    uassert_int_equal(mutex_delete_wait_result, -RT_ETIMEOUT);
+    uassert_int_equal(mutex_delete_next_wait_result, RT_EOK);
+    uassert_int_equal(rt_mutex_detach(&mutex_delete_static), RT_EOK);
+    mutex_delete_wait_timeout = RT_WAITING_FOREVER;
+    mutex_delete_unbind_test_thread();
+}
+
+/*
+ * Delete/detach a mutex right after release handed it over to a waiter,
+ * while the new owner is still READY and has not resumed yet. The take
+ * path of the handed-off owner must not dereference the stale mutex.
+ */
+static void test_mutex_delete_handed_off_owner(void)
+{
+#ifdef RT_USING_HEAP
+    mutex_delete_bind_test_thread();
+    /* Dynamic mutex: delete and poison storage when the allocator reuses it. */
+    mutex_delete_wait_timeout = RT_WAITING_FOREVER;
+    mutex_handoff_delete_detach_mode = RT_FALSE;
+
+    mutex_delete_dynamic = rt_mutex_create("hdoffmtx", RT_IPC_FLAG_PRIO);
+    uassert_true(mutex_delete_dynamic != RT_NULL);
+    uassert_int_equal(rt_mutex_take(mutex_delete_dynamic,
+                                    RT_WAITING_FOREVER),
+                      RT_EOK);
+
+    mutex_delete_wait_result = -RT_ERROR;
+
+    mutex_delete_waiter = rt_thread_create("mtxhand",
+                                           mutex_delete_waiter_entry,
+                                           mutex_delete_dynamic,
+                                           UTEST_THR_STACK_SIZE,
+                                           UTEST_THR_PRIORITY + 1,
+                                           10);
+    uassert_true(mutex_delete_waiter != RT_NULL);
+    mutex_delete_bind_waiter(mutex_delete_waiter);
+    uassert_int_equal(rt_thread_startup(mutex_delete_waiter), RT_EOK);
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_ready,
+                                  RT_WAITING_FOREVER),
+                      RT_EOK);
+    mutex_delete_wait_until_suspended(mutex_delete_waiter);
+
+    /* Hand the mutex over: the waiter becomes its owner and goes READY. */
+    uassert_int_equal(rt_mutex_release(mutex_delete_dynamic), RT_EOK);
+
+    {
+        /* The controller outranks everyone and deletes before the owner runs. */
+        rt_thread_t controller = rt_thread_create("mtxdel",
+                                                  mutex_handoff_delete_controller_entry,
+                                                  mutex_delete_dynamic,
+                                                  UTEST_THR_STACK_SIZE,
+                                                  UTEST_THR_PRIORITY - 1,
+                                                  10);
+        uassert_true(controller != RT_NULL);
+        mutex_delete_bind_waiter(controller);
+        uassert_int_equal(rt_thread_startup(controller), RT_EOK);
+    }
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_ready,
+                                  RT_WAITING_FOREVER),
+                      RT_EOK);
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_done,
+                                  rt_tick_from_millisecond(1000)),
+                      RT_EOK);
+    uassert_int_equal(mutex_delete_wait_result, -RT_ERROR);
+
+    if (mutex_delete_replacement_memory != RT_NULL)
+    {
+        rt_free(mutex_delete_replacement_memory);
+        mutex_delete_replacement_memory = RT_NULL;
+    }
+
+    /* static mutex: detach + object memory poisoning */
+    mutex_handoff_delete_detach_mode = RT_TRUE;
+
+    uassert_int_equal(rt_mutex_init(&mutex_delete_static,
+                                    "hdoffdet",
+                                    RT_IPC_FLAG_PRIO),
+                      RT_EOK);
+    uassert_int_equal(rt_mutex_take(&mutex_delete_static,
+                                    RT_WAITING_FOREVER),
+                      RT_EOK);
+
+    mutex_delete_wait_result = -RT_ERROR;
+
+    mutex_delete_waiter = rt_thread_create("mtxhand2",
+                                           mutex_delete_waiter_entry,
+                                           &mutex_delete_static,
+                                           UTEST_THR_STACK_SIZE,
+                                           UTEST_THR_PRIORITY + 1,
+                                           10);
+    uassert_true(mutex_delete_waiter != RT_NULL);
+    mutex_delete_bind_waiter(mutex_delete_waiter);
+    uassert_int_equal(rt_thread_startup(mutex_delete_waiter), RT_EOK);
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_ready,
+                                  RT_WAITING_FOREVER),
+                      RT_EOK);
+    mutex_delete_wait_until_suspended(mutex_delete_waiter);
+
+    uassert_int_equal(rt_mutex_release(&mutex_delete_static), RT_EOK);
+
+    {
+        rt_thread_t controller = rt_thread_create("mtxdtl",
+                                                  mutex_handoff_delete_controller_entry,
+                                                  &mutex_delete_static,
+                                                  UTEST_THR_STACK_SIZE,
+                                                  UTEST_THR_PRIORITY - 1,
+                                                  10);
+        uassert_true(controller != RT_NULL);
+        mutex_delete_bind_waiter(controller);
+        uassert_int_equal(rt_thread_startup(controller), RT_EOK);
+    }
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_ready,
+                                  RT_WAITING_FOREVER),
+                      RT_EOK);
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_done,
+                                  rt_tick_from_millisecond(1000)),
+                      RT_EOK);
+    uassert_int_equal(mutex_delete_wait_result, -RT_ERROR);
+    mutex_delete_unbind_test_thread();
+#endif /* RT_USING_HEAP */
+}
+
+#ifdef RT_USING_SIGNALS
+static void test_mutex_handoff_signal_timeout(void)
+{
+#ifdef RT_USING_HEAP
+    rt_mutex_t mutex;
+    rt_thread_t waiter;
+
+    mutex_delete_bind_test_thread();
+    mutex_handoff_signal_result = -RT_ERROR;
+    mutex_delete_wait_result = -RT_ERROR;
+
+    mutex = rt_mutex_create("sigmtx", RT_IPC_FLAG_PRIO);
+    uassert_true(mutex != RT_NULL);
+    uassert_int_equal(rt_mutex_take(mutex, RT_WAITING_FOREVER), RT_EOK);
+
+    waiter = rt_thread_create("mtxsig",
+                              mutex_handoff_signal_waiter_entry,
+                              mutex,
+                              UTEST_THR_STACK_SIZE,
+                              UTEST_THR_PRIORITY + 1,
+                              10);
+    uassert_true(waiter != RT_NULL);
+    mutex_delete_bind_waiter(waiter);
+    uassert_int_equal(rt_thread_startup(waiter), RT_EOK);
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_ready,
+                                  RT_WAITING_FOREVER),
+                      RT_EOK);
+    mutex_delete_wait_until_suspended(waiter);
+
+    uassert_int_equal(rt_mutex_release(mutex), RT_EOK);
+    uassert_int_equal(rt_thread_kill(waiter, SIGUSR1), RT_EOK);
+    rt_thread_mdelay(1);
+
+    uassert_int_equal(rt_sem_take(&mutex_delete_done,
+                                  rt_tick_from_millisecond(1000)),
+                      RT_EOK);
+    uassert_int_equal(mutex_handoff_signal_result, -RT_ETIMEOUT);
+    uassert_int_equal(mutex_delete_wait_result, RT_EOK);
+    uassert_int_equal(rt_mutex_delete(mutex), RT_EOK);
+
+    mutex_delete_unbind_test_thread();
+#endif /* RT_USING_HEAP */
+}
+#endif /* RT_USING_SIGNALS */
+
+#endif /* RT_USING_HEAP */
+
 static rt_err_t utest_tc_init(void)
 {
 #ifdef RT_USING_HEAP
+    rt_err_t result;
+
     dynamic_mutex = RT_NULL;
+    mutex_delete_dynamic = RT_NULL;
+    mutex_delete_replacement_memory = RT_NULL;
+    mutex_delete_wait_timeout = RT_WAITING_FOREVER;
+    mutex_delete_semaphores_initialized = RT_FALSE;
+
+    result = rt_sem_init(&mutex_delete_ready,
+                         "mtxready",
+                         0,
+                         RT_IPC_FLAG_FIFO);
+    if (result != RT_EOK)
+    {
+        return result;
+    }
+
+    result = rt_sem_init(&mutex_delete_done,
+                         "mtxdone",
+                         0,
+                         RT_IPC_FLAG_FIFO);
+    if (result != RT_EOK)
+    {
+        rt_sem_detach(&mutex_delete_ready);
+        return result;
+    }
+
+    result = rt_sem_init(&mutex_delete_restart,
+                         "mtxrst",
+                         0,
+                         RT_IPC_FLAG_FIFO);
+    if (result != RT_EOK)
+    {
+        rt_sem_detach(&mutex_delete_ready);
+        rt_sem_detach(&mutex_delete_done);
+        return result;
+    }
+
+    result = rt_sem_init(&mutex_delete_restart_done,
+                         "mtxrdone",
+                         0,
+                         RT_IPC_FLAG_FIFO);
+    if (result != RT_EOK)
+    {
+        rt_sem_detach(&mutex_delete_ready);
+        rt_sem_detach(&mutex_delete_done);
+        rt_sem_detach(&mutex_delete_restart);
+        return result;
+    }
+
+    mutex_delete_semaphores_initialized = RT_TRUE;
 #endif /* RT_USING_HEAP */
 
     return RT_EOK;
@@ -916,6 +1644,14 @@ static rt_err_t utest_tc_init(void)
 static rt_err_t utest_tc_cleanup(void)
 {
 #ifdef RT_USING_HEAP
+    if (mutex_delete_semaphores_initialized)
+    {
+        rt_sem_detach(&mutex_delete_ready);
+        rt_sem_detach(&mutex_delete_done);
+        rt_sem_detach(&mutex_delete_restart);
+        rt_sem_detach(&mutex_delete_restart_done);
+        mutex_delete_semaphores_initialized = RT_FALSE;
+    }
     dynamic_mutex = RT_NULL;
 #endif /* RT_USING_HEAP */
 
@@ -936,6 +1672,14 @@ static void testcase(void)
     UTEST_UNIT_RUN(test_dynamic_mutex_trytake);
     UTEST_UNIT_RUN(test_dynamic_pri_reverse);
     UTEST_UNIT_RUN(test_cross_thread_delete_mutex_owner);
+    UTEST_UNIT_RUN(test_mutex_delete_waiter);
+    UTEST_UNIT_RUN(test_mutex_timeout_delete_waiter);
+    UTEST_UNIT_RUN(test_mutex_timeout_ready_delete_waiter);
+    UTEST_UNIT_RUN(test_mutex_release_timeout_waiter);
+    UTEST_UNIT_RUN(test_mutex_delete_handed_off_owner);
+#ifdef RT_USING_SIGNALS
+    UTEST_UNIT_RUN(test_mutex_handoff_signal_timeout);
+#endif /* RT_USING_SIGNALS */
 #endif
     UTEST_UNIT_RUN(test_recurse_lock);
 }


### PR DESCRIPTION
A mutex waiter can race with timeout callbacks, mutex release, object
deletion/detachment, and thread exit. A waiter may already be READY while
its `rt_mutex_take()` path has not resumed yet, so accessing the mutex after
`rt_schedule()` without a lifetime guarantee can result in stale accesses,
incorrect wakeup errors, or corrupted priority-inheritance state.

The problematic cases include:

* `rt_mutex_delete()` / `rt_mutex_detach()` waking a suspended waiter and
  releasing or reusing the mutex before the waiter resumes.
* A waiter timing out and becoming READY while still retaining mutex-specific
  state, followed by the mutex being deleted before the waiter runs.
* `delete/detach` or `rt_mutex_release()` racing with a timeout callback that
  already owns the waiter's timer wakeup.
* A successful release handoff making a waiter the new mutex owner while the
  waiter is still READY and has not returned from `rt_schedule()`.
* Thread exit and priority propagation observing an in-flight handoff as if it
  were still a normal mutex wait dependency.

The fix makes the waiter lifetime and wakeup ownership explicit.

* Add `_mutex_detach_waiter_locked()` to unlink a mutex waiter and clear its
  `pending_object` while the scheduler lock is held. This helper only performs
  waiter bookkeeping and does not recompute PI state.

* Add `rt_mutex_timeout_waiter()` for the mutex timeout path. It detaches the
  waiter, updates the mutex priority, and updates the owner priority before the
  timed-out thread is inserted into the ready queue.

* Use `rt_sched_thread_ready()` in delete/detach and release paths to arbitrate
  wakeup ownership between the IPC path and an in-flight timeout callback.

  If `rt_sched_thread_ready()` succeeds, the IPC path owns the wakeup.

  If it fails because the timeout path already owns the timer wakeup, only the
  mutex-specific waiter state is detached and the timeout callback remains
  responsible for making the thread READY and setting its timeout error.

* Batch PI recomputation in delete/detach. Waiters are detached without
  repeatedly recalculating the old owner's inherited priority; the owner PI
  state is recomputed after the mutex is removed from the owner's taken list.

* In `rt_mutex_release()`, skip timeout-owned head waiters and continue looking
  for the next valid waiter instead of treating the first failed wakeup as if
  there were no usable waiters.

* Keep `thread->pending_object` pointing to the mutex after a successful release
  handoff. While the new owner has not completed its `rt_mutex_take()` wakeup
  path, this pointer acts as an in-flight handoff token and provides the mutex
  lifetime guarantee required by the resumed waiter.

* Delete/detach clears this handoff token and sets `RT_ERROR` before the mutex
  object can become invalid.

* After `rt_schedule()` returns, `_rt_mutex_take()` only dereferences the mutex
  when the handoff token is still valid. If another wakeup/delete path has
  already cleared the token, it returns the corresponding error without
  accessing the mutex again.

* Thread exit recognizes `pending_object == mutex && mutex->owner == thread` as
  an in-flight handoff token rather than a normal mutex wait dependency.

The mutex structure and ABI are unchanged. The internal timeout/drop helpers
are exposed only to kernel/IPC source files.

Regression coverage includes:

* dynamic mutex deletion followed by possible allocator reuse;
* static mutex detachment followed by object-memory poisoning;
* timeout -> READY -> mutex detach before the waiter runs;
* delete/detach racing with timeout wakeup ownership;
* release skipping a timeout-owned head waiter and waking the next valid
  waiter;
* release -> ownership handoff -> waiter READY -> mutex delete before the
  waiter resumes;
* release -> ownership handoff -> waiter READY -> static mutex detach and
  memory poisoning before the waiter resumes;
* thread-exit handling of an in-flight mutex handoff.

Validation:

* Parent UP QEMU reproduces the original stale mutex access/data abort.
* Fixed `core.mutex` regression tests pass.
* QEMU SMP with 2 CPUs passes.
* QEMU UP with 1 CPU passes.
* QEMU SMP with 1 CPU passes.
* `RT_DEBUGING_ASSERT` and `RT_DEBUGING_CRITICAL` were enabled during
  validation.
* `scons -j$(nproc) --strict -C bsp/qemu-vexpress-a9` passes.

#### 为什么提交这份 PR (why to submit this PR)

修复 mutex waiter 在 timeout、release handoff、delete/detach 和 thread exit
并发情况下可能在 mutex 生命周期结束后继续访问 mutex 的问题。

核心原则是：waiter 从 `rt_schedule()` 返回以后，只有仍持有有效的 mutex
handoff token 时才允许再次访问 mutex；如果 timeout、delete 或其他 wakeup
路径已经完成 cleanup，则直接返回对应错误，不再解引用可能已经失效的 mutex。

#### 你的解决方案是什么 (what is your solution)

1. 将 mutex waiter unlink 与 PI recompute 分离：
   `_mutex_detach_waiter_locked()` 仅维护 waiter 生命周期，
   `rt_mutex_timeout_waiter()` 和各调用路径负责必要的 priority inheritance 更新。

2. timeout waiter 在进入 READY 前完成 mutex-specific cleanup。

3. delete/detach 和 release 使用 `rt_sched_thread_ready()` 仲裁 wakeup ownership，
   避免 timeout callback 与 IPC 路径同时处理同一个 waiter。

4. delete/detach 批量清理 waiter 后只重新计算一次 owner PI。

5. release 跳过 timeout-owned 的队首 waiter并继续寻找下一个有效 waiter。

6. release 成功 handoff 后保留 `pending_object` 作为 in-flight lifetime token，
   直到 `_rt_mutex_take()` 完成 handoff 校验。

7. delete/detach 在 mutex 失效前清除此 token，并使 resumed waiter 返回
   `-RT_ERROR`。

8. `_rt_mutex_take()` 在 token 已失效时直接返回错误，不再通过旧 fallback
   路径重新访问 mutex。

9. thread exit 区分普通 mutex waiter 和 handed-off mutex owner。

#### 请提供验证的 bsp 和 config (provide the config and bsp)

* BSP:

  * `bsp/qemu-vexpress-a9`

* Config:

  * `RT_USING_MUTEX`
  * `RT_USING_HEAP` for dynamic mutex regression cases
  * mutex UTest enabled
  * validation additionally performed with
    `RT_DEBUGING_ASSERT` and `RT_DEBUGING_CRITICAL`

* Validation:

  * QEMU SMP, 2 CPUs: `core.mutex` passed
  * QEMU UP, 1 CPU: `core.mutex` passed
  * QEMU SMP, 1 CPU: `core.mutex` passed
  * strict QEMU build passed


<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
