### PR TITLE
[components][serial] Harden RT-Smart serial ioctl arguments

### DIFF
--- a/bsp/nxp/imx/imx6ull-smart/drivers/drv_uart.c
+++ b/bsp/nxp/imx/imx6ull-smart/drivers/drv_uart.c
@@ -178,6 +178,11 @@ static rt_err_t _uart_ops_configure( struct rt_serial_device *dev,
     RT_ASSERT(RT_NULL != dev);
     RT_ASSERT(RT_NULL != cfg);
 
+    if (cfg->baud_rate == 0 || cfg->baud_rate > BAUD_RATE_921600)
+    {
+        return -RT_EINVAL;
+    }
+
     uart = (struct imx_uart*)dev;
     periph = (UART_Type*)uart->periph.vaddr;
 
@@ -187,8 +192,6 @@ static rt_err_t _uart_ops_configure( struct rt_serial_device *dev,
 
     periph->UFCR &= ~UART_UFCR_RFDIV_MASK;
     periph->UFCR |=  UART_UFCR_RFDIV(5);
-
-    RT_ASSERT(cfg->baud_rate <= BAUD_RATE_921600);
 
     periph->UBIR = UART_UBIR_INC(15);
     periph->UBMR = UART_UBMR_MOD(HW_UART_BUS_CLOCK / cfg->baud_rate - 1);

--- a/components/drivers/serial/dev_serial.c
+++ b/components/drivers/serial/dev_serial.c
@@ -44,6 +44,10 @@
 #include <unistd.h>
 #include <poll.h>
 #include <sys/ioctl.h>
+#ifdef RT_USING_LWP
+#include <lwp.h>
+#include <lwp_user_mm.h>
+#endif
 
 #ifdef RT_USING_POSIX_TERMIOS
 #include <termios.h>
@@ -137,6 +141,112 @@ static int serial_fops_ioctl(struct dfs_file *fd, int cmd, void *args)
         fd->flags |= flags;
         break;
     }
+
+#ifdef RT_USING_LWP
+    if (lwp_self() != RT_NULL)
+    {
+        union serial_user_ioctl_arg
+        {
+            struct serial_configure config;
+            struct winsize winsize;
+#ifdef RT_USING_POSIX_TERMIOS
+            struct termios termios;
+            struct termio termio;
+#endif
+            rt_uint16_t oflag;
+            rt_size_t unread_bytes;
+        } karg;
+        size_t arg_size = 0;
+        void *kptr = args;
+        rt_bool_t copy_in = RT_FALSE;
+        rt_bool_t copy_out = RT_FALSE;
+
+        switch ((rt_ubase_t)cmd)
+        {
+        case RT_DEVICE_CTRL_CONFIG:
+            arg_size = sizeof(karg.config);
+            kptr = &karg.config;
+            copy_in = RT_TRUE;
+            break;
+        case RT_DEVICE_CTRL_NOTIFY_SET:
+            return -RT_EPERM;
+        case RT_DEVICE_CTRL_CONSOLE_OFLAG:
+            arg_size = sizeof(karg.oflag);
+            kptr = &karg.oflag;
+            copy_out = RT_TRUE;
+            break;
+        case FIONREAD:
+            arg_size = sizeof(karg.unread_bytes);
+            kptr = &karg.unread_bytes;
+            copy_out = RT_TRUE;
+            break;
+#ifdef RT_USING_POSIX_TERMIOS
+        case TCGETA:
+            arg_size = sizeof(karg.termio);
+            kptr = &karg.termio;
+            copy_out = RT_TRUE;
+            break;
+        case TCGETS:
+            arg_size = sizeof(karg.termios);
+            kptr = &karg.termios;
+            copy_out = RT_TRUE;
+            break;
+        case TCSETA:
+        case TCSETAW:
+        case TCSETAF:
+            arg_size = sizeof(karg.termio);
+            kptr = &karg.termio;
+            copy_in = RT_TRUE;
+            break;
+        case TCSETS:
+        case TCSETSW:
+        case TCSETSF:
+            arg_size = sizeof(karg.termios);
+            kptr = &karg.termios;
+            copy_in = RT_TRUE;
+            break;
+#endif
+        case TIOCSWINSZ:
+            arg_size = sizeof(karg.winsize);
+            kptr = &karg.winsize;
+            copy_in = RT_TRUE;
+            break;
+        case TIOCGWINSZ:
+            arg_size = sizeof(karg.winsize);
+            kptr = &karg.winsize;
+            copy_out = RT_TRUE;
+            break;
+        default:
+            break;
+        }
+
+        if (arg_size)
+        {
+            int ret;
+
+            if (args == RT_NULL || !lwp_user_accessable(args, arg_size))
+            {
+                return -RT_EFAULT;
+            }
+            if (copy_in && lwp_get_from_user(kptr, args, arg_size) != arg_size)
+            {
+                return -RT_EFAULT;
+            }
+
+            ret = rt_device_control(device, cmd, kptr);
+            if (ret != RT_EOK)
+            {
+                return ret;
+            }
+
+            if (copy_out && lwp_put_to_user(args, kptr, arg_size) != arg_size)
+            {
+                return -RT_EFAULT;
+            }
+            return ret;
+        }
+    }
+#endif
 
     return rt_device_control(device, cmd, args);
 }
@@ -1090,13 +1200,22 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
                     /*can not change buffer size*/
                     return -RT_EBUSY;
                 }
-                /* set serial configure */
-                serial->config = *pconfig;
+                if (pconfig->baud_rate == 0)
+                {
+                    return -RT_EINVAL;
+                }
+
                 if (serial->parent.ref_count)
                 {
                     /* serial device has been opened, to configure it */
-                    serial->ops->configure(serial, (struct serial_configure *) args);
+                    ret = serial->ops->configure(serial, pconfig);
+                    if (ret != RT_EOK)
+                    {
+                        return ret;
+                    }
                 }
+                /* set serial configure */
+                serial->config = *pconfig;
             }
             break;
         case RT_DEVICE_CTRL_NOTIFY_SET:

--- a/components/drivers/serial/dev_serial.c
+++ b/components/drivers/serial/dev_serial.c
@@ -1238,7 +1238,7 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
         case TCGETA:
         case TCGETS:
             {
-                struct termios *tio, tmp = {0};
+                struct termios *tio, tmp = { 0 };
 
                 if (cmd == TCGETS)
                 {

--- a/components/drivers/serial/dev_serial.c
+++ b/components/drivers/serial/dev_serial.c
@@ -154,12 +154,14 @@ static int serial_fops_ioctl(struct dfs_file *fd, int cmd, void *args)
             struct termio termio;
 #endif
             rt_uint16_t oflag;
-            rt_size_t unread_bytes;
+            int unread_bytes;
         } karg;
         size_t arg_size = 0;
         void *kptr = args;
         rt_bool_t copy_in = RT_FALSE;
         rt_bool_t copy_out = RT_FALSE;
+
+        rt_memset(&karg, 0, sizeof(karg));
 
         switch ((rt_ubase_t)cmd)
         {
@@ -1236,7 +1238,7 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
         case TCGETA:
         case TCGETS:
             {
-                struct termios *tio, tmp;
+                struct termios *tio, tmp = {0};
 
                 if (cmd == TCGETS)
                 {
@@ -1337,7 +1339,12 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
                 }
                 else config.parity = PARITY_NONE;
 
-                serial->ops->configure(serial, &config);
+                ret = serial->ops->configure(serial, &config);
+                if (ret != RT_EOK)
+                {
+                    return ret;
+                }
+                serial->config = config;
             }
             break;
 #ifndef RT_USING_TTY
@@ -1446,14 +1453,14 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
             break;
         case FIONREAD:
             {
-                rt_size_t recved = 0;
+                rt_ssize_t recved = 0;
                 rt_base_t level;
 
                 level = rt_spin_lock_irqsave(&(serial->spinlock));
                 recved = _serial_fifo_calc_recved_len(serial);
                 rt_spin_unlock_irqrestore(&(serial->spinlock), level);
 
-                *(rt_size_t *)args = recved;
+                *(int *)args = (int)recved;
             }
             break;
 #endif /* RT_USING_POSIX_STDIO */

--- a/components/drivers/serial/dev_serial_v2.c
+++ b/components/drivers/serial/dev_serial_v2.c
@@ -162,7 +162,7 @@ static int serial_fops_ioctl(struct dfs_file *fd, int cmd, void *args)
             struct termios termios;
 #endif
             rt_uint16_t oflag;
-            rt_size_t unread_bytes;
+            int unread_bytes;
             rt_ssize_t unread_count;
             rt_int32_t timeout;
         } karg;
@@ -170,6 +170,8 @@ static int serial_fops_ioctl(struct dfs_file *fd, int cmd, void *args)
         void *kptr = args;
         rt_bool_t copy_in = RT_FALSE;
         rt_bool_t copy_out = RT_FALSE;
+
+        rt_memset(&karg, 0, sizeof(karg));
 
         switch ((rt_ubase_t)cmd)
         {
@@ -1746,6 +1748,7 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
 #ifdef RT_USING_POSIX_STDIO
 #ifdef RT_USING_POSIX_TERMIOS
     case TCGETA:
+    case TCGETS:
     {
         struct termios *tio = (struct termios *)args;
         if (tio == RT_NULL)
@@ -1788,6 +1791,9 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
     case TCSETAW:
     case TCSETAF:
     case TCSETA:
+    case TCSETSW:
+    case TCSETSF:
+    case TCSETS:
     {
         int baudrate;
         struct serial_configure config;
@@ -1837,9 +1843,13 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
         else
             config.flowcontrol = RT_SERIAL_FLOWCONTROL_NONE;
 
+        ret = serial->ops->configure(serial, &config);
+        if (ret != RT_EOK)
+        {
+            break;
+        }
         /* set serial configure */
         serial->config = config;
-        serial->ops->configure(serial, &config);
     }
     break;
     case TCFLSH:
@@ -1954,9 +1964,9 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
             rt_ssize_t unread_bytes = 0;
             ret = _serial_get_unread_bytes_count(serial, &unread_bytes);
             if (ret == RT_EOK)
-                *(rt_size_t *)args = (rt_size_t)unread_bytes;
+                *(int *)args = (int)unread_bytes;
             else
-                *(rt_size_t *)args = 0;
+                *(int *)args = 0;
         }
         break;
 #endif /* RT_USING_POSIX_STDIO */

--- a/components/drivers/serial/dev_serial_v2.c
+++ b/components/drivers/serial/dev_serial_v2.c
@@ -36,6 +36,11 @@
 #include <sys/ioctl.h>
 #include <dfs_file.h>
 
+#ifdef RT_USING_LWP
+#include <lwp.h>
+#include <lwp_user_mm.h>
+#endif
+
 #ifdef RT_USING_POSIX_TERMIOS
 #include <termios.h>
 #endif
@@ -145,6 +150,127 @@ static int serial_fops_ioctl(struct dfs_file *fd, int cmd, void *args)
     default:
         break;
     }
+
+#ifdef RT_USING_LWP
+    if (lwp_self() != RT_NULL)
+    {
+        union serial_user_ioctl_arg
+        {
+            struct serial_configure config;
+            struct winsize winsize;
+#ifdef RT_USING_POSIX_TERMIOS
+            struct termios termios;
+#endif
+            rt_uint16_t oflag;
+            rt_size_t unread_bytes;
+            rt_ssize_t unread_count;
+            rt_int32_t timeout;
+        } karg;
+        size_t arg_size = 0;
+        void *kptr = args;
+        rt_bool_t copy_in = RT_FALSE;
+        rt_bool_t copy_out = RT_FALSE;
+
+        switch ((rt_ubase_t)cmd)
+        {
+        case RT_DEVICE_CTRL_CONFIG:
+            arg_size = sizeof(karg.config);
+            kptr = &karg.config;
+            copy_in = RT_TRUE;
+            break;
+        case RT_SERIAL_CTRL_GET_CONFIG:
+            arg_size = sizeof(karg.config);
+            kptr = &karg.config;
+            copy_out = RT_TRUE;
+            break;
+        case RT_DEVICE_CTRL_NOTIFY_SET:
+            return -RT_EPERM;
+        case RT_DEVICE_CTRL_CONSOLE_OFLAG:
+            arg_size = sizeof(karg.oflag);
+            kptr = &karg.oflag;
+            copy_out = RT_TRUE;
+            break;
+        case RT_SERIAL_CTRL_SET_RX_TIMEOUT:
+        case RT_SERIAL_CTRL_SET_TX_TIMEOUT:
+            arg_size = sizeof(karg.timeout);
+            kptr = &karg.timeout;
+            copy_in = RT_TRUE;
+            break;
+        case RT_SERIAL_CTRL_GET_RX_TIMEOUT:
+        case RT_SERIAL_CTRL_GET_TX_TIMEOUT:
+            arg_size = sizeof(karg.timeout);
+            kptr = &karg.timeout;
+            copy_out = RT_TRUE;
+            break;
+        case FIONREAD:
+            arg_size = sizeof(karg.unread_bytes);
+            kptr = &karg.unread_bytes;
+            copy_out = RT_TRUE;
+            break;
+        case RT_SERIAL_CTRL_GET_UNREAD_BYTES_COUNT:
+            arg_size = sizeof(karg.unread_count);
+            kptr = &karg.unread_count;
+            copy_out = RT_TRUE;
+            break;
+#ifdef RT_USING_POSIX_TERMIOS
+        case TCGETA:
+        case TCGETS:
+            arg_size = sizeof(karg.termios);
+            kptr = &karg.termios;
+            copy_out = RT_TRUE;
+            break;
+        case TCSETA:
+        case TCSETAW:
+        case TCSETAF:
+        case TCSETS:
+        case TCSETSW:
+        case TCSETSF:
+            arg_size = sizeof(karg.termios);
+            kptr = &karg.termios;
+            copy_in = RT_TRUE;
+            break;
+#endif
+        case TIOCSWINSZ:
+            arg_size = sizeof(karg.winsize);
+            kptr = &karg.winsize;
+            copy_in = RT_TRUE;
+            break;
+        case TIOCGWINSZ:
+            arg_size = sizeof(karg.winsize);
+            kptr = &karg.winsize;
+            copy_out = RT_TRUE;
+            break;
+        default:
+            break;
+        }
+
+        if (arg_size)
+        {
+            int ret;
+
+            if (args == RT_NULL || !lwp_user_accessable(args, arg_size))
+            {
+                return -RT_EFAULT;
+            }
+            if (copy_in && lwp_get_from_user(kptr, args, arg_size) != arg_size)
+            {
+                return -RT_EFAULT;
+            }
+
+            ret = rt_device_control(device, cmd, kptr);
+            if (ret != RT_EOK)
+            {
+                return ret;
+            }
+
+            if (copy_out && lwp_put_to_user(args, kptr, arg_size) != arg_size)
+            {
+                return -RT_EFAULT;
+            }
+            return ret;
+        }
+    }
+#endif
 
     return rt_device_control(device, cmd, args);
 }
@@ -1440,8 +1566,6 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
         else
         {
             struct serial_configure *pconfig = (struct serial_configure *)args;
-            struct serial_configure old_config = serial->config;
-
 #ifdef RT_SERIAL_USING_DMA
             if (rt_serial_rx_dma_event_mode_valid(pconfig->rx_dma_event_mode) != RT_TRUE)
             {
@@ -1463,13 +1587,19 @@ static rt_err_t rt_serial_control(struct rt_device *dev,
                 break;
             }
 
-            /* set serial configure */
-            serial->config = *pconfig;
-            ret = serial->ops->configure(serial, (struct serial_configure *)args);
+            if (pconfig->baud_rate == 0)
+            {
+                ret = -RT_EINVAL;
+                break;
+            }
+
+            ret = serial->ops->configure(serial, pconfig);
             if (ret != RT_EOK)
             {
-                serial->config = old_config;
+                break;
             }
+            /* set serial configure */
+            serial->config = *pconfig;
         }
         break;
     case RT_SERIAL_CTRL_GET_CONFIG:


### PR DESCRIPTION
## Description

Follow up on #11453 to harden the remaining RT-Smart serial ioctl paths.

- Marshal known serial ioctl payloads at the v1/v2 file boundary and copy results back to user space.
- Protect v2 `RT_SERIAL_CTRL_GET_UNREAD_BYTES_COUNT` and use the correct `struct termios` buffer for v2 termios commands.
- Reject invalid baud rates before imx6ull UART register updates and commit serial configuration only after hardware configuration succeeds.

## Validation

- `arm-none-eabi-gcc -fsyntax-only` for v1/v2 serial sources with LWP disabled.
- `arm-linux-musleabi-gcc -fsyntax-only` for v1/v2 serial sources and imx6ull UART driver with a temporary Musl/LWP configuration.
- Full imx6ull-smart SCons build is blocked by the existing Newlib/LWP configuration error in `components/lwp/lwp.h`.

## Changes

- `components/drivers/serial/dev_serial.c`
- `components/drivers/serial/dev_serial_v2.c`
- `bsp/nxp/imx/imx6ull-smart/drivers/drv_uart.c`