### PR TITLE
[finsh] Remove deprecated FINSH_FUNCTION_EXPORT_ALIAS

### DIFF
--- a/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/disp/disp_debug.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/disp/disp_debug.c
@@ -102,37 +102,83 @@ static int cmd_disp_debug(int argc, char **argv)
 
             /*enhance */
             if ( ! strcmp(argv[i], "-e")) {
-                if (argc > i+2) {
+                if (argc > i+1) {
                     i+=1;
 
                     switch(argv[i][0]) {
                     case 'm'://mode
+                        if (argc <= i + 2) {
+                            DE_WRN("-e %s para error!\n", argv[i]);
+                            err++;
+                            break;
+                        }
                         disp_enhance_mode_store(atoi(argv[i + 1]), atoi(argv[i + 2]));
+                        i += 2;
                         break;
                     case 's'://saturation
+                        if (argc <= i + 2) {
+                            DE_WRN("-e %s para error!\n", argv[i]);
+                            err++;
+                            break;
+                        }
                         disp_enhance_saturation_store(atoi(argv[i + 1]), atoi(argv[i + 2]));
+                        i += 2;
                         break;
                     case 'b'://bright
+                        if (argc <= i + 2) {
+                            DE_WRN("-e %s para error!\n", argv[i]);
+                            err++;
+                            break;
+                        }
                         disp_enhance_bright_store(atoi(argv[i + 1]), atoi(argv[i + 2]));
+                        i += 2;
                         break;
                     case 'c'://contrast
+                        if (argc <= i + 2) {
+                            DE_WRN("-e %s para error!\n", argv[i]);
+                            err++;
+                            break;
+                        }
                         disp_enhance_contrast_store(atoi(argv[i + 1]), atoi(argv[i + 2]));
+                        i += 2;
                         break;
                     case 'g'://gamma color_temperature
+                        if (argc <= i + 2) {
+                            DE_WRN("-e %s para error!\n", argv[i]);
+                            err++;
+                            break;
+                        }
                         printf("gamma %s %s %d %d\n",argv[i + 1],argv[i + 2],atoi(argv[i + 1]), atoi(argv[i + 2]));
                         disp_color_temperature_store(atoi(argv[i + 1]), atoi(argv[i + 2]));
+                        i += 2;
                         break;
                     case 'n'://denoise
+                        if (argc <= i + 2) {
+                            DE_WRN("-e %s para error!\n", argv[i]);
+                            err++;
+                            break;
+                        }
                         disp_enhance_denoise_store(atoi(argv[i + 1]), atoi(argv[i + 2]));
+                        i += 2;
                         break;
                     case 'd'://detail
+                        if (argc <= i + 2) {
+                            DE_WRN("-e %s para error!\n", argv[i]);
+                            err++;
+                            break;
+                        }
                         disp_enhance_detail_store(atoi(argv[i + 1]), atoi(argv[i + 2]));
+                        i += 2;
                         break;
                     case 'p'://print
-
+                        if (argc <= i + 1) {
+                            DE_WRN("-e %s para error!\n", argv[i]);
+                            err++;
+                            break;
+                        }
                         if (atoi(argv[i + 1]) < 0 || atoi(argv[i + 1]) > 1) {
-                            i-=1;
                             DE_WRN("para error!\n");
+                            err++;
                             break;
                         }
                         DISP_PRINT("screen %d:\n", atoi(argv[i + 1]));
@@ -150,13 +196,13 @@ static int cmd_disp_debug(int argc, char **argv)
                         DISP_PRINT("denoise %s\n", tmp);
                         disp_enhance_detail_show(atoi(argv[i + 1]), tmp);
                         DISP_PRINT("detail %s\n", tmp);
-                        i-=1;
+                        i += 1;
                         break;
                     default:
                         DE_WRN("para error!\n");
+                        err++;
                         break;
                     }
-                    i+=2;
                 } else {
                     DE_WRN("para error!\n");
                     err++;
@@ -181,7 +227,7 @@ static int cmd_disp_debug(int argc, char **argv)
             ++i;
         }
     }
-    return 0;
+    return err ? -1 : 0;
 }
 
 MSH_CMD_EXPORT_ALIAS(cmd_disp_debug, __cmd_disp, disp cmd);

--- a/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/disp/disp_debug.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/disp/disp_debug.c
@@ -48,7 +48,7 @@ static void print_reg(void)
     printf("csc\n");
     printf_from_to(0x51b0000,0x51b00ff);
 }
-static int cmd_disp_debug(int argc, const char **argv)
+static int cmd_disp_debug(int argc, char **argv)
 {
     int i = 0, err = 0;
     struct disp_manager *mgr = NULL;
@@ -184,4 +184,4 @@ static int cmd_disp_debug(int argc, const char **argv)
     return 0;
 }
 
-FINSH_FUNCTION_EXPORT_ALIAS(cmd_disp_debug, __cmd_disp, disp cmd);
+MSH_CMD_EXPORT_ALIAS(cmd_disp_debug, __cmd_disp, disp cmd);

--- a/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/disp/disp_debug.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/source/disp2/disp/disp_debug.c
@@ -102,12 +102,14 @@ static int cmd_disp_debug(int argc, char **argv)
 
             /*enhance */
             if ( ! strcmp(argv[i], "-e")) {
-                if (argc > i+1) {
+                if (argc > i + 1)
+                {
                     i+=1;
 
                     switch(argv[i][0]) {
                     case 'm'://mode
-                        if (argc <= i + 2) {
+                        if (argc <= i + 2)
+                        {
                             DE_WRN("-e %s para error!\n", argv[i]);
                             err++;
                             break;
@@ -116,7 +118,8 @@ static int cmd_disp_debug(int argc, char **argv)
                         i += 2;
                         break;
                     case 's'://saturation
-                        if (argc <= i + 2) {
+                        if (argc <= i + 2)
+                        {
                             DE_WRN("-e %s para error!\n", argv[i]);
                             err++;
                             break;
@@ -125,7 +128,8 @@ static int cmd_disp_debug(int argc, char **argv)
                         i += 2;
                         break;
                     case 'b'://bright
-                        if (argc <= i + 2) {
+                        if (argc <= i + 2)
+                        {
                             DE_WRN("-e %s para error!\n", argv[i]);
                             err++;
                             break;
@@ -134,7 +138,8 @@ static int cmd_disp_debug(int argc, char **argv)
                         i += 2;
                         break;
                     case 'c'://contrast
-                        if (argc <= i + 2) {
+                        if (argc <= i + 2)
+                        {
                             DE_WRN("-e %s para error!\n", argv[i]);
                             err++;
                             break;
@@ -143,17 +148,19 @@ static int cmd_disp_debug(int argc, char **argv)
                         i += 2;
                         break;
                     case 'g'://gamma color_temperature
-                        if (argc <= i + 2) {
+                        if (argc <= i + 2)
+                        {
                             DE_WRN("-e %s para error!\n", argv[i]);
                             err++;
                             break;
                         }
-                        printf("gamma %s %s %d %d\n",argv[i + 1],argv[i + 2],atoi(argv[i + 1]), atoi(argv[i + 2]));
+                        printf("gamma %s %s %d %d\n", argv[i + 1], argv[i + 2], atoi(argv[i + 1]), atoi(argv[i + 2]));
                         disp_color_temperature_store(atoi(argv[i + 1]), atoi(argv[i + 2]));
                         i += 2;
                         break;
                     case 'n'://denoise
-                        if (argc <= i + 2) {
+                        if (argc <= i + 2)
+                        {
                             DE_WRN("-e %s para error!\n", argv[i]);
                             err++;
                             break;
@@ -162,7 +169,8 @@ static int cmd_disp_debug(int argc, char **argv)
                         i += 2;
                         break;
                     case 'd'://detail
-                        if (argc <= i + 2) {
+                        if (argc <= i + 2)
+                        {
                             DE_WRN("-e %s para error!\n", argv[i]);
                             err++;
                             break;
@@ -171,7 +179,8 @@ static int cmd_disp_debug(int argc, char **argv)
                         i += 2;
                         break;
                     case 'p'://print
-                        if (argc <= i + 1) {
+                        if (argc <= i + 1)
+                        {
                             DE_WRN("-e %s para error!\n", argv[i]);
                             err++;
                             break;
@@ -203,7 +212,9 @@ static int cmd_disp_debug(int argc, char **argv)
                         err++;
                         break;
                     }
-                } else {
+                }
+                else
+                {
                     DE_WRN("para error!\n");
                     err++;
                 }

--- a/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_layer_alpha_test.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_layer_alpha_test.c
@@ -131,4 +131,4 @@ int disp_layer_alpha_test(int argc, char **argv)
     return 0;
 }
 
-FINSH_FUNCTION_EXPORT_ALIAS(disp_layer_alpha_test, __cmd_disp_layer_alpha_test, disp_layer_alpha_test);
+MSH_CMD_EXPORT_ALIAS(disp_layer_alpha_test, __cmd_disp_layer_alpha_test, disp_layer_alpha_test);

--- a/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_layer_cfg.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_layer_cfg.c
@@ -556,7 +556,4 @@ int parse_cmdline_and_set_config(int argc, char **argv)
     }
 }
 
-
-
-FINSH_FUNCTION_EXPORT_ALIAS(parse_cmdline_and_set_config, disp_layer_cfg, disp set layer);
-
+MSH_CMD_EXPORT_ALIAS(parse_cmdline_and_set_config, disp_layer_cfg, disp set layer);

--- a/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_layer_format_test.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_layer_format_test.c
@@ -135,4 +135,4 @@ int disp_layer_format_test(int argc, char **argv)
     return 0;
 }
 
-FINSH_FUNCTION_EXPORT_ALIAS(disp_layer_format_test, __cmd_disp_layer_format_test, disp_layer_format_test);
+MSH_CMD_EXPORT_ALIAS(disp_layer_format_test, __cmd_disp_layer_format_test, disp_layer_format_test);

--- a/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_layer_rgb_test.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_layer_rgb_test.c
@@ -79,4 +79,4 @@ int disp_layer_rgb_test(int argc, char **argv)
     return 0;
 }
 
-FINSH_FUNCTION_EXPORT_ALIAS(disp_layer_rgb_test, __cmd_disp_layer_rgb_test, disp_layer_rgb_test);
+MSH_CMD_EXPORT_ALIAS(disp_layer_rgb_test, __cmd_disp_layer_rgb_test, disp_layer_rgb_test);

--- a/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_layer_scal_test.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_layer_scal_test.c
@@ -146,4 +146,4 @@ int disp_layer_scal_test(int argc, char **argv)
     return 0;
 }
 
-FINSH_FUNCTION_EXPORT_ALIAS(disp_layer_scal_test, __cmd_disp_layer_scal_test, disp_layer_scal_test);
+MSH_CMD_EXPORT_ALIAS(disp_layer_scal_test, __cmd_disp_layer_scal_test, disp_layer_scal_test);

--- a/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_lbc_test.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_lbc_test.c
@@ -157,9 +157,4 @@ int lbc_test(int argc, char **argv)
     return 0;
 }
 
-
-
-
-
-FINSH_FUNCTION_EXPORT_ALIAS(lbc_test, __cmd_disp_lbc_test, disp lbc test);
-
+MSH_CMD_EXPORT_ALIAS(lbc_test, __cmd_disp_lbc_test, disp lbc test);

--- a/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_mem.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_mem.c
@@ -31,7 +31,9 @@ struct test_mem_cfg
     char filename[32];
 };
 
-static struct info_mm g_disp_mm[10];
+#define DISP_MEM_COUNT 10
+
+static struct info_mm g_disp_mm[DISP_MEM_COUNT];
 static int g_disp_mem_id = -1;
 
 #define DISP_TEST_BYTE_ALIGN(x) (((x + (4*1024-1)) >> 12) << 12)
@@ -72,6 +74,9 @@ static void disp_free(void *virt_addr, void *phys_addr, u32 num_bytes)
 
 static int disp_mem_release(int sel)
 {
+    if (sel < 0 || sel >= DISP_MEM_COUNT)
+        return -1;
+
     if (g_disp_mm[sel].info_base == NULL)
         return -1;
 
@@ -89,7 +94,7 @@ static int disp_mem_request(int sel, u32 size)
 
     uintptr_t phy_addr;
 
-    if ((sel >= 10) ||
+    if ((sel < 0) || (sel >= DISP_MEM_COUNT) ||
         (g_disp_mm[sel].info_base != NULL)) {
         printf("invalid param\n");
         return -1;
@@ -115,7 +120,7 @@ static int disp_mem_request(int sel, u32 size)
 
 u32 disp_mem_getadr(u32 memid)
 {
-    if (memid < 10)
+    if (memid < DISP_MEM_COUNT)
         return g_disp_mm[memid].mem_start;
     return 0;
 }
@@ -129,6 +134,12 @@ int disp_mem(u32 mem_id, u32 width, u32 height, u32 clear_flag, char *filename)
     void *mem = NULL;
     unsigned long count = width*height;
     char *tmp;
+
+    if (mem_id >= DISP_MEM_COUNT) {
+        printf("invalid mem_id\n");
+        return -1;
+    }
+
     if(clear_flag) {
         /* release memory && clear layer */
         disp_mem_release(mem_id);
@@ -229,9 +240,13 @@ int parse_cmdline_and_alloc(int argc, char **argv)
         if ( ! strcmp(argv[i], "-file")) {
             if (argc > i+1) {
                 i++;
-                p->filename[0] = '\0';
-                sprintf(p->filename,"%s",argv[i]);
-                printf("filename=%s\n", argv[i]);
+                if (rt_strlen(argv[i]) >= sizeof(p->filename)) {
+                    printf("filename is too long!!\n");
+                    err++;
+                } else {
+                    rt_strncpy(p->filename, argv[i], sizeof(p->filename));
+                    printf("filename=%s\n", argv[i]);
+                }
             }   else {
                 printf("no file described!!\n");
                 err ++;
@@ -259,6 +274,11 @@ int parse_cmdline_and_alloc(int argc, char **argv)
         }
 
         i++;
+    }
+
+    if (p->mem_id < 0 || p->mem_id >= DISP_MEM_COUNT) {
+        printf("mem_id para error!\n");
+        err++;
     }
 
     if(err > 0) {

--- a/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_mem.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_mem.c
@@ -75,7 +75,9 @@ static void disp_free(void *virt_addr, void *phys_addr, u32 num_bytes)
 static int disp_mem_release(int sel)
 {
     if (sel < 0 || sel >= DISP_MEM_COUNT)
+    {
         return -1;
+    }
 
     if (g_disp_mm[sel].info_base == NULL)
         return -1;
@@ -95,7 +97,8 @@ static int disp_mem_request(int sel, u32 size)
     uintptr_t phy_addr;
 
     if ((sel < 0) || (sel >= DISP_MEM_COUNT) ||
-        (g_disp_mm[sel].info_base != NULL)) {
+        (g_disp_mm[sel].info_base != NULL))
+    {
         printf("invalid param\n");
         return -1;
     }
@@ -121,7 +124,9 @@ static int disp_mem_request(int sel, u32 size)
 u32 disp_mem_getadr(u32 memid)
 {
     if (memid < DISP_MEM_COUNT)
+    {
         return g_disp_mm[memid].mem_start;
+    }
     return 0;
 }
 
@@ -135,7 +140,8 @@ int disp_mem(u32 mem_id, u32 width, u32 height, u32 clear_flag, char *filename)
     unsigned long count = width*height;
     char *tmp;
 
-    if (mem_id >= DISP_MEM_COUNT) {
+    if (mem_id >= DISP_MEM_COUNT)
+    {
         printf("invalid mem_id\n");
         return -1;
     }
@@ -240,10 +246,13 @@ int parse_cmdline_and_alloc(int argc, char **argv)
         if ( ! strcmp(argv[i], "-file")) {
             if (argc > i+1) {
                 i++;
-                if (rt_strlen(argv[i]) >= sizeof(p->filename)) {
+                if (rt_strlen(argv[i]) >= sizeof(p->filename))
+                {
                     printf("filename is too long!!\n");
                     err++;
-                } else {
+                }
+                else
+                {
                     rt_strncpy(p->filename, argv[i], sizeof(p->filename));
                     printf("filename=%s\n", argv[i]);
                 }
@@ -276,7 +285,8 @@ int parse_cmdline_and_alloc(int argc, char **argv)
         i++;
     }
 
-    if (p->mem_id < 0 || p->mem_id >= DISP_MEM_COUNT) {
+    if (p->mem_id < 0 || p->mem_id >= DISP_MEM_COUNT)
+    {
         printf("mem_id para error!\n");
         err++;
     }

--- a/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_mem.c
+++ b/bsp/allwinner/libraries/sunxi-hal/hal/test/disp2/disp_mem.c
@@ -135,11 +135,18 @@ int disp_mem(u32 mem_id, u32 width, u32 height, u32 clear_flag, char *filename)
         return 0;
     }
 
+    if (filename == NULL)
+    {
+        printf("filename is null.\n");
+        goto OUT;
+    }
+
     //for_test  we use r g b to set color buffer
-    if(filename[0] != 'r' && filename[0] != 'g' && filename[0] != 'b') {
-        if(filename != NULL)
-            fh = fopen(filename, "r");
-        if(!fh) {
+    if (filename[0] != 'r' && filename[0] != 'g' && filename[0] != 'b')
+    {
+        fh = fopen(filename, "r");
+        if (!fh)
+        {
             printf("open file %s fail. \n", filename);
             goto OUT;
         }
@@ -264,5 +271,4 @@ int parse_cmdline_and_alloc(int argc, char **argv)
     }
 }
 
-FINSH_FUNCTION_EXPORT_ALIAS(parse_cmdline_and_alloc, disp_mem, disp mem);
-
+MSH_CMD_EXPORT_ALIAS(parse_cmdline_and_alloc, disp_mem, disp mem);

--- a/bsp/apm32/libraries/Drivers/drv_common.c
+++ b/bsp/apm32/libraries/Drivers/drv_common.c
@@ -6,7 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2020-08-20     Abbcc        first version
- * 2022-03-04     stevetong459 FINSH_FUNCTION_EXPORT_ALIAS change to MSH_CMD_EXPORT for reboot function.
+ * 2022-03-04     stevetong459 Use MSH_CMD_EXPORT for reboot function.
  */
 
 #include "drv_common.h"

--- a/bsp/at91/at91sam9260/platform/reset.c
+++ b/bsp/at91/at91sam9260/platform/reset.c
@@ -30,7 +30,6 @@ void machine_shutdown(void)
 #ifdef RT_USING_FINSH
 
 #include <finsh.h>
-FINSH_FUNCTION_EXPORT_ALIAS(rt_hw_cpu_reset, reset, restart the system);
 
 #ifdef FINSH_USING_MSH
 int cmd_reset(int argc, char** argv)

--- a/bsp/fujitsu/mb9x/mb9bf506r/drivers/nand.c
+++ b/bsp/fujitsu/mb9x/mb9bf506r/drivers/nand.c
@@ -620,7 +620,6 @@ void nand_read(int block, int page)
     rt_kprintf("oob data:\n");
     dump_mem(nand_oob, 16);
 }
-FINSH_FUNCTION_EXPORT_ALIAS(nand_read, read_page, read page[block/page]);
 
 void nand_write(int block, int page)
 {
@@ -630,13 +629,11 @@ void nand_write(int block, int page)
 
     NF_WritePage(block, page, nand_buffer);
 }
-FINSH_FUNCTION_EXPORT_ALIAS(nand_write, write_page, write page[block/page]);
 
 void nand_erase(int block)
 {
     NF_EraseBlock(block);
 }
-FINSH_FUNCTION_EXPORT_ALIAS(nand_erase, erase_block, erase block[block]);
 
 void nand_readoob(int block, int page)
 {
@@ -646,7 +643,6 @@ void nand_readoob(int block, int page)
     rt_kprintf("oob data:\n");
     dump_mem(nand_oob, 16);
 }
-FINSH_FUNCTION_EXPORT_ALIAS(nand_readoob, readoob, read oob[block/page]);
 
 void nand_erase_chip(void)
 {
@@ -661,5 +657,4 @@ void nand_erase_chip(void)
         NF_EraseBlock(i);
     }
 }
-FINSH_FUNCTION_EXPORT_ALIAS(nand_erase_chip, erase_chip, erase whole chip);
 #endif

--- a/bsp/simulator/drivers/board.c
+++ b/bsp/simulator/drivers/board.c
@@ -93,7 +93,7 @@ MSH_CMD_EXPORT_ALIAS(rt_hw_exit, quit, exit rt-thread);
 int rt_hw_board_init(void)
 {
     /* init system memory */
-    RT_UNUSED(rt_hw_sram_init());
+    rt_hw_sram_init();
 
     uart_console_init();
 

--- a/bsp/simulator/drivers/board.c
+++ b/bsp/simulator/drivers/board.c
@@ -84,7 +84,6 @@ void rt_hw_exit(void)
 
 #if defined(RT_USING_FINSH)
 #include <finsh.h>
-FINSH_FUNCTION_EXPORT_ALIAS(rt_hw_exit, exit, exit rt - thread);
 MSH_CMD_EXPORT_ALIAS(rt_hw_exit, quit, exit rt-thread);
 #endif /* RT_USING_FINSH */
 
@@ -94,7 +93,7 @@ MSH_CMD_EXPORT_ALIAS(rt_hw_exit, quit, exit rt-thread);
 int rt_hw_board_init(void)
 {
     /* init system memory */
-    rt_hw_sram_init();
+    RT_UNUSED(rt_hw_sram_init());
 
     uart_console_init();
 

--- a/bsp/simulator/drivers/board.c
+++ b/bsp/simulator/drivers/board.c
@@ -93,7 +93,7 @@ MSH_CMD_EXPORT_ALIAS(rt_hw_exit, quit, exit rt-thread);
 int rt_hw_board_init(void)
 {
     /* init system memory */
-    rt_hw_sram_init();
+    RT_UNUSED(rt_hw_sram_init());
 
     uart_console_init();
 

--- a/bsp/simulator/drivers/module_win32.c
+++ b/bsp/simulator/drivers/module_win32.c
@@ -347,11 +347,6 @@ rt_module_t rt_module_open(const char *path)
     /* FreeLibrary(hinstlib); */
 }
 
-#if defined(RT_USING_FINSH)
-#include <finsh.h>
-FINSH_FUNCTION_EXPORT_ALIAS(rt_module_open, exec, exec module from a file);
-#endif
-
 #endif
 
 #define RT_MODULE_ARG_MAX    8

--- a/components/dfs/dfs_v1/src/dfs_posix.c
+++ b/components/dfs/dfs_v1/src/dfs_posix.c
@@ -982,10 +982,6 @@ int chdir(const char *path)
     return 0;
 }
 RTM_EXPORT(chdir);
-
-#ifdef RT_USING_FINSH
-FINSH_FUNCTION_EXPORT_ALIAS(chdir, cd, change current working directory);
-#endif
 #endif
 
 /**

--- a/components/dfs/dfs_v2/src/dfs_posix.c
+++ b/components/dfs/dfs_v2/src/dfs_posix.c
@@ -1252,10 +1252,6 @@ int chdir(const char *path)
     return 0;
 }
 RTM_EXPORT(chdir);
-
-#ifdef RT_USING_FINSH
-FINSH_FUNCTION_EXPORT_ALIAS(chdir, cd, change current working directory);
-#endif
 #endif
 
 /**

--- a/components/drivers/mtd/mtd_nand.c
+++ b/components/drivers/mtd/mtd_nand.c
@@ -411,15 +411,6 @@ help:
 MSH_CMD_EXPORT(mtd_nand, MTD nand device test function);
 #endif /* RT_USING_FINSH */
 
-#ifndef RT_USING_FINSH_ONLY
-FINSH_FUNCTION_EXPORT_ALIAS(mtd_nandid, nand_id, read ID - nandid(name));
-FINSH_FUNCTION_EXPORT_ALIAS(mtd_nand_read, nand_read, read page in nand - nand_read(name, block, page));
-FINSH_FUNCTION_EXPORT_ALIAS(mtd_nand_readoob, nand_readoob, read spare data in nand - nand_readoob(name, block, page));
-FINSH_FUNCTION_EXPORT_ALIAS(mtd_nand_write, nand_write, write dump data to nand - nand_write(name, block, page));
-FINSH_FUNCTION_EXPORT_ALIAS(mtd_nand_erase, nand_erase, nand_erase(name, block));
-FINSH_FUNCTION_EXPORT_ALIAS(mtd_nand_erase_all, nand_erase_all, erase all of nand device - nand_erase_all(name, block));
-#endif /* RT_USING_FINSH_ONLY */
-
 #endif /* defined(RT_MTD_NAND_DEBUG) && defined(RT_USING_FINSH) */
 
 #endif /* RT_USING_MTD_NAND */

--- a/components/drivers/pm/pm.c
+++ b/components/drivers/pm/pm.c
@@ -1299,7 +1299,6 @@ static void rt_pm_dump_status(void)
     }
     rt_kprintf("+--------+------+------------+-----------+\n");
 }
-FINSH_FUNCTION_EXPORT_ALIAS(rt_pm_dump_status, pm_dump, dump power management status);
 MSH_CMD_EXPORT_ALIAS(rt_pm_dump_status, pm_dump, dump power management status);
 #endif
 

--- a/components/finsh/finsh.h
+++ b/components/finsh/finsh.h
@@ -124,17 +124,6 @@ typedef long (*syscall_func)(void);
 /**
  * @ingroup group_finsh
  *
- * @brief Exports a system function with an alias name to finsh shell.
- *
- * @param[in] name Name of function.
- * @param[in] alias Alias name of function.
- * @param[in] desc Description of function, which will show in help.
- */
-#define FINSH_FUNCTION_EXPORT_ALIAS(name, alias, desc)
-
-/**
- * @ingroup group_finsh
- *
  * @brief Exports a command to module shell.
  *
  * @b Parameters

--- a/include/rtdef.h
+++ b/include/rtdef.h
@@ -206,7 +206,6 @@ typedef int (*init_fn_t)(void);
 #if !defined(RT_USING_FINSH)
 /* define these to empty, even if not include finsh.h file */
 #define FINSH_FUNCTION_EXPORT(name, desc)
-#define FINSH_FUNCTION_EXPORT_ALIAS(name, alias, desc)
 
 #define MSH_CMD_EXPORT(command, desc)
 #define MSH_CMD_EXPORT_ALIAS(command, alias, desc)


### PR DESCRIPTION
## Summary

- Remove the deprecated `FINSH_FUNCTION_EXPORT_ALIAS` definitions and all remaining call sites.
- Keep existing MSH command exports and migrate compatible Allwinner handlers to `MSH_CMD_EXPORT_ALIAS`.
- Remove stale conditional blocks and update the related driver changelog text.

Fixes RT-Thread/rt-thread#10814 and follows up on #10940.

## Validation

- Confirmed no `FINSH_FUNCTION_EXPORT_ALIAS` references remain.
- Changed lines pass clang-format checks.
- Simulator compilation reaches link stage; local linking requires SDL2.