### PR TITLE
[tools][keil] Preserve include path order

### DIFF
--- a/tools/targets/keil.py
+++ b/tools/targets/keil.py
@@ -223,7 +223,7 @@ def MDK45Project(env, tree, target, script):
     out = open(target, 'w')
     out.write('<?xml version="1.0" encoding="UTF-8" standalone="no" ?>\n')
 
-    CPPPATH = []
+    CPPPATH = list(env.get('CPPPATH', []))
     CPPDEFINES = env.get('CPPDEFINES', [])
     LINKFLAGS = ''
     CXXFLAGS = ''
@@ -286,7 +286,9 @@ def MDK45Project(env, tree, target, script):
 
     # write include path, definitions and link flags
     IncludePath = tree.find('Targets/Target/TargetOption/TargetArmAds/Cads/VariousControls/IncludePath')
-    IncludePath.text = ';'.join([_make_path_relative(project_path, os.path.normpath(i)) for i in set(CPPPATH)])
+    # Keep the same include path precedence as the SCons build environment.
+    paths = [_make_path_relative(project_path, os.path.normpath(i)) for i in CPPPATH]
+    IncludePath.text = ';'.join(dict.fromkeys(paths))
 
     Define = tree.find('Targets/Target/TargetOption/TargetArmAds/Cads/VariousControls/Define')
     Define.text = ', '.join(set(CPPDEFINES))


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

MDK5 工程生成器使用无序集合对头文件搜索路径去重，导致生成工程的 IncludePath 顺序不稳定。对于 bsp/renesas/ra8p1-titan-board/m85，错误顺序会优先选择 BSP 根目录下的 bsp_linker_info.h，而不是 board/bsp_linker_info.h，最终使 R_BSP_SecondaryCoreStart 声明缺失并导致 Keil 编译失败。

#### 你的解决方案是什么 (what is your solution)

修改 tools/targets/keil.py，以 SCons 构建环境中的 CPPPATH 作为生成工程的基础路径，保留 SConstruct 明确配置的搜索优先级。路径转换为相对路径后使用有序方式去重，保证 MDK 工程的头文件搜索顺序与 SCons 构建环境一致且生成结果稳定。

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: bsp/renesas/ra8p1-titan-board/m85

- .config: 未修改，使用仓库当前配置

- action: 未单独触发 GitHub Action；已完成本地 Env、SCons 和 Keil 构建验证

本地验证：

- Python 语法检查通过
- tools/testcases/test_refactor.py 通过
- scons --target=mdk5 --exec-path=C:\Keil_v5 生成并调用 Keil MDK 5.43 / ArmClang 6.24 编译成功
- 构建结果为 0 Error(s)，原有的 2 个重复弱符号 Warning 不属于本次修改范围

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)

