### PR TITLE
[tools] feat: auto-select Keil/IAR target by Kconfig linker script

### DIFF
--- a/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm33/rtconfig.py
+++ b/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm33/rtconfig.py
@@ -61,7 +61,6 @@ _LINKER_SCRIPT_BASE = {
     'FLEXSPI_NOR_HYPERRAM': 'MIMXRT1189xxxxx_cm33_flexspi_nor_hyperram',
 }[_LINKER_SCRIPT_TYPE]
 
-
 if PLATFORM == 'gcc':
     PREFIX = 'arm-none-eabi-'
     CC = PREFIX + 'gcc'
@@ -229,18 +228,23 @@ elif PLATFORM == 'iccarm':
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 
-# Map from linker script type to the matching Keil target name.
-_LINKER_SCRIPT_TO_KEIL_TARGET = {
+# Map from linker script type to the matching Keil target / IAR configuration name.
+# Keil targets and IAR configurations share the same names, so one table serves both.
+_LINKER_SCRIPT_TO_PROJECT_TARGET = {
     'RAM':                  'rtthread_ram',
     'FLEXSPI_NOR':          'rtthread_flexspi_nor',
     'FLEXSPI_NOR_HYPERRAM': 'rtthread_flexspi_nor_hyperram',
 }
 
+def _get_active_project_target():
+    """Return the Keil target / IAR config name matching the selected linker script."""
+    return _LINKER_SCRIPT_TO_PROJECT_TARGET.get(_LINKER_SCRIPT_TYPE, 'rtthread_ram')
+
 def update_keil_active_target(uvoptx_path='project.uvoptx'):
     """Set <IsCurrentTarget> in project.uvoptx to match the selected linker script."""
     import xml.etree.ElementTree as etree
 
-    active = _LINKER_SCRIPT_TO_KEIL_TARGET.get(_LINKER_SCRIPT_TYPE, 'rtthread_ram')
+    active = _get_active_project_target()
 
     if not os.path.exists(uvoptx_path):
         return
@@ -261,7 +265,17 @@ def update_keil_active_target(uvoptx_path='project.uvoptx'):
 
     print('Keil active target set to: ' + active)
 
+def iar_get_active_config():
+    """Return the IAR configuration name matching the selected linker script.
+
+    This hook is called by tools/targets/iar.py when generating the IAR
+    project so that the active configuration follows the Kconfig linker
+    script selection. It is board-specific and only defined here.
+    """
+    return _get_active_project_target()
+
 def dist_handle(BSP_ROOT, dist_dir):
+
     import sys
     cwd_path = os.getcwd()
     # sys.path.append(os.path.join(os.path.dirname(BSP_ROOT), 'tools'))

--- a/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm33/rtconfig.py
+++ b/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm33/rtconfig.py
@@ -247,10 +247,11 @@ def update_keil_active_target(uvoptx_path='project.uvoptx'):
     active = _get_active_project_target()
 
     if not os.path.exists(uvoptx_path):
-        return
+        return active
 
     tree = etree.parse(uvoptx_path)
     root = tree.getroot()
+
 
     for tgt in tree.findall('Target'):
         tname = tgt.find('TargetName')
@@ -265,7 +266,12 @@ def update_keil_active_target(uvoptx_path='project.uvoptx'):
 
     print('Keil active target set to: ' + active)
 
+    # Return the active target name so the caller (tools/targets/keil.py) can
+    # build the matching target with UV4.exe instead of the template's first one.
+    return active
+
 def iar_get_active_config():
+
     """Return the IAR configuration name matching the selected linker script.
 
     This hook is called by tools/targets/iar.py when generating the IAR

--- a/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm7/rtconfig.py
+++ b/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm7/rtconfig.py
@@ -262,7 +262,7 @@ def update_keil_active_target(uvoptx_path='project.uvoptx'):
     active = _get_active_project_target()
 
     if not os.path.exists(uvoptx_path):
-        return
+        return active
 
     tree = etree.parse(uvoptx_path)
     root = tree.getroot()
@@ -279,6 +279,11 @@ def update_keil_active_target(uvoptx_path='project.uvoptx'):
     out.close()
 
     print('Keil active target set to: ' + active)
+
+    # Return the active target name so the caller (tools/targets/keil.py) can
+    # build the matching target with UV4.exe instead of the template's first one.
+    return active
+
 
 def iar_get_active_config():
     """Return the IAR configuration name matching the selected linker script.

--- a/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm7/rtconfig.py
+++ b/bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm7/rtconfig.py
@@ -242,19 +242,24 @@ elif PLATFORM == 'iccarm':
     EXEC_PATH = EXEC_PATH + '/arm/bin/'
     POST_ACTION = 'ielftool --bin $TARGET rtthread.bin'
 
-# Map from linker script type to the matching Keil target name.
-_LINKER_SCRIPT_TO_KEIL_TARGET = {
+# Map from linker script type to the matching Keil target / IAR configuration name.
+# Keil targets and IAR configurations share the same names, so one table serves both.
+_LINKER_SCRIPT_TO_PROJECT_TARGET = {
     'RAM':                  'rtthread_ram',
     'HYPERRAM':             'rtthread_hyperram',
     'FLEXSPI_NOR':          'rtthread_flexspi_nor',
     'FLEXSPI_NOR_HYPERRAM': 'rtthread_flexspi_nor_hyperram',
 }
 
+def _get_active_project_target():
+    """Return the Keil target / IAR config name matching the selected linker script."""
+    return _LINKER_SCRIPT_TO_PROJECT_TARGET.get(_LINKER_SCRIPT_TYPE, 'rtthread_ram')
+
 def update_keil_active_target(uvoptx_path='project.uvoptx'):
     """Set <IsCurrentTarget> in project.uvoptx to match the selected linker script."""
     import xml.etree.ElementTree as etree
 
-    active = _LINKER_SCRIPT_TO_KEIL_TARGET.get(_LINKER_SCRIPT_TYPE, 'rtthread_ram')
+    active = _get_active_project_target()
 
     if not os.path.exists(uvoptx_path):
         return
@@ -274,6 +279,15 @@ def update_keil_active_target(uvoptx_path='project.uvoptx'):
     out.close()
 
     print('Keil active target set to: ' + active)
+
+def iar_get_active_config():
+    """Return the IAR configuration name matching the selected linker script.
+
+    This hook is called by tools/targets/iar.py when generating the IAR
+    project so that the active configuration follows the Kconfig linker
+    script selection. It is board-specific and only defined here.
+    """
+    return _get_active_project_target()
 
 def dist_handle(BSP_ROOT, dist_dir):
     import sys

--- a/tools/targets/iar.py
+++ b/tools/targets/iar.py
@@ -236,20 +236,27 @@ def IARProject(env, target, script):
         project_name = os.path.splitext(os.path.basename(target))[0]
         _update_iar_wsdt(wsdt_path, project_name, active_config)
 
-    # copy template.ewd (debugger settings) and template.ewt (build settings) to project files
+        # The IAR IDE keeps the workspace/session state in memory and writes it
+        # back on close, which can overwrite the active configuration we just
+        # generated. Remind the user to close the workspace before regenerating.
+        print('IAR active configuration set to: %s' % active_config)
+        print('Note: if the IAR workspace (.eww) is currently open, close it '
+              'before regenerating the project, otherwise the active target '
+              'will not be updated.')
+
+    # copy template.ewd (debugger settings) and template.ewt (build settings) to project files.
+    # The template sources are always template.ewd / template.ewt in the project directory;
+    # do not derive them from the output project name, otherwise a custom --project-name
+    # would make source and destination identical and trigger shutil.SameFileError.
     import shutil
-    ewd_template = target.replace('.ewp', '.ewd').replace('project', 'template')
+    ewd_template = os.path.join(project_path, 'template.ewd')
     ewd_target   = target.replace('.ewp', '.ewd')
-    if not os.path.exists(ewd_template):
-        ewd_template = 'template.ewd'
-    if os.path.exists(ewd_template):
+    if os.path.exists(ewd_template) and os.path.abspath(ewd_template) != os.path.abspath(ewd_target):
         shutil.copy2(ewd_template, ewd_target)
 
-    ewt_template = target.replace('.ewp', '.ewt').replace('project', 'template')
+    ewt_template = os.path.join(project_path, 'template.ewt')
     ewt_target   = target.replace('.ewp', '.ewt')
-    if not os.path.exists(ewt_template):
-        ewt_template = 'template.ewt'
-    if os.path.exists(ewt_template):
+    if os.path.exists(ewt_template) and os.path.abspath(ewt_template) != os.path.abspath(ewt_target):
         shutil.copy2(ewt_template, ewt_target)
 
 def IARPath():

--- a/tools/targets/iar.py
+++ b/tools/targets/iar.py
@@ -40,13 +40,14 @@ iar_workspace = r'''<?xml version="1.0" encoding="iso-8859-1"?>
 
 <workspace>
   <project>
-    <path>$WS_DIR$\%s</path>
-  </project>
+    <path>$WS_DIR$\%(project)s</path>
+  </project>%(active_config)s
   <batchBuild/>
 </workspace>
 
 
 '''
+
 
 def IARAddGroup(parent, name, files, project_path):
     group = SubElement(parent, 'group')
@@ -69,11 +70,47 @@ def IARAddGroup(parent, name, files, project_path):
         else:
             file_name.text = '$PROJ_DIR$\\' + path # ('$PROJ_DIR$\\' + path).decode(fs_encoding)
 
-def IARWorkspace(target):
-    # make an workspace
+def _update_iar_wsdt(wsdt_path, project_name, active_config):
+    """Update <CurrentConfigs><Project> in the IAR session file to set the active configuration."""
+    config_str = '%s/%s' % (project_name, active_config)
+
+    if not os.path.exists(wsdt_path):
+        # create a minimal wsdt if it does not exist yet
+        os.makedirs(os.path.dirname(wsdt_path), exist_ok=True)
+        content = '<?xml version="1.0"?>\n<Workspace>\n    <ConfigDictionary>\n        <CurrentConfigs>\n            <Project>%s</Project>\n        </CurrentConfigs>\n    </ConfigDictionary>\n</Workspace>\n' % config_str
+        with open(wsdt_path, 'w') as f:
+            f.write(content)
+        return
+
+    try:
+        tree = etree.parse(wsdt_path)
+        root = tree.getroot()
+        proj_elem = root.find('ConfigDictionary/CurrentConfigs/Project')
+        if proj_elem is not None:
+            proj_elem.text = config_str
+        else:
+            # create the elements if missing
+            cfg_dict = root.find('ConfigDictionary')
+            if cfg_dict is None:
+                cfg_dict = SubElement(root, 'ConfigDictionary')
+            cur_cfgs = cfg_dict.find('CurrentConfigs')
+            if cur_cfgs is None:
+                cur_cfgs = SubElement(cfg_dict, 'CurrentConfigs')
+            proj_elem = SubElement(cur_cfgs, 'Project')
+            proj_elem.text = config_str
+        tree.write(wsdt_path, encoding='unicode', xml_declaration=True)
+    except Exception as e:
+        print('Warning: could not update %s: %s' % (wsdt_path, e))
+
+def IARWorkspace(target, active_config=None):
+    # make an workspace, optionally setting the active configuration
     workspace = target.replace('.ewp', '.eww')
+    project_name = os.path.splitext(os.path.basename(target))[0]
+    active_elem = ''
+    if active_config:
+        active_elem = '\n  <activeConfig>\n    <name>%s/%s</name>\n  </activeConfig>' % (project_name, active_config)
     out = open(workspace, 'w')
-    xml = iar_workspace % target
+    xml = iar_workspace % {'project': target, 'active_config': active_elem}
     out.write(xml)
     out.close()
 
@@ -87,6 +124,7 @@ def IARProject(env, target, script):
 
     CPPPATH = []
     CPPDEFINES = env.get('CPPDEFINES', [])
+
     LOCAL_CPPDEFINES = []
     LINKFLAGS = ''
     CFLAGS = ''
@@ -160,6 +198,13 @@ def IARProject(env, target, script):
                 state = SubElement(option, 'state')
                 state.text = define
 
+        if name.text == 'IlinkConfigDefines':
+            # write bare symbol=value tokens from LINKFLAGS as IAR linker defines
+            import re
+            for token in re.findall(r'\S+', LINKFLAGS):
+                state = SubElement(option, 'state')
+                state.text = token
+
         if name.text == 'IlinkAdditionalLibs':
             for path in Libs:
                 state = SubElement(option, 'state')
@@ -173,7 +218,39 @@ def IARProject(env, target, script):
     out.write(etree.tostring(root, encoding='utf-8').decode())
     out.close()
 
-    IARWorkspace(target)
+    # Determine the active configuration from the BSP via an optional board-specific hook.
+    active_config = None
+    try:
+        import rtconfig
+        if hasattr(rtconfig, 'iar_get_active_config'):
+            active_config = rtconfig.iar_get_active_config()
+    except Exception as e:
+        print('Warning: could not get IAR active config: %s' % e)
+
+    IARWorkspace(target, active_config)
+
+    # update settings/project.wsdt to set the active configuration
+    if active_config:
+        wsdt_path = os.path.join('settings', os.path.splitext(os.path.basename(target))[0] + '.wsdt')
+
+        project_name = os.path.splitext(os.path.basename(target))[0]
+        _update_iar_wsdt(wsdt_path, project_name, active_config)
+
+    # copy template.ewd (debugger settings) and template.ewt (build settings) to project files
+    import shutil
+    ewd_template = target.replace('.ewp', '.ewd').replace('project', 'template')
+    ewd_target   = target.replace('.ewp', '.ewd')
+    if not os.path.exists(ewd_template):
+        ewd_template = 'template.ewd'
+    if os.path.exists(ewd_template):
+        shutil.copy2(ewd_template, ewd_target)
+
+    ewt_template = target.replace('.ewp', '.ewt').replace('project', 'template')
+    ewt_target   = target.replace('.ewp', '.ewt')
+    if not os.path.exists(ewt_template):
+        ewt_template = 'template.ewt'
+    if os.path.exists(ewt_template):
+        shutil.copy2(ewt_template, ewt_target)
 
 def IARPath():
     import rtconfig

--- a/tools/targets/keil.py
+++ b/tools/targets/keil.py
@@ -231,11 +231,15 @@ def MDK45Project(env, tree, target, script):
     CFLAGS = ''
     ProjectFiles = []
 
-    # add group
-    groups = tree.find('Targets/Target/Groups')
+    import copy
+
+    # add groups to the first target; they will be copied to all other targets afterward
+    first_target = tree.find('Targets/Target')
+    groups = first_target.find('Groups')
     if groups is None:
-        groups = SubElement(tree.find('Targets/Target'), 'Groups')
+        groups = SubElement(first_target, 'Groups')
     groups.clear() # clean old groups
+
     for group in script:
         group_tree = MDK4AddGroup(ProjectFiles, groups, group['name'], group['src'], project_path, group)
 
@@ -284,23 +288,39 @@ def MDK45Project(env, tree, target, script):
                     else:
                         group_tree = MDK4AddGroupForFN(ProjectFiles, groups, group['name'], full_path, project_path)
 
-    # write include path, definitions and link flags
-    IncludePath = tree.find('Targets/Target/TargetOption/TargetArmAds/Cads/VariousControls/IncludePath')
-    IncludePath.text = ';'.join([_make_path_relative(project_path, os.path.normpath(i)) for i in set(CPPPATH)])
+    # write include path, definitions and link flags for all targets in the template
+    include_path_text = ';'.join([_make_path_relative(project_path, os.path.normpath(i)) for i in set(CPPPATH)])
+    define_text = ', '.join(set(CPPDEFINES))
 
-    Define = tree.find('Targets/Target/TargetOption/TargetArmAds/Cads/VariousControls/Define')
-    Define.text = ', '.join(set(CPPDEFINES))
+    for target_node in tree.findall('Targets/Target'):
+        # copy groups from the first target to all other targets so they share the same source file list
+        if target_node is not first_target:
+            existing_groups = target_node.find('Groups')
+            if existing_groups is not None:
+                target_node.remove(existing_groups)
+            target_node.append(copy.deepcopy(groups))
 
-    if 'c99' in CXXFLAGS or 'c99' in CCFLAGS or 'c99' in CFLAGS:
-        uC99 = tree.find('Targets/Target/TargetOption/TargetArmAds/Cads/uC99')
-        uC99.text = '1'
+        inc = target_node.find('TargetOption/TargetArmAds/Cads/VariousControls/IncludePath')
+        if inc is not None:
+            inc.text = include_path_text
 
-    if 'gnu' in CXXFLAGS or 'gnu' in CCFLAGS or 'gnu' in CFLAGS:
-        uGnu = tree.find('Targets/Target/TargetOption/TargetArmAds/Cads/uGnu')
-        uGnu.text = '1'
+        dfn = target_node.find('TargetOption/TargetArmAds/Cads/VariousControls/Define')
+        if dfn is not None:
+            dfn.text = define_text
 
-    Misc = tree.find('Targets/Target/TargetOption/TargetArmAds/LDads/Misc')
-    Misc.text = LINKFLAGS
+        if 'c99' in CXXFLAGS or 'c99' in CCFLAGS or 'c99' in CFLAGS:
+            uC99 = target_node.find('TargetOption/TargetArmAds/Cads/uC99')
+            if uC99 is not None:
+                uC99.text = '1'
+
+        if 'gnu' in CXXFLAGS or 'gnu' in CCFLAGS or 'gnu' in CFLAGS:
+            uGnu = target_node.find('TargetOption/TargetArmAds/Cads/uGnu')
+            if uGnu is not None:
+                uGnu.text = '1'
+
+        misc = target_node.find('TargetOption/TargetArmAds/LDads/Misc')
+        if misc is not None:
+            misc.text = LINKFLAGS
 
     xml_indent(root)
     out.write(etree.tostring(root, encoding='utf-8').decode())
@@ -362,12 +382,22 @@ def MDK5Project(env, target, script):
     # copy uvopt file
     if os.path.exists('template.uvoptx'):
         import shutil
-        shutil.copy2('template.uvoptx', '{}.uvoptx'.format(os.path.splitext(target)[0]))
-        # build with UV4.exe
+        project_uvoptx = '{}.uvoptx'.format(os.path.splitext(target)[0])
+        shutil.copy2('template.uvoptx', project_uvoptx)
 
+        # Set the active target from the BSP via an optional board-specific hook.
+        try:
+            import rtconfig
+            if hasattr(rtconfig, 'update_keil_active_target'):
+                rtconfig.update_keil_active_target(project_uvoptx)
+        except Exception as e:
+            print('Warning: could not set Keil active target: %s' % e)
+
+        # build with UV4.exe
         if shutil.which('UV4.exe') is not None:
             target_name = template_tree.find('Targets/Target/TargetName')
             print('target_name:', target_name.text)
+
             log_file_path = 'keil.log'
             if os.path.exists(log_file_path):
                 os.remove(log_file_path)

--- a/tools/targets/keil.py
+++ b/tools/targets/keil.py
@@ -386,24 +386,33 @@ def MDK5Project(env, target, script):
         shutil.copy2('template.uvoptx', project_uvoptx)
 
         # Set the active target from the BSP via an optional board-specific hook.
+        # The hook returns the active target name so we build the matching target.
+        active_target_name = None
         try:
             import rtconfig
             if hasattr(rtconfig, 'update_keil_active_target'):
-                rtconfig.update_keil_active_target(project_uvoptx)
+                active_target_name = rtconfig.update_keil_active_target(project_uvoptx)
         except Exception as e:
             print('Warning: could not set Keil active target: %s' % e)
 
         # build with UV4.exe
         if shutil.which('UV4.exe') is not None:
-            target_name = template_tree.find('Targets/Target/TargetName')
-            print('target_name:', target_name.text)
+            # Prefer the active target reported by the BSP hook; fall back to the
+            # template's first target only when no hook is available.
+            if not active_target_name:
+                target_name = template_tree.find('Targets/Target/TargetName')
+                active_target_name = target_name.text
+            print('target_name:', active_target_name)
+
+            # Use the actual generated project file name (honors --project-name).
+            uvprojx_name = os.path.basename(target)
 
             log_file_path = 'keil.log'
             if os.path.exists(log_file_path):
                 os.remove(log_file_path)
             log_thread = threading.Thread(target=monitor_log_file, args=(log_file_path,))
             log_thread.start()
-            cmd = 'UV4.exe -b project.uvprojx -q -j0 -t '+ target_name.text +' -o '+log_file_path
+            cmd = 'UV4.exe -b '+ uvprojx_name +' -q -j0 -t '+ active_target_name +' -o '+log_file_path
             print('Start to build keil project')
             print(cmd)
             os.system(cmd)


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)
i.MX RT1180 EVK BSP 通过 Kconfig 选择不同的链接脚本（RAM / FLEXSPI_NOR / HYPERRAM / FLEXSPI_NOR_HYPERRAM），并在 Keil/IAR 工程中对应不同的 target/configuration。此前生成的工程无法自动选中与所选链接脚本匹配的 target/配置，需要手动切换。本 PR 通过在通用工具中引入"可选板级钩子"，让 BSP 自行决定激活哪个 target/配置，对不定义钩子的其他芯片零影响。

#### 你的解决方案是什么 (what is your solution)
- 板级专属逻辑（linker script -> target 名映射）放在 BSP 的 rtconfig.py。
- 通用工具（tools/targets/keil.py、iar.py）只通过 `hasattr(rtconfig, ...)` 探测并调用可选钩子，用 try/except 守卫。
- 未定义钩子的其他板子/芯片走原有代码路径，生成结果不变，向后兼容。

## **tools/targets/iar.py 改动详解**

### 1. 工作区模板占位符改造

改动前：
```python
iar_workspace = r'''... <path>$WS_DIR$\%s</path> ...'''
xml = iar_workspace % target
```

改动后：
```python
iar_workspace = r'''...
  <project>
    <path>$WS_DIR$\%(project)s</path>
  </project>%(active_config)s
  <batchBuild/>
...'''
xml = iar_workspace % {'project': target, 'active_config': active_elem}
```

说明：把匿名占位符 `%s` 改为命名占位符，新增 `%(active_config)s` 用于插入 `<activeConfig>` 段。无激活配置时 `active_elem` 为空串，渲染结果与旧版逐字节一致，保证对其他板子无影响。

### 2. IARWorkspace 增加 active_config 参数

```python
def IARWorkspace(target, active_config=None):
    workspace = target.replace('.ewp', '.eww')
    project_name = os.path.splitext(os.path.basename(target))[0]
    active_elem = ''
    if active_config:
        active_elem = '\n  <activeConfig>\n    <name>%s/%s</name>\n  </activeConfig>' % (project_name, active_config)
    out = open(workspace, 'w')
    xml = iar_workspace % {'project': target, 'active_config': active_elem}
    out.write(xml)
    out.close()
```

说明：新增可选参数（默认 `None`，向后兼容）。有配置时在 `.eww` 中写入 `<activeConfig><name>项目名/配置名</name></activeConfig>`，声明工程默认激活哪个 configuration。

### 3. 新增 _update_iar_wsdt() 函数

```python
def _update_iar_wsdt(wsdt_path, project_name, active_config):
    config_str = '%s/%s' % (project_name, active_config)
    if not os.path.exists(wsdt_path):
        # 文件不存在则创建最小化 .wsdt
        os.makedirs(os.path.dirname(wsdt_path), exist_ok=True)
        content = '...<ConfigDictionary><CurrentConfigs><Project>%s</Project>...' % config_str
        with open(wsdt_path, 'w') as f:
            f.write(content)
        return
    try:
        tree = etree.parse(wsdt_path)
        root = tree.getroot()
        proj_elem = root.find('ConfigDictionary/CurrentConfigs/Project')
        if proj_elem is not None:
            proj_elem.text = config_str          # 已有节点直接改文本
        else:
            # 缺失则逐级补建 ConfigDictionary -> CurrentConfigs -> Project
            ...
        tree.write(wsdt_path, encoding='unicode', xml_declaration=True)
    except Exception as e:
        print('Warning: could not update %s: %s' % (wsdt_path, e))
```

说明：`.wsdt` 是 IAR 的会话文件，其 `<CurrentConfigs><Project>` 决定 IDE 实际选中的配置。只更新 `.eww` 不够，需同步 `.wsdt`。函数分"文件不存在则新建"和"文件存在则改/补节点"两种情况，出错只警告不中断。

### 4. IlinkConfigDefines 处理块（新增）

```python
if name.text == 'IlinkConfigDefines':
    # write bare symbol=value tokens from LINKFLAGS as IAR linker defines
    import re
    for token in re.findall(r'\S+', LINKFLAGS):
        state = SubElement(option, 'state')
        state.text = token
```

说明：这是更新 IAR 工程的 `IlinkConfigDefines` 选项（对应 IDE 中 Linker -> Config -> Configuration file symbol definitions）。作用是把 SCons 收集到的 LINKFLAGS 里的链接器符号定义（如 `symbol=value` 这类给链接脚本用的宏）用 `re.findall(r'\S+', ...)` 按空白拆分成一个个 token，写成 `<state>` 子节点注入到该 option 下，使链接脚本依赖的符号能正确传给 ilinkarm。

注意：此块不受 `active_config` 守卫，对所有 IAR 板子生效；但仅当模板 `.ewp` 中存在 `IlinkConfigDefines` 选项且 LINKFLAGS 非空时才写入，多数板子该项为空、行为基本不变。

### 5. IARProject 中的钩子调用与文件复制（新增）

```python
# 通过可选板级钩子获取激活配置
active_config = None
try:
    import rtconfig
    if hasattr(rtconfig, 'iar_get_active_config'):
        active_config = rtconfig.iar_get_active_config()
except Exception as e:
    print('Warning: could not get IAR active config: %s' % e)

IARWorkspace(target, active_config)

# 有配置时同步 settings/<project>.wsdt
if active_config:
    wsdt_path = os.path.join('settings', os.path.splitext(os.path.basename(target))[0] + '.wsdt')
    project_name = os.path.splitext(os.path.basename(target))[0]
    _update_iar_wsdt(wsdt_path, project_name, active_config)

# 复制 template.ewd(调试器设置) / template.ewt(构建设置) 到工程文件
import shutil
ewd_template = target.replace('.ewp', '.ewd').replace('project', 'template')
ewd_target   = target.replace('.ewp', '.ewd')
if not os.path.exists(ewd_template):
    ewd_template = 'template.ewd'
if os.path.exists(ewd_template):
    shutil.copy2(ewd_template, ewd_target)
# .ewt 同理
```

说明：
- 钩子部分用 `hasattr` + `try/except` 守卫，其他芯片没有 `iar_get_active_config` 则 `active_config` 保持 `None`，`.wsdt` 更新整段跳过，行为不变。
- `.ewd`/`.ewt` 复制：把调试器设置和构建设置从模板复制到实际工程文件，均有 `os.path.exists` 保护，模板不存在则安全跳过。此段不受 `active_config` 守卫，对所有 IAR 板子生效。

---

## **tools/targets/keil.py 改动详解**

### 1. MDK45Project：多 Target 支持

改动前（只处理第一个 Target）：
```python
groups = tree.find('Targets/Target/Groups')
if groups is None:
    groups = SubElement(tree.find('Targets/Target'), 'Groups')
groups.clear()
...
IncludePath = tree.find('Targets/Target/.../IncludePath')
IncludePath.text = ...
Define = tree.find('Targets/Target/.../Define')
Define.text = ...
```

改动后（遍历所有 Target）：
```python
import copy
first_target = tree.find('Targets/Target')
groups = first_target.find('Groups')
if groups is None:
    groups = SubElement(first_target, 'Groups')
groups.clear()
...
include_path_text = ';'.join([...])
define_text = ', '.join(set(CPPDEFINES))
for target_node in tree.findall('Targets/Target'):
    # 把第一个 target 的 groups 深拷贝到其它 target，使各 target 共享同一份源文件列表
    if target_node is not first_target:
        existing_groups = target_node.find('Groups')
        if existing_groups is not None:
            target_node.remove(existing_groups)
        target_node.append(copy.deepcopy(groups))
    inc = target_node.find('.../IncludePath')
    if inc is not None:
        inc.text = include_path_text
    dfn = target_node.find('.../Define')
    if dfn is not None:
        dfn.text = define_text
    # uC99 / uGnu / Misc 同样在循环内、加 is not None 保护
```

说明：
- 旧逻辑只给模板里第一个 Target 填充 groups/include/define/link flags，多 target 模板下其余 target 是空的。
- 新逻辑先在第一个 target 构建 groups，再用 `copy.deepcopy` 复制到所有其它 target，并对每个 target 分别写入 IncludePath、Define、uC99、uGnu、Misc(链接选项)。
- 所有 find 都加了 `if ... is not None` 空值保护，比旧版直接 `.text =` 更健壮。
- 对单 target 模板（绝大多数板子）：`findall` 只返回一个节点，`target_node is first_target` 恒为真，跳过 deepcopy，行为与旧版等价。

### 2. MDK5Project：复制 uvoptx 后调用可选钩子

改动前：
```python
if os.path.exists('template.uvoptx'):
    import shutil
    shutil.copy2('template.uvoptx', '{}.uvoptx'.format(os.path.splitext(target)[0]))
    # build with UV4.exe
    if shutil.which('UV4.exe') is not None:
        ...
```

改动后：
```python
if os.path.exists('template.uvoptx'):
    import shutil
    project_uvoptx = '{}.uvoptx'.format(os.path.splitext(target)[0])
    shutil.copy2('template.uvoptx', project_uvoptx)

    # 通过可选板级钩子设置激活 target
    try:
        import rtconfig
        if hasattr(rtconfig, 'update_keil_active_target'):
            rtconfig.update_keil_active_target(project_uvoptx)
    except Exception as e:
        print('Warning: could not set Keil active target: %s' % e)

    # build with UV4.exe
    if shutil.which('UV4.exe') is not None:
        ...
```

说明：复制得到 `project.uvoptx` 后，若 BSP 定义了 `update_keil_active_target` 钩子则调用它，把 `.uvoptx` 里匹配所选 linker script 的 target 的 `<IsCurrentTarget>` 置 1、其余置 0。用 `hasattr` + `try/except` 守卫，其他芯片跳过，行为不变。

---

## **bsp/nxp/imx/imxrt/imxrt1180-nxp-evk/cm33/rtconfig.py（cm7 同步）中的实现**

### 1. linker script -> target/配置名映射表

```python
# Keil target 与 IAR configuration 共用同一套名称
_LINKER_SCRIPT_TO_PROJECT_TARGET = {
    'RAM':                  'rtthread_ram',
    'FLEXSPI_NOR':          'rtthread_flexspi_nor',
    'FLEXSPI_NOR_HYPERRAM': 'rtthread_flexspi_nor_hyperram',
    # cm7 额外包含: 'HYPERRAM': 'rtthread_hyperram'
}

def _get_active_project_target():
    """Return the Keil target / IAR config name matching the selected linker script."""
    return _LINKER_SCRIPT_TO_PROJECT_TARGET.get(_LINKER_SCRIPT_TYPE, 'rtthread_ram')
```

### 2. Keil 钩子：设置激活 target

```python
def update_keil_active_target(uvoptx_path='project.uvoptx'):
    """Set <IsCurrentTarget> in project.uvoptx to match the selected linker script."""
    import xml.etree.ElementTree as etree
    active = _get_active_project_target()
    if not os.path.exists(uvoptx_path):
        return
    tree = etree.parse(uvoptx_path)
    root = tree.getroot()
    for tgt in tree.findall('Target'):
        tname = tgt.find('TargetName')
        is_current = tgt.find('TargetOption/OPTFL/IsCurrentTarget')
        if tname is not None and is_current is not None:
            is_current.text = '1' if tname.text == active else '0'
    out = open(uvoptx_path, 'w')
    out.write('<?xml version="1.0" encoding="UTF-8" standalone="no" ?>\n')
    out.write(etree.tostring(root, encoding='utf-8').decode())
    out.close()
    print('Keil active target set to: ' + active)
```

### 3. IAR 钩子：返回激活 configuration 名

```python
def iar_get_active_config():
    """Return the IAR configuration name matching the selected linker script.

    This hook is called by tools/targets/iar.py when generating the IAR
    project so that the active configuration follows the Kconfig linker
    script selection. It is board-specific and only defined here.
    """
    return _get_active_project_target()
```

说明：cm7/rtconfig.py 做同样改动，仅 target 映射表多一个 HYPERRAM 条目（cm7 特有）。原 cm7 里的 `_LINKER_SCRIPT_TO_KEIL_TARGET` 已统一重命名为 `_LINKER_SCRIPT_TO_PROJECT_TARGET`，并抽出 `_get_active_project_target()` 供两个钩子复用。

---

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:
CONFIG_BSP_LINKER_SCRIPT_RAM
CONFIG_BSP_LINKER_SCRIPT_HYPERRAM
CONFIG_BSP_LINKER_SCRIPT_FLEXSPI_NOR
CONFIG_BSP_LINKER_SCRIPT_FLEXSPI_NOR_HYPERRAM

**新增的功能也初步测试了其他项目生成IAR和KEIL工程的兼容性，包括bsp\nxp\imx\imxrt\imxrt1060-nxp-evk, bsp\nxp\mcx\mcxn\frdm-mcxn947 和 bsp\stm32\stm32h743-st-nucleo**

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [x] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
