### PR TITLE
[bsp/renesas][drivers] Fix SPI configuration faults

### DIFF
--- a/bsp/renesas/libraries/HAL_Drivers/drivers/drv_sci.c
+++ b/bsp/renesas/libraries/HAL_Drivers/drivers/drv_sci.c
@@ -668,7 +668,17 @@ static rt_err_t ra_hw_spi_configure(struct rt_spi_device *device,
 #endif
 
     /**< Configure Select Line */
-    rt_pin_write(device->cs_pin, PIN_HIGH);
+    if (!(configuration->mode & RT_SPI_NO_CS) && (device->cs_pin != PIN_NONE))
+    {
+        if (configuration->mode & RT_SPI_CS_HIGH)
+        {
+            rt_pin_write(device->cs_pin, PIN_LOW);
+        }
+        else
+        {
+            rt_pin_write(device->cs_pin, PIN_HIGH);
+        }
+    }
 
     /**< config bitrate */
 #ifdef R_SCI_B_SPI_H

--- a/bsp/renesas/libraries/HAL_Drivers/drivers/drv_spi.c
+++ b/bsp/renesas/libraries/HAL_Drivers/drivers/drv_spi.c
@@ -36,6 +36,7 @@ static struct rt_event complete_event = { 0 };
 #define R_SPI_Read         R_SPI_B_Read
 #define R_SPI_WriteRead    R_SPI_B_WriteRead
 #define R_SPI_Open         R_SPI_B_Open
+#define R_SPI_Close        R_SPI_B_Close
 #define spi_extended_cfg_t spi_b_extended_cfg_t
 
 #elif defined(SOC_SERIES_R7SA6W1)
@@ -44,6 +45,7 @@ static struct rt_event complete_event = { 0 };
 #define R_SPI_Read         R_SPI_W_Read
 #define R_SPI_WriteRead    R_SPI_W_WriteRead
 #define R_SPI_Open         R_SPI_W_Open
+#define R_SPI_Close        R_SPI_W_Close
 #define spi_extended_cfg_t spi_w_extended_cfg_t
 
 #endif
@@ -75,6 +77,8 @@ static struct ra_spi_handle spi_handle[] = {
 };
 
 static struct ra_spi spi_config[sizeof(spi_handle) / sizeof(spi_handle[0])] = { 0 };
+static spi_cfg_t fsp_config[sizeof(spi_handle) / sizeof(spi_handle[0])] = { 0 };
+static spi_extended_cfg_t fsp_extended_config[sizeof(spi_handle) / sizeof(spi_handle[0])] = { 0 };
 
 void spi0_callback(spi_callback_args_t *p_args)
 {
@@ -232,6 +236,9 @@ static rt_err_t ra_hw_spi_configure(struct rt_spi_device *device,
     rt_err_t err = RT_EOK;
 
     struct ra_spi *spi_dev = rt_container_of(device->bus, struct ra_spi, bus);
+    rt_size_t index = spi_dev - spi_config;
+    spi_cfg_t *fsp_cfg = &fsp_config[index];
+    spi_extended_cfg_t *spi_cfg = &fsp_extended_config[index];
 
     /**< data_width : 1 -> 8 bits , 2 -> 16 bits, 4 -> 32 bits, default 32 bits*/
     rt_uint8_t data_width = configuration->data_width / 8;
@@ -239,10 +246,22 @@ static rt_err_t ra_hw_spi_configure(struct rt_spi_device *device,
     configuration->data_width = configuration->data_width / 8;
     spi_dev->rt_spi_cfg_t = configuration;
 
-    spi_extended_cfg_t *spi_cfg = (spi_extended_cfg_t *)spi_dev->ra_spi_handle_t->spi_cfg_t->p_extend;
+    *fsp_cfg = *spi_dev->ra_spi_handle_t->spi_cfg_t;
+    *spi_cfg = *(const spi_extended_cfg_t *)spi_dev->ra_spi_handle_t->spi_cfg_t->p_extend;
+    fsp_cfg->p_extend = spi_cfg;
 
     /**< Configure Select Line */
-    rt_pin_write(device->cs_pin, PIN_HIGH);
+    if (!(configuration->mode & RT_SPI_NO_CS) && (device->cs_pin != PIN_NONE))
+    {
+        if (configuration->mode & RT_SPI_CS_HIGH)
+        {
+            rt_pin_write(device->cs_pin, PIN_LOW);
+        }
+        else
+        {
+            rt_pin_write(device->cs_pin, PIN_HIGH);
+        }
+    }
 
     /**< config bitrate */
 #if defined(SOC_SERIES_R7FA8M85) || defined(SOC_SERIES_R7KA8P1)
@@ -256,7 +275,12 @@ static rt_err_t ra_hw_spi_configure(struct rt_spi_device *device,
 #endif
 
     /**< init */
-    err = R_SPI_Open((spi_ctrl_t *)spi_dev->ra_spi_handle_t->spi_ctrl_t, (spi_cfg_t const * const)spi_dev->ra_spi_handle_t->spi_cfg_t);
+    err = R_SPI_Open((spi_ctrl_t *)spi_dev->ra_spi_handle_t->spi_ctrl_t, fsp_cfg);
+    if (err == FSP_ERR_ALREADY_OPEN)
+    {
+        R_SPI_Close((spi_ctrl_t *)spi_dev->ra_spi_handle_t->spi_ctrl_t);
+        err = R_SPI_Open((spi_ctrl_t *)spi_dev->ra_spi_handle_t->spi_ctrl_t, fsp_cfg);
+    }
     /* handle error */
     if (RT_EOK != err)
     {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)

Renesas SPI 和 SCI SPI 驱动在配置软件片选时没有检查 `RT_SPI_NO_CS` 和 `PIN_NONE`。无片选设备通过 `rt_spi_bus_attach_device()` 挂载后，无效引脚号会被 RA GPIO 驱动当作 PFS 索引使用，从而触发总线异常。

此外，SPI 驱动将 FSP 生成的 `const` 扩展配置强制转换为可写指针，并让波特率计算函数直接写入该配置。在 RA8P1 M85 上，该配置位于 Flash，写入时会触发 `IMPRECISERR`。SPI 控制器已经打开后也无法直接应用下一档时钟配置，导致时钟矩阵测试不能连续运行。

#### 你的解决方案是什么 (what is your solution)

分别修改 `bsp/renesas/libraries/HAL_Drivers/drivers/drv_sci.c` 和 `drv_spi.c`：

- 当配置为 `RT_SPI_NO_CS` 或 `cs_pin == PIN_NONE` 时跳过 CS 引脚写操作；
- 对有效 CS，根据 `RT_SPI_CS_HIGH` 设置正确的空闲电平；
- 为每个 SPI 总线保存可写的 FSP 基础配置和扩展配置副本，在副本中计算运行时波特率，避免修改 Flash 中的生成配置；
- SPI 配置变化且 FSP 实例已经打开时，关闭并使用新配置重新打开控制器。

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: `bsp/renesas/ra8d1-vision-board`
  - 使用 `sci2s`，MOSI/MISO 回环，最大时钟 1 MHz，`components.drivers.spi.loopback` 测试通过。
- BSP: `bsp/renesas/ra8p1-titan-board/m85`
  - 使用 `spi0`，MOSI/MISO 回环，时钟矩阵最大 10 MHz，`components.drivers.spi.loopback` 测试通过。

- .config:
  - RA8D1: `CONFIG_BSP_USING_SCI2=y`、`CONFIG_BSP_USING_SCI2_SPI=y`、`CONFIG_RT_UTEST_SPI_LOOPBACK=y`、`CONFIG_RT_UTEST_SPI_LOOPBACK_BUS_NAME="sci2s"`、`CONFIG_RT_UTEST_SPI_LOOPBACK_MAX_HZ=1000000`
  - RA8P1 M85: `CONFIG_BSP_USING_SPI0=y`、`CONFIG_RT_UTEST_SPI_LOOPBACK=y`、`CONFIG_RT_UTEST_SPI_LOOPBACK_BUS_NAME="spi0"`、`CONFIG_RT_UTEST_SPI_LOOPBACK_MAX_HZ=10000000`

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
