### PR TITLE
fix(netdev): 修复无网卡时 ping 命令空指针崩溃

### DIFF
--- a/components/net/netdev/src/netdev.c
+++ b/components/net/netdev/src/netdev.c
@@ -1340,6 +1340,11 @@ int netdev_cmd_ping(char* target_name, char *netdev_name, rt_uint32_t times, rt_
     if (netdev == RT_NULL)
     {
         netdev = netdev_default;
+        if (netdev == RT_NULL)
+        {
+            rt_kprintf("ping: not found default netif, please specify netdev name.\n");
+            return -RT_ERROR;
+        }
         rt_kprintf("ping: not found specified netif, using default netdev %s.\n", netdev->name);
     }
 
@@ -1410,6 +1415,12 @@ int netdev_cmd_ping(char* target_name, char *netdev_name, rt_uint32_t times, rt_
         /* if the response time is more than NETDEV_PING_DELAY, no need to delay */
         delay_tick = ((rt_tick_get() - start_tick) > NETDEV_PING_DELAY) || (index == times) ? 0 : NETDEV_PING_DELAY;
         rt_thread_delay(delay_tick);
+    }
+
+    if (times == 0)
+    {
+        rt_kprintf("ping: send times is zero, no ping statistics.\n");
+        return -RT_ERROR;
     }
 
     /* print ping statistics */


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

Fixes #11744 

netdev_cmd_ping 中 netdev 回退到 netdev_default 后未判空，
QEMU 无网卡环境下执行 ping 直接解引用 NULL 崩溃（data abort）。

#### 你的解决方案是什么 (what is your solution)

回退后增加空指针检查，提示无可用网卡并返回错误。

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP:

bsp/qemu-vexpress-a9

- .config:

```diff
@@ -419,7 +420,15 @@ CONFIG_RT_USING_POSIX_MESSAGE_SEMAPHORE=y
 # Network
 #
 # CONFIG_RT_USING_SAL is not set
-# CONFIG_RT_USING_NETDEV is not set
+CONFIG_RT_USING_NETDEV=y
+CONFIG_NETDEV_USING_IFCONFIG=y
+CONFIG_NETDEV_USING_PING=y
+CONFIG_NETDEV_USING_NETSTAT=y
+CONFIG_NETDEV_USING_AUTO_DEFAULT=y
+# CONFIG_NETDEV_USING_LINK_STATUS_CALLBACK is not set
+# CONFIG_NETDEV_USING_IPV6 is not set
+CONFIG_NETDEV_IPV4=1
+CONFIG_NETDEV_IPV6=0
 # CONFIG_RT_USING_LWIP is not set
 # CONFIG_RT_USING_AT is not set
 # end of Network
```

- action:

```bash
WARNING: Image format was not specified for 'sd.bin' and probing guessed raw.
         Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the restrictions.
pulseaudio: set_sink_input_volume() failed
pulseaudio: Reason: Invalid argument
pulseaudio: set_sink_input_mute() failed
pulseaudio: Reason: Invalid argument

 \ | /
- RT -     Thread Operating System
 / | \     5.3.0 build Aug 26 2026 14:33:35
 2006 - 2024 Copyright by RT-Thread team
[I/SDIO] SD card capacity 65536 KB.
[I/SDIO] SD card switch to High Speed / SDR25 mode
[I/FileSystem] file system initialization done!

Hello RT-Thread!
msh />ping
ping
msh />ping 1.2.3.4
ping: not found default netif, please specify netdev name.
msh />ping 1.2.3.4 0
ping: not found default netif, please specify netdev name.
msh />ping 1        
ping: not found default netif, please specify netdev name.
msh />      
```

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
