### PR TITLE
[net][sal] Free DFS v2 vnode when socket creation fails

### DIFF
--- a/components/net/sal/socket/net_sockets.c
+++ b/components/net/sal/socket/net_sockets.c
@@ -670,6 +670,10 @@ int socket(int domain, int type, int protocol)
     }
     else
     {
+#ifdef RT_USING_DFS_V2
+        dfs_vnode_destroy(d->vnode);
+        d->vnode = RT_NULL;
+#endif
         /* release fd */
         fd_release(fd);
         rt_set_errno(-ENOMEM);

--- a/components/net/sal/socket/net_sockets.c
+++ b/components/net/sal/socket/net_sockets.c
@@ -63,7 +63,7 @@ int accept(int s, struct sockaddr *addr, socklen_t *addrlen)
         }
 
         d = fd_get(fd);
-        if(d)
+        if (d)
         {
 #ifdef RT_USING_DFS_V2
             d->fops = dfs_net_get_fops();

--- a/components/net/utest/SConscript
+++ b/components/net/utest/SConscript
@@ -17,6 +17,9 @@ if GetDepend('RT_UTEST_TC_USING_SAL'):
     # Add sal test source if enabled
     src += ['tc_sal_socket.c']
 
+    if GetDepend(['RT_USING_DFS_V2', 'SAL_USING_POSIX']):
+        src += ['tc_sal_socket_failure.c']
+
 # Define the test group with proper dependencies
 group = DefineGroup('utestcases', src, depend = [''], CPPPATH = CPPPATH)
 

--- a/components/net/utest/tc_sal_socket_failure.c
+++ b/components/net/utest/tc_sal_socket_failure.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2006-2026, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <rtthread.h>
+#include <sys/socket.h>
+
+#include "utest.h"
+
+static void TC_sal_socket_failure_cleanup(void)
+{
+    rt_size_t used_before;
+    rt_size_t used_after;
+    int i;
+
+    /* Warm up the descriptor and SAL tables before measuring the heap. */
+    uassert_int_equal(socket(-1, SOCK_STREAM, 0), -1);
+    rt_memory_info(RT_NULL, &used_before, RT_NULL);
+
+    for (i = 0; i < 32; i++)
+    {
+        uassert_int_equal(socket(-1, SOCK_STREAM, 0), -1);
+    }
+
+    rt_memory_info(RT_NULL, &used_after, RT_NULL);
+    LOG_I("heap used before: %lu, after: %lu",
+          (unsigned long)used_before, (unsigned long)used_after);
+    uassert_int_equal(used_after, used_before);
+}
+
+static void utest_do_tc(void)
+{
+    UTEST_UNIT_RUN(TC_sal_socket_failure_cleanup);
+}
+UTEST_TC_EXPORT(utest_do_tc, "components.net.sal.socket_failure_cleanup", RT_NULL, RT_NULL, 5);


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
#### 为什么提交这份PR (why to submit this PR)

With DFS v2, `socket()` allocates a `dfs_file` and a separate `dfs_vnode` before calling `sal_socket()`. If `sal_socket()` fails, `fd_release()` destroys only the `dfs_file`, so every failed call leaks one vnode.

On the simulator, 32 repeated invalid-domain calls increased heap use from 2568 to 7944 bytes before this change, a 5376-byte leak.

Fixes #11710.

#### 你的解决方案是什么 (what is your solution)

Destroy the initialized vnode with `dfs_vnode_destroy()` before releasing the failed descriptor, and clear `d->vnode` to avoid leaving a stale pointer. The cleanup is guarded by `RT_USING_DFS_V2`, so DFS v1 keeps its existing descriptor-owned cleanup path.

Add a focused Utest case that warms up the descriptor/SAL tables, repeats the failure 32 times, and verifies that heap use does not increase. After the fix, heap use remained 2400 bytes before and after the loop.

AI assistance: OpenAI Codex:GPT-5 assisted with issue research, implementation, and test preparation. The submitted diff and test results were reviewed locally.

#### 请提供验证的bsp和config (provide the config and bsp) 

- BSP: `bsp/simulator`

- .config:
  - `CONFIG_RT_USING_DFS_V2=y`
  - `CONFIG_SAL_USING_POSIX=y`
  - `CONFIG_RT_USING_UTEST=y`
  - `CONFIG_RT_USING_UTESTCASES=y`
  - `CONFIG_RT_UTEST_TC_USING_SAL=y`

- Tests:
  - DFS v2 i686 MinGW simulator build: `python -m SCons -j4` — passed.
  - `components.net.sal.socket_failure_cleanup` — failed before the fix (`2568 -> 7944` bytes), passed after the fix (`2400 -> 2400` bytes).
  - Restored default DFS v1 targeted build: `python -m SCons -j1 build\kernel\components\net\sal\socket\net_sockets.obj` — passed.
  - `python tools/ci/clang_format_check.py --repo https://github.com/RT-Thread/rt-thread --branch master --clang-format-executable clang-format` — passed.
  - `git diff upstream/master..HEAD --check` — passed.

- Environment note: the repository's full default MSVC simulator build stops in unchanged `drivers/board.c:87` because of an existing command-export macro error; the affected DFS v1 object compiles successfully when targeted directly.

- action: N/A — no workflow run was created on the fork branch; local build and test results are listed above.

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
