### PR TITLE
[tools][eclipse] Sync assembler include paths

### DIFF
--- a/tools/targets/eclipse.py
+++ b/tools/targets/eclipse.py
@@ -183,6 +183,7 @@ def HandleToolOption(tools, env, project, reset):
     paths = [ConverToRttEclipsePathFormat(RelativeProjectPath(env, os.path.normpath(i)).replace('\\', '/')) for i in project['CPPPATH']]
 
     compile_include_paths_options = []
+    assembler_include_paths_options = []
     compile_include_files_options = []
     compile_defs_options = []
     linker_scriptfile_option = None
@@ -200,7 +201,9 @@ def HandleToolOption(tools, env, project, reset):
             # find all compile options
             for option in options:
                 option_id = option.get('id')
-                if ('compiler.include.paths' in  option_id) or ('compiler.option.includepaths' in  option_id) or ('compiler.tasking.include' in  option_id):
+                if ('assembler.include.paths' in option_id) or ('assembler.option.includepaths' in option_id):
+                    assembler_include_paths_options += [option]
+                elif ('compiler.include.paths' in  option_id) or ('compiler.option.includepaths' in  option_id) or ('compiler.tasking.include' in  option_id):
                     compile_include_paths_options += [option]
                 elif option.get('id').find('compiler.include.files') != -1 or option.get('id').find('compiler.option.includefiles') != -1 :
                     compile_include_files_options += [option]
@@ -229,7 +232,7 @@ def HandleToolOption(tools, env, project, reset):
                     linker_newlib_nano_option = option
 
     # change the inclue path
-    for option in compile_include_paths_options:
+    for option in compile_include_paths_options + assembler_include_paths_options:
         # find all of paths in this project
         include_paths = option.findall('listOptionValue')
         for item in include_paths:


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

Eclipse/STM32CubeIDE 工程生成器目前只将 SCons `project['CPPPATH']` 同步到 C/C++ Compiler 的 include paths，没有同步到 Assembler 的 include paths。

对于需要通过 C 预处理器处理的汇编源文件（`.S`），这会造成 SCons 原生构建与生成后的 Eclipse/CDT 工程之间存在配置差异。

例如 Cortex-M4 的 `libcpu/arm/cortex-m4/context_gcc.S` 包含：

```asm
#include <rtconfig.h>
```

SCons 构建时 BSP 根目录已经通过 `CPPPATH` 提供给汇编器，因此可以正常找到 `rtconfig.h`；但通过 `scons --target=eclipse` 生成 STM32CubeIDE/Eclipse 工程后，相同 include paths 只存在于 Compiler 配置中，Assembler 配置缺失，可能导致：

```text
context_gcc.S: fatal error: rtconfig.h: No such file or directory
```

本 PR 使生成后的 Assembler 与 Compiler 使用同一组由 SCons `project['CPPPATH']` 派生的 include paths，保持 SCons 与 Eclipse/CDT 工程生成结果一致。

#### 你的解决方案是什么 (what is your solution)

在 `tools/targets/eclipse.py` 的 `HandleToolOption()` 中：

1. 增加对 Eclipse/CDT Assembler include path option 的收集：

   * `assembler.include.paths`
   * `assembler.option.includepaths`

2. 复用当前由 `project['CPPPATH']` 生成的 include path 列表，同时更新 Compiler 和 Assembler include paths。

3. 保留现有的 reset/update 行为：

   * `reset=True` 时按原有逻辑清理已有配置；
   * `reset=False` 时只清理由 RT-Thread 工程生成器管理的路径；
   * 不删除用户自行配置的非 RT-Thread include paths。

本次修改仅涉及 `tools/targets/eclipse.py`，最终 diff 为 `+5/-2`，不改变 SCons 原生构建行为。

本地验证结果：

* `python3 -m py_compile tools/targets/eclipse.py`：通过。
* 使用两个 STM32F4 Cortex-M4 项目配置执行 `scons --target=eclipse`：通过。
* 生成后 Compiler 与 Assembler 的 SCons-managed include path 集合一致。
* 生成的 Assembler include paths 包含 BSP project root，可解析 `rtconfig.h`。
* 直接预处理 `libcpu/arm/cortex-m4/context_gcc.S` 可正确解析 `<rtconfig.h>`。
* 重复执行 `scons --target=eclipse` 后生成结果保持一致，验证生成过程幂等。
* 对最终单文件 diff 执行三轮 full-scope 本地代码审查，未发现 consensus issue、specialized finding 或 optional suggestion。

未在本环境中执行完整 STM32CubeIDE IDE 内构建。

#### 请提供验证的bsp和config (provide the config and bsp)

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

* BSP:

  * External STM32F4 Cortex-M4 BSP: `rtt_5axis`
  * External STM32F4 Cortex-M4 BSP: `rtt_6axis`
  * These BSPs are project-local and are not paths in the upstream RT-Thread repository.

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

* .config:

  * No additional `.config` change is required for the Eclipse generator fix.
  * The validation project enables Cortex-M4 RT-Thread configuration and contains preprocessed assembly sources that depend on project include paths.

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

* action:

  * Not available. Validation was performed locally; no fork GitHub Actions run is available for this branch.

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

* [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
* [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

* [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
* [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
* [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
* [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
* [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
* [x] 代码是高质量的 Code in this PR is of high quality
* [ ] 已经使用[[formatting](https://github.com/mysterywolf/formatting)](https://github.com/mysterywolf/formatting) 等源码格式化工具确保格式符合[[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [[RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
* [ ] 如果是新增bsp, 已经添加ci检查到[[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)