### PR TITLE
[mprotect][kconfig] Add safe defaults for MPU region count options

### DIFF
--- a/components/mprotect/Kconfig
+++ b/components/mprotect/Kconfig
@@ -17,12 +17,20 @@ if RT_USING_MEM_PROTECTION
 
     config NUM_MEM_REGIONS
     int "Total number of memory protection regions supported by hardware"
+    default 8
+    help
+        The number of MPU regions supported by the target MCU. The common value
+        for Cortex-M4/M7/M33 is 8, but some MCUs expose 4, 12, or 16 regions.
+        Set this to the actual value reported by the hardware, otherwise the MPU
+        initialization will reject the configuration at runtime.
 
     config NUM_EXCLUSIVE_REGIONS
     int "Total number of exclusive memory regions added using rt_mprotect_add_exclusive_region API"
+    default 0
 
     config NUM_CONFIGURABLE_REGIONS
     int "Maximum number of configurable memory regions for each thread, excluding stack guard and exclusive regions added using rt_mprotect_add_exclusive_region API"
+    default 0
 endif
 
 endmenu

--- a/components/mprotect/README.md
+++ b/components/mprotect/README.md
@@ -83,6 +83,18 @@ rt_mem_region_t static_regions[NUM_STATIC_REGIONS] = {
 - 如果开启了`RT_USING_HW_STACK_GUARD`：`NUM_STATIC_REGIONS` + `NUM_CONFIGURABLE_REGIONS` + `NUM_EXCLUSIVE_REGIONS` + 2 <= `NUM_MEM_REGIONS`
 - 如果没有开启`RT_USING_HW_STACK_GUARD`：`NUM_STATIC_REGIONS` + `NUM_CONFIGURABLE_REGIONS` + `NUM_EXCLUSIVE_REGIONS` <= `NUM_MEM_REGIONS`
 
+`NUM_MEM_REGIONS` / `NUM_CONFIGURABLE_REGIONS` / `NUM_EXCLUSIVE_REGIONS` 在 Kconfig 中均已提供默认值（分别为 `8` / `0` / `0`），即使不显式配置也不会生成空宏导致编译失败。其中 `NUM_MEM_REGIONS` 取决于具体 MCU，请务必按目标芯片实际的 MPU region 数量修改，否则 MPU 初始化时会因配置值与硬件不符而报错。
+
+## STM32 CubeMX 集成注意事项
+如果从 STM32 CubeMX 生成的工程集成，需要注意 `stm32f4xx_it.c`（或对应型号的 `stm32xxx_it.c`）中由 CubeMX 默认生成的 `MemManage_Handler` 会与本组件冲突：
+
+- `libcpu/arm/cortex-m4/mpu.c`（以及 `cortex-m7`、`cortex-m33` 的 `mpu.c`）已经提供了 `MemManage_Handler`，用于读取 `CFSR`/`MMFAR`、定位 MPU region 并调用异常钩子；
+- CubeMX 生成的 `stm32f4xx_it.c` 同样包含一个强符号的 `MemManage_Handler`（默认为 `while(1)` 死循环），两者同时参与链接会报 `multiple definition of 'MemManage_Handler'`。
+
+解决方法（任选其一）：
+1. 确保 `stm32f4xx_it.c` 不参与编译（RT-Thread 官方 STM32 BSP 默认如此）；
+2. 若确需编译 `stm32f4xx_it.c`，删除其中 CubeMX 生成的 `MemManage_Handler` 函数定义。
+
 ## 异常检测
 程序可以注册钩子函数，用来检测内存异常：
 ```


### PR DESCRIPTION
## 描述 / Description

修复 `NUM_MEM_REGIONS` / `NUM_CONFIGURABLE_REGIONS` / `NUM_EXCLUSIVE_REGIONS` 缺少 Kconfig 默认值导致的问题：开启 `RT_USING_HW_STACK_GUARD` 但未显式配置时，`rtconfig.h` 会生成空宏（如 `#define NUM_CONFIGURABLE_REGIONS`），进而展开成非法 C 表达式（`(2 + )`、`for (i = 0U; i < ; i++)`），导致 cortex-m4/m7/m33 的 MPU 代码编译失败。

Fix empty-macro compile failure caused by missing Kconfig defaults on the three MPU region count options.

## 修复 / Changes

- `components/mprotect/Kconfig`：为三个 int 配置项添加安全默认值
  - `NUM_MEM_REGIONS = 8`（Cortex-M4/M7/M33 常见值，按实际 MCU 修改）
  - `NUM_CONFIGURABLE_REGIONS = 0`
  - `NUM_EXCLUSIVE_REGIONS = 0`
- `components/mprotect/README.md`：补充 CubeMX 生成的 `MemManage_Handler` 与 mpu.c 强符号冲突的说明及解决方式

## 验证 / Validation

- 本地模拟开启 `RT_USING_HW_STACK_GUARD` 且不显式配置 NUM_*：生成 `NUM_MEM_REGIONS 8` / `NUM_CONFIGURABLE_REGIONS 0` / `NUM_EXCLUSIVE_REGIONS 0`，不再为空宏
- STM32F407 BSP 编译通过（开启 HW_STACK_GUARD），`mpu.o` 正常编译、`LINK rt-thread.elf` 成功
- 确认 `MemManage_Handler` 符号唯一（来自 mpu.c），`stm32f4xx_it.c` 默认不参与编译

## 参考 / Reference

- 原始 PR：#11740（Cortex-M4 硬件栈守护）
- 问题反馈：wdfk-prog 在 #11740 的后续评论中报告