### PR TITLE
fix[arm][cortex-m4]: clarify MPU permission expressions

### DIFF
--- a/libcpu/arm/cortex-m4/mpu.h
+++ b/libcpu/arm/cortex-m4/mpu.h
@@ -22,17 +22,17 @@
  * These are identical to Cortex-M7 because both cores implement the
  * ARMv7-M MPU with the same AP/XN bit layout in the RASR register. */
 /* Privileged No Access, Unprivileged No Access */
-#define P_NA_U_NA ((0x0 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk | MPU_RASR_XN_Msk)
+#define P_NA_U_NA (((0x0 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk) | MPU_RASR_XN_Msk)
 /* Privileged Read Write, Unprivileged No Access */
-#define P_RW_U_NA ((0x1 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk | MPU_RASR_XN_Msk)
+#define P_RW_U_NA (((0x1 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk) | MPU_RASR_XN_Msk)
 /* Privileged Read Write, Unprivileged Read Only */
-#define P_RW_U_RO ((0x2 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk | MPU_RASR_XN_Msk)
+#define P_RW_U_RO (((0x2 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk) | MPU_RASR_XN_Msk)
 /* Privileged Read Write, Unprivileged Read Write */
-#define P_RW_U_RW ((0x3 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk | MPU_RASR_XN_Msk)
+#define P_RW_U_RW (((0x3 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk) | MPU_RASR_XN_Msk)
 /* Privileged Read Only, Unprivileged No Access */
-#define P_RO_U_NA ((0x5 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk | MPU_RASR_XN_Msk)
+#define P_RO_U_NA (((0x5 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk) | MPU_RASR_XN_Msk)
 /* Privileged Read Only, Unprivileged Read Only */
-#define P_RO_U_RO ((0x6 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk | MPU_RASR_XN_Msk)
+#define P_RO_U_RO (((0x6 << MPU_RASR_AP_Pos) & MPU_RASR_AP_Msk) | MPU_RASR_XN_Msk)
 
 /* MPU attributes for configuring code region permission */
 /* Privileged Read Write Execute, Unprivileged Read Write Execute */


### PR DESCRIPTION
## Pull Request Description (PR description)

#### Why is this PR needed

The Cortex-M4 MPU data-permission macros combine `&` and `|` in the same parenthesized expression. GCC emits `-Wparentheses` warnings when these macros are expanded, including by the hardware stack guard and memory-protection paths.

#### What is your solution

Add explicit parentheses around the AP mask expression before OR-ing `MPU_RASR_XN_Msk` for all six Cortex-M4 data-permission macros.

This is a warning-only cleanup: operator grouping is made explicit without changing the resulting MPU RASR permission/XN bits, public interfaces, or runtime behavior.

#### Verification

- Reproduced 6 `-Wparentheses` warnings with the original expressions using GCC.
- Verified the updated expressions produce 0 `-Wparentheses` warnings in the same focused compile check.
- `git diff --check` equivalent passed for the intended patch.
- Full-scope three-pass static review completed with `generic-correctness`, `arm-cortex`, and `systematic-debugging`; no actionable findings.
- No full RT-Thread BSP build or target-board runtime test was executed for this warning-only macro change.

### Intent for your PR

- [ ] This PR is a draft intended to get feedback during code review
- [x] This PR is mature and ready to be integrated into the repository

### Code Quality

- [x] I have carefully checked the diff between this PR and the previous code
- [x] The style guide is followed, including spacing, naming, and related conventions
- [x] Redundant code has been removed, including `#if 0` blocks and commented-out dead code
- [x] All modifications are justified and do not affect other software components or BSPs
- [x] I have added comments where the code is difficult to understand
- [x] The code in this PR is of high quality
- [ ] I used formatting tools such as formatting to ensure compliance with the RT-Thread coding style
- [ ] If this PR adds a new BSP, I have added the CI check entry to `.github/ALL_BSP_COMPILE.json`