### PR TITLE
fix[usb]: stop aliasing rt_ringbuffer as rt_serial_rx_fifo in VCOM

### DIFF
--- a/components/legacy/usb/usbdevice/class/cdc_vcom.c
+++ b/components/legacy/usb/usbdevice/class/cdc_vcom.c
@@ -338,6 +338,9 @@ static rt_err_t _ep_out_handler(ufunction_t func, rt_size_t size)
 {
     rt_base_t level;
     struct vcom *data;
+#ifdef RT_USING_SERIAL_V2
+    struct rt_serial_rx_fifo *rx_fifo;
+#endif
 
     RT_ASSERT(func != RT_NULL);
 
@@ -351,7 +354,15 @@ static rt_err_t _ep_out_handler(ufunction_t func, rt_size_t size)
         /* receive data from USB VCOM */
         level = rt_hw_interrupt_disable();
 
+#ifdef RT_USING_SERIAL_V2
+        rx_fifo = (struct rt_serial_rx_fifo *)data->serial.serial_rx;
+        if (rx_fifo != RT_NULL)
+        {
+            rt_ringbuffer_put(&rx_fifo->rb, data->ep_out->buffer, size);
+        }
+#else
         rt_ringbuffer_put(&data->rx_ringbuffer, data->ep_out->buffer, size);
+#endif
         rt_hw_interrupt_enable(level);
 
         /* notify receive data */
@@ -513,10 +524,6 @@ static rt_err_t _function_enable(ufunction_t func)
     data = (struct vcom*)func->user_data;
     data->ep_out->buffer = rt_malloc(CDC_RX_BUFSIZE);
     RT_ASSERT(data->ep_out->buffer != RT_NULL);
-
-#ifdef RT_USING_SERIAL_V2
-    data->serial.serial_rx = &data->rx_ringbuffer;
-#endif
 
     data->ep_out->request.buffer = data->ep_out->buffer;
     data->ep_out->request.size = EP_MAXPACKET(data->ep_out);
@@ -719,18 +726,30 @@ static int _vcom_getc(struct rt_serial_device *serial)
     rt_base_t level;
     struct ufunction *func;
     struct vcom *data;
+#ifdef RT_USING_SERIAL_V2
+    struct rt_serial_rx_fifo *rx_fifo;
+#endif
 
     func = (struct ufunction*)serial->parent.user_data;
     data = (struct vcom*)func->user_data;
+    RT_UNUSED(data);
 
     result = -1;
 
     level = rt_hw_interrupt_disable();
 
+#ifdef RT_USING_SERIAL_V2
+    rx_fifo = (struct rt_serial_rx_fifo *)serial->serial_rx;
+    if(rx_fifo != RT_NULL && rt_ringbuffer_getchar(&rx_fifo->rb, &ch) != 0)
+    {
+        result = ch;
+    }
+#else
     if(rt_ringbuffer_getchar(&data->rx_ringbuffer, &ch) != 0)
     {
         result = ch;
     }
+#endif
 
     rt_hw_interrupt_enable(level);
 

--- a/components/legacy/usb/usbdevice/class/cdc_vcom.c
+++ b/components/legacy/usb/usbdevice/class/cdc_vcom.c
@@ -337,6 +337,7 @@ static rt_err_t _ep_in_handler(ufunction_t func, rt_size_t size)
 static rt_err_t _ep_out_handler(ufunction_t func, rt_size_t size)
 {
     rt_base_t level;
+    rt_bool_t notify_rx = RT_FALSE;
     struct vcom *data;
 #ifdef RT_USING_SERIAL_V2
     struct rt_serial_rx_fifo *rx_fifo;
@@ -355,18 +356,30 @@ static rt_err_t _ep_out_handler(ufunction_t func, rt_size_t size)
         level = rt_hw_interrupt_disable();
 
 #ifdef RT_USING_SERIAL_V2
-        rx_fifo = (struct rt_serial_rx_fifo *)data->serial.serial_rx;
-        if (rx_fifo != RT_NULL)
+        if (data->serial.config.rx_bufsz == 0)
         {
-            rt_ringbuffer_put(&rx_fifo->rb, data->ep_out->buffer, size);
+            rt_ringbuffer_put(&data->rx_ringbuffer, data->ep_out->buffer, size);
+        }
+        else
+        {
+            rx_fifo = (struct rt_serial_rx_fifo *)data->serial.serial_rx;
+            if (rx_fifo != RT_NULL)
+            {
+                rt_ringbuffer_put(&rx_fifo->rb, data->ep_out->buffer, size);
+                notify_rx = RT_TRUE;
+            }
         }
 #else
         rt_ringbuffer_put(&data->rx_ringbuffer, data->ep_out->buffer, size);
+        notify_rx = RT_TRUE;
 #endif
         rt_hw_interrupt_enable(level);
 
         /* notify receive data */
-        rt_hw_serial_isr(&data->serial,RT_SERIAL_EVENT_RX_IND);
+        if (notify_rx)
+        {
+            rt_hw_serial_isr(&data->serial, RT_SERIAL_EVENT_RX_IND);
+        }
     }
 
     data->ep_out->request.buffer = data->ep_out->buffer;
@@ -732,20 +745,29 @@ static int _vcom_getc(struct rt_serial_device *serial)
 
     func = (struct ufunction*)serial->parent.user_data;
     data = (struct vcom*)func->user_data;
-    RT_UNUSED(data);
 
     result = -1;
 
     level = rt_hw_interrupt_disable();
 
 #ifdef RT_USING_SERIAL_V2
-    rx_fifo = (struct rt_serial_rx_fifo *)serial->serial_rx;
-    if(rx_fifo != RT_NULL && rt_ringbuffer_getchar(&rx_fifo->rb, &ch) != 0)
+    if (serial->config.rx_bufsz == 0)
     {
-        result = ch;
+        if (rt_ringbuffer_getchar(&data->rx_ringbuffer, &ch) != 0)
+        {
+            result = ch;
+        }
+    }
+    else
+    {
+        rx_fifo = (struct rt_serial_rx_fifo *)serial->serial_rx;
+        if (rx_fifo != RT_NULL && rt_ringbuffer_getchar(&rx_fifo->rb, &ch) != 0)
+        {
+            result = ch;
+        }
     }
 #else
-    if(rt_ringbuffer_getchar(&data->rx_ringbuffer, &ch) != 0)
+    if (rt_ringbuffer_getchar(&data->rx_ringbuffer, &ch) != 0)
     {
         result = ch;
     }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

Fixes #11739

With `RT_USB_DEVICE_CDC` and `RT_USING_SERIAL_V2` both enabled, `_function_enable()` assigned the embedded `rx_ringbuffer` to `serial.serial_rx`:

```c
data->serial.serial_rx = &data->rx_ringbuffer;
```

Serial V2 reads that pointer as a `struct rt_serial_rx_fifo *`. Because `rt_ringbuffer` is the first member of `rt_serial_rx_fifo`, ring-buffer access happened to work, while `rx_cpt`, `rx_cpt_index` and `rx_timeout` landed on the members that follow `rx_ringbuffer` inside `struct vcom`, corrupting `tx_rbp`. The layout shifts again when `RT_SERIAL_USING_DMA` is enabled, which inserts `dma_ping_rb` ahead of those fields.

Serial V2 already owns the receive FIFO: `dev_serial_v2.c` allocates it with `rt_malloc()` on open and releases it with `rt_free()` on close. The assignment therefore also overwrote the FIFO allocated at open time, and made the close path call `rt_free()` on memory inside `struct vcom` that was never dynamically allocated. The problem becomes reachable once the USB host configures the CDC device.

#### 你的解决方案是什么 (what is your solution)

- Remove the `data->serial.serial_rx = &data->rx_ringbuffer;` assignment from `_function_enable()`, so the RX FIFO that Serial V2 allocated on open stays intact.
- In `_ep_out_handler()`, under `RT_USING_SERIAL_V2`, cast `serial.serial_rx` to `struct rt_serial_rx_fifo *` and push the received data into `rx_fifo->rb`, guarded against `RT_NULL` for the case where the serial device has not been opened yet. This matches `rt_hw_serial_isr()`, which reports `RX_IND` from `serial_rx->rb`.
- In `_vcom_getc()`, drain the same FIFO under `RT_USING_SERIAL_V2`.
- The Serial V1 path is left unchanged in the `#else` branches, so `data->rx_ringbuffer` is still used when `RT_USING_SERIAL_V2` is not defined.

No API or Kconfig change is involved. The diff is limited to `components/legacy/usb/usbdevice/class/cdc_vcom.c` (+23 / -4).

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: Not board-specific. The change is in the common component
  `components/legacy/usb/usbdevice/class/cdc_vcom.c`, which is shared by every BSP that
  provides a USB device controller. It was not verified on physical hardware. Verification
  was done by code review, struct-layout analysis of `struct vcom` versus
  `struct rt_serial_rx_fifo`, and build checks. Testing on a board with a USB device
  controller and `RT_USB_DEVICE_CDC` + `RT_USING_SERIAL_V2` enabled is very welcome.

- .config: `RT_USING_SERIAL_V2`, `RT_USB_DEVICE`, `RT_USB_DEVICE_CDC`

- action: https://github.com/Finder16/rt-thread/actions/runs/33252216932
  (`qemu-vexpress-a9`, `sourcery-arm`, branch `fix/vcom-serial-v2-rx-fifo`, result: success)

  Note: no BSP in the tree enables `RT_USB_DEVICE_CDC` together with `RT_USING_SERIAL_V2` in
  its default `.config`, so `cdc_vcom.c` is not compiled by the BSP build CI. The linked run
  only confirms that the tree still builds with this change applied. Review of the USB CDC
  path itself, and testing on hardware with a USB device controller, would be appreciated.

#### 贡献者 (Contributors)

This issue was analyzed and reported together with:

- Ijae Kim (ijk5201@psu.edu)
- Myeonghun Pak (mhun512@gmail.com)
- Yuho Choi (yqc5929@psu.edu)
- Taegyu Kim (tgkim@psu.edu)

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
