### PR TITLE
[components][sal] Fix SIOCGIFCONF buffer overflow

### DIFF
--- a/components/net/sal/src/sal_socket.c
+++ b/components/net/sal/src/sal_socket.c
@@ -1572,21 +1572,41 @@ int sal_ioctlsocket(int socket, long cmd, void *arg)
 
         case SIOCGIFCONF:
         {
-            struct ifconf *ifconf_tmp;
-            ifconf_tmp = (struct ifconf *)arg;
-            int count_size = 0;
+            const int sal_ifreq_size = (int)sizeof(struct sal_ifreq);
+            struct ifconf *ifconf_tmp = (struct ifconf *)arg;
+            char *ifc_buf = ifconf_tmp->ifc_ifcu.ifcu_buf;
+            int buffer_size = ifconf_tmp->ifc_len;
+            int copied_size = 0;
+
+            if (buffer_size < 0)
+            {
+                LOG_E("ifconfig: network interface device list buffer size error.\n");
+                rt_set_errno(EINVAL);
+                return -1;
+            }
 
             for (node = &(cur_netdev_list->list); node; node = rt_slist_next(node))
             {
                 struct sal_ifreq sal_ifreq_temp;
-                count_size++;
+                if (ifc_buf == RT_NULL)
+                {
+                    copied_size += sal_ifreq_size;
+                    continue;
+                }
+
+                if (buffer_size - copied_size < sal_ifreq_size)
+                {
+                    break;
+                }
+
+                rt_memset(&sal_ifreq_temp, 0, sizeof(struct sal_ifreq));
                 netdev = rt_list_entry(node, struct netdev, list);
                 rt_strcpy(sal_ifreq_temp.ifr_ifrn.ifrn_name, netdev->name);
-                rt_memcpy(ifconf_tmp->ifc_ifcu.ifcu_buf, &sal_ifreq_temp, sizeof(struct sal_ifreq));
-                ifconf_tmp->ifc_ifcu.ifcu_buf += sizeof(struct sal_ifreq);
+                rt_memcpy(ifc_buf, &sal_ifreq_temp, sizeof(struct sal_ifreq));
+                copied_size += sal_ifreq_size;
+                ifc_buf += sizeof(struct sal_ifreq);
             }
-            ifconf_tmp->ifc_len = sizeof(struct sal_ifreq) * count_size;
-            ifconf_tmp->ifc_ifcu.ifcu_buf = ifconf_tmp->ifc_ifcu.ifcu_buf - sizeof(struct sal_ifreq) * count_size;
+            ifconf_tmp->ifc_len = copied_size;
             return 0;
         }
         case SIOCGIFINDEX:

--- a/components/net/utest/tc_sal_socket.c
+++ b/components/net/utest/tc_sal_socket.c
@@ -61,6 +61,16 @@
 static char test_send_data[] = "Hello, RT-Thread SAL!";
 static char test_recv_buffer[TEST_BUFFER_SIZE];
 
+struct sal_test_ifconf
+{
+    int ifc_len;
+    union
+    {
+        char *ifcu_buf;
+        struct sal_ifreq *ifcu_req;
+    } ifc_ifcu;
+};
+
 /* Local IP for tests (fallback to loopback) */
 static char local_ip[16] = "127.0.0.1";
 
@@ -162,6 +172,83 @@ static void close_test_socket(int sock)
         sal_closesocket(sock);
         LOG_I("Closed socket %d", sock);
     }
+}
+
+static void TC_sal_socket_siocgifconf(void)
+{
+    struct sal_test_ifconf ifconf;
+    struct sal_ifreq *ifreq;
+    unsigned char buffer[sizeof(struct sal_ifreq)];
+    char *original_buffer;
+    size_t index;
+    size_t name_length;
+    int sock;
+    int ret;
+
+    sock = create_test_socket(AF_INET, SOCK_DGRAM, 0);
+    uassert_true(sock >= 0);
+    if (sock < 0)
+    {
+        return;
+    }
+
+    /* A zero-sized destination must not be written. */
+    memset(buffer, 0xA5, sizeof(buffer));
+    ifconf.ifc_len = 0;
+    ifconf.ifc_ifcu.ifcu_buf = (char *)buffer;
+    ret = sal_ioctlsocket(sock, SIOCGIFCONF, &ifconf);
+    uassert_int_equal(ret, 0);
+    uassert_int_equal(ifconf.ifc_len, 0);
+    for (index = 0; index < sizeof(buffer); index++)
+    {
+        uassert_int_equal(buffer[index], 0xA5);
+    }
+
+    /* A NULL destination queries the required buffer size. */
+    ifconf.ifc_len = sizeof(buffer);
+    ifconf.ifc_ifcu.ifcu_buf = RT_NULL;
+    ret = sal_ioctlsocket(sock, SIOCGIFCONF, &ifconf);
+    uassert_int_equal(ret, 0);
+    uassert_true(ifconf.ifc_len >= sizeof(struct sal_ifreq));
+    uassert_int_equal(ifconf.ifc_len % sizeof(struct sal_ifreq), 0);
+
+    /* A negative buffer length must be rejected without writing. */
+    memset(buffer, 0xA5, sizeof(buffer));
+    ifconf.ifc_len = -1;
+    ifconf.ifc_ifcu.ifcu_buf = (char *)buffer;
+    ret = sal_ioctlsocket(sock, SIOCGIFCONF, &ifconf);
+    uassert_int_equal(rt_get_errno(), EINVAL);
+    uassert_int_equal(ret, -1);
+    for (index = 0; index < sizeof(buffer); index++)
+    {
+        uassert_int_equal(buffer[index], 0xA5);
+    }
+
+    /* Returned bytes outside the interface name must be initialized. */
+    memset(buffer, 0xA5, sizeof(buffer));
+    original_buffer = (char *)buffer;
+    ifconf.ifc_len = sizeof(buffer);
+    ifconf.ifc_ifcu.ifcu_buf = original_buffer;
+    ret = sal_ioctlsocket(sock, SIOCGIFCONF, &ifconf);
+    uassert_int_equal(ret, 0);
+    uassert_int_equal(ifconf.ifc_len, sizeof(struct sal_ifreq));
+    uassert_true(ifconf.ifc_ifcu.ifcu_buf == original_buffer);
+
+    ifreq = (struct sal_ifreq *)buffer;
+    for (name_length = 0; name_length < IFNAMSIZ; name_length++)
+    {
+        if (ifreq->ifr_ifrn.ifrn_name[name_length] == '\0')
+        {
+            break;
+        }
+    }
+    uassert_true(name_length > 0 && name_length < IFNAMSIZ);
+    for (index = name_length + 1; index < sizeof(*ifreq); index++)
+    {
+        uassert_int_equal(buffer[index], 0);
+    }
+
+    close_test_socket(sock);
 }
 
 /* Server thread function */
@@ -1021,6 +1108,7 @@ static void utest_do_tc(void)
     UTEST_UNIT_RUN(TC_sal_socket_send_recv);
     UTEST_UNIT_RUN(TC_sal_socket_udp_communication);
     UTEST_UNIT_RUN(TC_sal_socket_getpeername_getsockname);
+    UTEST_UNIT_RUN(TC_sal_socket_siocgifconf);
     UTEST_UNIT_RUN(TC_sal_socket_close);
 
     LOG_I("===========================================");


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

Fixes #11763 

#### 为什么提交这份PR (why to submit this PR)

修复 SAL 模块，用户获取网卡信息可能写越界 / 栈帧内存泄漏的问题

#### 你的解决方案是什么 (what is your solution)

初始化 sal_ifreq_temp 结构体，并对 buffer_size 进行长度校验

#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

rt-thread/bsp/qemu-vexpress-a9

UT 代码如下

```c
struct sal_test_ifconf
{
    int ifc_len;
    union
    {
        char *ifcu_buf;
        struct sal_ifreq *ifcu_req;
    } ifc_ifcu;
};

static void TC_sal_socket_siocgifconf(void)
{
    struct sal_test_ifconf ifconf;
    struct sal_ifreq *ifreq;
    unsigned char buffer[sizeof(struct sal_ifreq)];
    char *original_buffer;
    size_t index;
    size_t name_length;
    int sock;
    int ret;

    sock = create_test_socket(AF_INET, SOCK_DGRAM, 0);
    uassert_true(sock >= 0);
    if (sock < 0)
    {
        return;
    }

    /* A zero-sized destination must not be written. */
    memset(buffer, 0xA5, sizeof(buffer));
    ifconf.ifc_len = 0;
    ifconf.ifc_ifcu.ifcu_buf = (char *)buffer;
    ret = sal_ioctlsocket(sock, SIOCGIFCONF, &ifconf);
    uassert_int_equal(ret, 0);
    uassert_int_equal(ifconf.ifc_len, 0);
    for (index = 0; index < sizeof(buffer); index++)
    {
        uassert_int_equal(buffer[index], 0xA5);
    }

    /* A NULL destination must not be dereferenced. */
    ifconf.ifc_len = sizeof(buffer);
    ifconf.ifc_ifcu.ifcu_buf = RT_NULL;
    ret = sal_ioctlsocket(sock, SIOCGIFCONF, &ifconf);
    uassert_int_equal(ret, 0);
    uassert_int_equal(ifconf.ifc_len, 0);

    /* A negative buffer length must be rejected without writing. */
    memset(buffer, 0xA5, sizeof(buffer));
    ifconf.ifc_len = -1;
    ifconf.ifc_ifcu.ifcu_buf = (char *)buffer;
    ret = sal_ioctlsocket(sock, SIOCGIFCONF, &ifconf);
    uassert_int_equal(ret, -1);
    for (index = 0; index < sizeof(buffer); index++)
    {
        uassert_int_equal(buffer[index], 0xA5);
    }

    /* Returned bytes outside the interface name must be initialized. */
    memset(buffer, 0xA5, sizeof(buffer));
    original_buffer = (char *)buffer;
    ifconf.ifc_len = sizeof(buffer);
    ifconf.ifc_ifcu.ifcu_buf = original_buffer;
    ret = sal_ioctlsocket(sock, SIOCGIFCONF, &ifconf);
    uassert_int_equal(ret, 0);
    uassert_int_equal(ifconf.ifc_len, sizeof(struct sal_ifreq));
    uassert_true(ifconf.ifc_ifcu.ifcu_buf == original_buffer);

    ifreq = (struct sal_ifreq *)buffer;
    for (name_length = 0; name_length < IFNAMSIZ; name_length++)
    {
        if (ifreq->ifr_ifrn.ifrn_name[name_length] == '\0')
        {
            break;
        }
    }
    uassert_true(name_length > 0 && name_length < IFNAMSIZ);
    for (index = name_length + 1; index < sizeof(*ifreq); index++)
    {
        uassert_int_equal(buffer[index], 0);
    }

    close_test_socket(sock);
}
```

验证日志

```shell
msh />utest_list
[I/utest] Commands list : 
[I/utest] [testcase name]:components.net.sal.socket_basic; [run timeout]:30
msh />utest_run components.net.sal.socket_basic
[I/utest] [==========] [ utest    ] loop 1/1
[I/utest] [==========] [ utest    ] started
[I/utest] [----------] [ testcase ] (components.net.sal.socket_basic) started
[I/utest] ===========================================
[I/utest] Starting SAL Socket Basic API Tests
[I/utest] ===========================================
[I/utest] Checking network device status...
[I/utest] Network test socket created successfully: 0
[I/utest] Using loopback IP address for testing: 127.0.0.1
[I/utest] Network device appears operational
[I/utest] [==========] utest unit name: (TC_sal_socket_create)
[I/utest] Starting TC_sal_socket_create tests...
[I/utest] Testing TCP socket creation...
[I/utest] TCP socket created: 0
[I/utest] Closed socket 0
[I/utest] Testing UDP socket creation...
[I/utest] UDP socket created: 0
[I/utest] Closed socket 0
[I/utest] Testing invalid family parameter...
[E/sal.skt] Invalid family: -1 (must be 0 ~ 47)
[E/sal.skt] SAL socket protocol family input failed, return error -1.
[I/utest] Invalid family result: -1
[I/utest] Testing invalid type parameter...
[E/sal.skt] Invalid type: -1 (must be 0 ~ 524289)
[E/sal.skt] SAL socket protocol family input failed, return error -2.
[I/utest] Invalid type result: -2
[I/utest] Testing invalid protocol parameter...
[E/sal.skt] Invalid protocol: -1 (must be 0 ~ 255)
[E/sal.skt] SAL socket protocol family input failed, return error -4.
[I/utest] Invalid protocol result: -4
[I/utest] TC_sal_socket_create tests completed
[I/utest] [==========] utest unit name: (TC_sal_socket_bind)
[I/utest] Starting TC_sal_socket_bind tests...
[I/utest] Creating socket for bind test on port 9000...
[I/utest] Created socket 0 (domain=2, type=1, protocol=0)
[I/utest] Attempting to bind socket 0 to port 9000...
[I/utest] Bind result: 0 (expected 0)
[I/utest] Closed socket 0
[I/utest] Skipping NULL address bind test (would cause assertion)
[I/utest] Testing bind with invalid socket...
[I/utest] Invalid socket bind result: -1 (expected -1)
[I/utest] TC_sal_socket_bind tests completed
[I/utest] [==========] utest unit name: (TC_sal_socket_listen)
[I/utest] Starting TC_sal_socket_listen tests...
[I/utest] Creating socket for listen test...
[I/utest] Created socket 0 (domain=2, type=1, protocol=0)
[I/utest] Binding socket 0 for listen test on port 9002...
[I/utest] Testing listen with backlog 5 on socket 0...
[I/utest] Listen result: 0 (expected 0)
[I/utest] Testing listen with invalid backlog (-1)...
[I/utest] Invalid backlog listen result: 0
[I/utest] Closed socket 0
[I/utest] Testing listen on invalid socket...
[I/utest] Invalid socket listen result: -1 (expected -1)
[I/utest] TC_sal_socket_listen tests completed
[I/utest] [==========] utest unit name: (TC_sal_socket_connect)
[I/utest] Starting TC_sal_socket_connect tests...
[I/utest] Setting up test server on port 9004...
[I/utest] Setting up threaded test server on port 9004
[I/utest] Created server thread
[I/utest] Created client thread
[I/utest] Started server and client threads
[I/utest] Starting client thread for port 9004
[I/utest] Starting server thread on port 9004
[I/utest] Created socket 0 (domain=2, type=1, protocol=0)
[I/utest] Server socket 0 bound to port 9004
[I/utest] Server socket 0 listening with backlog 5
[I/utest] Server ready and signaled on port 9004
[I/utest] Created socket 1 (domain=2, type=1, protocol=0)
[I/utest] Attempting to connect to server 127.0.0.1:9004
[I/utest] Connect result: -1
[E/utest] Connection to server failed: return=-1, errno=104
[I/utest] Closed socket 1
[I/utest] Cleaned up threads and event
[I/utest] Test server setup partially successful (connect verified)
[I/utest] Test server setup completed successfully
[I/utest] Testing connect to invalid address 192.168.999.999...
[I/utest] Created socket 1 (domain=2, type=1, protocol=0)
[I/utest] Invalid address connect result: -1 (expected -1)
[I/utest] Closed socket 1
[I/utest] TC_sal_socket_connect tests completed
[I/utest] [==========] utest unit name: (TC_sal_socket_accept)
[I/utest] Starting TC_sal_socket_accept tests...
[I/utest] Creating server socket...
[I/utest] Created socket 1 (domain=2, type=1, protocol=0)
[I/utest] Binding server socket 1 to port 9006...
[I/utest] Starting to listen on server socket 1...
[I/utest] Testing accept with timeout on socket 1...
[I/utest] Accept timed out as expected: -1
[I/utest] Closed socket 1
[I/utest] Testing accept on invalid socket...
[I/utest] Invalid socket accept result: -1 (expected -1)
[I/utest] TC_sal_socket_accept tests completed
[I/utest] [==========] utest unit name: (TC_sal_socket_send_recv)
[I/utest] Starting TC_sal_socket_send_recv tests...
[I/utest] Setting up test server on port 9008...
[I/utest] Setting up threaded test server on port 9008
[I/utest] Created server thread
[I/utest] Created client thread
[I/utest] Started server and client threads
[I/utest] Starting client thread for port 9008
[I/utest] Starting server thread on port 9008
[I/utest] Created socket 1 (domain=2, type=1, protocol=0)
[I/utest] Server socket 1 bound to port 9008
[I/utest] Server socket 1 listening with backlog 5
[I/utest] Server ready and signaled on port 9008
[I/utest] Created socket 2 (domain=2, type=1, protocol=0)
[I/utest] Attempting to connect to server 127.0.0.1:9008
[I/utest] Connect result: -1
[E/utest] Connection to server failed: return=-1, errno=104
[I/utest] Closed socket 2
[I/utest] Cleaned up threads and event
[I/utest] Test server setup partially successful (connect verified)
[I/utest] Testing send/recv with data exchange...
[I/utest] Created socket 2 (domain=2, type=1, protocol=0)
[I/utest] Created socket 3 (domain=2, type=1, protocol=0)
[I/utest] Server socket 2 bound to port 9009
[I/utest] Server socket 2 listening
[E/utest] Client connect failed: -1
[I/utest] Closed socket 41
[I/utest] Closed socket 3
[I/utest] Closed socket 2
[I/utest] Cleaned up test connection sockets
[I/utest] TC_sal_socket_send_recv tests completed
[I/utest] [==========] utest unit name: (TC_sal_socket_udp_communication)
[I/utest] Starting TC_sal_socket_udp_communication tests...
[I/utest] Created socket 2 (domain=2, type=2, protocol=0)
[I/utest] Created socket 3 (domain=2, type=2, protocol=0)
[I/utest] Server socket 2 bound to port 9010
[I/utest] Client socket 3 bound to port 9110
[I/utest] Sending 21 bytes from client to server...
[I/utest] Client sent 21 bytes to server
[W/utest] UDP recv failed, may be expected: -1 bytes received, errno=11
[I/utest] Closed socket 2
[I/utest] Closed socket 3
[I/utest] TC_sal_socket_udp_communication tests completed
[I/utest] [==========] utest unit name: (TC_sal_socket_getpeername_getsockname)
[I/utest] Starting TC_sal_socket_getpeername_getsockname tests...
[I/utest] Created socket 2 (domain=2, type=1, protocol=0)
[I/utest] Server socket 2 bound to port 9012
[I/utest] Testing getsockname on socket 2...
[I/utest] Getsockname result: 0 (expected 0)
[I/utest] Closed socket 2
[I/utest] Testing getsockname/getpeername on invalid socket...
[I/utest] Invalid socket getsockname result: -1 (expected -1)
[I/utest] Invalid socket getpeername result: -1 (expected -1)
[I/utest] TC_sal_socket_getpeername_getsockname tests completed
[I/utest] [==========] utest unit name: (TC_sal_socket_siocgifconf)
[I/utest] Created socket 2 (domain=2, type=2, protocol=0)
[E/sal.skt] ifconfig: network interface device list buffer size error.

[I/utest] Closed socket 2
[I/utest] [==========] utest unit name: (TC_sal_socket_close)
[I/utest] Starting TC_sal_socket_close tests...
[I/utest] Testing close valid socket...
[I/utest] Created socket 2 (domain=2, type=1, protocol=0)
[I/utest] Closing socket 2...
[I/utest] Testing close invalid socket...
[I/utest] Testing double close...
[I/utest] Created socket 2 (domain=2, type=1, protocol=0)
[I/utest] Double closing socket 2 (should be safe)
[I/utest] TC_sal_socket_close tests completed
[I/utest] ===========================================
[I/utest] SAL Socket Basic API Tests Completed
[I/utest] ===========================================
[I/utest] [  PASSED  ] [ result   ] testcase (components.net.sal.socket_basic)
[I/utest] [----------] [ testcase ] (components.net.sal.socket_basic) finished
[I/utest] [==========] [ utest    ] 1 tests from 1 testcase ran.
[I/utest] [  PASSED  ] [ result   ] 1 tests.
[I/utest] [==========] [ utest    ] finished
```

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

```diff
--- a/bsp/qemu-vexpress-a9/.config
+++ b/bsp/qemu-vexpress-a9/.config

+CONFIG_RT_USING_POSIX_SOCKET=y
+CONFIG_RT_USING_SAL=y
+CONFIG_SAL_USING_LWIP=y
+CONFIG_RT_USING_NETDEV=y
+CONFIG_RT_USING_LWIP=y
+CONFIG_RT_USING_LWIP203=y
+CONFIG_RT_USING_UTEST=y
```

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

https://github.com/Huoyanlifusu/rt-thread/actions/runs/33349075279/job/99358741679

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
