### PR TITLE
[components][lwp] Remove terminal/ from global CPPPATH

### DIFF
--- a/components/lwp/SConscript
+++ b/components/lwp/SConscript
@@ -45,10 +45,11 @@ if platform in platform_file.keys(): # support platforms
         CPPPATH += [cwd + '/arch/' + arch + '/' + cpu]
 
 # Terminal I/O Subsystem
+# terminal/*.c resolve their own headers via quoted-include directory lookup;
+# keep the internal path out of the global CPPPATH
 termios_path = ['./terminal/', './terminal/freebsd/']
 for item in termios_path:
     src += Glob(item + '*.c')
-CPPPATH += ['./terminal/']
 
 # Remove optional sources
 if not GetDepend(['LWP_USING_RUNTIME']):


### PR DESCRIPTION
Related issue: #10980

## Summary

This is a minimal demonstration of the CPPPATH convention discussed in #10980: a component no longer leaks its internal directory into the global include path.

`components/lwp/SConscript` added `./terminal/` to the global `CPPPATH`. A repo-wide check shows every unqualified include of the terminal subsystem's own headers (`terminal.h`, `tty_config.h`, `bsd_porting.h`, ...) comes from sources inside `components/lwp/terminal/` itself, where the compiler's quoted-include directory lookup already resolves them. External consumers (e.g. `lwp.c`, `lwp_jobctrl.c`) use `<terminal/terminal.h>`, which resolves via the component's existing `CPPPATH = [cwd]` entry. So the global injection is unnecessary and only pollutes the global include path.

Other candidate entries were checked and intentionally left alone because they are load-bearing:
- `CPPPATH = [cwd]` and `arch/<arch>/<cpu>`: required by `lwp_arch.h` consumers inside and outside the component
- `vdso` paths: required by `components/libc/compilers/common/ctime.c` (`<vdso_kernel.h>`)

## Verification

- Static include-resolution check across all `.c/.h/.S` under `components/lwp` (plus external consumers): 167 include directives, resolution identical with and without `./terminal/` in the include path
- SCons dry-run on a RT-Thread Smart enabled BSP: all SConscript files execute correctly (actual cross-compilation requires the riscv toolchain, which CI covers)

CC @Huoyanlifusu — this is the code-side counterpart of the SCons documentation work you mentioned in the issue; hope it serves as a small example.