### PR TITLE
[net][at] Reject overlong numeric hostnames

### DIFF
--- a/components/net/at/at_socket/at_socket.c
+++ b/components/net/at/at_socket/at_socket.c
@@ -1409,6 +1409,7 @@ static int _gethostbyname_by_device(const char *name, ip_addr_t *addr)
     struct at_device *device = RT_NULL;
     char ipstr[16] = { 0 };
     size_t idx = 0;
+    size_t name_len = 0;
 
     device = at_device_get_first_initialized();
     if (device == RT_NULL)
@@ -1421,9 +1422,10 @@ static int _gethostbyname_by_device(const char *name, ip_addr_t *addr)
         return -1;
     }
 
-    for (idx = 0; idx < strlen(name) && !isalpha(name[idx]); idx++);
+    name_len = strlen(name);
+    for (idx = 0; idx < name_len && !isalpha((unsigned char)name[idx]); idx++);
 
-    if (idx < strlen(name))
+    if (idx < name_len)
     {
         if (at_dlock == RT_NULL)
         {
@@ -1444,7 +1446,13 @@ static int _gethostbyname_by_device(const char *name, ip_addr_t *addr)
     }
     else
     {
-        strncpy(ipstr, name, strlen(name));
+        if (name_len >= sizeof(ipstr))
+        {
+            return -1;
+        }
+
+        rt_memcpy(ipstr, name, name_len);
+        ipstr[name_len] = '\0';
     }
 
 #if NETDEV_IPV4 && NETDEV_IPV6


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

#### 为什么提交这份PR (why to submit this PR)

`_gethostbyname_by_device()` copied numeric-looking hostnames into a 16-byte
stack buffer with `strncpy(ipstr, name, strlen(name))`. A 16-byte input removed
the terminator, while a 17-byte or longer input wrote beyond the buffer before
`inet_aton()` could reject it.

This path is reachable through the AT-backed resolver APIs, including
`getaddrinfo()` and `gethostbyname*()`.

#### 你的解决方案是什么 (what is your solution)

Cache the hostname length once, classify characters with the required unsigned
`ctype` input, and reject numeric-looking strings that cannot fit in `ipstr`.
For accepted strings, copy the validated length and add the terminator
explicitly. This keeps the existing AT/domain resolution behavior unchanged and
removes the unbounded stack write.

Fixes #11332

#### 请提供验证的bsp和config (provide the config and bsp)

- BSP: Host-side validation using `bsp/simulator` headers and MSVC; no physical hardware required.
- .config: Compile-time coverage for `RT_USING_AT`, `AT_USING_SOCKET`, `RT_USING_SAL`, and `RT_USING_NETDEV`.
- action: GitHub Actions pending.

#### Testing

- PASS: MSVC `/W4 /RTC1 /GS` boundary harness using the numeric-host branch:
  15 bytes accepted, 16 and 17 bytes rejected.
- PASS: Direct compile of `components/net/at/at_socket/at_socket.c` with MSVC
  `/W4`; no warnings in the changed lines.
- PASS: MSVC `/analyze`; no diagnostics in the changed code.
- PASS: `clang-format --dry-run --Werror -style=file -lines=1409:1457`.
- PASS: `git diff --check`.

AI assistance: OpenAI Codex:GPT-5 assisted with investigation, implementation,
and local verification. The commit contains the matching `Assisted-by` trailer.

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [x] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json) 详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
