### PR TITLE
fix[tools][eclipse]: handle hidden directories in source exclusion

### DIFF
--- a/tools/targets/eclipse.py
+++ b/tools/targets/eclipse.py
@@ -27,6 +27,8 @@ from utils import xml_indent
 MODULE_VER_NUM = 6
 
 source_pattern = ['*.c', '*.cpp', '*.cxx', '*.cc', '*.s', '*.S', '*.asm','*.cmd']
+# Source control metadata directories should not be recursively scanned.
+scm_metadata_dirs = ('.git', '.svn', '.hg')
 
 
 def OSPath(path):
@@ -94,16 +96,19 @@ def CollectAllFilesinPath(path, pattern):
     for item in pattern:
         files += glob.glob(path + '/' + item)
 
-    list = os.listdir(path)
-    if len(list):
-        for item in list:
-            if item.startswith('.'):
+    items = os.listdir(path)
+    if len(items):
+        for item in items:
+            # Do not recursively scan source control metadata.
+            if item in scm_metadata_dirs:
                 continue
             if item == 'bsp':
                 continue
 
-            if os.path.isdir(os.path.join(path, item)):
-                files = files + CollectAllFilesinPath(os.path.join(path, item), pattern)
+            fullpath = os.path.join(path, item)
+            if os.path.isdir(fullpath):
+                files = files + CollectAllFilesinPath(fullpath, pattern)
+
     return files
 
 
@@ -127,17 +132,15 @@ def ExcludePaths(rootpath, paths):
 
     files = os.listdir(OSPath(rootpath))
     for file in files:
-        if file.startswith('.'):
-            continue
-
         fullname = os.path.join(OSPath(rootpath), file)
 
         if os.path.isdir(fullname):
-            # print(fullname)
-            if not fullname in paths:
-                ret = ret + [fullname]
+            # Hidden directories must follow the same exclusion rules
+            # as normal directories.
+            if fullname not in paths:
+                ret.append(fullname)
             else:
-                ret = ret + ExcludePaths(fullname, paths)
+                ret.extend(ExcludePaths(fullname, paths))
 
     return ret
 
@@ -426,16 +429,24 @@ def GenExcluding(env, project):
 
     paths = exclude_paths
     exclude_paths = []
-    # remove the folder which not has source code by source_pattern
+
+    # Remove folders which do not contain source files matching source_pattern.
     for path in paths:
-        # add bsp and libcpu folder and not collect source files (too more files)
+        # Add bsp and libcpu directly and do not collect source files
+        # because these trees contain too many files.
         if path.endswith('rt-thread\\bsp') or path.endswith('rt-thread\\libcpu'):
-            exclude_paths += [path]
+            exclude_paths.append(path)
             continue
 
-        set = CollectAllFilesinPath(path, source_pattern)
-        if len(set):
-            exclude_paths += [path]
+        # Source control metadata is never part of the target build and may
+        # contain a very large number of files, so do not recursively scan it.
+        if os.path.basename(os.path.normpath(path)) in scm_metadata_dirs:
+            exclude_paths.append(path)
+            continue
+
+        files = CollectAllFilesinPath(path, source_pattern)
+        if len(files):
+            exclude_paths.append(path)
 
     exclude_paths = [RelativeProjectPath(env, path).replace('\\', '/') for path in exclude_paths]
 


### PR DESCRIPTION
#### 为什么提交这份PR (why to submit this PR)

当前 `tools/targets/eclipse.py` 在执行 `scons --target=eclipse` 生成 Eclipse/CDT 工程时，`ExcludePaths()` 会无条件跳过所有以 `.` 开头的隐藏目录：

```python
if file.startswith('.'):
    continue
````

这会导致隐藏目录无法进入后续的 source exclusion 计算。

对于只包含配置文件的 `.git`、`.vscode`、`.settings` 等目录，这通常不会产生明显问题；但如果隐藏目录中存在可编译源文件，例如：

```text
component/
├── SConscript
├── src/
└── .github/
    └── ci/
        ├── device-host-test.c
        └── lifecycle-host-test.c
```

而这些 `*.c` 文件并没有被对应 `SConscript` 加入目标固件构建，则原生 SCons 构建不会编译它们。

但是通过：

```sh
scons --target=eclipse
```

生成 Eclipse/CDT Managed Build 工程后，由于 `.github` 被 `ExcludePaths()` 直接跳过，没有加入 `.cproject` 的 `excluding` 列表，CDT 仍可能把其中的 `*.c` 文件识别为工程源码，并在 IDE Build 时进行目标平台编译。

实际使用中可以导致类似以下情况：

```text
.github/ci/.../host-test.c
```

中的 Host Test stub 与真实 RT-Thread API 同时参与 ARM firmware 编译，从而出现：

```text
conflicting types for 'rt_sem_init'
conflicting types for 'rt_mutex_take'
conflicting types for 'rt_thread_create'
```

等错误。

该问题并不局限于 `.github`。

类似：

```text
.tests/
.ci/
.host/
```

等任何包含源代码的隐藏目录，只要没有参与实际目标构建，都可能遇到同样的问题。

因此这里需要修复的是 Eclipse source exclusion 对隐藏目录的一般处理逻辑，而不是对 `.github` 做特殊处理。

#### 你的解决方案是什么 (what is your solution)

本 PR 修改 `tools/targets/eclipse.py` 中隐藏目录的 source exclusion 处理逻辑。

主要修改如下：

1. `ExcludePaths()` 不再无条件跳过所有以 `.` 开头的目录。

隐藏目录现在与普通目录使用相同的 exclusion 判断逻辑：

* 如果目录属于当前工程使用的目录，则继续递归分析；
* 如果目录不属于当前工程使用的目录，则作为 exclusion candidate 处理。

这样可以避免隐藏目录绕过 Eclipse source exclusion 计算。

2. `CollectAllFilesinPath()` 不再跳过所有隐藏目录。

原来的逻辑：

```python
if item.startswith('.'):
    continue
```

会导致以下结构无法被检测：

```text
unused/
└── .tests/
    └── host-test.c
```

本 PR 改为允许递归检查普通隐藏目录，从而能够正确检测其中是否存在：

```text
*.c
*.cpp
*.cxx
*.cc
*.s
*.S
*.asm
*.cmd
```

等 Eclipse 可编译源文件。

3. 对源码版本控制元数据目录进行单独处理。

为避免递归扫描：

```text
.git
.svn
.hg
```

等可能包含大量文件的版本控制元数据目录，增加：

```python
scm_metadata_dirs = ('.git', '.svn', '.hg')
```

`CollectAllFilesinPath()` 不递归这些目录。

同时，如果这些目录已经被判定为 exclusion candidate，则直接加入 Eclipse exclusion，而不继续扫描其内部文件。

因此本次修改不会为了判断 `.git` 是否包含源文件而递归遍历 `.git/objects` 等目录。

最终行为为：

```text
普通目录
    |
    +-- 参与工程 -> 按原有逻辑继续分析
    |
    +-- 未参与工程 -> 检查是否包含源代码并生成 exclusion

隐藏目录
    |
    +-- 参与工程 -> 按原有逻辑继续分析
    |
    +-- 未参与工程 -> 检查是否包含源代码并生成 exclusion

.git / .svn / .hg
    |
    +-- 未参与工程 -> 直接 exclusion，不递归扫描
```

本 PR 不修改原生 SCons firmware build 的源码选择逻辑，仅修复 `scons --target=eclipse` 生成的 Eclipse/CDT source exclusion 与实际工程源码选择不一致的问题。


#### 请提供验证的bsp和config (provide the config and bsp)

* BSP:

  `bsp/stm32/stm32f407-atk-explorer`

* `.config`:

  本修改属于 Eclipse project generator 修复，不依赖额外 Kconfig 配置。

* action: