### PR TITLE
bsp/wch：ch32_drivers 适配 RT-Thread 5.3.0 设备驱动框架

### DIFF
--- a/bsp/wch/risc-v/libraries/ch32_drivers/drv_adc.c
+++ b/bsp/wch/risc-v/libraries/ch32_drivers/drv_adc.c
@@ -11,6 +11,7 @@
 #include <board.h>
 #include <rtthread.h>
 #include <rtdevice.h>
+#include <drivers/adc.h>
 #include "drv_adc.h"
 
 #if defined(BSP_USING_ADC1) || defined(BSP_USING_ADC2)

--- a/bsp/wch/risc-v/libraries/ch32_drivers/drv_can.c
+++ b/bsp/wch/risc-v/libraries/ch32_drivers/drv_can.c
@@ -17,6 +17,43 @@
 #define DBG_LVL DBG_INFO
 #define DBG_ENABLE
 #include <rtdbg.h>
+#include <drivers/dev_can.h>
+
+/* 5.3.0: SJW/BS1/BS2 time-quantum macros were removed from dev_can.h */
+#ifndef CAN_SJW_1tq
+#define CAN_SJW_1tq   0x00
+#define CAN_SJW_2tq   0x01
+#define CAN_SJW_3tq   0x02
+#define CAN_SJW_4tq   0x03
+#endif
+#ifndef CAN_BS1_1tq
+#define CAN_BS1_1tq   0x00
+#define CAN_BS1_2tq   0x01
+#define CAN_BS1_3tq   0x02
+#define CAN_BS1_4tq   0x03
+#define CAN_BS1_5tq   0x04
+#define CAN_BS1_6tq   0x05
+#define CAN_BS1_7tq   0x06
+#define CAN_BS1_8tq   0x07
+#define CAN_BS1_9tq   0x08
+#define CAN_BS1_10tq  0x09
+#define CAN_BS1_11tq  0x0A
+#define CAN_BS1_12tq  0x0B
+#define CAN_BS1_13tq  0x0C
+#define CAN_BS1_14tq  0x0D
+#define CAN_BS1_15tq  0x0E
+#define CAN_BS1_16tq  0x0F
+#endif
+#ifndef CAN_BS2_1tq
+#define CAN_BS2_1tq   0x00
+#define CAN_BS2_2tq   0x01
+#define CAN_BS2_3tq   0x02
+#define CAN_BS2_4tq   0x03
+#define CAN_BS2_5tq   0x04
+#define CAN_BS2_6tq   0x05
+#define CAN_BS2_7tq   0x06
+#define CAN_BS2_8tq   0x07
+#endif
 
 //兼容老版的can宏定义
 #ifndef RT_CAN_MODE_LISTEN

--- a/bsp/wch/risc-v/libraries/ch32_drivers/drv_i2c.h
+++ b/bsp/wch/risc-v/libraries/ch32_drivers/drv_i2c.h
@@ -13,6 +13,7 @@
 
 #include <rtthread.h>
 #include <rtdevice.h>
+#include <drivers/dev_i2c.h>
 
 struct i2c_bus_device
 {

--- a/bsp/wch/risc-v/libraries/ch32_drivers/drv_rtc.c
+++ b/bsp/wch/risc-v/libraries/ch32_drivers/drv_rtc.c
@@ -11,6 +11,7 @@
 
 #include <rtthread.h>
 #include <rtdevice.h>
+#include <drivers/dev_rtc.h>
 #include <sys/time.h>
 #include "board.h"
 

--- a/bsp/wch/risc-v/libraries/ch32_drivers/drv_spi.h
+++ b/bsp/wch/risc-v/libraries/ch32_drivers/drv_spi.h
@@ -13,6 +13,7 @@
 
 #include <rtthread.h>
 #include <rtdevice.h>
+#include <drivers/dev_spi.h>
 #include <rthw.h>
 
 #include "ch32v30x_rcc.h"


### PR DESCRIPTION
## 问题

5.3.0 对设备驱动框架做了头文件重构：

- 外设头改名：drivers/spi.h 改为 drivers/dev_spi.h、drivers/i2c.h 改为 drivers/dev_i2c.h、drivers/rtc.h 改为 drivers/dev_rtc.h、drivers/can.h 改为 drivers/dev_can.h、drivers/pwm.h 改为 drivers/dev_pwm.h
- rtdevice.h 改为不再隐式包含这些外设头

而 bsp/wch/risc-v/libraries/ch32_drivers 下的驱动（drv_spi.h、drv_i2c.h、drv_rtc.c、drv_can.c、drv_adc.c）仍然依赖 rtdevice.h 的隐式包含，没有显式 include 新的头文件。结果是在 .config 中启用 SPI/I2C/ADC/PWM/RTC/CAN 后编译直接报错（结构体不完整、宏未定义）。

## 修复

- 各驱动显式 include 对应的 5.3.0 新头（drivers/dev_spi.h 等）
- drv_can.c 补齐被 dev_can.h 移走的 SJW/BS1/BS2 位时序宏（CAN_SJW_1tq~4tq、CAN_BS1_1tq~16tq、CAN_BS2_1tq~8tq）

## 验证

- 启用 SPI1 编译通过：scons -j8 --exec-path=<工具链>\bin，rtthread.bin 正常生成，退出码 0
- SPI_Flash / IIC / ADC / PWM / RTC / CAN 六项在独立工程中均编译链接通过
- 已在开发板上实测 PIN / SPI / RTC / ADC / PWM / HWtimer 六项外设全部通过

## 影响范围

- 该库为 WCH RISC-V 系列 BSP 共用，ch32v103r-evt 等同族 BSP 有望一并修复