### PR TITLE
[bsp/renesas][drivers] Fix SCI SPI runtime configuration and transfer errors

### DIFF
--- a/bsp/renesas/libraries/HAL_Drivers/drivers/drv_sci.c
+++ b/bsp/renesas/libraries/HAL_Drivers/drivers/drv_sci.c
@@ -7,6 +7,7 @@
  * Date           Author       Notes
  * 2023-09-24     Vandoul      first version
  * 2023-09-27     Vandoul      add sci uart
+ * 2026-09-09     CYFS         fix SCI SPI configuration and transfer errors
  */
 
 #include "drv_sci.h"
@@ -531,6 +532,14 @@ const struct rt_i2c_bus_device_ops sci_ops_i2c =
  * @{
  */
 #ifdef BSP_USING_SCIn_SPI
+static spi_cfg_t sci_spi_config[RA_SCI_INDEX_MAX];
+#ifdef R_SCI_B_SPI_H
+static sci_b_spi_extended_cfg_t sci_spi_extended_config[RA_SCI_INDEX_MAX];
+#else
+static sci_spi_extended_cfg_t sci_spi_extended_config[RA_SCI_INDEX_MAX];
+#endif
+static rt_bool_t sci_spi_opened[RA_SCI_INDEX_MAX];
+
 void sci_spi_irq_callback(spi_callback_args_t *p_args)
 {
     rt_interrupt_enter();
@@ -566,14 +575,31 @@ void sci_spi_irq_callback(spi_callback_args_t *p_args)
 static spi_bit_width_t ra_width_shift(rt_uint8_t data_width)
 {
     spi_bit_width_t bit_width = SPI_BIT_WIDTH_8_BITS;
-    if (data_width == 1)
+    if (data_width == 8)
         bit_width = SPI_BIT_WIDTH_8_BITS;
-    else if (data_width == 2)
+    else if (data_width == 16)
         bit_width = SPI_BIT_WIDTH_16_BITS;
-    else if (data_width == 4)
+    else if (data_width == 32)
         bit_width = SPI_BIT_WIDTH_32_BITS;
 
     return bit_width;
+}
+
+static rt_err_t ra_spi_wait_complete(struct ra_sci_object *obj)
+{
+    rt_err_t err = ra_wait_complete(obj);
+
+    if (err != RT_EOK)
+    {
+        LOG_E("%s transfer failed. %d", obj->param->bus_name, err);
+        /* Stop access to the caller's buffers before returning an error. */
+        R_SCI_SPI_Close((spi_ctrl_t *)obj->param->sci_ctrl);
+        sci_spi_opened[obj - sci_obj] = RT_FALSE;
+        obj->sbus.owner = RT_NULL;
+        rt_event_control(&obj->event, RT_IPC_CMD_RESET, RT_NULL);
+    }
+
+    return err;
 }
 
 static rt_err_t ra_write_message(struct rt_spi_device *device, const void *send_buf, const rt_size_t len)
@@ -594,7 +620,11 @@ static rt_err_t ra_write_message(struct rt_spi_device *device, const void *send_
         return -RT_ERROR;
     }
     /* Wait for SPI_EVENT_TRANSFER_COMPLETE callback event. */
-    ra_wait_complete(obj);
+    err = ra_spi_wait_complete(obj);
+    if (err != RT_EOK)
+    {
+        return err;
+    }
     return len;
 }
 
@@ -616,7 +646,11 @@ static rt_err_t ra_read_message(struct rt_spi_device *device, void *recv_buf, co
         return -RT_ERROR;
     }
     /* Wait for SPI_EVENT_TRANSFER_COMPLETE callback event. */
-    ra_wait_complete(obj);
+    err = ra_spi_wait_complete(obj);
+    if (err != RT_EOK)
+    {
+        return err;
+    }
     return len;
 }
 
@@ -639,11 +673,14 @@ static rt_err_t ra_write_read_message(struct rt_spi_device *device, struct rt_sp
     }
 
     /* Wait for SPI_EVENT_TRANSFER_COMPLETE callback event. */
-    ra_wait_complete(obj);
+    err = ra_spi_wait_complete(obj);
+    if (err != RT_EOK)
+    {
+        return err;
+    }
     return message->length;
 }
 
-/**< init spi TODO : MSB does not support modification */
 static rt_err_t ra_hw_spi_configure(struct rt_spi_device *device,
                                     struct rt_spi_configuration *configuration)
 {
@@ -654,59 +691,71 @@ static rt_err_t ra_hw_spi_configure(struct rt_spi_device *device,
     struct ra_sci_object *obj =  rt_container_of(device->bus, struct ra_sci_object, sbus);
     const struct ra_sci_param *param = obj->param;
     const spi_cfg_t *cfg = (const spi_cfg_t *)param->sci_cfg;
+    rt_size_t index = obj - sci_obj;
+    spi_cfg_t *fsp_cfg = &sci_spi_config[index];
 
-    /**< data_width : 1 -> 8 bits , 2 -> 16 bits, 4 -> 32 bits, default 32 bits*/
-    rt_uint8_t data_width = configuration->data_width / 8;
-    RT_ASSERT(data_width == 1 || data_width == 2 || data_width == 4);
-    configuration->data_width = configuration->data_width / 8;
-    obj->spi_cfg = configuration;
+    if ((configuration->data_width != 8 && configuration->data_width != 16 && configuration->data_width != 32) ||
+        configuration->max_hz == 0)
+    {
+        return -RT_EINVAL;
+    }
 
 #ifdef R_SCI_B_SPI_H
-    sci_b_spi_extended_cfg_t spi_cfg = *(sci_b_spi_extended_cfg_t *)cfg->p_extend;
+    sci_b_spi_extended_cfg_t spi_cfg = *(const sci_b_spi_extended_cfg_t *)cfg->p_extend;
 #else
-    sci_spi_extended_cfg_t *spi_cfg = (sci_spi_extended_cfg_t *)cfg->p_extend;
+    sci_spi_extended_cfg_t spi_cfg = *(const sci_spi_extended_cfg_t *)cfg->p_extend;
 #endif
-
-    /**< Configure Select Line */
-    if (!(configuration->mode & RT_SPI_NO_CS) && (device->cs_pin != PIN_NONE))
-    {
-        if (configuration->mode & RT_SPI_CS_HIGH)
-        {
-            rt_pin_write(device->cs_pin, PIN_LOW);
-        }
-        else
-        {
-            rt_pin_write(device->cs_pin, PIN_HIGH);
-        }
-    }
 
     /**< config bitrate */
 #ifdef R_SCI_B_SPI_H
-    R_SCI_B_SPI_CalculateBitrate(obj->spi_cfg->max_hz, SCI_B_SPI_SOURCE_CLOCK_PCLK, &spi_cfg.clk_div);
+    err = R_SCI_B_SPI_CalculateBitrate(configuration->max_hz, SCI_B_SPI_SOURCE_CLOCK_PCLK, &spi_cfg.clk_div);
 #elif defined(SOC_SERIES_R9A07G0)
-    R_SCI_SPI_CalculateBitrate(obj->spi_cfg->max_hz, SCI_SPI_CLOCK_SOURCE_PCLKM, false);
+    err = R_SCI_SPI_CalculateBitrate(configuration->max_hz, spi_cfg.clock_source, &spi_cfg.clk_div);
 #else
-    R_SCI_SPI_CalculateBitrate(obj->spi_cfg->max_hz, &spi_cfg->clk_div, false);
+    err = R_SCI_SPI_CalculateBitrate(configuration->max_hz, &spi_cfg.clk_div, false);
 #endif
-
-    /**< init */
-    err = R_SCI_SPI_Open((spi_ctrl_t *)param->sci_ctrl, cfg);
-    /* handle error */
-    if (err == FSP_ERR_IN_USE)
+    if (err != FSP_SUCCESS)
     {
-        R_SCI_SPI_Close((spi_ctrl_t *)param->sci_ctrl);
-        err = R_SCI_SPI_Open((spi_ctrl_t *)param->sci_ctrl, cfg);
+        LOG_E("%s bitrate configuration failed. %d", param->bus_name, err);
+        return -RT_EINVAL;
     }
+
+    /* Close explicitly: FSP may compile out the already-open check. */
+    if (sci_spi_opened[index])
+    {
+        err = R_SCI_SPI_Close((spi_ctrl_t *)param->sci_ctrl);
+        if (err != FSP_SUCCESS)
+        {
+            LOG_E("%s close failed. %d", param->bus_name, err);
+            return -RT_ERROR;
+        }
+        sci_spi_opened[index] = RT_FALSE;
+    }
+
+    *fsp_cfg = *cfg;
+    sci_spi_extended_config[index] = spi_cfg;
+    fsp_cfg->p_extend = &sci_spi_extended_config[index];
+    fsp_cfg->operating_mode = (configuration->mode & RT_SPI_SLAVE) ? SPI_MODE_SLAVE : SPI_MODE_MASTER;
+    fsp_cfg->clk_phase = (configuration->mode & RT_SPI_CPHA) ? SPI_CLK_PHASE_EDGE_EVEN : SPI_CLK_PHASE_EDGE_ODD;
+    fsp_cfg->clk_polarity = (configuration->mode & RT_SPI_CPOL) ? SPI_CLK_POLARITY_HIGH : SPI_CLK_POLARITY_LOW;
+    fsp_cfg->bit_order = (configuration->mode & RT_SPI_MSB) ? SPI_BIT_ORDER_MSB_FIRST : SPI_BIT_ORDER_LSB_FIRST;
+    fsp_cfg->p_callback = sci_spi_irq_callback;
+    fsp_cfg->p_context = obj;
+
+    if (!(configuration->mode & RT_SPI_NO_CS) && (device->cs_pin != PIN_NONE))
+    {
+        rt_pin_write(device->cs_pin, (configuration->mode & RT_SPI_CS_HIGH) ? PIN_LOW : PIN_HIGH);
+    }
+
+    rt_event_control(&obj->event, RT_IPC_CMD_RESET, RT_NULL);
+    err = R_SCI_SPI_Open((spi_ctrl_t *)param->sci_ctrl, fsp_cfg);
     if (RT_EOK != err)
     {
         LOG_E("%s init failed. %d", param->bus_name, err);
         return -RT_ERROR;
     }
-    err = R_SCI_SPI_CallbackSet((spi_ctrl_t *)param->sci_ctrl, sci_spi_irq_callback, obj, NULL);
-    if (FSP_SUCCESS != err)
-    {
-        LOG_E("R_SCI_I2C_CallbackSet API failed,%d", err);
-    }
+    sci_spi_opened[index] = RT_TRUE;
+    obj->spi_cfg = configuration;
     return RT_EOK;
 }
 

--- a/bsp/renesas/libraries/HAL_Drivers/drivers/drv_sci.c
+++ b/bsp/renesas/libraries/HAL_Drivers/drivers/drv_sci.c
@@ -15,53 +15,53 @@
 #ifdef BSP_USING_SCI
 
 //#define DRV_DEBUG
-#define DBG_TAG              "drv.sci"
+#define DBG_TAG "drv.sci"
 #ifdef DRV_DEBUG
-    #define DBG_LVL               DBG_LOG
+#define DBG_LVL DBG_LOG
 #else
-    #define DBG_LVL               DBG_INFO
+#define DBG_LVL DBG_INFO
 #endif /* DRV_DEBUG */
 #include <rtdbg.h>
 
 #ifdef R_SCI_B_SPI_H
-    #define R_SCI_SPI_Write             R_SCI_B_SPI_Write
-    #define R_SCI_SPI_Read              R_SCI_B_SPI_Read
-    #define R_SCI_SPI_WriteRead         R_SCI_B_SPI_WriteRead
-    #define R_SCI_SPI_Open              R_SCI_B_SPI_Open
-    #define R_SCI_SPI_Close             R_SCI_B_SPI_Close
-    #define R_SCI_SPI_CallbackSet       R_SCI_B_SPI_CallbackSet
+#define R_SCI_SPI_Write       R_SCI_B_SPI_Write
+#define R_SCI_SPI_Read        R_SCI_B_SPI_Read
+#define R_SCI_SPI_WriteRead   R_SCI_B_SPI_WriteRead
+#define R_SCI_SPI_Open        R_SCI_B_SPI_Open
+#define R_SCI_SPI_Close       R_SCI_B_SPI_Close
+#define R_SCI_SPI_CallbackSet R_SCI_B_SPI_CallbackSet
 #endif
 
 enum
 {
-#ifdef        BSP_USING_SCI0
+#ifdef BSP_USING_SCI0
     RA_SCI_INDEX0,
 #endif
-#ifdef        BSP_USING_SCI1
+#ifdef BSP_USING_SCI1
     RA_SCI_INDEX1,
 #endif
-#ifdef        BSP_USING_SCI2
+#ifdef BSP_USING_SCI2
     RA_SCI_INDEX2,
 #endif
-#ifdef        BSP_USING_SCI3
+#ifdef BSP_USING_SCI3
     RA_SCI_INDEX3,
 #endif
-#ifdef        BSP_USING_SCI4
+#ifdef BSP_USING_SCI4
     RA_SCI_INDEX4,
 #endif
-#ifdef        BSP_USING_SCI5
+#ifdef BSP_USING_SCI5
     RA_SCI_INDEX5,
 #endif
-#ifdef        BSP_USING_SCI6
+#ifdef BSP_USING_SCI6
     RA_SCI_INDEX6,
 #endif
-#ifdef        BSP_USING_SCI7
+#ifdef BSP_USING_SCI7
     RA_SCI_INDEX7,
 #endif
-#ifdef        BSP_USING_SCI8
+#ifdef BSP_USING_SCI8
     RA_SCI_INDEX8,
 #endif
-#ifdef        BSP_USING_SCI9
+#ifdef BSP_USING_SCI9
     RA_SCI_INDEX9,
 #endif
     RA_SCI_INDEX_MAX,
@@ -69,20 +69,20 @@ enum
 
 struct ra_sci_param
 {
-    const char  bus_name[RT_NAME_MAX];
-    const void  *sci_ctrl;
-    const void  *sci_cfg;
-    const void  *ops;
+    const char bus_name[RT_NAME_MAX];
+    const void *sci_ctrl;
+    const void *sci_cfg;
+    const void *ops;
 };
 
 #ifdef RT_USING_I2C
-    rt_weak const struct rt_i2c_bus_device_ops sci_ops_i2c;
+rt_weak const struct rt_i2c_bus_device_ops sci_ops_i2c;
 #endif
 #ifdef RT_USING_SPI
-    rt_weak const struct rt_spi_ops            sci_ops_spi;
+rt_weak const struct rt_spi_ops sci_ops_spi;
 #endif
 #ifdef RT_USING_SERIAL
-    rt_weak const struct rt_uart_ops           sci_ops_uart;
+rt_weak const struct rt_uart_ops sci_ops_uart;
 #endif
 
 struct ra_sci_object
@@ -92,20 +92,20 @@ struct ra_sci_object
 #ifdef RT_USING_SPI
         struct
         {
-            struct rt_spi_bus           sbus;
+            struct rt_spi_bus sbus;
             struct rt_spi_configuration *spi_cfg;
         };
 #endif
 #ifdef RT_USING_I2C
         struct
         {
-            struct rt_i2c_bus_device    ibus;
+            struct rt_i2c_bus_device ibus;
         };
 #endif
 #ifdef RT_USING_SERIAL
         struct
         {
-            struct rt_serial_device     ubus;
+            struct rt_serial_device ubus;
         };
 #endif
     };
@@ -113,14 +113,14 @@ struct ra_sci_object
     struct rt_event event;
 };
 
-#define _TO_STR(_a)                 #_a
-#define CONCAT3STR(_a,_b,_c)        _TO_STR(_a##_b##_c)
+#define _TO_STR(_a)            #_a
+#define CONCAT3STR(_a, _b, _c) _TO_STR(_a##_b##_c)
 
-#define RA_SCI_EVENT_ABORTED        1
-#define RA_SCI_EVENT_RX_COMPLETE    2
-#define RA_SCI_EVENT_TX_COMPLETE    4
-#define RA_SCI_EVENT_ERROR          8
-#define RA_SCI_EVENT_ALL            15
+#define RA_SCI_EVENT_ABORTED     1
+#define RA_SCI_EVENT_RX_COMPLETE 2
+#define RA_SCI_EVENT_TX_COMPLETE 4
+#define RA_SCI_EVENT_ERROR       8
+#define RA_SCI_EVENT_ALL         15
 
 /**
  * Bus name format: sci[x][y], where x=0~9 and y=s/i/u
@@ -129,12 +129,14 @@ struct ra_sci_object
  * - sci_i2c:  sci0i
  * - sci_uart: sci0u
  */
-#define RA_SCI_HANDLE_ITEM(idx,type,id)    {.bus_name=CONCAT3STR(sci,idx,id),.sci_ctrl=&g_sci##idx##_ctrl,.sci_cfg=&g_sci##idx##_cfg,.ops=&sci_ops_##type}
+#define RA_SCI_HANDLE_ITEM(idx, type, id)                                                                                          \
+    {                                                                                                                              \
+        .bus_name = CONCAT3STR(sci, idx, id), .sci_ctrl = &g_sci##idx##_ctrl, .sci_cfg = &g_sci##idx##_cfg, .ops = &sci_ops_##type \
+    }
 
-const static struct ra_sci_param sci_param[] =
-{
-#ifdef        BSP_USING_SCI0
-#ifdef        BSP_USING_SCI0_SPI
+const static struct ra_sci_param sci_param[] = {
+#ifdef BSP_USING_SCI0
+#ifdef BSP_USING_SCI0_SPI
     RA_SCI_HANDLE_ITEM(0, spi, s),
 #elif defined(BSP_USING_SCI0_I2C)
     RA_SCI_HANDLE_ITEM(0, i2c, i),
@@ -143,8 +145,8 @@ const static struct ra_sci_param sci_param[] =
 #endif
 #endif
 
-#ifdef        BSP_USING_SCI1
-#ifdef        BSP_USING_SCI1_SPI
+#ifdef BSP_USING_SCI1
+#ifdef BSP_USING_SCI1_SPI
     RA_SCI_HANDLE_ITEM(1, spi, s),
 #elif defined(BSP_USING_SCI1_I2C)
     RA_SCI_HANDLE_ITEM(1, i2c, i),
@@ -153,8 +155,8 @@ const static struct ra_sci_param sci_param[] =
 #endif
 #endif
 
-#ifdef        BSP_USING_SCI2
-#ifdef        BSP_USING_SCI2_SPI
+#ifdef BSP_USING_SCI2
+#ifdef BSP_USING_SCI2_SPI
     RA_SCI_HANDLE_ITEM(2, spi, s),
 #elif defined(BSP_USING_SCI2_I2C)
     RA_SCI_HANDLE_ITEM(2, i2c, i),
@@ -163,8 +165,8 @@ const static struct ra_sci_param sci_param[] =
 #endif
 #endif
 
-#ifdef        BSP_USING_SCI3
-#ifdef        BSP_USING_SCI3_SPI
+#ifdef BSP_USING_SCI3
+#ifdef BSP_USING_SCI3_SPI
     RA_SCI_HANDLE_ITEM(3, spi, s),
 #elif defined(BSP_USING_SCI3_I2C)
     RA_SCI_HANDLE_ITEM(3, i2c, i),
@@ -173,8 +175,8 @@ const static struct ra_sci_param sci_param[] =
 #endif
 #endif
 
-#ifdef        BSP_USING_SCI4
-#ifdef        BSP_USING_SCI4_SPI
+#ifdef BSP_USING_SCI4
+#ifdef BSP_USING_SCI4_SPI
     RA_SCI_HANDLE_ITEM(4, spi, s),
 #elif defined(BSP_USING_SCI4_I2C)
     RA_SCI_HANDLE_ITEM(4, i2c, i),
@@ -183,8 +185,8 @@ const static struct ra_sci_param sci_param[] =
 #endif
 #endif
 
-#ifdef        BSP_USING_SCI5
-#ifdef        BSP_USING_SCI5_SPI
+#ifdef BSP_USING_SCI5
+#ifdef BSP_USING_SCI5_SPI
     RA_SCI_HANDLE_ITEM(5, spi, s),
 #elif defined(BSP_USING_SCI5_I2C)
     RA_SCI_HANDLE_ITEM(5, i2c, i),
@@ -193,8 +195,8 @@ const static struct ra_sci_param sci_param[] =
 #endif
 #endif
 
-#ifdef        BSP_USING_SCI6
-#ifdef        BSP_USING_SCI6_SPI
+#ifdef BSP_USING_SCI6
+#ifdef BSP_USING_SCI6_SPI
     RA_SCI_HANDLE_ITEM(6, spi, s),
 #elif defined(BSP_USING_SCI6_I2C)
     RA_SCI_HANDLE_ITEM(6, i2c, i),
@@ -203,8 +205,8 @@ const static struct ra_sci_param sci_param[] =
 #endif
 #endif
 
-#ifdef        BSP_USING_SCI7
-#ifdef        BSP_USING_SCI7_SPI
+#ifdef BSP_USING_SCI7
+#ifdef BSP_USING_SCI7_SPI
     RA_SCI_HANDLE_ITEM(7, spi, s),
 #elif defined(BSP_USING_SCI7_I2C)
     RA_SCI_HANDLE_ITEM(7, i2c, i),
@@ -213,8 +215,8 @@ const static struct ra_sci_param sci_param[] =
 #endif
 #endif
 
-#ifdef        BSP_USING_SCI8
-#ifdef        BSP_USING_SCI8_SPI
+#ifdef BSP_USING_SCI8
+#ifdef BSP_USING_SCI8_SPI
     RA_SCI_HANDLE_ITEM(8, spi, s),
 #elif defined(BSP_USING_SCI8_I2C)
     RA_SCI_HANDLE_ITEM(8, i2c, i),
@@ -223,8 +225,8 @@ const static struct ra_sci_param sci_param[] =
 #endif
 #endif
 
-#ifdef        BSP_USING_SCI9
-#ifdef        BSP_USING_SCI9_SPI
+#ifdef BSP_USING_SCI9
+#ifdef BSP_USING_SCI9_SPI
     RA_SCI_HANDLE_ITEM(9, spi, s),
 #elif defined(BSP_USING_SCI9_I2C)
     RA_SCI_HANDLE_ITEM(9, i2c, i),
@@ -255,39 +257,38 @@ rt_used static rt_err_t ra_wait_complete(struct ra_sci_object *obj)
  * @{
  */
 #ifdef BSP_USING_SCIn_UART
-const static int uart_buff_size[][2] =
-{
-#ifdef        BSP_USING_SCI0_UART
-    {BSP_SCI0_UART_RX_BUFSIZE, BSP_SCI0_UART_TX_BUFSIZE},
+const static int uart_buff_size[][2] = {
+#ifdef BSP_USING_SCI0_UART
+    { BSP_SCI0_UART_RX_BUFSIZE, BSP_SCI0_UART_TX_BUFSIZE },
 #endif
-#ifdef        BSP_USING_SCI1_UART
-    {BSP_SCI1_UART_RX_BUFSIZE, BSP_SCI1_UART_TX_BUFSIZE},
+#ifdef BSP_USING_SCI1_UART
+    { BSP_SCI1_UART_RX_BUFSIZE, BSP_SCI1_UART_TX_BUFSIZE },
 #endif
-#ifdef        BSP_USING_SCI2_UART
-    {BSP_SCI2_UART_RX_BUFSIZE, BSP_SCI2_UART_TX_BUFSIZE},
+#ifdef BSP_USING_SCI2_UART
+    { BSP_SCI2_UART_RX_BUFSIZE, BSP_SCI2_UART_TX_BUFSIZE },
 #endif
-#ifdef        BSP_USING_SCI3_UART
-    {BSP_SCI3_UART_RX_BUFSIZE, BSP_SCI3_UART_TX_BUFSIZE},
+#ifdef BSP_USING_SCI3_UART
+    { BSP_SCI3_UART_RX_BUFSIZE, BSP_SCI3_UART_TX_BUFSIZE },
 #endif
-#ifdef        BSP_USING_SCI4_UART
-    {BSP_SCI4_UART_RX_BUFSIZE, BSP_SCI4_UART_TX_BUFSIZE},
+#ifdef BSP_USING_SCI4_UART
+    { BSP_SCI4_UART_RX_BUFSIZE, BSP_SCI4_UART_TX_BUFSIZE },
 #endif
-#ifdef        BSP_USING_SCI5_UART
-    {BSP_SCI5_UART_RX_BUFSIZE, BSP_SCI5_UART_TX_BUFSIZE},
+#ifdef BSP_USING_SCI5_UART
+    { BSP_SCI5_UART_RX_BUFSIZE, BSP_SCI5_UART_TX_BUFSIZE },
 #endif
-#ifdef        BSP_USING_SCI6_UART
-    {BSP_SCI6_UART_RX_BUFSIZE, BSP_SCI6_UART_TX_BUFSIZE},
+#ifdef BSP_USING_SCI6_UART
+    { BSP_SCI6_UART_RX_BUFSIZE, BSP_SCI6_UART_TX_BUFSIZE },
 #endif
-#ifdef        BSP_USING_SCI7_UART
-    {BSP_SCI7_UART_RX_BUFSIZE, BSP_SCI7_UART_TX_BUFSIZE},
+#ifdef BSP_USING_SCI7_UART
+    { BSP_SCI7_UART_RX_BUFSIZE, BSP_SCI7_UART_TX_BUFSIZE },
 #endif
-#ifdef        BSP_USING_SCI8_UART
-    {BSP_SCI8_UART_RX_BUFSIZE, BSP_SCI8_UART_TX_BUFSIZE},
+#ifdef BSP_USING_SCI8_UART
+    { BSP_SCI8_UART_RX_BUFSIZE, BSP_SCI8_UART_TX_BUFSIZE },
 #endif
-#ifdef        BSP_USING_SCI9_UART
-    {BSP_SCI9_UART_RX_BUFSIZE, BSP_SCI9_UART_TX_BUFSIZE},
+#ifdef BSP_USING_SCI9_UART
+    { BSP_SCI9_UART_RX_BUFSIZE, BSP_SCI9_UART_TX_BUFSIZE },
 #endif
-    {0, 0},
+    { 0, 0 },
 };
 
 void sci_uart_irq_callback(uart_callback_args_t *p_args)
@@ -302,7 +303,7 @@ void sci_uart_irq_callback(uart_callback_args_t *p_args)
         {
             struct rt_serial_device *serial = &obj->ubus;
             struct rt_serial_rx_fifo *rx_fifo;
-            rx_fifo = (struct rt_serial_rx_fifo *) serial->serial_rx;
+            rx_fifo = (struct rt_serial_rx_fifo *)serial->serial_rx;
             RT_ASSERT(rx_fifo != RT_NULL);
 
             rt_ringbuffer_putchar(&(rx_fifo->rb), (rt_uint8_t)p_args->data);
@@ -326,13 +327,13 @@ static rt_err_t ra_uart_configure(struct rt_serial_device *serial, struct serial
     param = obj->param;
     RT_ASSERT(param != RT_NULL);
 
-    err = R_SCI_UART_Open((uart_ctrl_t *const)param->sci_ctrl, (uart_cfg_t *const)param->sci_cfg);
+    err = R_SCI_UART_Open((uart_ctrl_t * const)param->sci_ctrl, (uart_cfg_t * const)param->sci_cfg);
     if (FSP_SUCCESS != err)
     {
         return -RT_ERROR;
     }
 
-    err = R_SCI_UART_CallbackSet((uart_ctrl_t *const)param->sci_ctrl, sci_uart_irq_callback, obj, NULL);
+    err = R_SCI_UART_CallbackSet((uart_ctrl_t * const)param->sci_ctrl, sci_uart_irq_callback, obj, NULL);
     if (FSP_SUCCESS != err)
     {
         //LOG_W("R_SCI_UART_CallbackSet API failed,%d", err);
@@ -373,10 +374,10 @@ static int ra_uart_getc(struct rt_serial_device *serial)
     return RT_EOK;
 }
 
-static rt_ssize_t ra_uart_transmit(struct rt_serial_device     *serial,
-                                   rt_uint8_t           *buf,
-                                   rt_size_t             size,
-                                   rt_uint32_t           tx_flag)
+static rt_ssize_t ra_uart_transmit(struct rt_serial_device *serial,
+                                   rt_uint8_t *buf,
+                                   rt_size_t size,
+                                   rt_uint32_t tx_flag)
 {
     RT_ASSERT(serial != RT_NULL);
     RT_ASSERT(buf != RT_NULL);
@@ -384,8 +385,7 @@ static rt_ssize_t ra_uart_transmit(struct rt_serial_device     *serial,
     return 0;
 }
 
-const struct rt_uart_ops sci_ops_uart =
-{
+const struct rt_uart_ops sci_ops_uart = {
     .configure = ra_uart_configure,
     .control = ra_uart_control,
     .putc = ra_uart_putc,
@@ -515,11 +515,10 @@ static rt_ssize_t ra_i2c_mst_xfer(struct rt_i2c_bus_device *bus,
     return (rt_ssize_t)i;
 }
 
-const struct rt_i2c_bus_device_ops sci_ops_i2c =
-{
-    .master_xfer        = ra_i2c_mst_xfer,
-    .slave_xfer         = RT_NULL,
-    .i2c_bus_control    = RT_NULL
+const struct rt_i2c_bus_device_ops sci_ops_i2c = {
+    .master_xfer = ra_i2c_mst_xfer,
+    .slave_xfer = RT_NULL,
+    .i2c_bus_control = RT_NULL
 };
 #endif
 /**
@@ -550,15 +549,15 @@ void sci_spi_irq_callback(spi_callback_args_t *p_args)
         uint32_t event = 0;
         switch (p_args->event)
         {
-        case SPI_EVENT_ERR_MODE_FAULT   :
+        case SPI_EVENT_ERR_MODE_FAULT:
         case SPI_EVENT_ERR_READ_OVERFLOW:
-        case SPI_EVENT_ERR_PARITY       :
-        case SPI_EVENT_ERR_OVERRUN      :
-        case SPI_EVENT_ERR_FRAMING      :
+        case SPI_EVENT_ERR_PARITY:
+        case SPI_EVENT_ERR_OVERRUN:
+        case SPI_EVENT_ERR_FRAMING:
         case SPI_EVENT_ERR_MODE_UNDERRUN:
             event |= RA_SCI_EVENT_ERROR;
             break;
-        case SPI_EVENT_TRANSFER_ABORTED :
+        case SPI_EVENT_TRANSFER_ABORTED:
             event |= RA_SCI_EVENT_ABORTED;
             break;
         case SPI_EVENT_TRANSFER_COMPLETE:
@@ -576,11 +575,17 @@ static spi_bit_width_t ra_width_shift(rt_uint8_t data_width)
 {
     spi_bit_width_t bit_width = SPI_BIT_WIDTH_8_BITS;
     if (data_width == 8)
+    {
         bit_width = SPI_BIT_WIDTH_8_BITS;
+    }
     else if (data_width == 16)
+    {
         bit_width = SPI_BIT_WIDTH_16_BITS;
+    }
     else if (data_width == 32)
+    {
         bit_width = SPI_BIT_WIDTH_32_BITS;
+    }
 
     return bit_width;
 }
@@ -608,7 +613,7 @@ static rt_err_t ra_write_message(struct rt_spi_device *device, const void *send_
     RT_ASSERT(send_buf != NULL);
     RT_ASSERT(len > 0);
     rt_err_t err = RT_EOK;
-    struct ra_sci_object *obj =  rt_container_of(device->bus, struct ra_sci_object, sbus);
+    struct ra_sci_object *obj = rt_container_of(device->bus, struct ra_sci_object, sbus);
     const struct ra_sci_param *param = obj->param;
 
     spi_bit_width_t bit_width = ra_width_shift(obj->spi_cfg->data_width);
@@ -634,7 +639,7 @@ static rt_err_t ra_read_message(struct rt_spi_device *device, void *recv_buf, co
     RT_ASSERT(recv_buf != NULL);
     RT_ASSERT(len > 0);
     rt_err_t err = RT_EOK;
-    struct ra_sci_object *obj =  rt_container_of(device->bus, struct ra_sci_object, sbus);
+    struct ra_sci_object *obj = rt_container_of(device->bus, struct ra_sci_object, sbus);
     const struct ra_sci_param *param = obj->param;
 
     spi_bit_width_t bit_width = ra_width_shift(obj->spi_cfg->data_width);
@@ -660,7 +665,7 @@ static rt_err_t ra_write_read_message(struct rt_spi_device *device, struct rt_sp
     RT_ASSERT(message != NULL);
     RT_ASSERT(message->length > 0);
     rt_err_t err = RT_EOK;
-    struct ra_sci_object *obj =  rt_container_of(device->bus, struct ra_sci_object, sbus);
+    struct ra_sci_object *obj = rt_container_of(device->bus, struct ra_sci_object, sbus);
     const struct ra_sci_param *param = obj->param;
 
     spi_bit_width_t bit_width = ra_width_shift(obj->spi_cfg->data_width);
@@ -688,7 +693,7 @@ static rt_err_t ra_hw_spi_configure(struct rt_spi_device *device,
     RT_ASSERT(configuration != NULL);
     rt_err_t err = RT_EOK;
 
-    struct ra_sci_object *obj =  rt_container_of(device->bus, struct ra_sci_object, sbus);
+    struct ra_sci_object *obj = rt_container_of(device->bus, struct ra_sci_object, sbus);
     const struct ra_sci_param *param = obj->param;
     const spi_cfg_t *cfg = (const spi_cfg_t *)param->sci_cfg;
     rt_size_t index = obj - sci_obj;
@@ -770,9 +775,13 @@ static rt_ssize_t ra_spixfer(struct rt_spi_device *device, struct rt_spi_message
     if (message->cs_take && !(device->config.mode & RT_SPI_NO_CS) && (device->cs_pin != PIN_NONE))
     {
         if (device->config.mode & RT_SPI_CS_HIGH)
+        {
             rt_pin_write(device->cs_pin, PIN_HIGH);
+        }
         else
+        {
             rt_pin_write(device->cs_pin, PIN_LOW);
+        }
     }
 
     if (message->length > 0)
@@ -790,22 +799,25 @@ static rt_ssize_t ra_spixfer(struct rt_spi_device *device, struct rt_spi_message
         else if (message->send_buf != RT_NULL && message->recv_buf != RT_NULL)
         {
             /**< send and receive message */
-            err =  ra_write_read_message(device, message);
+            err = ra_write_read_message(device, message);
         }
     }
 
     if (message->cs_release && !(device->config.mode & RT_SPI_NO_CS) && (device->cs_pin != PIN_NONE))
     {
         if (device->config.mode & RT_SPI_CS_HIGH)
+        {
             rt_pin_write(device->cs_pin, PIN_LOW);
+        }
         else
+        {
             rt_pin_write(device->cs_pin, PIN_HIGH);
+        }
     }
     return err;
 }
 
-const struct rt_spi_ops sci_ops_spi =
-{
+const struct rt_spi_ops sci_ops_spi = {
     .configure = ra_hw_spi_configure,
     .xfer = ra_spixfer,
 };
@@ -838,60 +850,60 @@ static int ra_hw_sci_init(void)
 #endif
 #ifdef BSP_USING_SCIn_I2C
             if ((uint32_t)param->ops == (uint32_t)&sci_ops_i2c)
-            {
-                obj->ibus.ops = param->ops;
-                obj->ibus.priv = 0;
+        {
+            obj->ibus.ops = param->ops;
+            obj->ibus.priv = 0;
                 /* opening IIC master module */
 #if defined(SOC_SERIES_R7FA8M85) || defined(SOC_SERIES_R7KA8P1)
-                err = R_SCI_B_I2C_Open((i2c_master_ctrl_t *)param->sci_ctrl, param->sci_cfg);
+            err = R_SCI_B_I2C_Open((i2c_master_ctrl_t *)param->sci_ctrl, param->sci_cfg);
 #else
-                err = R_SCI_I2C_Open((i2c_master_ctrl_t *)param->sci_ctrl, param->sci_cfg);
+            err = R_SCI_I2C_Open((i2c_master_ctrl_t *)param->sci_ctrl, param->sci_cfg);
 #endif
-                if (err != FSP_SUCCESS)
-                {
-                    LOG_E("R_IIC_MASTER_Open API failed,%d", err);
-                    continue;
-                }
+            if (err != FSP_SUCCESS)
+            {
+                LOG_E("R_IIC_MASTER_Open API failed,%d", err);
+                continue;
+            }
 #if defined(SOC_SERIES_R7FA8M85) || defined(SOC_SERIES_R7KA8P1)
-                err = R_SCI_B_I2C_CallbackSet((i2c_master_ctrl_t *)param->sci_ctrl, sci_i2c_irq_callback, obj, NULL);
+            err = R_SCI_B_I2C_CallbackSet((i2c_master_ctrl_t *)param->sci_ctrl, sci_i2c_irq_callback, obj, NULL);
 #else
-                err = R_SCI_I2C_CallbackSet((i2c_master_ctrl_t *)param->sci_ctrl, sci_i2c_irq_callback, obj, NULL);
+            err = R_SCI_I2C_CallbackSet((i2c_master_ctrl_t *)param->sci_ctrl, sci_i2c_irq_callback, obj, NULL);
 #endif
                 /* handle error */
-                if (FSP_SUCCESS != err)
-                {
-                    LOG_E("R_SCI_I2C_CallbackSet API failed,%d", err);
-                    continue;
-                }
-
-                err = rt_i2c_bus_device_register(&obj->ibus, param->bus_name);
-                if (RT_EOK != err)
-                {
-                    LOG_E("i2c bus %s register failed,%d", param->bus_name, err);
-                    continue;
-                }
+            if (FSP_SUCCESS != err)
+            {
+                LOG_E("R_SCI_I2C_CallbackSet API failed,%d", err);
+                continue;
             }
-            else
+
+            err = rt_i2c_bus_device_register(&obj->ibus, param->bus_name);
+            if (RT_EOK != err)
+            {
+                LOG_E("i2c bus %s register failed,%d", param->bus_name, err);
+                continue;
+            }
+        }
+        else
 #endif
 #ifdef BSP_USING_SCIn_UART
-                if ((uint32_t)param->ops == (uint32_t)&sci_ops_uart)
-                {
-                    if (rt_device_find(param->bus_name) != RT_NULL)
-                    {
-                        continue;
-                    }
-                    struct rt_serial_device *serial = &obj->ubus;
-                    obj->ubus.ops = param->ops;
-                    serial->config.rx_bufsz = uart_buff_size[bufsz_idx][0];
-                    serial->config.tx_bufsz = uart_buff_size[bufsz_idx][1];
-                    bufsz_idx ++;
-                    err = rt_hw_serial_register(serial, param->bus_name, RT_DEVICE_FLAG_RDWR, RT_NULL);
-                    if (RT_EOK != err)
-                    {
-                        LOG_E("uart %s register failed,%d", param->bus_name, err);
-                        continue;
-                    }
-                }
+            if ((uint32_t)param->ops == (uint32_t)&sci_ops_uart)
+        {
+            if (rt_device_find(param->bus_name) != RT_NULL)
+            {
+                continue;
+            }
+            struct rt_serial_device *serial = &obj->ubus;
+            obj->ubus.ops = param->ops;
+            serial->config.rx_bufsz = uart_buff_size[bufsz_idx][0];
+            serial->config.tx_bufsz = uart_buff_size[bufsz_idx][1];
+            bufsz_idx++;
+            err = rt_hw_serial_register(serial, param->bus_name, RT_DEVICE_FLAG_RDWR, RT_NULL);
+            if (RT_EOK != err)
+            {
+                LOG_E("uart %s register failed,%d", param->bus_name, err);
+                continue;
+            }
+        }
 #endif
         {
         }
@@ -926,7 +938,7 @@ rt_weak int rt_hw_usart_init(void)
             obj->ubus.ops = param->ops;
             serial->config.rx_bufsz = uart_buff_size[bufsz_idx][0];
             serial->config.tx_bufsz = uart_buff_size[bufsz_idx][1];
-            bufsz_idx ++;
+            bufsz_idx++;
             err = rt_hw_serial_register(serial, param->bus_name, RT_DEVICE_FLAG_RDWR, RT_NULL);
             if (RT_EOK != err)
             {


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[
<!-- 这段方括号里的内容是您**必须填写并替换掉**的，否则PR不可能被合并。**方括号外面的内容不需要修改，但请仔细阅读。**
The content in this square bracket must be filled in and replaced, otherwise, PR can not be merged. The contents outside square brackets need not be changed, but please read them carefully.

请在这里填写您的PR描述，可以包括以下之一的内容：为什么提交这份PR；解决的问题是什么，你的解决方案是什么；
Please fill in your PR description here, which can include one of the following items: why to submit this PR; what is the problem solved and what is your solution;

并确认并列出已经在什么情况或板卡上进行了测试。
And confirm in which case or board has been tested. -->

#### 为什么提交这份PR (why to submit this PR)

在 RZ/N2L EtherKit 的 SCI SPI 回环排查中发现，共享 SCI SPI 驱动存在以下问题：RZ 分频接口将 false 作为分频结果指针传入，且未使用 FSP 配置中的实际时钟源；运行时配置没有可靠地传递给 FSP，重复配置也未正确关闭旧实例；配置过程将 RT-Thread 的位宽从 bit 改成 byte；收发等待超时或出错后仍返回传输长度，导致调用方误判传输成功。


#### 你的解决方案是什么 (what is your solution)

为每条 SCI 总线保存持久的可写 FSP 配置及扩展配置副本，修正各 SCI 分支的分频调用，并在 RZ 分支使用实际配置的时钟源；检查分频错误，在重新配置前显式关闭已打开的实例。保持 RT-Thread 位宽单位为 bit，同步主从模式、时钟极性/相位、位序和回调上下文，保留无片选及无效 CS 引脚保护。

统一处理发送、接收和全双工传输的等待结果，在超时或错误时关闭传输、清理事件和总线归属，使后续操作可以重新配置并重试。

已通过 RZ、普通 SCI、SCI_B 三条分支的主机模拟测试，覆盖 6 档时钟、1～512 字节收发、配置生命周期、多总线隔离及错误恢复



#### 请提供验证的bsp和config (provide the config and bsp) 

<!-- 请填写验证bsp目录下面的目录比如bsp/stm32/stm32l496-st-nucleo

Please provide the path of verfied bsp. Like bsp/stm32/stm32l496-st-nucleo  bsp/ESP32_C3 -->

- BSP:

<!-- 请填写.config 文件中需要改动的config

Please provide the changed config of .config file to how to verify the PR file like CONFIG_BSP_USING_I2C CONFIG_BSP_USING_WDT -->

- .config:

<!-- 请提供自己仓库的PR branch的action的编译链接相关PR文件成功的链接：

Please provide the link of action triggered by your own repo's action  

https://github.com/RT-Thread/rt-thread/actions/workflows/manual_dist.yml -->

- action:

]

<!-- 以下的内容不应该在提交PR时的message修改，修改下述message，PR会被直接关闭。请在提交PR后，浏览器查看PR并对以下检查项逐项check，没问题后逐条在页面上打钩。
The following content must not be changed in the submitted PR message. Otherwise, the PR will be closed immediately. After submitted PR, please use a web browser to visit PR, and check items one by one, and ticked them if no problem. -->

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [ ] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [ ] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [ ] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [ ] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [ ] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [ ] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [ ] 代码是高质量的 Code in this PR is of high quality
- [ ] 已经使用[clang-format](https://clang.llvm.org/docs/ClangFormat.html) 源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_cn.md) This PR has been formatted with clang-format and complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/7.contribution/coding_style_en.md)
- [ ] 如果是新增bsp, 已经添加ci检查到[.github/ALL_BSP_COMPILE.json](https://github.com/RT-Thread/rt-thread/blob/master/.github/ALL_BSP_COMPILE.json)  详细请参考链接[BSP自查](https://www.rt-thread.org/document/site/#/rt-thread-version/rt-thread-standard/development-guide/bsp-selfcheck/bsp_selfcheck)
