### PR TITLE
[docs] point QEMU Linux quick start at qemu-nographic.sh

### DIFF
--- a/documentation/2.quick-start/quick_start_qemu/quick_start_qemu_linux.md
+++ b/documentation/2.quick-start/quick_start_qemu/quick_start_qemu_linux.md
@@ -141,6 +141,8 @@ The main files and directories of `qemu-vexpress-a9` BSP are described as follow
 | drivers          | The underlying driver provided by RT-Thread |
 | qemu.bat         | Script files running on Windows platform    |
 | qemu.sh          | Script files running on Linux platform      |
+| qemu-nographic.bat | Script files running on Windows platform, without a graphical window |
+| qemu-nographic.sh | Script files running on Linux platform, without a graphical window |
 | qemu-dbg.bat     | Debugging script files on Windows platform  |
 | qemu-dbg.sh      | Debugging script files on Linux platform    |
 | README.md        | Description document of BSP                 |
@@ -159,6 +161,16 @@ Switch to the QEMU BSP directory and enter the `scons` command to compile the pr
 After compiling, type `./qemu.sh` to start the virtual machine and BSP project. `qemu.sh` is a Linux batch file. This file is located in the BSP folder, mainly including the execution instructions of QEMU. The first run of the project will create a blank `sd.bin` file under the BSP folder, which is a virtual SD card with a size of 64M. The Env command interface displays the initialization information and version number information printed during the start-up of RT-Thread system, and the QEMU virtual machine is also running. As shown in the following picture:
 
 ![run the project](figures/ubuntu-qume-sh.png)
+
+`qemu.sh` opens a graphical window for the emulated CLCD display, so it
+needs a desktop session. Over SSH, or on a machine without a display, it
+fails with an error such as `gtk initialization failed`. Use
+`./qemu-nographic.sh` instead, which runs the same BSP with the console
+on the terminal:
+
+```shell
+./qemu-nographic.sh
+```
 
 ### 5.3 Run the Finsh Console
 


### PR DESCRIPTION
## Problem

The QEMU Linux quick start only ever mentions `./qemu.sh`, and its file table omits the `qemu-nographic` scripts entirely.

`qemu.sh` passes `-serial stdio` without `-nographic`, so QEMU opens a GTK window for the emulated CLCD. On a headless machine or over SSH it stops at `gtk initialization failed` (reproduced by running it with `DISPLAY` unset), with nothing in the guide explaining what to do next — even though the BSP already ships `qemu-nographic.sh` for exactly this case, and the BSP README itself recommends it for servers.

## Change

- Add both `qemu-nographic` scripts to the file table in chapter 4
- Document `./qemu-nographic.sh` in section 5.2, right where the project is first run
