### PR TITLE
[docs] fix outdated GNU GCC toolchain link in qemu-vexpress-a9 README

### DIFF
--- a/bsp/qemu-vexpress-a9/README.md
+++ b/bsp/qemu-vexpress-a9/README.md
@@ -40,7 +40,13 @@
 
   ![image-20220626114020634](figures/image-20220626114020634.png)
 
-- 如果在Linux下使用，请自行下载[GNU GCC工具链][3]。
+- 如果在Linux下使用，推荐用发行版的包管理器安装 `arm-none-eabi` 工具链，`rtconfig.py` 默认的 `EXEC_PATH` 即为 `/usr/bin`，装好后无需额外配置。以 Debian/Ubuntu 为例：
+
+  ```shell
+  sudo apt install gcc-arm-none-eabi libstdc++-arm-none-eabi-newlib
+  ```
+
+  其中 `libstdc++-arm-none-eabi-newlib` 提供链接阶段 `-lsupc++` 所需的库。也可以从 [Arm GNU Toolchain 下载页][3] 获取官方预编译版本，解压后用 `RTT_EXEC_PATH` 环境变量指向其 `bin` 目录。
 
 ## 3 执行和退出
 
@@ -244,6 +250,6 @@ msh />QEMU: Terminated
 
 [1]: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.subset.boards.express/index.html
 [2]: https://www.rt-thread.org/download.html#download-rt-thread-env-tool
-[3]: https://launchpad.net/gcc-arm-embedded/5.0/5-2016-q3-update/+download/gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2
+[3]: https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads
 [4]: https://github.com/BernardXiong
 [5]: https://github.com/recan-li


### PR DESCRIPTION
## Problem

`bsp/qemu-vexpress-a9/README.md` tells Linux users to download the GNU GCC
toolchain from a launchpad.net URL. Launchpad shut down its gcc-arm-embedded
downloads years ago — the URL now returns 503 — and the tarball it names is a
2016 Q3 build (gcc 5.4).

## Change

- Point the link to Arm GNU Toolchain Downloads, the same page already
  referenced by `bsp/nxp/imx/imx91/README.md`. The old `gnu-rm` page covers the
  GNU Arm Embedded Toolchain, which Arm has superseded.
- Mention installing the toolchain from the distribution package manager, with
  Debian/Ubuntu given as one example, since `rtconfig.py` already defaults
  `EXEC_PATH` to `/usr/bin`. `libstdc++-arm-none-eabi-newlib` is listed because
  `LFLAGS` links with `-lsupc++`; `binutils-arm-none-eabi` is pulled in as a
  dependency of `gcc-arm-none-eabi` and does not need to be named.
- Note `RTT_EXEC_PATH` for users who prefer Arm's prebuilt tarball.

This BSP has no English README, so no counterpart file needs the same edit.
